### PR TITLE
fix: harden pr-merge-guard.sh portability and JSON parsing

### DIFF
--- a/.claude/hooks/pr-merge-guard.sh
+++ b/.claude/hooks/pr-merge-guard.sh
@@ -62,15 +62,17 @@ if [ "$CR_STATUS" = "success" ]; then
   exit 0
 fi
 
-if [ "$CR_STATUS" = "pending" ]; then
-  cat >&2 <<MSG
+case "$CR_STATUS" in
+  pending|queued|in_progress)
+    cat >&2 <<MSG
 BLOCKED: CodeRabbit review still in progress for PR #${PR_NUMBER}.
 Wait for review to complete before merging.
 To check: gh pr checks ${PR_NUMBER}
 To bypass (human-approved): touch ${STATE_DIR}/pr-merge-approved-${PR_NUMBER}
 MSG
-  exit 2
-fi
+    exit 2
+    ;;
+esac
 
 if [ -z "$CR_STATUS" ]; then
   cat >&2 <<MSG

--- a/.claude/hooks/pr-merge-guard.sh
+++ b/.claude/hooks/pr-merge-guard.sh
@@ -6,10 +6,10 @@
 #   PreToolUse(Bash) → detect "gh pr merge" → check CodeRabbit status → block/allow
 
 INPUT=$(cat)
-COMMAND=$(echo "$INPUT" | sed -n 's/.*"command"\s*:\s*"\([^"]*\)".*/\1/p')
+COMMAND=$(echo "$INPUT" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
 
 # Only intercept gh pr merge commands
-echo "$COMMAND" | grep -qE 'gh\s+pr\s+merge' || exit 0
+echo "$COMMAND" | grep -qE 'gh[[:space:]]+pr[[:space:]]+merge' || exit 0
 
 # Extract PR number from command (e.g., "gh pr merge 15 --merge")
 PR_NUMBER=$(echo "$COMMAND" | sed -n 's/.*gh[[:space:]]\+pr[[:space:]]\+merge[[:space:]]\+\([0-9]\+\).*/\1/p')
@@ -22,6 +22,11 @@ if [ -z "$PR_NUMBER" ]; then
   exit 2
 fi
 
+# Validate PR_NUMBER is numeric only (防止路径遍历)
+case "$PR_NUMBER" in
+  ''|*[!0-9]*) echo "BLOCKED: Invalid PR number: $PR_NUMBER" >&2; exit 2 ;;
+esac
+
 # Allow manual bypass via state flag (e.g., human-approved merge)
 STATE_DIR="$(dirname "$0")/state"
 FLAG="$STATE_DIR/pr-merge-approved-${PR_NUMBER}"
@@ -31,7 +36,7 @@ if [ -f "$FLAG" ]; then
 fi
 
 # Check CodeRabbit status via gh pr checks
-CR_STATUS=$(gh pr checks "$PR_NUMBER" --json name,state -q '.[] | select(.name | test("CodeRabbit";"i")) | .state' 2>/dev/null | tr '[:upper:]' '[:lower:]')
+CR_STATUS=$(gh pr checks "$PR_NUMBER" --json name,state -q '.[] | select(.name | test("CodeRabbit";"i")) | .state' 2>/dev/null | head -n1 | tr '[:upper:]' '[:lower:]')
 
 if [ "$CR_STATUS" = "success" ]; then
   exit 0

--- a/.claude/hooks/pr-merge-guard.sh
+++ b/.claude/hooks/pr-merge-guard.sh
@@ -6,16 +6,19 @@
 #   PreToolUse(Bash) → detect "gh pr merge" → check CodeRabbit status → block/allow
 
 INPUT=$(cat)
-COMMAND=$(echo "$INPUT" | grep -oP '"command"\s*:\s*"\K[^"]*')
+COMMAND=$(echo "$INPUT" | sed -n 's/.*"command"\s*:\s*"\([^"]*\)".*/\1/p')
 
 # Only intercept gh pr merge commands
 echo "$COMMAND" | grep -qE 'gh\s+pr\s+merge' || exit 0
 
 # Extract PR number from command (e.g., "gh pr merge 15 --merge")
-PR_NUMBER=$(echo "$COMMAND" | grep -oP 'gh\s+pr\s+merge\s+\K\d+')
+PR_NUMBER=$(echo "$COMMAND" | sed -n 's/.*gh[[:space:]]\+pr[[:space:]]\+merge[[:space:]]\+\([0-9]\+\).*/\1/p')
 
 if [ -z "$PR_NUMBER" ]; then
-  echo "BLOCKED: could not extract PR number from merge command." >&2
+  PR_NUMBER=$(gh pr view --json number -q '.number' 2>/dev/null)
+fi
+if [ -z "$PR_NUMBER" ]; then
+  echo "BLOCKED: could not determine PR number from command or current branch." >&2
   exit 2
 fi
 
@@ -28,9 +31,9 @@ if [ -f "$FLAG" ]; then
 fi
 
 # Check CodeRabbit status via gh pr checks
-CR_STATUS=$(gh pr checks "$PR_NUMBER" 2>/dev/null | grep -i "CodeRabbit" | awk '{print $2}')
+CR_STATUS=$(gh pr checks "$PR_NUMBER" --json name,state -q '.[] | select(.name | test("CodeRabbit";"i")) | .state' 2>/dev/null | tr '[:upper:]' '[:lower:]')
 
-if [ "$CR_STATUS" = "pass" ]; then
+if [ "$CR_STATUS" = "success" ]; then
   exit 0
 fi
 

--- a/.claude/hooks/pr-merge-guard.sh
+++ b/.claude/hooks/pr-merge-guard.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# GATE: block gh pr merge unless CodeRabbit review has completed.
+# Token cost: ~1 gh API call when intercepted.
+#
+# Pattern: same as pre-commit-guard.sh
+#   PreToolUse(Bash) → detect "gh pr merge" → check CodeRabbit status → block/allow
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | grep -oP '"command"\s*:\s*"\K[^"]*')
+
+# Only intercept gh pr merge commands
+echo "$COMMAND" | grep -qE 'gh\s+pr\s+merge' || exit 0
+
+# Extract PR number from command (e.g., "gh pr merge 15 --merge")
+PR_NUMBER=$(echo "$COMMAND" | grep -oP 'gh\s+pr\s+merge\s+\K\d+')
+
+if [ -z "$PR_NUMBER" ]; then
+  echo "BLOCKED: could not extract PR number from merge command." >&2
+  exit 2
+fi
+
+# Allow manual bypass via state flag (e.g., human-approved merge)
+STATE_DIR="$(dirname "$0")/state"
+FLAG="$STATE_DIR/pr-merge-approved-${PR_NUMBER}"
+if [ -f "$FLAG" ]; then
+  rm -f "$FLAG" 2>/dev/null
+  exit 0
+fi
+
+# Check CodeRabbit status via gh pr checks
+CR_STATUS=$(gh pr checks "$PR_NUMBER" 2>/dev/null | grep -i "CodeRabbit" | awk '{print $2}')
+
+if [ "$CR_STATUS" = "pass" ]; then
+  exit 0
+fi
+
+if [ "$CR_STATUS" = "pending" ]; then
+  cat >&2 <<MSG
+BLOCKED: CodeRabbit review still in progress for PR #${PR_NUMBER}.
+Wait for review to complete before merging.
+To check: gh pr checks ${PR_NUMBER}
+To bypass (human-approved): touch ${STATE_DIR}/pr-merge-approved-${PR_NUMBER}
+MSG
+  exit 2
+fi
+
+if [ -z "$CR_STATUS" ]; then
+  cat >&2 <<MSG
+BLOCKED: No CodeRabbit check found for PR #${PR_NUMBER}.
+Ensure CodeRabbit is configured and has started reviewing.
+To bypass (human-approved): touch ${STATE_DIR}/pr-merge-approved-${PR_NUMBER}
+MSG
+  exit 2
+fi
+
+# CR_STATUS is something unexpected (fail, etc.)
+cat >&2 <<MSG
+BLOCKED: CodeRabbit status is "${CR_STATUS}" for PR #${PR_NUMBER}.
+Review must pass before agent can merge.
+To bypass (human-approved): touch ${STATE_DIR}/pr-merge-approved-${PR_NUMBER}
+MSG
+exit 2

--- a/.claude/hooks/pr-merge-guard.sh
+++ b/.claude/hooks/pr-merge-guard.sh
@@ -12,7 +12,15 @@ COMMAND=$(echo "$INPUT" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\([^"]*
 echo "$COMMAND" | grep -qE 'gh[[:space:]]+pr[[:space:]]+merge' || exit 0
 
 # Extract PR selector — first non-flag token after `gh pr merge`
-PR_SELECTOR=$(echo "$COMMAND" | sed -n 's/.*gh[[:space:]][[:space:]]*pr[[:space:]][[:space:]]*merge[[:space:]][[:space:]]*\([^[:space:]][^[:space:]]*\).*/\1/p')
+# Strip `gh pr merge` prefix, then find first token not starting with -
+MERGE_ARGS=$(echo "$COMMAND" | sed -n 's/.*gh[[:space:]][[:space:]]*pr[[:space:]][[:space:]]*merge[[:space:]][[:space:]]*//p')
+PR_SELECTOR=""
+for token in $MERGE_ARGS; do
+  case "$token" in
+    -*) continue ;;
+    *) PR_SELECTOR="$token"; break ;;
+  esac
+done
 PR_NUMBER=""
 
 case "$PR_SELECTOR" in

--- a/.claude/hooks/pr-merge-guard.sh
+++ b/.claude/hooks/pr-merge-guard.sh
@@ -11,24 +11,36 @@ COMMAND=$(echo "$INPUT" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\([^"]*
 # Only intercept gh pr merge commands
 echo "$COMMAND" | grep -qE 'gh[[:space:]]+pr[[:space:]]+merge' || exit 0
 
-# Extract PR number from command (e.g., "gh pr merge 15 --merge")
-PR_NUMBER=$(echo "$COMMAND" | sed -n 's/.*gh[[:space:]]\+pr[[:space:]]\+merge[[:space:]]\+\([0-9]\+\).*/\1/p')
+# Extract PR selector — first non-flag token after `gh pr merge`
+PR_SELECTOR=$(echo "$COMMAND" | sed -n 's/.*gh[[:space:]]\+pr[[:space:]]\+merge[[:space:]]\+\([^[:space:]]\+\).*/\1/p')
+PR_NUMBER=""
 
-if [ -z "$PR_NUMBER" ]; then
-  PR_NUMBER=$(gh pr view --json number -q '.number' 2>/dev/null)
-fi
+case "$PR_SELECTOR" in
+  ''|--*)
+    # No selector or flag-only; fallback to current branch PR
+    PR_NUMBER=$(gh pr view --json number -q '.number' 2>/dev/null)
+    ;;
+  *[!0-9]*)
+    # URL or branch name selector — resolve via gh
+    PR_NUMBER=$(gh pr view "$PR_SELECTOR" --json number -q '.number' 2>/dev/null)
+    ;;
+  *)
+    # Pure numeric
+    PR_NUMBER="$PR_SELECTOR"
+    ;;
+esac
+
 if [ -z "$PR_NUMBER" ]; then
   echo "BLOCKED: could not determine PR number from command or current branch." >&2
   exit 2
 fi
 
-# Validate PR_NUMBER is numeric only (防止路径遍历)
-case "$PR_NUMBER" in
-  ''|*[!0-9]*) echo "BLOCKED: Invalid PR number: $PR_NUMBER" >&2; exit 2 ;;
-esac
-
 # Allow manual bypass via state flag (e.g., human-approved merge)
 STATE_DIR="$(dirname "$0")/state"
+if ! mkdir -p "$STATE_DIR"; then
+  echo "BLOCKED: cannot create state dir: $STATE_DIR" >&2
+  exit 2
+fi
 FLAG="$STATE_DIR/pr-merge-approved-${PR_NUMBER}"
 if [ -f "$FLAG" ]; then
   rm -f "$FLAG" 2>/dev/null

--- a/.claude/hooks/pr-merge-guard.sh
+++ b/.claude/hooks/pr-merge-guard.sh
@@ -12,7 +12,7 @@ COMMAND=$(echo "$INPUT" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\([^"]*
 echo "$COMMAND" | grep -qE 'gh[[:space:]]+pr[[:space:]]+merge' || exit 0
 
 # Extract PR selector — first non-flag token after `gh pr merge`
-PR_SELECTOR=$(echo "$COMMAND" | sed -n 's/.*gh[[:space:]]\+pr[[:space:]]\+merge[[:space:]]\+\([^[:space:]]\+\).*/\1/p')
+PR_SELECTOR=$(echo "$COMMAND" | sed -n 's/.*gh[[:space:]][[:space:]]*pr[[:space:]][[:space:]]*merge[[:space:]][[:space:]]*\([^[:space:]][^[:space:]]*\).*/\1/p')
 PR_NUMBER=""
 
 case "$PR_SELECTOR" in

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -23,6 +23,11 @@
             "type": "command",
             "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/pre-commit-guard.sh\"",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/pr-merge-guard.sh\"",
+            "timeout": 15
           }
         ]
       }

--- a/packages/orchestrator/src/rtk-wrapper.ts
+++ b/packages/orchestrator/src/rtk-wrapper.ts
@@ -53,6 +53,7 @@ function shouldWrapCommand(command: string, config?: RTKConfig): boolean {
   return config.commands.some((candidate) => normalizeCommandName(candidate) === normalizedCommand);
 }
 
+/** Wrap a CLI command with RTK if the command is in the configured list. */
 export function wrapWithRTK(
   command: string,
   args: readonly string[] = [],
@@ -68,6 +69,7 @@ export function wrapWithRTK(
   };
 }
 
+/** Check whether the RTK binary is installed and responds to --version. */
 export async function isRTKAvailable(config?: RTKConfig): Promise<boolean> {
   if (!config?.enabled) {
     return true;
@@ -111,6 +113,7 @@ function normalizeSpawnInvocation(
   return { args: [], options: argsOrOptions as SpawnOptions | undefined };
 }
 
+/** Install a global child_process.spawn wrapper that routes commands through RTK. */
 export function installRTKCommandWrapper(config?: RTKConfig): void {
   activeConfig = config?.enabled
     ? {

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -573,6 +573,7 @@ export class TaskManager {
 
 // ─── Prompt Builders ───
 
+/** Build the dispatch prompt sent to the Dev Agent for implementation. */
 export function buildDevPrompt(task: TaskBundle, kbContext?: string): string {
   const lines: string[] = [];
 
@@ -657,6 +658,7 @@ export function buildReferencePrompt(
   return lines.join("\n");
 }
 
+/** Build the blind-review prompt sent to the Acceptance Agent. */
 export function buildAcceptancePrompt(
   task: TaskBundle,
   acceptance: AcceptanceBundle,
@@ -712,6 +714,7 @@ export function buildAcceptancePrompt(
   return lines.join("\n");
 }
 
+/** Build the rework prompt sent to the Dev Agent after acceptance failure. */
 export function buildReworkPrompt(
   task: TaskBundle,
   acceptance: AcceptanceBundle,
@@ -784,6 +787,7 @@ function truncate(content: string, maxLen: number): string {
   return content.slice(0, maxLen) + "\n...[truncated]";
 }
 
+/** Build the Main Agent review prompt with sanitized pre-checks and diff. */
 export function buildMainReviewPrompt(task: TaskBundle): string {
   const lines: string[] = [];
 


### PR DESCRIPTION
## Summary
- **[Major]** Replace `grep -P` (PCRE) with portable `sed -n` for macOS compatibility (lines 9, 15)
- **[Minor]** Add implicit PR number fallback via `gh pr view --json number` when no PR number in command
- **[Trivial]** Replace fragile `awk` text parsing with `gh pr checks --json` structured extraction

Closes TASK-HOOK-001

## Test plan
- [ ] Verify no `grep -P` remains in the file
- [ ] Trace: `gh pr merge 42 --merge` with CodeRabbit SUCCESS → exit 0
- [ ] Trace: `gh pr merge --merge` (no number) → fallback resolves PR from current branch
- [ ] Trace: CodeRabbit PENDING → exit 2 with blocking message
- [ ] Trace: Bypass flag file exists → exit 0 and flag cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **文档**
  * 为若干导出函数补充 JSDoc 注释，改善说明与可读性。

* **维护**
  * 新增本地 PR 合并保护：在本地拦截合并命令并仅当名为 “CodeRabbit” 的检查为成功时允许合并，否则阻止并返回提示和错误码。
  * 支持每个 PR 的本地一次性绕过标记（使用后移除）。
  * 将该合并保护加入预工具执行序列并配置超时。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->