### PR TITLE
docs(orchestrator): add JSDoc for docstring coverage ≥80%

### DIFF
--- a/packages/orchestrator/src/rtk-wrapper.ts
+++ b/packages/orchestrator/src/rtk-wrapper.ts
@@ -53,6 +53,7 @@ function shouldWrapCommand(command: string, config?: RTKConfig): boolean {
   return config.commands.some((candidate) => normalizeCommandName(candidate) === normalizedCommand);
 }
 
+/** Wrap a CLI command with RTK if the command is in the configured list. */
 export function wrapWithRTK(
   command: string,
   args: readonly string[] = [],
@@ -68,6 +69,7 @@ export function wrapWithRTK(
   };
 }
 
+/** Check whether the RTK binary is installed and responds to --version. */
 export async function isRTKAvailable(config?: RTKConfig): Promise<boolean> {
   if (!config?.enabled) {
     return true;
@@ -111,6 +113,7 @@ function normalizeSpawnInvocation(
   return { args: [], options: argsOrOptions as SpawnOptions | undefined };
 }
 
+/** Install a global child_process.spawn wrapper that routes commands through RTK. */
 export function installRTKCommandWrapper(config?: RTKConfig): void {
   activeConfig = config?.enabled
     ? {

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -573,6 +573,7 @@ export class TaskManager {
 
 // ─── Prompt Builders ───
 
+/** Build the dispatch prompt sent to the Dev Agent for implementation. */
 export function buildDevPrompt(task: TaskBundle, kbContext?: string): string {
   const lines: string[] = [];
 
@@ -657,6 +658,7 @@ export function buildReferencePrompt(
   return lines.join("\n");
 }
 
+/** Build the blind-review prompt sent to the Acceptance Agent. */
 export function buildAcceptancePrompt(
   task: TaskBundle,
   acceptance: AcceptanceBundle,
@@ -712,6 +714,7 @@ export function buildAcceptancePrompt(
   return lines.join("\n");
 }
 
+/** Build the rework prompt sent to the Dev Agent after acceptance failure. */
 export function buildReworkPrompt(
   task: TaskBundle,
   acceptance: AcceptanceBundle,
@@ -784,6 +787,7 @@ function truncate(content: string, maxLen: number): string {
   return content.slice(0, maxLen) + "\n...[truncated]";
 }
 
+/** Build the Main Agent review prompt with sanitized pre-checks and diff. */
 export function buildMainReviewPrompt(task: TaskBundle): string {
   const lines: string[] = [];
 


### PR DESCRIPTION
## Summary
- Add JSDoc docstrings to 7 exported functions missing them in `task-manager.ts` and `rtk-wrapper.ts`
- Brings docstring coverage from 66.67% above the 80% threshold

## Files changed
- `packages/orchestrator/src/task-manager.ts` — 4 functions
- `packages/orchestrator/src/rtk-wrapper.ts` — 3 functions

## Test plan
- [x] tsc --noEmit passes
- [x] Docstring-only changes, no logic modifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 文档

* **文档** - 改进了内部代码注释和文档清晰度，无用户可见功能变更。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->