### PR TITLE
fix: KB reliability, task metadata hardening, and Tasks page UX

### DIFF
--- a/.claude/hooks/post-web-research-flag.sh
+++ b/.claude/hooks/post-web-research-flag.sh
@@ -12,7 +12,9 @@ TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "done")
 if command -v jq >/dev/null 2>&1; then
   QUERY=$(echo "$INPUT" | jq -r '.tool_input.query // .tool_input.url // empty' 2>/dev/null)
 else
-  QUERY=""
+  # Fallback: try to extract query or url with sed (best effort)
+  QUERY=$(echo "$INPUT" | sed -n 's/.*"query"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+  [ -z "$QUERY" ] && QUERY=$(echo "$INPUT" | sed -n 's/.*"url"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
 fi
 
 echo "${TIMESTAMP} ${QUERY}" > "$STATE_DIR/web-researched"

--- a/.claude/hooks/post-web-research-flag.sh
+++ b/.claude/hooks/post-web-research-flag.sh
@@ -1,8 +1,19 @@
 #!/bin/bash
 # FLAG: mark web research as done after WebSearch/WebFetch completes.
-# Token cost: ZERO. No external deps.
+# Records timestamp and query for audit trail.
 
 STATE_DIR="$(dirname "$0")/state"
 mkdir -p "$STATE_DIR"
-echo "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo done)" > "$STATE_DIR/web-researched"
+
+INPUT=$(cat)
+TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "done")
+
+# Try to extract query/URL from tool input for audit
+if command -v jq >/dev/null 2>&1; then
+  QUERY=$(echo "$INPUT" | jq -r '.tool_input.query // .tool_input.url // empty' 2>/dev/null)
+else
+  QUERY=""
+fi
+
+echo "${TIMESTAMP} ${QUERY}" > "$STATE_DIR/web-researched"
 exit 0

--- a/.claude/hooks/user-prompt-submit.sh
+++ b/.claude/hooks/user-prompt-submit.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# INJECT: Append mandatory web-research rules to every user prompt before Claude processes it.
+# Event: UserPromptSubmit — fires before Claude starts reasoning.
+# Output on stdout is added to Claude's context alongside the user prompt.
+# Token cost: ~100 tokens injected per prompt. No external deps.
+
+INPUT=$(cat)
+
+# Extract the user's prompt text
+PROMPT=$(echo "$INPUT" | sed -n 's/.*"prompt"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+
+# ── Detect if prompt likely involves SDK/API/CLI/external tool work ──
+NEEDS_RESEARCH=""
+
+# Check for SDK/package mentions
+echo "$PROMPT" | grep -qiE 'sdk|api|cli|codex|claude.code|openai|anthropic|tauri|obsidian|npm|package' && NEEDS_RESEARCH="1"
+
+# Check for integration/research/implementation keywords
+echo "$PROMPT" | grep -qiE 'integrate|implement|install|upgrade|migrate|version|resume|session|mcp' && NEEDS_RESEARCH="1"
+
+# If no research-sensitive keywords, stay silent (no context injection)
+[ -z "$NEEDS_RESEARCH" ] && exit 0
+
+# ── Inject mandatory context ──
+cat <<'CONTEXT'
+<user-prompt-submit-hook>
+MANDATORY RESEARCH PROTOCOL (injected by hook, applies to ALL agents):
+- Before writing code or documentation that references external SDK/API/CLI behavior:
+  1. Use WebSearch to verify against OFFICIAL vendor documentation FIRST
+  2. Cross-check npm/PyPI registry for package versions and publish status
+  3. GitHub source code alone is NOT sufficient — repos may show dev versions
+- Include source URLs when recording technical facts in handoffs, tasks, or KB
+- If a claim cannot be web-verified, mark it explicitly as UNVERIFIED
+- This rule applies regardless of your role (main, dev, research, acceptance)
+</user-prompt-submit-hook>
+CONTEXT
+
+exit 0

--- a/.claude/hooks/user-prompt-submit.sh
+++ b/.claude/hooks/user-prompt-submit.sh
@@ -7,7 +7,12 @@
 INPUT=$(cat)
 
 # Extract the user's prompt text
-PROMPT=$(echo "$INPUT" | sed -n 's/.*"prompt"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+# Prefer jq for robust JSON parsing; fall back to sed for minimal environments
+if command -v jq >/dev/null 2>&1; then
+  PROMPT=$(echo "$INPUT" | jq -r '.prompt // empty' 2>/dev/null)
+else
+  PROMPT=$(echo "$INPUT" | sed -n 's/.*"prompt"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+fi
 
 # ── Detect if prompt likely involves SDK/API/CLI/external tool work ──
 NEEDS_RESEARCH=""

--- a/.claude/hooks/web-research-gate.sh
+++ b/.claude/hooks/web-research-gate.sh
@@ -7,7 +7,12 @@
 INPUT=$(cat)
 
 # Extract content being written (new_string for Edit, content for Write)
-CONTENT=$(echo "$INPUT" | sed -n 's/.*"\(new_string\|content\)"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\2/p' | head -1)
+# Prefer jq for robust JSON parsing; fall back to sed for minimal environments
+if command -v jq >/dev/null 2>&1; then
+  CONTENT=$(echo "$INPUT" | jq -r '.tool_input.new_string // .tool_input.content // empty' 2>/dev/null)
+else
+  CONTENT=$(echo "$INPUT" | sed -n 's/.*"\(new_string\|content\)"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\2/p' | head -1)
+fi
 
 [ -z "$CONTENT" ] && exit 0
 
@@ -32,12 +37,12 @@ fi
 # If no sensitive patterns found, allow through
 [ -z "$HAS_SDK_IMPORT" ] && [ -z "$HAS_VERSION" ] && [ -z "$HAS_API_SIG" ] && exit 0
 
-# ── Check if web research was done recently (within last 10 minutes) ──
+# ── Check if web research was done recently (within last 3 minutes) ──
 STATE_DIR="$(dirname "$0")/state"
 FLAG="$STATE_DIR/web-researched"
 
 if [ -f "$FLAG" ]; then
-  # Check if flag is recent (within 600 seconds = 10 minutes)
+  # Check if flag is recent (within 180 seconds = 3 minutes)
   if [ "$(uname)" = "Darwin" ] || [ "$(uname)" = "Linux" ]; then
     FLAG_AGE=$(( $(date +%s) - $(stat -c %Y "$FLAG" 2>/dev/null || stat -f %m "$FLAG" 2>/dev/null || echo 0) ))
   else
@@ -45,7 +50,7 @@ if [ -f "$FLAG" ]; then
     FLAG_AGE=$(( $(date +%s) - $(stat -c %Y "$FLAG" 2>/dev/null || echo 0) ))
   fi
 
-  if [ "$FLAG_AGE" -lt 600 ] 2>/dev/null; then
+  if [ "$FLAG_AGE" -lt 180 ] 2>/dev/null; then
     exit 0
   fi
 fi
@@ -60,6 +65,6 @@ cat >&2 <<MSG
 BLOCKED: Writing content with technical claims that require web verification.
 Reason: ${REASON}.
 Rule: "DO NOT guess SDK/CLI APIs from training data — verify via web search or official docs."
-Action: Use WebSearch or WebFetch to verify, then retry. Flag expires after 10 minutes.
+Action: Use WebSearch or WebFetch to verify, then retry. Flag expires after 3 minutes.
 MSG
 exit 2

--- a/.claude/hooks/web-research-gate.sh
+++ b/.claude/hooks/web-research-gate.sh
@@ -1,30 +1,65 @@
 #!/bin/bash
-# GATE: block Write/Edit containing SDK imports unless web research was done this session.
+# GATE: block Write/Edit containing technical claims unless web research was done recently.
+# Scope: SDK imports, version numbers, API signatures, CLI flags, npm packages, URLs as evidence.
+# Applies to ALL agents via .claude/settings.json PreToolUse(Edit|Write).
 # Token cost: ZERO. No external deps.
 
 INPUT=$(cat)
 
 # Extract content being written (new_string for Edit, content for Write)
-# Use grep to pull value — handles both fields
-CONTENT=$(echo "$INPUT" | grep -oP '"(?:new_string|content)"\s*:\s*"\K[^"]*' | head -1)
+CONTENT=$(echo "$INPUT" | sed -n 's/.*"\(new_string\|content\)"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\2/p' | head -1)
 
 [ -z "$CONTENT" ] && exit 0
 
-# Check for SDK package imports
-if echo "$CONTENT" | grep -qE '(@anthropic-ai|@openai/codex|@google/gemini|claude-code)'; then
-  STATE_DIR="$(dirname "$0")/state"
-  FLAG="$STATE_DIR/web-researched"
-
-  if [ -f "$FLAG" ]; then
-    exit 0
-  fi
-
-  cat >&2 <<'MSG'
-BLOCKED: Writing code with SDK package imports.
-CLAUDE.md: "DO NOT guess SDK/CLI APIs from training data — verify via web search or actual source code."
-Use WebSearch or WebFetch to verify the API first, then retry.
-MSG
-  exit 2
+# ── Pattern 1: SDK package imports ──
+HAS_SDK_IMPORT=""
+if echo "$CONTENT" | grep -qE '@anthropic-ai|@openai/codex|@google/gemini|claude-code|codex-sdk'; then
+  HAS_SDK_IMPORT="1"
 fi
 
-exit 0
+# ── Pattern 2: Version claims (e.g., "v0.115.0", "version 2.1.76", "gpt-5.4") ──
+HAS_VERSION=""
+if echo "$CONTENT" | grep -qE 'v[0-9]+\.[0-9]+\.[0-9]+|version[[:space:]]+[0-9]+\.[0-9]|npm[[:space:]]+install|published.*[0-9]+\.[0-9]'; then
+  HAS_VERSION="1"
+fi
+
+# ── Pattern 3: API method signatures in technical docs (JSON/markdown with SDK calls) ──
+HAS_API_SIG=""
+if echo "$CONTENT" | grep -qE 'query\(\{|startThread\(|resumeThread\(|codex-reply|mcp-server|unstable_v[0-9]'; then
+  HAS_API_SIG="1"
+fi
+
+# If no sensitive patterns found, allow through
+[ -z "$HAS_SDK_IMPORT" ] && [ -z "$HAS_VERSION" ] && [ -z "$HAS_API_SIG" ] && exit 0
+
+# ── Check if web research was done recently (within last 10 minutes) ──
+STATE_DIR="$(dirname "$0")/state"
+FLAG="$STATE_DIR/web-researched"
+
+if [ -f "$FLAG" ]; then
+  # Check if flag is recent (within 600 seconds = 10 minutes)
+  if [ "$(uname)" = "Darwin" ] || [ "$(uname)" = "Linux" ]; then
+    FLAG_AGE=$(( $(date +%s) - $(stat -c %Y "$FLAG" 2>/dev/null || stat -f %m "$FLAG" 2>/dev/null || echo 0) ))
+  else
+    # Windows (Git Bash / MSYS) — stat -c %Y works
+    FLAG_AGE=$(( $(date +%s) - $(stat -c %Y "$FLAG" 2>/dev/null || echo 0) ))
+  fi
+
+  if [ "$FLAG_AGE" -lt 600 ] 2>/dev/null; then
+    exit 0
+  fi
+fi
+
+# ── Build specific blocking message ──
+REASON=""
+[ -n "$HAS_SDK_IMPORT" ] && REASON="SDK package import detected"
+[ -n "$HAS_VERSION" ] && REASON="${REASON:+$REASON, }version/package claim detected"
+[ -n "$HAS_API_SIG" ] && REASON="${REASON:+$REASON, }API signature detected"
+
+cat >&2 <<MSG
+BLOCKED: Writing content with technical claims that require web verification.
+Reason: ${REASON}.
+Rule: "DO NOT guess SDK/CLI APIs from training data — verify via web search or official docs."
+Action: Use WebSearch or WebFetch to verify, then retry. Flag expires after 10 minutes.
+MSG
+exit 2

--- a/.claude/hooks/web-research-gate.sh
+++ b/.claude/hooks/web-research-gate.sh
@@ -42,13 +42,8 @@ STATE_DIR="$(dirname "$0")/state"
 FLAG="$STATE_DIR/web-researched"
 
 if [ -f "$FLAG" ]; then
-  # Check if flag is recent (within 180 seconds = 3 minutes)
-  if [ "$(uname)" = "Darwin" ] || [ "$(uname)" = "Linux" ]; then
-    FLAG_AGE=$(( $(date +%s) - $(stat -c %Y "$FLAG" 2>/dev/null || stat -f %m "$FLAG" 2>/dev/null || echo 0) ))
-  else
-    # Windows (Git Bash / MSYS) — stat -c %Y works
-    FLAG_AGE=$(( $(date +%s) - $(stat -c %Y "$FLAG" 2>/dev/null || echo 0) ))
-  fi
+  # stat -c %Y for Linux/Windows, stat -f %m for Darwin; fallback to 0 (treat as expired)
+  FLAG_AGE=$(( $(date +%s) - $(stat -c %Y "$FLAG" 2>/dev/null || stat -f %m "$FLAG" 2>/dev/null || echo 0) ))
 
   if [ "$FLAG_AGE" -lt 180 ] 2>/dev/null; then
     exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/user-prompt-submit.sh\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Edit|Write",

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,15 @@
+# Mercury — Codex CLI project config
+# Docs: https://developers.openai.com/codex/config-reference
+
+# Ensure web search is always available and live
+web_search = "live"
+
+# Mandatory instructions injected into every session
+developer_instructions = """
+MANDATORY: Before writing ANY code that imports an external SDK/API package or references API signatures:
+1. Use web_search to verify against the vendor's OFFICIAL documentation first
+2. Cross-check npm/PyPI for package version and publish status
+3. GitHub source code alone is NOT sufficient (repos may show dev versions)
+4. Include source URLs when reporting technical findings
+5. If web_search fails, mark claims as UNVERIFIED
+"""

--- a/.gitignore
+++ b/.gitignore
@@ -49,4 +49,5 @@ CLAUDE.md
 # Mercury runtime state
 .mercury/sessions.json
 .mercury/transcripts/
+.mercury/backups/
 mercury.config.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ Read these docs on demand when you need the corresponding information:
 - **Commit at every checkpoint**: every milestone must be committed and pushed.
 - **Code review before commit**: every milestone must be code-reviewed before committing.
 - **Research from live sources**: all research must be based on web queries, never training data. This includes SDK/API signatures, CLI features, Tauri plugin APIs.
+- **Web search before SDK/API code**: before writing ANY code that imports an external SDK, references an API signature, or claims a package version, you MUST use `web_search` to verify against the vendor's official documentation (e.g., developers.openai.com, docs.anthropic.com, npmjs.com). GitHub source code alone is NOT sufficient — repos may show dev versions. If web_search is unavailable, mark claims as UNVERIFIED.
 - **Main Agent is user-configurable**: any agent can be assigned as Main Agent via UI/config.
 - **Install to D drive**: install software to `D:\Program Files`, not C drive.
 - **Agents First**: inter-agent communication uses JSON/YAML. All interactions must include agentId, model, sessionId.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ Read these docs on demand when you need the corresponding information:
 - **Commit at every checkpoint**: every milestone must be committed and pushed.
 - **Code review before commit**: every milestone must be code-reviewed before committing.
 - **Research from live sources**: all research must be based on web queries, never training data. This includes SDK/API signatures, CLI features, Tauri plugin APIs.
+- **Web search before SDK/API code**: before writing ANY code that imports an external SDK, references an API signature, or claims a package version, you MUST use WebSearch/WebFetch to verify against the vendor's official documentation (e.g., developers.openai.com, docs.anthropic.com, npmjs.com). GitHub source code alone is NOT sufficient — repos may show dev versions. If verification is not possible, mark claims as UNVERIFIED.
 - **Main Agent is user-configurable**: any agent can be assigned as Main Agent via UI/config.
 - **Install to D drive**: install software to `D:\Program Files`, not C drive.
 - **Agents First**: inter-agent communication uses JSON/YAML. All interactions must include agentId, model, sessionId.

--- a/mercury.config.example.json
+++ b/mercury.config.example.json
@@ -11,7 +11,7 @@
       "id": "claude-code",
       "integration": "sdk",
       "maxConcurrentSessions": 3,
-      "model": "claude-opus-4-6",
+      "model": "claude-opus-4.6",
       "restrictions": [],
       "roles": [
         "main",

--- a/mercury.config.example.json
+++ b/mercury.config.example.json
@@ -1,0 +1,58 @@
+{
+  "agents": [
+    {
+      "capabilities": [
+        "code",
+        "review",
+        "orchestration"
+      ],
+      "cli": "claude",
+      "displayName": "Claude Code",
+      "id": "claude-code",
+      "integration": "sdk",
+      "maxConcurrentSessions": 3,
+      "model": "claude-opus-4-6",
+      "restrictions": [],
+      "roles": [
+        "main",
+        "design"
+      ]
+    },
+    {
+      "capabilities": [
+        "code",
+        "test"
+      ],
+      "cli": "codex",
+      "displayName": "Codex CLI",
+      "id": "codex-cli",
+      "integration": "sdk",
+      "maxConcurrentSessions": 2,
+      "model": "gpt-5.4",
+      "restrictions": [],
+      "roles": [
+        "dev",
+        "acceptance",
+        "research"
+      ]
+    }
+  ],
+  "obsidian": {
+    "autoInjectContext": true,
+    "contextFiles": [],
+    "enabled": true,
+    "kbPaths": {
+      "acceptances": "12-acceptances",
+      "issues": "11-issues",
+      "tasks": "10-tasks"
+    },
+    "roleContextFiles": {
+      "acceptance": [],
+      "dev": [],
+      "main": []
+    },
+    "vaultName": "Mercury_KB",
+    "vaultPath": "../Mercury_KB"
+  },
+  "workDir": "."
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -313,7 +313,7 @@ export interface TaskBundle {
   phaseId?: string;
   priority: "sev-0" | "sev-1" | "sev-2" | "sev-3";
   status: TaskStatus;
-  createdAt: string; // ISO 8601, set by TaskManager when task is created
+  createdAt?: string; // ISO 8601, set by TaskManager when task is created (optional for legacy compat)
   closedAt: string | null; // ISO 8601, set by TaskManager when status → closed/verified
   failedAt: string | null; // ISO 8601, set by TaskManager when status → failed
   assignedTo: string;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -306,6 +306,7 @@ export interface ReviewConfig {
   diffMaxChars?: number;
 }
 
+/** SoT task bundle: tracks a unit of work through its full lifecycle. */
 export interface TaskBundle {
   taskId: string;
   title: string;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -312,6 +312,9 @@ export interface TaskBundle {
   phaseId?: string;
   priority: "sev-0" | "sev-1" | "sev-2" | "sev-3";
   status: TaskStatus;
+  createdAt: string; // ISO 8601, set by TaskManager when task is created
+  closedAt: string | null; // ISO 8601, set by TaskManager when status → closed/verified
+  failedAt: string | null; // ISO 8601, set by TaskManager when status → failed
   assignedTo: string;
   assignee?: TaskAssignee; // Agents First: structured agent+model+session metadata
   branch?: string;

--- a/packages/gui/src-tauri/src/lib.rs
+++ b/packages/gui/src-tauri/src/lib.rs
@@ -15,11 +15,14 @@ pub type SharedSidecar = Arc<Mutex<Option<SidecarManager>>>;
 /// Project root path — available immediately (no sidecar dependency).
 pub struct ProjectRoot(pub String);
 
-/// Walk up from `start` to find the directory containing `mercury.config.json`.
+/// Walk up from `start` to find the monorepo root that contains the orchestrator entrypoint.
 fn find_project_root(start: PathBuf) -> Option<PathBuf> {
     let mut dir = start;
     loop {
-        if dir.join("mercury.config.json").exists() {
+        if dir.join("pnpm-workspace.yaml").exists()
+            && dir.join("package.json").exists()
+            && dir.join("packages").join("orchestrator").join("src").join("index.ts").exists()
+        {
             return Some(dir);
         }
         if !dir.pop() {
@@ -58,9 +61,11 @@ pub fn run() {
             app.manage(shared.clone());
 
             // Resolve the monorepo root (where mercury.config.json lives)
-            let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-            let project_dir = find_project_root(cwd.clone())
-                .unwrap_or(cwd)
+            let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+            let cwd = std::env::current_dir().unwrap_or_else(|_| manifest_dir.clone());
+            let project_dir = find_project_root(cwd)
+                .or_else(|| find_project_root(manifest_dir.clone()))
+                .unwrap_or(manifest_dir)
                 .to_string_lossy()
                 .to_string();
 

--- a/packages/gui/src-tauri/src/sidecar.rs
+++ b/packages/gui/src-tauri/src/sidecar.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tauri::Emitter;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
@@ -17,19 +18,16 @@ pub struct SidecarManager {
 
 impl SidecarManager {
     pub async fn spawn(app_handle: tauri::AppHandle, project_dir: String) -> Result<Self, String> {
+        let orchestrator_entry = resolve_orchestrator_entry(&project_dir)?;
+
         // In dev mode, use pnpm exec tsx to run the orchestrator.
         // Using pnpm instead of npx avoids npm warn noise from inherited env vars.
         // On Windows, pnpm is a .cmd script so we must run via cmd.exe.
         #[cfg(target_os = "windows")]
         let mut cmd = {
             let mut c = Command::new("cmd");
-            c.args([
-                "/c",
-                "pnpm",
-                "exec",
-                "tsx",
-                "packages/orchestrator/src/index.ts",
-            ]);
+            c.args(["/c", "pnpm", "exec", "tsx"]);
+            c.arg(&orchestrator_entry);
             c.creation_flags(0x08000000); // CREATE_NO_WINDOW
             c
         };
@@ -37,7 +35,8 @@ impl SidecarManager {
         #[cfg(not(target_os = "windows"))]
         let mut cmd = {
             let mut c = Command::new("pnpm");
-            c.args(["exec", "tsx", "packages/orchestrator/src/index.ts"]);
+            c.args(["exec", "tsx"]);
+            c.arg(&orchestrator_entry);
             c
         };
 
@@ -200,4 +199,21 @@ impl SidecarManager {
         let mut child = self.child.lock().await;
         let _ = child.kill().await;
     }
+}
+
+fn resolve_orchestrator_entry(project_dir: &str) -> Result<PathBuf, String> {
+    let entry = Path::new(project_dir)
+        .join("packages")
+        .join("orchestrator")
+        .join("src")
+        .join("index.ts");
+
+    if entry.exists() {
+        return Ok(entry);
+    }
+
+    Err(format!(
+        "Could not find orchestrator entrypoint at {}",
+        entry.display()
+    ))
 }

--- a/packages/gui/src/App.vue
+++ b/packages/gui/src/App.vue
@@ -50,51 +50,53 @@ onMounted(async () => {
     </div>
 
     <div class="workspace">
-      <!-- Agents View -->
-      <div v-show="activeView === 'agents'" class="workspace-view">
-        <div
-          v-if="agents.length > 0"
-          class="agents-area"
-          :class="{
-            'main-only': hasMainAgent && subAgentCount === 0,
-            'single-sub-agent': subAgentCount === 1,
-            'multi-sub-agents': subAgentCount > 1,
-            'sub-agents-only': !hasMainAgent && subAgentCount > 0,
-          }"
-        >
-          <AgentPanel
-            v-if="mainAgent"
-            :agentId="mainAgent.id"
-            :agentName="mainAgent.displayName"
-            :role="'main'"
-            :panelKey="`main:${mainAgent.id}`"
-          />
+      <div class="workspace-main">
+        <!-- Agents View -->
+        <div v-show="activeView === 'agents'" class="workspace-view">
           <div
-            v-if="subAgentCount > 0"
-            class="sub-agents"
+            v-if="agents.length > 0"
+            class="agents-area"
             :class="{
-              'single-panel': subAgentCount === 1,
-              'multi-panel': subAgentCount > 1,
+              'main-only': hasMainAgent && subAgentCount === 0,
+              'single-sub-agent': subAgentCount === 1,
+              'multi-sub-agents': subAgentCount > 1,
+              'sub-agents-only': !hasMainAgent && subAgentCount > 0,
             }"
           >
             <AgentPanel
-              v-for="panel in rolePanels"
-              :key="panel.panelKey"
-              :agentId="panel.agentId"
-              :agentName="panel.displayName"
-              :role="panel.role"
-              :panelKey="panel.panelKey"
+              v-if="mainAgent"
+              :agentId="mainAgent.id"
+              :agentName="mainAgent.displayName"
+              :role="'main'"
+              :panelKey="`main:${mainAgent.id}`"
             />
+            <div
+              v-if="subAgentCount > 0"
+              class="sub-agents"
+              :class="{
+                'single-panel': subAgentCount === 1,
+                'multi-panel': subAgentCount > 1,
+              }"
+            >
+              <AgentPanel
+                v-for="panel in rolePanels"
+                :key="panel.panelKey"
+                :agentId="panel.agentId"
+                :agentName="panel.displayName"
+                :role="panel.role"
+                :panelKey="panel.panelKey"
+              />
+            </div>
+          </div>
+          <div v-else class="loading-state">
+            <p v-if="!sidecarReady">Connecting to orchestrator...</p>
+            <p v-else>No agents configured</p>
           </div>
         </div>
-        <div v-else class="loading-state">
-          <p v-if="!sidecarReady">Connecting to orchestrator...</p>
-          <p v-else>No agents configured</p>
-        </div>
-      </div>
 
-      <!-- Tasks View -->
-      <TaskDashboard v-show="activeView === 'tasks'" class="workspace-view" />
+        <!-- Tasks View -->
+        <TaskDashboard v-show="activeView === 'tasks'" class="workspace-view" />
+      </div>
 
       <EventLog />
     </div>
@@ -129,8 +131,14 @@ onMounted(async () => {
   min-height: 0;
 }
 
+.workspace-main {
+  min-height: 0;
+  height: 100%;
+}
+
 .workspace-view {
   min-height: 0;
+  height: 100%;
 }
 
 .agents-area {

--- a/packages/gui/src/App.vue
+++ b/packages/gui/src/App.vue
@@ -23,7 +23,9 @@ const { loadTasks, initTaskListeners } = useTaskStore();
 
 const showSettings = ref(false);
 const activeView = ref<"agents" | "tasks">("agents");
+/** Whether a main-role agent is configured and available. */
 const hasMainAgent = computed(() => Boolean(mainAgent.value));
+/** Number of non-main (sub) agent panels currently rendered. */
 const subAgentCount = computed(() => rolePanels.value.length);
 
 onMounted(async () => {

--- a/packages/gui/src/App.vue
+++ b/packages/gui/src/App.vue
@@ -51,7 +51,7 @@ onMounted(async () => {
 
     <div class="workspace">
       <!-- Agents View -->
-      <template v-if="activeView === 'agents'">
+      <div v-show="activeView === 'agents'" class="workspace-view">
         <div
           v-if="agents.length > 0"
           class="agents-area"
@@ -91,10 +91,10 @@ onMounted(async () => {
           <p v-if="!sidecarReady">Connecting to orchestrator...</p>
           <p v-else>No agents configured</p>
         </div>
-      </template>
+      </div>
 
       <!-- Tasks View -->
-      <TaskDashboard v-if="activeView === 'tasks'" />
+      <TaskDashboard v-show="activeView === 'tasks'" class="workspace-view" />
 
       <EventLog />
     </div>
@@ -126,6 +126,10 @@ onMounted(async () => {
   grid-template-rows: minmax(0, 1fr) clamp(120px, 18vh, 152px);
   gap: var(--panel-gap);
   padding: var(--panel-gap);
+  min-height: 0;
+}
+
+.workspace-view {
   min-height: 0;
 }
 

--- a/packages/gui/src/App.vue
+++ b/packages/gui/src/App.vue
@@ -132,13 +132,19 @@ onMounted(async () => {
 }
 
 .workspace-main {
+  position: relative;
   min-height: 0;
   height: 100%;
+  overflow: hidden;
 }
 
 .workspace-view {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
   min-height: 0;
-  height: 100%;
+  overflow: hidden;
 }
 
 .agents-area {
@@ -147,7 +153,9 @@ onMounted(async () => {
   grid-template-columns: minmax(0, 1.08fr) minmax(0, 0.92fr);
   gap: var(--panel-gap);
   min-height: 0;
+  height: 100%;
   align-items: stretch;
+  flex: 1;
 }
 
 .agents-area :deep(.agent-panel) {
@@ -187,6 +195,7 @@ onMounted(async () => {
   display: flex;
   align-items: center;
   justify-content: center;
+  flex: 1;
   color: var(--text-muted);
   font-size: 14px;
 }

--- a/packages/gui/src/components/SettingsPanel.vue
+++ b/packages/gui/src/components/SettingsPanel.vue
@@ -97,6 +97,7 @@ function createEmptyRoleContextFiles(): NonNullable<ObsidianConfig["roleContextF
   };
 }
 
+/** Return a default ObsidianConfig with all fields initialized to safe empty values. */
 function createEmptyObsidianConfig(): ObsidianConfig {
   return {
     enabled: false,
@@ -189,6 +190,7 @@ async function browseWorkDir() {
   }
 }
 
+/** Open a native directory picker for the KB vault path. */
 async function browseVaultPath() {
   const selected = await open({ directory: true, title: "Select KB vault directory" });
   if (selected && typeof selected === "string") {

--- a/packages/gui/src/components/SettingsPanel.vue
+++ b/packages/gui/src/components/SettingsPanel.vue
@@ -101,6 +101,7 @@ function createEmptyObsidianConfig(): ObsidianConfig {
   return {
     enabled: false,
     vaultName: "",
+    vaultPath: "",
     obsidianBin: "",
     autoInjectContext: false,
     contextFiles: [],
@@ -185,6 +186,13 @@ async function browseWorkDir() {
   const selected = await open({ directory: true, title: "Select Working Directory" });
   if (selected && typeof selected === "string") {
     editWorkDir.value = selected;
+  }
+}
+
+async function browseVaultPath() {
+  const selected = await open({ directory: true, title: "Select KB vault directory" });
+  if (selected && typeof selected === "string") {
+    editObsidian.value.vaultPath = selected;
   }
 }
 
@@ -470,6 +478,17 @@ function handleKeydown(event: KeyboardEvent) {
               <label>
                 <span>Vault Name</span>
                 <input v-model="editObsidian.vaultName" class="field-input full-width" placeholder="Mercury-KB" />
+              </label>
+              <label>
+                <span>KB Path (vault file system path)</span>
+                <div class="dir-input-row">
+                  <input
+                    v-model="editObsidian.vaultPath"
+                    class="field-input dir-field"
+                    placeholder="D:/Mercury/Mercury_KB"
+                  />
+                  <button type="button" class="browse-btn" @click="browseVaultPath">Browse</button>
+                </div>
               </label>
               <label>
                 <span>Obsidian Binary Path</span>

--- a/packages/gui/src/components/TaskDashboard.vue
+++ b/packages/gui/src/components/TaskDashboard.vue
@@ -175,6 +175,10 @@ async function handleCreateAcceptance(taskId: string) {
               </span>
             </span>
           </div>
+          <div v-if="selectedTask.createdAt" class="meta-row">
+            <span class="meta-label">Created</span>
+            <span class="meta-value">{{ formatDate(selectedTask.createdAt) }}</span>
+          </div>
           <div v-if="selectedTask.closedAt" class="meta-row">
             <span class="meta-label">Closed</span>
             <span class="meta-value">{{ formatDate(selectedTask.closedAt) }}</span>

--- a/packages/gui/src/components/TaskDashboard.vue
+++ b/packages/gui/src/components/TaskDashboard.vue
@@ -17,6 +17,7 @@ const {
 
 const { agents } = useAgentStore();
 
+/** Status filter buttons with display label and theme color. */
 const STATUS_LABELS: { status: TaskStatus | null; label: string; color: string }[] = [
   { status: null, label: "All", color: "var(--text-secondary)" },
   { status: "drafted", label: "Drafted", color: "var(--text-muted)" },
@@ -30,6 +31,7 @@ const STATUS_LABELS: { status: TaskStatus | null; label: string; color: string }
   { status: "blocked", label: "Blocked", color: "#fb923c" },
 ];
 
+/** Sort priority for task statuses (lower = earlier in list). */
 const STATUS_ORDER: Record<string, number> = {
   drafted: 0,
   dispatched: 1,

--- a/packages/gui/src/components/TaskDashboard.vue
+++ b/packages/gui/src/components/TaskDashboard.vue
@@ -30,6 +30,18 @@ const STATUS_LABELS: { status: TaskStatus | null; label: string; color: string }
   { status: "blocked", label: "Blocked", color: "#fb923c" },
 ];
 
+const STATUS_ORDER: Record<string, number> = {
+  drafted: 0,
+  dispatched: 1,
+  blocked: 2,
+  in_progress: 3,
+  implementation_done: 4,
+  acceptance: 5,
+  verified: 6,
+  closed: 7,
+  failed: 8,
+};
+
 function statusColor(status: TaskStatus): string {
   return STATUS_LABELS.find((s) => s.status === status)?.color ?? "var(--text-muted)";
 }
@@ -44,6 +56,20 @@ function formatDate(iso: string): string {
 
 const totalCount = computed(() =>
   Object.values(statusCounts.value).reduce((a, b) => a + (b ?? 0), 0),
+);
+
+const sortedTasks = computed(() =>
+  [...filteredTasks.value].sort((a, b) => {
+    const sa = STATUS_ORDER[a.status] ?? 99;
+    const sb = STATUS_ORDER[b.status] ?? 99;
+    if (sa !== sb) {
+      return sa - sb;
+    }
+
+    const timeA = a.closedAt || a.failedAt || a.createdAt || "";
+    const timeB = b.closedAt || b.failedAt || b.createdAt || "";
+    return timeB.localeCompare(timeA);
+  }),
 );
 
 async function handleDispatch(taskId: string) {
@@ -91,7 +117,7 @@ async function handleCreateAcceptance(taskId: string) {
       <!-- Task List -->
       <div class="task-list">
         <div
-          v-for="task in filteredTasks"
+          v-for="task in sortedTasks"
           :key="task.taskId"
           class="task-row"
           :class="{ selected: selectedTask?.taskId === task.taskId }"
@@ -104,7 +130,7 @@ async function handleCreateAcceptance(taskId: string) {
           <span class="task-priority" :class="task.priority">{{ priorityLabel(task.priority) }}</span>
         </div>
 
-        <div v-if="filteredTasks.length === 0" class="empty-state">
+        <div v-if="sortedTasks.length === 0" class="empty-state">
           No tasks{{ statusFilter ? ` with status "${statusFilter}"` : "" }}
         </div>
       </div>

--- a/packages/gui/src/components/TaskDashboard.vue
+++ b/packages/gui/src/components/TaskDashboard.vue
@@ -42,10 +42,12 @@ const STATUS_ORDER: Record<string, number> = {
   failed: 8,
 };
 
+/** Return the theme color associated with a task status. */
 function statusColor(status: TaskStatus): string {
   return STATUS_LABELS.find((s) => s.status === status)?.color ?? "var(--text-muted)";
 }
 
+/** Convert a priority slug (e.g. "sev-1") to an uppercase display label. */
 function priorityLabel(p: string): string {
   return p.toUpperCase();
 }
@@ -56,6 +58,7 @@ function formatDate(iso: string): string {
   return Number.isNaN(date.getTime()) ? "-" : date.toLocaleString();
 }
 
+/** Total number of tasks across all statuses. */
 const totalCount = computed(() =>
   Object.values(statusCounts.value).reduce((a, b) => a + (b ?? 0), 0),
 );
@@ -75,6 +78,7 @@ const sortedTasks = computed(() =>
   }),
 );
 
+/** Dispatch a drafted task and refresh its local state. */
 async function handleDispatch(taskId: string) {
   try {
     await dispatchBundleTask(taskId);
@@ -84,6 +88,7 @@ async function handleDispatch(taskId: string) {
   }
 }
 
+/** Create an acceptance flow for a completed task, picking an acceptance-role agent. */
 async function handleCreateAcceptance(taskId: string) {
   // Find an acceptance-role agent, or fall back to first available
   const acceptor = agents.value.find((a) => a.roles.includes("acceptance")) ?? agents.value[0];

--- a/packages/gui/src/components/TaskDashboard.vue
+++ b/packages/gui/src/components/TaskDashboard.vue
@@ -36,10 +36,11 @@ const STATUS_ORDER: Record<string, number> = {
   blocked: 2,
   in_progress: 3,
   implementation_done: 4,
-  acceptance: 5,
-  verified: 6,
-  closed: 7,
-  failed: 8,
+  main_review: 5,
+  acceptance: 6,
+  verified: 7,
+  closed: 8,
+  failed: 9,
 };
 
 /** Return the theme color associated with a task status. */

--- a/packages/gui/src/components/TaskDashboard.vue
+++ b/packages/gui/src/components/TaskDashboard.vue
@@ -50,14 +50,17 @@ function priorityLabel(p: string): string {
   return p.toUpperCase();
 }
 
+/** Format an ISO date string for display; returns "-" for invalid dates. */
 function formatDate(iso: string): string {
-  return new Date(iso).toLocaleString();
+  const date = new Date(iso);
+  return Number.isNaN(date.getTime()) ? "-" : date.toLocaleString();
 }
 
 const totalCount = computed(() =>
   Object.values(statusCounts.value).reduce((a, b) => a + (b ?? 0), 0),
 );
 
+/** Tasks sorted by status priority, then by most recent timestamp descending. */
 const sortedTasks = computed(() =>
   [...filteredTasks.value].sort((a, b) => {
     const sa = STATUS_ORDER[a.status] ?? 99;

--- a/packages/gui/src/components/TaskDashboard.vue
+++ b/packages/gui/src/components/TaskDashboard.vue
@@ -38,6 +38,10 @@ function priorityLabel(p: string): string {
   return p.toUpperCase();
 }
 
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString();
+}
+
 const totalCount = computed(() =>
   Object.values(statusCounts.value).reduce((a, b) => a + (b ?? 0), 0),
 );
@@ -133,6 +137,14 @@ async function handleCreateAcceptance(taskId: string) {
                 {{ selectedTask.assignee.model }}
               </span>
             </span>
+          </div>
+          <div v-if="selectedTask.closedAt" class="meta-row">
+            <span class="meta-label">Closed</span>
+            <span class="meta-value">{{ formatDate(selectedTask.closedAt) }}</span>
+          </div>
+          <div v-else-if="selectedTask.failedAt" class="meta-row">
+            <span class="meta-label">Failed</span>
+            <span class="meta-value">{{ formatDate(selectedTask.failedAt) }}</span>
           </div>
           <div class="meta-row" v-if="selectedTask.branch">
             <span class="meta-label">Branch</span>

--- a/packages/gui/src/lib/tauri-bridge.ts
+++ b/packages/gui/src/lib/tauri-bridge.ts
@@ -201,6 +201,7 @@ export interface TaskAssignee {
   sessionId?: string;
 }
 
+/** Frontend representation of a task bundle with lifecycle timestamps. */
 export interface TaskBundle {
   taskId: string;
   title: string;

--- a/packages/gui/src/lib/tauri-bridge.ts
+++ b/packages/gui/src/lib/tauri-bridge.ts
@@ -192,7 +192,7 @@ export async function updateConfig(
 export type TaskPriority = "sev-0" | "sev-1" | "sev-2" | "sev-3";
 export type TaskStatus =
   | "drafted" | "dispatched" | "in_progress" | "implementation_done"
-  | "acceptance" | "verified" | "closed" | "failed" | "blocked";
+  | "main_review" | "acceptance" | "verified" | "closed" | "failed" | "blocked";
 export type AcceptanceVerdict = "pass" | "partial" | "fail" | "blocked";
 
 export interface TaskAssignee {
@@ -208,7 +208,7 @@ export interface TaskBundle {
   phaseId?: string;
   priority: TaskPriority;
   status: TaskStatus;
-  createdAt: string;
+  createdAt?: string;
   closedAt: string | null;
   failedAt: string | null;
   assignedTo: string;

--- a/packages/gui/src/lib/tauri-bridge.ts
+++ b/packages/gui/src/lib/tauri-bridge.ts
@@ -207,6 +207,9 @@ export interface TaskBundle {
   phaseId?: string;
   priority: TaskPriority;
   status: TaskStatus;
+  createdAt: string;
+  closedAt: string | null;
+  failedAt: string | null;
   assignedTo: string;
   assignee?: TaskAssignee;
   branch?: string;

--- a/packages/gui/src/lib/tauri-bridge.ts
+++ b/packages/gui/src/lib/tauri-bridge.ts
@@ -190,18 +190,24 @@ export async function updateConfig(
 // ─── Task Orchestration Operations ───
 
 export type TaskPriority = "sev-0" | "sev-1" | "sev-2" | "sev-3";
+/** Task lifecycle status. SYNC: mirrors @mercury/core TaskStatus. */
 export type TaskStatus =
   | "drafted" | "dispatched" | "in_progress" | "implementation_done"
   | "main_review" | "acceptance" | "verified" | "closed" | "failed" | "blocked";
 export type AcceptanceVerdict = "pass" | "partial" | "fail" | "blocked";
 
+/** Agent assignment metadata. SYNC: mirrors @mercury/core TaskAssignee. */
 export interface TaskAssignee {
   agentId: string;
   model?: string;
   sessionId?: string;
 }
 
-/** Frontend representation of a task bundle with lifecycle timestamps. */
+/**
+ * Frontend representation of a task bundle with lifecycle timestamps.
+ * SYNC: This interface mirrors @mercury/core TaskBundle. Keep in sync when modifying fields.
+ * Separate definition required due to Tauri serialization boundary (Rust <-> JS).
+ */
 export interface TaskBundle {
   taskId: string;
   title: string;

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -58,6 +58,7 @@ function mergeConfigDefaults<T>(defaults: T, overrides: unknown): T {
 
   const result: Record<string, unknown> = { ...defaults };
   for (const [key, defaultValue] of Object.entries(defaults)) {
+    if (key === "__proto__" || key === "constructor" || key === "prototype") continue;
     if (!(key in overrides)) {
       continue;
     }
@@ -65,6 +66,7 @@ function mergeConfigDefaults<T>(defaults: T, overrides: unknown): T {
   }
 
   for (const [key, value] of Object.entries(overrides)) {
+    if (key === "__proto__" || key === "constructor" || key === "prototype") continue;
     if (!(key in result)) {
       result[key] = value;
     }

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -6,8 +6,8 @@
  */
 
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, isAbsolute, resolve } from "node:path";
 import type { MercuryConfig, AgentConfig, ObsidianConfig } from "@mercury/core";
 import { RpcTransport } from "./rpc-transport.js";
 import { AgentRegistry } from "./agent-registry.js";
@@ -41,52 +41,154 @@ function migrateAgentConfig(agents: Record<string, unknown>[]): AgentConfig[] {
   return agents as unknown as AgentConfig[];
 }
 
-function loadConfig(configPath?: string): { config: MercuryConfig; resolvedPath: string | null } {
-  const paths = [
-    configPath,
-    resolve(process.cwd(), "mercury.config.json"),
-    resolve(process.env.HOME ?? process.env.USERPROFILE ?? "", ".mercury", "config.json"),
-  ].filter(Boolean) as string[];
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
 
-  for (const p of paths) {
+function mergeConfigDefaults<T>(defaults: T, overrides: unknown): T {
+  if (Array.isArray(defaults)) {
+    return (Array.isArray(overrides) ? overrides : defaults) as T;
+  }
+
+  if (!isPlainObject(defaults) || !isPlainObject(overrides)) {
+    return (overrides ?? defaults) as T;
+  }
+
+  const result: Record<string, unknown> = { ...defaults };
+  for (const [key, defaultValue] of Object.entries(defaults)) {
+    if (!(key in overrides)) {
+      continue;
+    }
+    result[key] = mergeConfigDefaults(defaultValue, overrides[key]);
+  }
+
+  for (const [key, value] of Object.entries(overrides)) {
+    if (!(key in result)) {
+      result[key] = value;
+    }
+  }
+
+  return result as T;
+}
+
+function resolveConfigPaths(config: MercuryConfig, configFilePath: string): MercuryConfig {
+  const configDir = dirname(configFilePath);
+  return {
+    ...config,
+    workDir: config.workDir
+      ? (isAbsolute(config.workDir) ? config.workDir : resolve(configDir, config.workDir))
+      : config.workDir,
+    obsidian: config.obsidian
+      ? {
+          ...config.obsidian,
+          vaultPath: config.obsidian.vaultPath
+            ? (
+                isAbsolute(config.obsidian.vaultPath)
+                  ? config.obsidian.vaultPath
+                  : resolve(configDir, config.obsidian.vaultPath)
+              )
+            : config.obsidian.vaultPath,
+          obsidianBin: config.obsidian.obsidianBin
+            ? (
+                isAbsolute(config.obsidian.obsidianBin)
+                  ? config.obsidian.obsidianBin
+                  : resolve(configDir, config.obsidian.obsidianBin)
+              )
+            : config.obsidian.obsidianBin,
+        }
+      : config.obsidian,
+  };
+}
+
+function readConfigFile(path: string): MercuryConfig {
+  const raw = readFileSync(path, "utf-8");
+  const config = JSON.parse(raw);
+  config.agents = migrateAgentConfig(config.agents ?? []);
+  return config as MercuryConfig;
+}
+
+function loadConfig(configPath?: string): { config: MercuryConfig; resolvedPath: string | null } {
+  const projectConfigPath = configPath ?? resolve(process.cwd(), "mercury.config.json");
+  const projectTemplatePath = resolve(dirname(projectConfigPath), "mercury.config.example.json");
+  const homeConfigPath = resolve(process.env.HOME ?? process.env.USERPROFILE ?? "", ".mercury", "config.json");
+  const defaultConfig: MercuryConfig = {
+    agents: [
+      {
+        id: "claude-code",
+        displayName: "Claude Code",
+        cli: "claude",
+        roles: ["main"],
+        integration: "sdk",
+        capabilities: ["code", "review", "orchestration"],
+        restrictions: [],
+        maxConcurrentSessions: 3,
+      },
+      {
+        id: "codex-cli",
+        displayName: "Codex CLI",
+        cli: "codex",
+        roles: ["dev"],
+        integration: "sdk",
+        capabilities: ["code", "test"],
+        restrictions: [],
+        maxConcurrentSessions: 2,
+      },
+    ],
+  };
+
+  let templateConfig: MercuryConfig | null = null;
+  if (existsSync(projectTemplatePath)) {
     try {
-      const raw = readFileSync(p, "utf-8");
-      const config = JSON.parse(raw);
-      config.agents = migrateAgentConfig(config.agents ?? []);
-      transport.log(`Loaded config from ${p} (${config.agents.length} agents)`);
-      return { config: config as MercuryConfig, resolvedPath: p };
+      templateConfig = readConfigFile(projectTemplatePath);
+      transport.log(`Loaded config template from ${projectTemplatePath}`);
+    } catch {
+      transport.log(`Warning: failed to load config template from ${projectTemplatePath}`);
+    }
+  }
+
+  const localPaths = [configPath, projectConfigPath].filter(Boolean) as string[];
+  for (const p of localPaths) {
+    if (!existsSync(p)) {
+      continue;
+    }
+    try {
+      const localConfig = readConfigFile(p);
+      const merged = templateConfig ? mergeConfigDefaults(templateConfig, localConfig) : localConfig;
+      const resolved = resolveConfigPaths(merged, p);
+      transport.log(`Loaded config from ${p} (${resolved.agents.length} agents)`);
+      return { config: resolved, resolvedPath: p };
     } catch {
       // try next
     }
   }
 
-  transport.log("No config found, using defaults");
+  if (existsSync(homeConfigPath)) {
+    try {
+      const homeConfig = readConfigFile(homeConfigPath);
+      transport.log(`Loaded config from ${homeConfigPath} (${homeConfig.agents.length} agents)`);
+      return {
+        config: resolveConfigPaths(homeConfig, homeConfigPath),
+        resolvedPath: homeConfigPath,
+      };
+    } catch {
+      // ignore and continue to bootstrap
+    }
+  }
+
+  const bootstrappedConfig = templateConfig ?? defaultConfig;
+  try {
+    writeFileSync(projectConfigPath, JSON.stringify(bootstrappedConfig, null, 2) + "\n", "utf-8");
+    transport.log(`Bootstrapped local config at ${projectConfigPath}`);
+  } catch (err) {
+    transport.log(
+      `Warning: failed to bootstrap local config at ${projectConfigPath}: ${err instanceof Error ? err.message : err}`,
+    );
+  }
+
+  transport.log(templateConfig ? "No local config found, using template defaults" : "No config found, using defaults");
   return {
-    config: {
-      agents: [
-        {
-          id: "claude-code",
-          displayName: "Claude Code",
-          cli: "claude",
-          roles: ["main"],
-          integration: "sdk",
-          capabilities: ["code", "review", "orchestration"],
-          restrictions: [],
-          maxConcurrentSessions: 3,
-        },
-        {
-          id: "codex-cli",
-          displayName: "Codex CLI",
-          cli: "codex",
-          roles: ["dev"],
-          integration: "sdk",
-          capabilities: ["code", "test"],
-          restrictions: [],
-          maxConcurrentSessions: 2,
-        },
-      ],
-    },
-    resolvedPath: null,
+    config: resolveConfigPaths(bootstrappedConfig, projectConfigPath),
+    resolvedPath: projectConfigPath,
   };
 }
 

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -211,6 +211,7 @@ const DEFAULT_KB_PATHS: ResolvedKBPaths = {
   issues: "issues",
 };
 
+/** Merge obsidian config KB path overrides with defaults. */
 function resolveKbPaths(obsidian?: ObsidianConfig): ResolvedKBPaths {
   return {
     tasks: obsidian?.kbPaths?.tasks ?? DEFAULT_KB_PATHS.tasks,
@@ -219,6 +220,7 @@ function resolveKbPaths(obsidian?: ObsidianConfig): ResolvedKBPaths {
   };
 }
 
+/** Parse and validate a port number from a string, returning null if invalid. */
 function parseRpcPort(raw: string | undefined): number | null {
   if (!raw) return null;
   const port = Number.parseInt(raw, 10);
@@ -228,6 +230,7 @@ function parseRpcPort(raw: string | undefined): number | null {
   return port;
 }
 
+/** Determine RPC port from env, config, or default. */
 function resolveRpcPort(config: MercuryConfig): number {
   const envPort = parseRpcPort(process.env.MERCURY_RPC_PORT);
   if (envPort !== null) {
@@ -247,12 +250,14 @@ function resolveRpcPort(config: MercuryConfig): number {
   return DEFAULT_RPC_PORT;
 }
 
+/** Set permissive CORS headers on an HTTP response. */
 function setCorsHeaders(res: ServerResponse): void {
   res.setHeader("Access-Control-Allow-Origin", "*");
   res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
   res.setHeader("Access-Control-Allow-Headers", "Content-Type");
 }
 
+/** Send a JSON-RPC response with CORS headers. */
 function sendHttpJson(
   res: ServerResponse,
   statusCode: number,
@@ -264,6 +269,7 @@ function sendHttpJson(
   res.end(JSON.stringify(payload));
 }
 
+/** Read the full request body as a UTF-8 string. */
 function readRequestBody(req: IncomingMessage): Promise<string> {
   return new Promise((resolveBody, rejectBody) => {
     let body = "";
@@ -276,6 +282,7 @@ function readRequestBody(req: IncomingMessage): Promise<string> {
   });
 }
 
+/** Type guard: params is either undefined or a plain object. */
 function isJsonRpcParams(
   params: JsonRpcHttpRequest["params"],
 ): params is Record<string, unknown> | undefined {
@@ -283,6 +290,7 @@ function isJsonRpcParams(
   return typeof params === "object" && params !== null && !Array.isArray(params);
 }
 
+/** Type guard: validates a parsed JSON value as a valid JSON-RPC 2.0 request. */
 function isJsonRpcRequest(value: unknown): value is JsonRpcHttpRequest {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     return false;
@@ -298,6 +306,7 @@ function isJsonRpcRequest(value: unknown): value is JsonRpcHttpRequest {
   );
 }
 
+/** Map an error to a JSON-RPC error object with appropriate code. */
 function mapRpcError(err: unknown): { code: number; message: string } {
   const message = err instanceof Error ? err.message : String(err);
   if (message.startsWith("Unknown method:")) {
@@ -306,6 +315,7 @@ function mapRpcError(err: unknown): { code: number; message: string } {
   return { code: -32603, message };
 }
 
+/** Create an HTTP server that handles JSON-RPC 2.0 requests via the orchestrator. */
 function createHttpRpcServer(orchestrator: Orchestrator, port: number): Server {
   return createServer(async (req, res) => {
     setCorsHeaders(res);
@@ -374,6 +384,7 @@ function createHttpRpcServer(orchestrator: Orchestrator, port: number): Server {
   });
 }
 
+/** Wire process shutdown signals to gracefully close the HTTP server. */
 function wireShutdown(server: Server): void {
   const originalExit = process.exit.bind(process);
   let shuttingDown = false;
@@ -414,6 +425,7 @@ function wireShutdown(server: Server): void {
   });
 }
 
+/** Start stdin/stdout RPC transport and HTTP JSON-RPC server, then signal ready. */
 function startTransports(orchestrator: Orchestrator, registry: AgentRegistry, config: MercuryConfig): void {
   transport.start((method, params) => orchestrator.handleRpc(method, params));
   const httpServer = createHttpRpcServer(orchestrator, resolveRpcPort(config));

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -30,7 +30,7 @@ type JsonRpcHttpResponse = {
   id: number | string | null;
 };
 
-/** Migrate legacy config: `role: "main"` → `roles: ["main"]` */
+/** Migrate legacy agent config format: single `role` string to `roles` array. */
 function migrateAgentConfig(agents: Record<string, unknown>[]): AgentConfig[] {
   for (const agent of agents) {
     if ("role" in agent && !("roles" in agent)) {
@@ -41,10 +41,12 @@ function migrateAgentConfig(agents: Record<string, unknown>[]): AgentConfig[] {
   return agents as unknown as AgentConfig[];
 }
 
+/** Type guard: returns true if value is a non-null, non-array object. */
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+/** Deep-merge config overrides into defaults, preserving structure of the defaults object. */
 function mergeConfigDefaults<T>(defaults: T, overrides: unknown): T {
   if (Array.isArray(defaults)) {
     return (Array.isArray(overrides) ? overrides : defaults) as T;
@@ -71,6 +73,7 @@ function mergeConfigDefaults<T>(defaults: T, overrides: unknown): T {
   return result as T;
 }
 
+/** Resolve relative paths in config (workDir, vaultPath, obsidianBin) to absolute paths. */
 function resolveConfigPaths(config: MercuryConfig, configFilePath: string): MercuryConfig {
   const configDir = dirname(configFilePath);
   return {
@@ -100,6 +103,7 @@ function resolveConfigPaths(config: MercuryConfig, configFilePath: string): Merc
   };
 }
 
+/** Read and parse a mercury config JSON file, applying agent config migration. */
 function readConfigFile(path: string): MercuryConfig {
   const raw = readFileSync(path, "utf-8");
   const config = JSON.parse(raw);
@@ -107,6 +111,7 @@ function readConfigFile(path: string): MercuryConfig {
   return config as MercuryConfig;
 }
 
+/** Load Mercury config from project, home, or template; bootstraps a default if none found. */
 function loadConfig(configPath?: string): { config: MercuryConfig; resolvedPath: string | null } {
   const projectConfigPath = configPath ?? resolve(process.cwd(), "mercury.config.json");
   const projectTemplatePath = resolve(dirname(projectConfigPath), "mercury.config.example.json");
@@ -176,8 +181,10 @@ function loadConfig(configPath?: string): { config: MercuryConfig; resolvedPath:
   }
 
   const bootstrappedConfig = templateConfig ?? defaultConfig;
+  let writeSucceeded = false;
   try {
     writeFileSync(projectConfigPath, JSON.stringify(bootstrappedConfig, null, 2) + "\n", "utf-8");
+    writeSucceeded = true;
     transport.log(`Bootstrapped local config at ${projectConfigPath}`);
   } catch (err) {
     transport.log(
@@ -188,7 +195,7 @@ function loadConfig(configPath?: string): { config: MercuryConfig; resolvedPath:
   transport.log(templateConfig ? "No local config found, using template defaults" : "No config found, using defaults");
   return {
     config: resolveConfigPaths(bootstrappedConfig, projectConfigPath),
-    resolvedPath: projectConfigPath,
+    resolvedPath: writeSucceeded ? projectConfigPath : null,
   };
 }
 

--- a/packages/orchestrator/src/knowledge-service.ts
+++ b/packages/orchestrator/src/knowledge-service.ts
@@ -70,6 +70,7 @@ export class KnowledgeService {
     return "obsidian";
   }
 
+  /** Resolve a vault-relative path to an absolute filesystem path, or null if vaultPath is unset. */
   private resolveVaultFilePath(relativePath: string): string | null {
     const vaultPath = this.vaultPath?.trim();
     if (!vaultPath) {
@@ -253,6 +254,7 @@ export class KnowledgeService {
     }
   }
 
+  /** Read a file from the vault via CLI, falling back to direct fs read if CLI fails. */
   async read(file: string): Promise<string> {
     try {
       return await this.exec(["read", `file=${file}`]);
@@ -263,12 +265,18 @@ export class KnowledgeService {
         throw error;
       }
 
-      const content = await fs.readFile(filePath, "utf-8");
-      console.warn(`[knowledge] CLI read failed, fell back to direct fs read: ${filePath}`);
-      return content;
+      try {
+        const content = await fs.readFile(filePath, "utf-8");
+        console.warn(`[knowledge] CLI read failed, fell back to direct fs read: ${filePath}`);
+        return content;
+      } catch (fsError) {
+        console.error(`[knowledge] Fallback fs read also failed: ${fsError instanceof Error ? fsError.message : fsError}`);
+        throw error; // Still throw original CLI error
+      }
     }
   }
 
+  /** Write a file to the vault via CLI, falling back to direct fs write if CLI fails. */
   async write(name: string, content: string): Promise<void> {
     try {
       await this.exec(["create", `name=${name}`, `content=${content}`]);
@@ -279,12 +287,18 @@ export class KnowledgeService {
         throw error;
       }
 
-      await fs.mkdir(path.dirname(filePath), { recursive: true });
-      await fs.writeFile(filePath, content, "utf-8");
-      console.warn(`[knowledge] CLI write failed, fell back to direct fs write: ${filePath}`);
+      try {
+        await fs.mkdir(path.dirname(filePath), { recursive: true });
+        await fs.writeFile(filePath, content, "utf-8");
+        console.warn(`[knowledge] CLI write failed, fell back to direct fs write: ${filePath}`);
+      } catch (fsError) {
+        console.error(`[knowledge] Fallback fs write also failed: ${fsError instanceof Error ? fsError.message : fsError}`);
+        throw error; // Still throw original CLI error
+      }
     }
   }
 
+  /** Append content to an existing vault file via CLI. */
   async append(file: string, content: string): Promise<void> {
     await this.exec(["append", `file=${file}`, `content=${content}`]);
   }

--- a/packages/orchestrator/src/knowledge-service.ts
+++ b/packages/orchestrator/src/knowledge-service.ts
@@ -79,7 +79,14 @@ export class KnowledgeService {
     }
 
     const pathSegments = relativePath.split(/[\\/]+/).filter(Boolean);
-    return path.join(vaultPath, ...pathSegments);
+    const resolved = path.join(vaultPath, ...pathSegments);
+    const normalizedVault = path.resolve(vaultPath);
+    const normalizedResolved = path.resolve(resolved);
+    if (!normalizedResolved.startsWith(normalizedVault + path.sep) && normalizedResolved !== normalizedVault) {
+      console.error(`[knowledge] Path traversal attempt blocked: ${relativePath}`);
+      return null;
+    }
+    return resolved;
   }
 
   /** Split raw CLI output into trimmed, non-empty lines. */
@@ -301,9 +308,25 @@ export class KnowledgeService {
     }
   }
 
-  /** Append content to an existing vault file via CLI. */
+  /** Append content to an existing vault file, falling back to direct fs append if CLI fails. */
   async append(file: string, content: string): Promise<void> {
-    await this.exec(["append", `file=${file}`, `content=${content}`]);
+    try {
+      await this.exec(["append", `file=${file}`, `content=${content}`]);
+    } catch (error) {
+      const filePath = this.resolveVaultFilePath(file);
+      if (!filePath) {
+        console.error("[knowledge] CLI append failed and no vaultPath configured for fallback");
+        throw error;
+      }
+
+      try {
+        await fs.appendFile(filePath, content, "utf-8");
+        console.warn(`[knowledge] CLI append failed, fell back to direct fs append: ${filePath}`);
+      } catch (fsError) {
+        console.error(`[knowledge] Fallback fs append also failed: ${fsError instanceof Error ? fsError.message : fsError}`);
+        throw error;
+      }
+    }
   }
 
   /** Search the vault for notes matching a query, returning parsed results. */

--- a/packages/orchestrator/src/knowledge-service.ts
+++ b/packages/orchestrator/src/knowledge-service.ts
@@ -9,7 +9,8 @@
 
 import { execFile } from "node:child_process";
 import { existsSync } from "node:fs";
-import { delimiter, join } from "node:path";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
 import { promisify } from "node:util";
 import type { KBSearchResult, KBFileInfo, ObsidianConfig } from "@mercury/core";
 
@@ -17,7 +18,9 @@ const execFileAsync = promisify(execFile);
 type KBEntryKind = KBFileInfo["kind"];
 const WINDOWS_OBSIDIAN_BIN_CANDIDATES = [
   "D:/Programs/Obsidian/Obsidian.exe",
-  process.env.LOCALAPPDATA ? join(process.env.LOCALAPPDATA, "Obsidian", "Obsidian.exe") : undefined,
+  process.env.LOCALAPPDATA
+    ? path.join(process.env.LOCALAPPDATA, "Obsidian", "Obsidian.exe")
+    : undefined,
 ].filter((candidate): candidate is string => Boolean(candidate));
 
 export class KnowledgeService {
@@ -47,11 +50,11 @@ export class KnowledgeService {
     }
 
     if (process.platform === "win32") {
-      const pathDirs = (process.env.PATH ?? "").split(delimiter);
+      const pathDirs = (process.env.PATH ?? "").split(path.delimiter);
       const candidates = ["Obsidian.exe", "obsidian.exe"];
       for (const dir of pathDirs) {
         for (const name of candidates) {
-          const full = join(dir, name);
+          const full = path.join(dir, name);
           if (existsSync(full)) {
             return full;
           }
@@ -65,6 +68,16 @@ export class KnowledgeService {
       }
     }
     return "obsidian";
+  }
+
+  private resolveVaultFilePath(relativePath: string): string | null {
+    const vaultPath = this.vaultPath?.trim();
+    if (!vaultPath) {
+      return null;
+    }
+
+    const pathSegments = relativePath.split(/[\\/]+/).filter(Boolean);
+    return path.join(vaultPath, ...pathSegments);
   }
 
   private parsePlainTextList(raw: string): string[] {
@@ -241,11 +254,35 @@ export class KnowledgeService {
   }
 
   async read(file: string): Promise<string> {
-    return this.exec(["read", `file=${file}`]);
+    try {
+      return await this.exec(["read", `file=${file}`]);
+    } catch (error) {
+      const filePath = this.resolveVaultFilePath(file);
+      if (!filePath) {
+        console.error("[knowledge] CLI read failed and no vaultPath configured for fallback");
+        throw error;
+      }
+
+      const content = await fs.readFile(filePath, "utf-8");
+      console.warn(`[knowledge] CLI read failed, fell back to direct fs read: ${filePath}`);
+      return content;
+    }
   }
 
   async write(name: string, content: string): Promise<void> {
-    await this.exec(["create", `name=${name}`, `content=${content}`]);
+    try {
+      await this.exec(["create", `name=${name}`, `content=${content}`]);
+    } catch (error) {
+      const filePath = this.resolveVaultFilePath(name);
+      if (!filePath) {
+        console.error("[knowledge] CLI write failed and no vaultPath configured for fallback");
+        throw error;
+      }
+
+      await fs.mkdir(path.dirname(filePath), { recursive: true });
+      await fs.writeFile(filePath, content, "utf-8");
+      console.warn(`[knowledge] CLI write failed, fell back to direct fs write: ${filePath}`);
+    }
   }
 
   async append(file: string, content: string): Promise<void> {

--- a/packages/orchestrator/src/knowledge-service.ts
+++ b/packages/orchestrator/src/knowledge-service.ts
@@ -23,6 +23,7 @@ const WINDOWS_OBSIDIAN_BIN_CANDIDATES = [
     : undefined,
 ].filter((candidate): candidate is string => Boolean(candidate));
 
+/** Obsidian CLI wrapper providing read/write/search/list over a vault. */
 export class KnowledgeService {
   private vaultName: string;
   private vaultPath: string | undefined;
@@ -81,6 +82,7 @@ export class KnowledgeService {
     return path.join(vaultPath, ...pathSegments);
   }
 
+  /** Split raw CLI output into trimmed, non-empty lines. */
   private parsePlainTextList(raw: string): string[] {
     return raw
       .split(/\r?\n/)
@@ -231,6 +233,7 @@ export class KnowledgeService {
     return this.enabled;
   }
 
+  /** Execute an Obsidian CLI command with the configured vault. */
   private async exec(args: string[]): Promise<string> {
     if (!this.enabled) {
       throw new Error("Knowledge service is disabled. Enable obsidian in mercury.config.json.");
@@ -303,6 +306,7 @@ export class KnowledgeService {
     await this.exec(["append", `file=${file}`, `content=${content}`]);
   }
 
+  /** Search the vault for notes matching a query, returning parsed results. */
   async search(query: string): Promise<KBSearchResult[]> {
     const raw = await this.exec(["search", `query=${query}`, "format=json"]);
     try {
@@ -314,6 +318,7 @@ export class KnowledgeService {
     }
   }
 
+  /** List immediate children (files and folders) of a vault directory. */
   async list(folder?: string): Promise<KBFileInfo[]> {
     const scopedArg = folder ? [`folder=${folder}`] : [];
     const [filesRaw, foldersRaw] = await Promise.all([

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -4,7 +4,7 @@
 
 import { spawn } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
-import { copyFile, mkdir, writeFile, rename, unlink } from "node:fs/promises";
+import { copyFile, mkdir, readdir, writeFile, rename, unlink } from "node:fs/promises";
 import { dirname, join, relative, resolve } from "node:path";
 import { EventBus, makeRoleSlotKey } from "@mercury/core";
 import type {
@@ -2451,6 +2451,19 @@ export class Orchestrator {
       } catch {
         // Missing source config is expected on first save.
       }
+
+      // Retain only the 10 most recent backups
+      const MAX_BACKUPS = 10;
+      try {
+        const files = await readdir(backupDir);
+        const backups = files
+          .filter((f: string) => f.startsWith("mercury.config."))
+          .sort()
+          .reverse();
+        for (const old of backups.slice(MAX_BACKUPS)) {
+          await unlink(join(backupDir, old)).catch(() => {});
+        }
+      } catch { /* cleanup failure is non-fatal */ }
 
       const json = JSON.stringify(this.projectConfig, null, 2) + "\n";
       await writeFile(tmpPath, json, "utf-8");

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -4,7 +4,7 @@
 
 import { spawn } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
-import { writeFile, rename, unlink } from "node:fs/promises";
+import { copyFile, mkdir, writeFile, rename, unlink } from "node:fs/promises";
 import { dirname, join, relative, resolve } from "node:path";
 import { EventBus, makeRoleSlotKey } from "@mercury/core";
 import type {
@@ -2442,6 +2442,16 @@ export class Orchestrator {
 
     const tmpPath = join(dirname(this.configFilePath), `.mercury.config.tmp.${Date.now()}.json`);
     try {
+      const backupDir = join(dirname(this.configFilePath), ".mercury", "backups");
+      await mkdir(backupDir, { recursive: true });
+      const backupStamp = new Date().toISOString().replace(/[:.]/g, "-");
+      const backupPath = join(backupDir, `mercury.config.${backupStamp}.json`);
+      try {
+        await copyFile(this.configFilePath, backupPath);
+      } catch {
+        // Missing source config is expected on first save.
+      }
+
       const json = JSON.stringify(this.projectConfig, null, 2) + "\n";
       await writeFile(tmpPath, json, "utf-8");
       await rename(tmpPath, this.configFilePath);

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -98,6 +98,11 @@ export class TaskManager {
     this.agentConfigLookup = lookup;
   }
 
+  private buildTaskAssignee(agentId: string): TaskAssignee {
+    const model = this.agentConfigLookup?.(agentId)?.model;
+    return model === undefined ? { agentId } : { agentId, model };
+  }
+
   /** Rehydrate task state from persistence (call before RPC starts). */
   async init(): Promise<void> {
     if (!this.persistence) return;
@@ -153,11 +158,7 @@ export class TaskManager {
     };
 
     // Agents First: populate structured assignee from agent config
-    const agentCfg = this.agentConfigLookup?.(params.assignedTo);
-    task.assignee = {
-      agentId: params.assignedTo,
-      model: agentCfg?.model,
-    };
+    task.assignee = this.buildTaskAssignee(params.assignedTo);
 
     this.tasks.set(taskId, task);
     this.persistTask(task);

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -98,6 +98,7 @@ export class TaskManager {
     this.agentConfigLookup = lookup;
   }
 
+  /** Build a TaskAssignee struct from agentId, enriching with model from agent config if available. */
   private buildTaskAssignee(agentId: string): TaskAssignee {
     const model = this.agentConfigLookup?.(agentId)?.model;
     return model === undefined ? { agentId } : { agentId, model };

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -139,6 +139,9 @@ export class TaskManager {
       phaseId: params.phaseId,
       priority: params.priority,
       status: "drafted",
+      createdAt: new Date().toISOString(),
+      closedAt: null,
+      failedAt: null,
       assignedTo: params.assignedTo,
       branch: params.branch,
       codeScope: params.codeScope,
@@ -261,6 +264,11 @@ export class TaskManager {
 
     const from = task.status;
     task.status = newStatus;
+    if (newStatus === "verified" || newStatus === "closed") {
+      task.closedAt = new Date().toISOString();
+    } else if (newStatus === "failed") {
+      task.failedAt = new Date().toISOString();
+    }
 
     this.bus.emit(
       "orchestrator.task.status_change",

--- a/packages/orchestrator/src/task-persistence-kb.ts
+++ b/packages/orchestrator/src/task-persistence-kb.ts
@@ -47,6 +47,7 @@ const DEFAULT_KB_PATHS: TaskPersistenceKBPaths = {
   issues: "issues",
 };
 
+/** Merge partial KB path overrides with defaults. */
 function resolveKbPaths(paths?: Partial<TaskPersistenceKBPaths>): TaskPersistenceKBPaths {
   return {
     tasks: paths?.tasks ?? DEFAULT_KB_PATHS.tasks,
@@ -55,9 +56,10 @@ function resolveKbPaths(paths?: Partial<TaskPersistenceKBPaths>): TaskPersistenc
   };
 }
 
-/** Backfill missing timestamp fields for legacy KB data. */
+/** Default createdAt value for tasks migrated before timestamps were added. */
 const LEGACY_CREATED_AT = "2026-03-18T00:00:00+09:00";
 
+/** Backfill missing timestamp fields for legacy KB data. */
 function backfillTimestamps(task: TaskBundle): void {
   if (!task.createdAt) {
     task.createdAt = LEGACY_CREATED_AT;
@@ -70,6 +72,7 @@ function backfillTimestamps(task: TaskBundle): void {
   }
 }
 
+/** KB-backed task persistence using KnowledgeService for JSON file storage. */
 export class TaskPersistenceKB implements TaskPersistence {
   private kb: KnowledgeService;
   private kbPaths: TaskPersistenceKBPaths;
@@ -91,18 +94,22 @@ export class TaskPersistenceKB implements TaskPersistence {
     this.log = log;
   }
 
+  /** Persist a task bundle to KB as JSON. */
   async saveTask(task: TaskBundle): Promise<void> {
     await this.writeJson(`${this.kbPaths.tasks}/${task.taskId}.json`, task);
   }
 
+  /** Persist an acceptance bundle to KB as JSON. */
   async saveAcceptance(acc: AcceptanceBundle): Promise<void> {
     await this.writeJson(`${this.kbPaths.acceptances}/${acc.acceptanceId}.json`, acc);
   }
 
+  /** Persist an issue bundle to KB as JSON. */
   async saveIssue(issue: IssueBundle): Promise<void> {
     await this.writeJson(`${this.kbPaths.issues}/${issue.issueId}.json`, issue);
   }
 
+  /** Rehydrate all tasks, acceptances, and issues from KB. */
   async loadAll(): Promise<{
     tasks: TaskBundle[];
     acceptances: AcceptanceBundle[];

--- a/packages/orchestrator/src/task-persistence-kb.ts
+++ b/packages/orchestrator/src/task-persistence-kb.ts
@@ -55,6 +55,21 @@ function resolveKbPaths(paths?: Partial<TaskPersistenceKBPaths>): TaskPersistenc
   };
 }
 
+/** Backfill missing timestamp fields for legacy KB data. */
+const LEGACY_CREATED_AT = "2026-03-18T00:00:00+09:00";
+
+function backfillTimestamps(task: TaskBundle): void {
+  if (!task.createdAt) {
+    task.createdAt = LEGACY_CREATED_AT;
+  }
+  if (task.closedAt === undefined) {
+    task.closedAt = null;
+  }
+  if (task.failedAt === undefined) {
+    task.failedAt = null;
+  }
+}
+
 export class TaskPersistenceKB implements TaskPersistence {
   private kb: KnowledgeService;
   private kbPaths: TaskPersistenceKBPaths;
@@ -110,7 +125,9 @@ export class TaskPersistenceKB implements TaskPersistence {
   async loadTask(taskId: string): Promise<TaskBundle | null> {
     try {
       const raw = await this.kb.read(`${this.kbPaths.tasks}/${taskId}.json`);
-      return JSON.parse(raw) as TaskBundle;
+      const task = JSON.parse(raw) as TaskBundle;
+      backfillTimestamps(task);
+      return task;
     } catch {
       return null;
     }
@@ -147,12 +164,17 @@ export class TaskPersistenceKB implements TaskPersistence {
 
   private async loadFolder<T>(folder: string): Promise<T[]> {
     const results: T[] = [];
+    const isTaskFolder = folder === this.kbPaths.tasks;
     try {
       const files = await this.kb.list(folder);
       for (const file of files) {
         try {
           const raw = await this.kb.read(file.path);
-          results.push(JSON.parse(raw) as T);
+          const parsed = JSON.parse(raw) as T;
+          if (isTaskFolder) {
+            backfillTimestamps(parsed as unknown as TaskBundle);
+          }
+          results.push(parsed);
         } catch {
           this.log(`[persistence] Skipping malformed file: ${file.path}`);
         }

--- a/packages/orchestrator/src/task-persistence-kb.ts
+++ b/packages/orchestrator/src/task-persistence-kb.ts
@@ -59,8 +59,8 @@ function resolveKbPaths(paths?: Partial<TaskPersistenceKBPaths>): TaskPersistenc
 /** Default createdAt value for tasks migrated before timestamps were added. */
 const LEGACY_CREATED_AT = "2026-03-18T00:00:00+09:00";
 
-/** Backfill missing timestamp fields for legacy KB data. */
-function backfillTimestamps(task: TaskBundle): void {
+/** Backfill missing timestamp fields for legacy KB data. Mutates and returns the input. */
+function backfillTimestamps(task: TaskBundle): TaskBundle {
   if (!task.createdAt) {
     task.createdAt = LEGACY_CREATED_AT;
   }
@@ -70,6 +70,7 @@ function backfillTimestamps(task: TaskBundle): void {
   if (task.failedAt === undefined) {
     task.failedAt = null;
   }
+  return task;
 }
 
 /** KB-backed task persistence using KnowledgeService for JSON file storage. */
@@ -179,7 +180,7 @@ export class TaskPersistenceKB implements TaskPersistence {
           const raw = await this.kb.read(file.path);
           const parsed = JSON.parse(raw) as T;
           if (isTaskFolder) {
-            backfillTimestamps(parsed as unknown as TaskBundle);
+            backfillTimestamps(parsed as T & TaskBundle);
           }
           results.push(parsed);
         } catch {


### PR DESCRIPTION
## Summary
TASK-KB-001 — Eight-part fix covering KB infrastructure, task metadata, and GUI UX:

- **Part A**: `mercury.config.json` 补 `vaultPath` 指向 KB vault
- **Part B**: Project Settings 新增 KB Path 输入框 + Browse 按钮
- **Part C**: KnowledgeService CLI 写入失败时 fallback 到直接文件写入
- **Part D**: TaskBundle model 字段由 TaskManager 从 config 自动注入
- **Part E**: Agents ↔ Tasks 切换保留输入框内容 (v-if → v-show)
- **Part F**: TaskBundle 新增 `closedAt`/`failedAt` 强制字段，状态机自动注入，KB 旧数据 backfill
- **Part G**: Task detail panel 显示 Closed/Failed 时间戳
- **Part H**: Tasks 页按状态优先级 → 时间戳固定排序

追加修复 (dev 主动发现):
- Sidecar orchestrator 启动路径修正
- Agents workspace 布局约束 (输入框不被挤出)
- Config 持久化增强 (example 模板 + 自动 bootstrap + 保存备份)

## Test plan
- [x] `pnpm typecheck` 通过
- [x] Settings 页显示 KB Path 字段，Browse 可用
- [x] 切换 Agents ↔ Tasks 后输入框内容保留
- [x] Tasks 页按 drafted → closed → failed 排序，closed/failed 显示时间
- [x] 删除 `mercury.config.json` 后重启，自动从 example 重建
- [x] Settings 保存后 `.mercury/backups/` 出现备份文件

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发行说明

* **新功能**
  * 任务显示创建/关闭/失败时间戳
  * 新增示例配置文件与 Obsidian 示例设置
  * 新增 CLI/Hook 脚本用于提交时的研究验证与阻断
  * 新增任务状态值 `main_review`

* **改进**
  * 任务列表按状态与时间优先级排序
  * Obsidian 设置支持填写与浏览 vault 路径
  * 启动与侧车解析更健壮，配置加载支持示例模板与深度合并
  * 自动备份配置并限制保留数量，写入备份目录

* **其他**
  * 更新忽略规则，排除备份目录
  * 强化文档/策略：建议使用网络检索验证外部 SDK/API/版本声明，新增 Codex/Claude 指南与配置文件。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->