### PR TITLE
feat(hooks): PR merge guard — CodeRabbit review required

### DIFF
--- a/.claude/hooks/pr-merge-guard.sh
+++ b/.claude/hooks/pr-merge-guard.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# GATE: block gh pr merge unless CodeRabbit review has completed.
+# Token cost: ~1 gh API call when intercepted.
+#
+# Pattern: same as pre-commit-guard.sh
+#   PreToolUse(Bash) → detect "gh pr merge" → check CodeRabbit status → block/allow
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | grep -oP '"command"\s*:\s*"\K[^"]*')
+
+# Only intercept gh pr merge commands
+echo "$COMMAND" | grep -qE 'gh\s+pr\s+merge' || exit 0
+
+# Extract PR number from command (e.g., "gh pr merge 15 --merge")
+PR_NUMBER=$(echo "$COMMAND" | grep -oP 'gh\s+pr\s+merge\s+\K\d+')
+
+if [ -z "$PR_NUMBER" ]; then
+  echo "BLOCKED: could not extract PR number from merge command." >&2
+  exit 2
+fi
+
+# Allow manual bypass via state flag (e.g., human-approved merge)
+STATE_DIR="$(dirname "$0")/state"
+FLAG="$STATE_DIR/pr-merge-approved-${PR_NUMBER}"
+if [ -f "$FLAG" ]; then
+  rm -f "$FLAG" 2>/dev/null
+  exit 0
+fi
+
+# Check CodeRabbit status via gh pr checks
+CR_STATUS=$(gh pr checks "$PR_NUMBER" 2>/dev/null | grep -i "CodeRabbit" | awk '{print $2}')
+
+if [ "$CR_STATUS" = "pass" ]; then
+  exit 0
+fi
+
+if [ "$CR_STATUS" = "pending" ]; then
+  cat >&2 <<MSG
+BLOCKED: CodeRabbit review still in progress for PR #${PR_NUMBER}.
+Wait for review to complete before merging.
+To check: gh pr checks ${PR_NUMBER}
+To bypass (human-approved): touch ${STATE_DIR}/pr-merge-approved-${PR_NUMBER}
+MSG
+  exit 2
+fi
+
+if [ -z "$CR_STATUS" ]; then
+  cat >&2 <<MSG
+BLOCKED: No CodeRabbit check found for PR #${PR_NUMBER}.
+Ensure CodeRabbit is configured and has started reviewing.
+To bypass (human-approved): touch ${STATE_DIR}/pr-merge-approved-${PR_NUMBER}
+MSG
+  exit 2
+fi
+
+# CR_STATUS is something unexpected (fail, etc.)
+cat >&2 <<MSG
+BLOCKED: CodeRabbit status is "${CR_STATUS}" for PR #${PR_NUMBER}.
+Review must pass before agent can merge.
+To bypass (human-approved): touch ${STATE_DIR}/pr-merge-approved-${PR_NUMBER}
+MSG
+exit 2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -23,6 +23,11 @@
             "type": "command",
             "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/pre-commit-guard.sh\"",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/pr-merge-guard.sh\"",
+            "timeout": 15
           }
         ]
       }


### PR DESCRIPTION
## Summary
- New `pr-merge-guard.sh` hook blocks `gh pr merge` until CodeRabbit review passes
- Registered as PreToolUse(Bash) hook in settings.json (timeout 15s for gh API call)
- Human bypass: `touch .claude/hooks/state/pr-merge-approved-{PR_NUMBER}`

## Behavior
| Scenario | Result |
|----------|--------|
| CodeRabbit status = `pass` | ✅ Allow merge |
| CodeRabbit status = `pending` | ❌ Block — review in progress |
| No CodeRabbit check found | ❌ Block — not configured or not started |
| CodeRabbit status = `fail` | ❌ Block — review failed |
| Non-merge command | ✅ Skip — not intercepted |

## Test plan
- [x] Dry-run: non-existent PR → blocked (no check found)
- [x] Dry-run: reviewed PR #15 → allowed (pass)
- [x] Dry-run: non-merge command → skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **Chores**
  * 新增拉取请求合并流程的自动化检查机制，需完成指定审查后方可合并。支持管理员绕过选项。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->