### PR TITLE
fix(task-manager): sanitize review prompt inputs

### DIFF
--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -770,6 +770,20 @@ export function buildReworkPrompt(
 
 // ─── Main Review Prompt (Phase 4: two-stage verification) ───
 
+const MAX_DIFF_CHARS = 30_000;
+const MAX_PRECHECKS_CHARS = 10_000;
+
+/** Escape triple-backtick sequences to prevent Markdown fence breakout */
+function sanitizeFenceContent(content: string): string {
+  return content.replace(/```/g, "` ` `");
+}
+
+/** Truncate content with a marker if it exceeds maxLen */
+function truncate(content: string, maxLen: number): string {
+  if (content.length <= maxLen) return content;
+  return content.slice(0, maxLen) + "\n...[truncated]";
+}
+
 export function buildMainReviewPrompt(task: TaskBundle): string {
   const lines: string[] = [];
 
@@ -778,22 +792,29 @@ export function buildMainReviewPrompt(task: TaskBundle): string {
 
   // Full receipt (Main Agent is the originator — not blind)
   if (task.implementationReceipt) {
+    const receiptJson = sanitizeFenceContent(
+      JSON.stringify(task.implementationReceipt, null, 2)
+    );
     lines.push("## Implementation Receipt");
     lines.push("```json");
-    lines.push(JSON.stringify(task.implementationReceipt, null, 2));
+    lines.push(receiptJson);
     lines.push("```");
     lines.push("");
   }
 
+  const preChecksRaw = JSON.stringify(task.mainReview?.preChecks ?? [], null, 2);
+  const preChecksSafe = truncate(sanitizeFenceContent(preChecksRaw), MAX_PRECHECKS_CHARS);
   lines.push("## Pre-check Results");
   lines.push("```json");
-  lines.push(JSON.stringify(task.mainReview?.preChecks ?? [], null, 2));
+  lines.push(preChecksSafe);
   lines.push("```");
   lines.push("");
 
+  const diffRaw = task.mainReview?.gitDiff?.trim() || "# No diff captured";
+  const diffSafe = truncate(sanitizeFenceContent(diffRaw), MAX_DIFF_CHARS);
   lines.push("## Git Diff (`develop...HEAD`)");
   lines.push("```diff");
-  lines.push(task.mainReview?.gitDiff?.trim() || "# No diff captured");
+  lines.push(diffSafe);
   lines.push("```");
   lines.push("");
 


### PR DESCRIPTION
## Summary
- Escape triple-backtick sequences in `preChecks`, `gitDiff`, `implementationReceipt` to prevent Markdown fence breakout
- Add length caps (30K diff, 10K preChecks) with `...[truncated]` markers
- Addresses CodeRabbit Critical finding on PR #3

Closes #10

## Test plan
- [x] tsc --noEmit passes
- [x] Code review completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了大型提示内容的处理，添加了字符长度限制以提高系统稳定性
  * 优化了提示构建中的内容格式化处理

<!-- end of auto-generated comment: release notes by coderabbit.ai -->