### PR TITLE
feat(gui): Batch 1 quick wins — palette builtins, session buttons, history nav

### DIFF
--- a/packages/gui/src/components/AgentPanel.vue
+++ b/packages/gui/src/components/AgentPanel.vue
@@ -451,7 +451,7 @@ watch(
       <div class="panel-status">
         <button
           class="history-button"
-          title="Archive current session (marks as complete)"
+          title="Archive current session"
           @click="archiveSession(panelKey)"
           :disabled="status === 'active' || !sessionId"
         >

--- a/packages/gui/src/components/AgentPanel.vue
+++ b/packages/gui/src/components/AgentPanel.vue
@@ -277,13 +277,19 @@ watch(inputText, (val) => {
   }
 });
 
-async function loadSlashCommands() {
-  if (backendCommands.value.length > 0) return;
+/** Fetch backend slash commands. Skips if already loaded unless force is true. */
+async function loadSlashCommands(force = false) {
+  if (!force && backendCommands.value.length > 0) return;
   try {
     backendCommands.value = await getSlashCommands(props.agentId);
   } catch {
     backendCommands.value = [];
   }
+}
+
+/** Focus handler for textarea — loads commands on first focus. */
+function handleTextareaFocus() {
+  loadSlashCommands();
 }
 
 async function scrollMessagesToBottom() {
@@ -577,7 +583,7 @@ watch(
         @keydown="handleKeydown"
         @input="resizeTextarea"
         @paste="handlePaste"
-        @focus="loadSlashCommands"
+        @focus="handleTextareaFocus"
       ></textarea>
     </div>
 

--- a/packages/gui/src/components/AgentPanel.vue
+++ b/packages/gui/src/components/AgentPanel.vue
@@ -240,13 +240,17 @@ function getApprovalRequestId(metadata?: Record<string, unknown>): string | null
 
 // ─── Slash Commands ───
 
-/** Built-in commands handled by Mercury GUI (not from backend CLI). */
+/**
+ * Commands registered in the palette but not returned by the backend CLI.
+ * - "built-in": intercepted by Mercury GUI (never reaches backend)
+ * - "passthrough": forwarded to backend CLI as-is (palette entry for discoverability)
+ */
 const BUILTIN_COMMANDS: SlashCommand[] = [
   { name: "/new", description: "Start a new session (clears current context)", category: "built-in" },
   { name: "/clear", description: "Clear messages and stop current session", category: "built-in" },
   { name: "/resume", description: "Resume a previous session", category: "built-in", args: [{ name: "sessionId", description: "Session ID to resume", required: false, type: "string" }] },
-  { name: "/compact", description: "Compact conversation context", category: "built-in" },
   { name: "/history", description: "View session history", category: "built-in" },
+  { name: "/compact", description: "Compact conversation context", category: "passthrough" },
 ];
 
 const backendCommands = ref<SlashCommand[]>([]);
@@ -466,6 +470,7 @@ watch(
         <span v-else-if="status === 'error'" class="status-badge error">
           <span>error</span>
         </span>
+        <!-- v-else: only renders when status is idle (active/error handled above) -->
         <button
           v-else
           class="new-session-btn"

--- a/packages/gui/src/components/AgentPanel.vue
+++ b/packages/gui/src/components/AgentPanel.vue
@@ -262,7 +262,7 @@ const slashCommands = computed(() => {
   return [...BUILTIN_COMMANDS, ...deduped];
 });
 const showSlashPalette = computed(() =>
-  inputText.value.startsWith("/") && !slashCommandSelected.value,
+  inputText.value.startsWith("/") && !slashCommandSelected.value && historyIndex.value === -1,
 );
 const slashQuery = computed(() => {
   if (!showSlashPalette.value) return "";

--- a/packages/gui/src/components/AgentPanel.vue
+++ b/packages/gui/src/components/AgentPanel.vue
@@ -18,12 +18,16 @@ const props = defineProps<{
 }>();
 
 const { agents, getStatus, getSession, getSessionInfo, getWorkDir, setWorkDir, getGitBranch, setGitBranch, clearSession, defaultWorkDir } = useAgentStore();
-const { getMessages, sendPrompt, clearMessages, openSessionPicker, openHistory } = useMessageStore();
+const { getMessages, sendPrompt, clearMessages, openSessionPicker, openHistory, archiveSession, newSession, getUserMessageHistory } = useMessageStore();
 
 const inputText = ref("");
 const messagesEl = ref<HTMLDivElement>();
 const textareaEl = ref<HTMLTextAreaElement>();
 const paletteRef = ref<InstanceType<typeof SlashCommandPalette>>();
+
+// ─── Command History Navigation (↑↓) ───
+const historyIndex = ref(-1); // -1 = not browsing history
+const savedInput = ref(""); // saves current input when entering history mode
 
 const status = computed(() => getStatus(props.panelKey));
 const messages = computed(() => getMessages(props.panelKey));
@@ -236,8 +240,23 @@ function getApprovalRequestId(metadata?: Record<string, unknown>): string | null
 
 // ─── Slash Commands ───
 
-const slashCommands = ref<SlashCommand[]>([]);
+/** Built-in commands handled by Mercury GUI (not from backend CLI). */
+const BUILTIN_COMMANDS: SlashCommand[] = [
+  { name: "/new", description: "Start a new session (clears current context)", category: "built-in" },
+  { name: "/clear", description: "Clear messages and stop current session", category: "built-in" },
+  { name: "/resume", description: "Resume a previous session", category: "built-in", args: [{ name: "sessionId", description: "Session ID to resume", required: false, type: "string" }] },
+  { name: "/compact", description: "Compact conversation context", category: "built-in" },
+  { name: "/history", description: "View session history", category: "built-in" },
+];
+
+const backendCommands = ref<SlashCommand[]>([]);
 const slashCommandSelected = ref(false);
+/** Merged command list: built-in first, then backend commands (deduped). */
+const slashCommands = computed(() => {
+  const builtinNames = new Set(BUILTIN_COMMANDS.map((c) => c.name));
+  const deduped = backendCommands.value.filter((c) => !builtinNames.has(c.name));
+  return [...BUILTIN_COMMANDS, ...deduped];
+});
 const showSlashPalette = computed(() =>
   inputText.value.startsWith("/") && !slashCommandSelected.value,
 );
@@ -255,11 +274,11 @@ watch(inputText, (val) => {
 });
 
 async function loadSlashCommands() {
-  if (slashCommands.value.length > 0) return;
+  if (backendCommands.value.length > 0) return;
   try {
-    slashCommands.value = await getSlashCommands(props.agentId);
+    backendCommands.value = await getSlashCommands(props.agentId);
   } catch {
-    slashCommands.value = [];
+    backendCommands.value = [];
   }
 }
 
@@ -314,12 +333,15 @@ async function handleSend() {
   const images = pendingImages.value.length > 0 ? [...pendingImages.value] : undefined;
   inputText.value = "";
   pendingImages.value = [];
+  historyIndex.value = -1;
+  savedInput.value = "";
   resizeTextarea();
   // Use empty prompt for image-only sends — adapter handles content block construction
   await sendPrompt(props.panelKey, prompt, images);
 }
 
 function handleKeydown(e: KeyboardEvent) {
+  // Slash palette takes priority for navigation keys
   if (showSlashPalette.value && ["ArrowUp", "ArrowDown", "Tab", "Escape"].includes(e.key)) {
     paletteRef.value?.handleKeydown(e);
     return;
@@ -330,6 +352,40 @@ function handleKeydown(e: KeyboardEvent) {
       return;
     }
   }
+
+  // ↑↓ command history navigation (only when not in slash palette)
+  if (e.key === "ArrowUp" && !showSlashPalette.value) {
+    const history = getUserMessageHistory(props.panelKey);
+    if (history.length === 0) return;
+    // Only activate history nav when cursor is at the start or input is empty
+    const el = textareaEl.value;
+    if (el && el.selectionStart !== 0 && inputText.value !== "") return;
+    e.preventDefault();
+    if (historyIndex.value === -1) {
+      savedInput.value = inputText.value;
+      historyIndex.value = history.length - 1;
+    } else if (historyIndex.value > 0) {
+      historyIndex.value--;
+    }
+    inputText.value = history[historyIndex.value];
+    nextTick(() => resizeTextarea());
+    return;
+  }
+  if (e.key === "ArrowDown" && !showSlashPalette.value && historyIndex.value !== -1) {
+    e.preventDefault();
+    const history = getUserMessageHistory(props.panelKey);
+    if (historyIndex.value < history.length - 1) {
+      historyIndex.value++;
+      inputText.value = history[historyIndex.value];
+    } else {
+      // Back to the saved input
+      historyIndex.value = -1;
+      inputText.value = savedInput.value;
+    }
+    nextTick(() => resizeTextarea());
+    return;
+  }
+
   if (e.key === "Enter" && !e.shiftKey) {
     e.preventDefault();
     handleSend();
@@ -383,6 +439,14 @@ watch(
       <div class="panel-status">
         <button
           class="history-button"
+          title="Archive current session (marks as complete)"
+          @click="archiveSession(panelKey)"
+          :disabled="status === 'active' || !sessionId"
+        >
+          Archive
+        </button>
+        <button
+          class="history-button"
           title="Resumable sessions (same role, same agent)"
           @click="openSessionPicker(panelKey)"
         >
@@ -391,13 +455,23 @@ watch(
         <button class="history-button" @click="openHistory(panelKey)">
           History
         </button>
-        <span class="status-badge" :class="status">
-          <span v-if="status === 'active'" class="status-indicator" aria-hidden="true">
+        <!-- Active: show spinner badge. Idle/Error: show New Session button -->
+        <span v-if="status === 'active'" class="status-badge active">
+          <span class="status-indicator" aria-hidden="true">
             <span class="status-pulse"></span>
             <span class="status-spinner"></span>
           </span>
-          <span>{{ status }}</span>
+          <span>active</span>
         </span>
+        <span v-else-if="status === 'error'" class="status-badge error">
+          <span>error</span>
+        </span>
+        <button
+          v-else
+          class="new-session-btn"
+          title="Start new session"
+          @click="newSession(panelKey)"
+        >+</button>
       </div>
     </div>
 
@@ -659,6 +733,31 @@ watch(
 .history-button:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+.new-session-btn {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  color: var(--text-secondary);
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  -webkit-app-region: no-drag;
+  padding: 0;
+  transition: border-color 0.15s, color 0.15s, background 0.15s;
+}
+
+.new-session-btn:hover {
+  border-color: var(--accent-main);
+  color: var(--accent-main);
+  background: rgba(0, 212, 255, 0.08);
 }
 
 .status-badge.idle {

--- a/packages/gui/src/components/AgentPanel.vue
+++ b/packages/gui/src/components/AgentPanel.vue
@@ -378,11 +378,19 @@ function handleKeydown(e: KeyboardEvent) {
   if (e.key === "ArrowDown" && !showSlashPalette.value && historyIndex.value !== -1) {
     e.preventDefault();
     const history = getUserMessageHistory(props.panelKey);
-    if (historyIndex.value < history.length - 1) {
+    // Bounds check: history may have changed since ArrowUp set historyIndex
+    if (history.length === 0) {
+      historyIndex.value = -1;
+      inputText.value = savedInput.value;
+    } else if (historyIndex.value >= history.length) {
+      // Index out of range — clamp to last entry
+      historyIndex.value = history.length - 1;
+      inputText.value = history[historyIndex.value];
+    } else if (historyIndex.value < history.length - 1) {
       historyIndex.value++;
       inputText.value = history[historyIndex.value];
     } else {
-      // Back to the saved input
+      // At the end of history — back to saved input
       historyIndex.value = -1;
       inputText.value = savedInput.value;
     }
@@ -475,6 +483,7 @@ watch(
           v-else
           class="new-session-btn"
           title="Start new session"
+          aria-label="Start new session"
           @click="newSession(panelKey)"
         >+</button>
       </div>

--- a/packages/gui/src/stores/messages.ts
+++ b/packages/gui/src/stores/messages.ts
@@ -395,9 +395,14 @@ function dismissHistoryView(): void {
 }
 
 /**
- * Archive the current session — stops backend, clears the panel, and shows
- * a confirmation message. Functionally similar to newSession but provides
- * explicit user feedback that the session was archived.
+ * Archive the current session — stops the backend session via bridgeStopSession,
+ * clears the panel, and shows a "Session archived" confirmation message.
+ *
+ * NOTE: Both archiveSession and newSession call the same bridgeStopSession backend
+ * API. There is no distinct backend "archive" endpoint yet. The difference is
+ * purely frontend UX: Archive shows a confirmation message, New Session does not.
+ * A dedicated archive_session backend API can be added in a future iteration to
+ * persist archive metadata (e.g., completion status, tags).
  */
 async function archiveSession(panelKey: string): Promise<void> {
   const { setStatus, clearSession, getSession } = useAgentStore();
@@ -423,7 +428,8 @@ async function archiveSession(panelKey: string): Promise<void> {
 }
 
 /**
- * Start a new session — clears context without marking previous as complete.
+ * Start a new session — stops the current backend session and clears the panel.
+ * Uses the same bridgeStopSession call as archiveSession (see note above).
  */
 async function newSession(panelKey: string): Promise<void> {
   const { setStatus, clearSession, getSession } = useAgentStore();

--- a/packages/gui/src/stores/messages.ts
+++ b/packages/gui/src/stores/messages.ts
@@ -385,8 +385,9 @@ function dismissHistoryView(): void {
 }
 
 /**
- * Archive the current session — marks it as complete and clears the panel.
- * Unlike /new which just clears context, Archive signals intentional session completion.
+ * Archive the current session — stops backend, clears the panel, and shows
+ * a confirmation message. Functionally similar to newSession but provides
+ * explicit user feedback that the session was archived.
  */
 async function archiveSession(panelKey: string): Promise<void> {
   const { setStatus, clearSession, getSession } = useAgentStore();
@@ -435,7 +436,9 @@ async function newSession(panelKey: string): Promise<void> {
  */
 function getUserMessageHistory(panelKey: string): string[] {
   const msgs = messages.value.get(panelKey) ?? [];
-  return msgs.filter((m) => m.role === "user").map((m) => m.content);
+  return msgs
+    .filter((m) => m.role === "user" && m.content.trim() !== "")
+    .map((m) => m.content);
 }
 
 export function useMessageStore() {

--- a/packages/gui/src/stores/messages.ts
+++ b/packages/gui/src/stores/messages.ts
@@ -463,6 +463,7 @@ async function newSession(panelKey: string): Promise<void> {
 
 /**
  * Get user message history for a panel (for ↑↓ navigation).
+ * Filters on each call — acceptable for MAX_MESSAGES_PER_PANEL (200).
  */
 function getUserMessageHistory(panelKey: string): string[] {
   const msgs = messages.value.get(panelKey) ?? [];

--- a/packages/gui/src/stores/messages.ts
+++ b/packages/gui/src/stores/messages.ts
@@ -92,16 +92,19 @@ function loadFromStorage(): void {
   }
 }
 
+/** Retrieve messages for a specific panel. */
 function getMessages(panelKey: string): DisplayMessage[] {
   return messages.value.get(panelKey) ?? [];
 }
 
+/** Append a message to a panel's history and persist to localStorage. */
 function appendMessage(panelKey: string, msg: DisplayMessage) {
   const current = messages.value.get(panelKey) ?? [];
   messages.value = new Map(messages.value).set(panelKey, [...current, msg]);
   saveToStorage();
 }
 
+/** Clear all messages for a panel and persist to localStorage. */
 function clearMessages(panelKey: string) {
   messages.value = new Map(messages.value).set(panelKey, []);
   saveToStorage();
@@ -235,6 +238,7 @@ function resolvePanelKey(_agentId: string, sessionId: string): string | null {
 
 let messageListenersInitialized = false;
 
+/** Register Tauri event listeners for agent messages, status, and errors. */
 async function initMessageListeners() {
   if (messageListenersInitialized) return;
   messageListenersInitialized = true;
@@ -279,6 +283,7 @@ async function initMessageListeners() {
   });
 }
 
+/** Resume a session selected from the SessionPicker modal. */
 async function pickSession(sessionId: string): Promise<void> {
   const pick = pendingSessionPick.value;
   if (!pick) return;
@@ -313,10 +318,12 @@ async function pickSession(sessionId: string): Promise<void> {
   }
 }
 
+/** Close the session picker modal without selecting a session. */
 function dismissSessionPick(): void {
   pendingSessionPick.value = null;
 }
 
+/** Open the session picker modal listing resumable sessions for this panel. */
 async function openSessionPicker(panelKey: string): Promise<void> {
   const colonIdx = panelKey.indexOf(":");
   const role = panelKey.slice(0, colonIdx);
@@ -343,6 +350,7 @@ async function openSessionPicker(panelKey: string): Promise<void> {
   }
 }
 
+/** Open the history panel showing all sessions for this panel's agent. */
 async function openHistory(panelKey: string): Promise<void> {
   const colonIdx = panelKey.indexOf(":");
   const agentId = panelKey.slice(colonIdx + 1);
@@ -369,6 +377,7 @@ async function openHistory(panelKey: string): Promise<void> {
   }
 }
 
+/** Load transcript messages for a session into the history viewer. */
 async function selectHistorySession(sessionId: string): Promise<void> {
   const current = pendingHistoryView.value;
   if (!current) return;
@@ -380,6 +389,7 @@ async function selectHistorySession(sessionId: string): Promise<void> {
   };
 }
 
+/** Close the history viewer modal. */
 function dismissHistoryView(): void {
   pendingHistoryView.value = null;
 }
@@ -396,7 +406,7 @@ async function archiveSession(panelKey: string): Promise<void> {
 
   const sid = getSession(panelKey);
   if (sid) {
-    try { await bridgeStopSession(agentId, sid); } catch { /* best-effort */ }
+    try { await bridgeStopSession(agentId, sid); } catch (e) { console.debug("archiveSession: stop failed (best-effort)", e); }
     sessionToPanelKey.delete(sid);
   }
 
@@ -422,7 +432,7 @@ async function newSession(panelKey: string): Promise<void> {
 
   const sid = getSession(panelKey);
   if (sid) {
-    try { await bridgeStopSession(agentId, sid); } catch { /* best-effort */ }
+    try { await bridgeStopSession(agentId, sid); } catch (e) { console.debug("newSession: stop failed (best-effort)", e); }
     sessionToPanelKey.delete(sid);
   }
 

--- a/packages/gui/src/stores/messages.ts
+++ b/packages/gui/src/stores/messages.ts
@@ -381,12 +381,26 @@ async function openHistory(panelKey: string): Promise<void> {
 async function selectHistorySession(sessionId: string): Promise<void> {
   const current = pendingHistoryView.value;
   if (!current) return;
-  const result = await bridgeGetSessionMessages(sessionId);
-  pendingHistoryView.value = {
-    ...current,
-    selectedSessionId: sessionId,
-    messages: result.messages,
-  };
+
+  // Mark as selected immediately for UI responsiveness
+  pendingHistoryView.value = { ...current, selectedSessionId: sessionId, messages: [] };
+
+  try {
+    const result = await bridgeGetSessionMessages(sessionId);
+    // Guard against stale response: only apply if this session is still selected
+    if (pendingHistoryView.value?.selectedSessionId !== sessionId) return;
+    pendingHistoryView.value = {
+      ...pendingHistoryView.value,
+      messages: result.messages,
+    };
+  } catch (e) {
+    console.debug("selectHistorySession: failed to load transcript", e);
+    if (pendingHistoryView.value?.selectedSessionId !== sessionId) return;
+    pendingHistoryView.value = {
+      ...pendingHistoryView.value,
+      messages: [],
+    };
+  }
 }
 
 /** Close the history viewer modal. */

--- a/packages/gui/src/stores/messages.ts
+++ b/packages/gui/src/stores/messages.ts
@@ -112,24 +112,25 @@ function clearMessages(panelKey: string) {
  * @param panelKey - roleSlotKey "{role}:{agentId}"
  */
 async function sendPrompt(panelKey: string, prompt: string, images?: ImageAttachment[]) {
-  const { setStatus, setSessionInfo, clearSession } = useAgentStore();
+  const { setStatus, setSessionInfo } = useAgentStore();
 
   // Parse panelKey to get role and agentId
   const colonIdx = panelKey.indexOf(":");
   const role = panelKey.slice(0, colonIdx);
   const agentId = panelKey.slice(colonIdx + 1);
 
-  // Handle /clear and /new — clear frontend messages and end backend session
+  // Handle built-in commands — intercepted before reaching the backend
   const trimmed = prompt.trim().toLowerCase();
+
+  // /history — open history panel
+  if (trimmed === "/history") {
+    await openHistory(panelKey);
+    return;
+  }
+
+  // /clear and /new — delegate to newSession
   if (trimmed === "/clear" || trimmed === "/new") {
-    const sid = useAgentStore().getSession(panelKey);
-    if (sid) {
-      try { await bridgeStopSession(agentId, sid); } catch { /* best-effort */ }
-      sessionToPanelKey.delete(sid);
-    }
-    clearMessages(panelKey);
-    clearSession(panelKey);
-    setStatus(panelKey, "idle");
+    await newSession(panelKey);
     return;
   }
 
@@ -383,6 +384,60 @@ function dismissHistoryView(): void {
   pendingHistoryView.value = null;
 }
 
+/**
+ * Archive the current session — marks it as complete and clears the panel.
+ * Unlike /new which just clears context, Archive signals intentional session completion.
+ */
+async function archiveSession(panelKey: string): Promise<void> {
+  const { setStatus, clearSession, getSession } = useAgentStore();
+  const colonIdx = panelKey.indexOf(":");
+  const agentId = panelKey.slice(colonIdx + 1);
+
+  const sid = getSession(panelKey);
+  if (sid) {
+    try { await bridgeStopSession(agentId, sid); } catch { /* best-effort */ }
+    sessionToPanelKey.delete(sid);
+  }
+
+  // Clear first, then show confirmation so user sees it in the fresh panel
+  clearMessages(panelKey);
+  clearSession(panelKey);
+  setStatus(panelKey, "idle");
+
+  appendMessage(panelKey, {
+    role: "system",
+    content: "Session archived",
+    timestamp: Date.now(),
+  });
+}
+
+/**
+ * Start a new session — clears context without marking previous as complete.
+ */
+async function newSession(panelKey: string): Promise<void> {
+  const { setStatus, clearSession, getSession } = useAgentStore();
+  const colonIdx = panelKey.indexOf(":");
+  const agentId = panelKey.slice(colonIdx + 1);
+
+  const sid = getSession(panelKey);
+  if (sid) {
+    try { await bridgeStopSession(agentId, sid); } catch { /* best-effort */ }
+    sessionToPanelKey.delete(sid);
+  }
+
+  clearMessages(panelKey);
+  clearSession(panelKey);
+  setStatus(panelKey, "idle");
+}
+
+/**
+ * Get user message history for a panel (for ↑↓ navigation).
+ */
+function getUserMessageHistory(panelKey: string): string[] {
+  const msgs = messages.value.get(panelKey) ?? [];
+  return msgs.filter((m) => m.role === "user").map((m) => m.content);
+}
+
 export function useMessageStore() {
   return {
     messages,
@@ -399,5 +454,8 @@ export function useMessageStore() {
     openHistory,
     selectHistorySession,
     dismissHistoryView,
+    archiveSession,
+    newSession,
+    getUserMessageHistory,
   };
 }


### PR DESCRIPTION
## Summary
- **UI-1**: Register built-in commands (/new, /clear, /resume, /compact, /history) in SlashCommandPalette so they appear in the dropdown
- **UI-2**: Replace IDLE status badge with + New Session button; add Archive button left of Resume
- **UI-5**: Arrow Up/Down command history navigation in the input box

## Test plan
- [ ] Verify /new, /clear, /resume, /compact, /history appear in slash command palette
- [ ] Verify built-in commands are deduplicated against backend commands
- [ ] Verify + button creates new session, Archive button marks session complete
- [ ] Verify ↑↓ keys cycle through user message history
- [ ] Verify history navigation saves/restores current input
- [ ] Type check passes: `vue-tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 添加会话存档，归档后停止会话并在面板追加确认消息（“Session archived”）
  * 新增“新会话”按钮，一键重置面板会话（不追加确认消息）
  * 斜杠命令优化：内置与后端命令合并去重，部分命令（/history、/clear、/new）在发送时被拦截处理
  * 输入框支持上下箭头浏览并恢复用户输入历史，包含光标与空输入判定及边界保护
  * 面板头部状态改进：活跃/错误/空闲三类展示，新增归档按钮及相关禁用/样式逻辑
<!-- end of auto-generated comment: release notes by coderabbit.ai -->