### PR TITLE
feat(gui): Batch 2 core UX — message differentiation, inline status

### DIFF
--- a/packages/gui/src/components/AgentPanel.vue
+++ b/packages/gui/src/components/AgentPanel.vue
@@ -509,21 +509,24 @@ watch(
         <!-- User messages: right-aligned with avatar -->
         <template v-else-if="msg.role === 'user'">
           <div class="message-bubble user-bubble">
-            <!-- getApprovalRequestId is O(1) — two property checks; double-call is acceptable -->
+            <!-- ApprovalCard is exclusive — replaces normal content -->
             <ApprovalCard
               v-if="getApprovalRequestId(msg.metadata)"
               :requestId="getApprovalRequestId(msg.metadata)!"
             />
-            <div v-else-if="msg.images && msg.images.length > 0" class="message-images">
-              <img
-                v-for="(img, j) in msg.images"
-                :key="j"
-                :src="imageDataUri(img)"
-                :alt="img.filename || 'attached image'"
-                class="inline-image"
-              />
-            </div>
-            <div v-else class="message-content">{{ msg.content }}</div>
+            <!-- Images and text are independent — both can render for the same message -->
+            <template v-else>
+              <div v-if="msg.images && msg.images.length > 0" class="message-images">
+                <img
+                  v-for="(img, j) in msg.images"
+                  :key="j"
+                  :src="imageDataUri(img)"
+                  :alt="img.filename || 'attached image'"
+                  class="inline-image"
+                />
+              </div>
+              <div v-if="msg.content" class="message-content">{{ msg.content }}</div>
+            </template>
           </div>
           <span class="msg-avatar user-avatar">U</span>
         </template>

--- a/packages/gui/src/components/AgentPanel.vue
+++ b/packages/gui/src/components/AgentPanel.vue
@@ -509,6 +509,7 @@ watch(
         <!-- User messages: right-aligned with avatar -->
         <template v-else-if="msg.role === 'user'">
           <div class="message-bubble user-bubble">
+            <!-- getApprovalRequestId is O(1) — two property checks; double-call is acceptable -->
             <ApprovalCard
               v-if="getApprovalRequestId(msg.metadata)"
               :requestId="getApprovalRequestId(msg.metadata)!"
@@ -587,7 +588,7 @@ watch(
       />
       <div class="input-row">
         <!-- Inline status indicator: only shown when active -->
-        <span v-if="status === 'active'" class="inline-status" title="Agent is working...">
+        <span v-if="status === 'active'" class="inline-status" role="status" aria-label="Agent is working" title="Agent is working...">
           <span class="status-spinner-sm"></span>
         </span>
         <textarea

--- a/packages/gui/src/components/AgentPanel.vue
+++ b/packages/gui/src/components/AgentPanel.vue
@@ -473,20 +473,13 @@ watch(
         <button class="history-button" @click="openHistory(panelKey)">
           History
         </button>
-        <!-- Active: show spinner badge. Idle/Error: show New Session button -->
-        <span v-if="status === 'active'" class="status-badge active">
-          <span class="status-indicator" aria-hidden="true">
-            <span class="status-pulse"></span>
-            <span class="status-spinner"></span>
-          </span>
-          <span>active</span>
-        </span>
-        <span v-else-if="status === 'error'" class="status-badge error">
+        <!-- Error badge in header; active status moved to inline input area -->
+        <span v-if="status === 'error'" class="status-badge error">
           <span>error</span>
         </span>
-        <!-- v-else: only renders when status is idle (active/error handled above) -->
+        <!-- Idle: show New Session button -->
         <button
-          v-else
+          v-else-if="status === 'idle'"
           class="new-session-btn"
           title="Start new session"
           aria-label="Start new session"
@@ -600,7 +593,7 @@ watch(
         <textarea
           ref="textareaEl"
           v-model="inputText"
-          :placeholder="status === 'active' ? `${agentName} is working... (type to queue)` : `Send to ${agentName}...`"
+          :placeholder="status === 'active' ? 'working... (type to queue)' : `Send to ${agentName}...`"
           rows="1"
           @keydown="handleKeydown"
           @input="resizeTextarea"
@@ -1292,7 +1285,8 @@ watch(
 
 @media (prefers-reduced-motion: reduce) {
   .status-spinner,
-  .status-pulse {
+  .status-pulse,
+  .status-spinner-sm {
     animation: none;
   }
 }

--- a/packages/gui/src/components/AgentPanel.vue
+++ b/packages/gui/src/components/AgentPanel.vue
@@ -503,29 +503,47 @@ watch(
       <div
         v-for="(msg, i) in messages"
         :key="i"
-        class="message"
+        class="message-row"
         :class="msg.role"
       >
-        <ApprovalCard
-          v-if="getApprovalRequestId(msg.metadata)"
-          :requestId="getApprovalRequestId(msg.metadata)!"
-        />
-        <!-- Inline images -->
-        <div v-else-if="msg.images && msg.images.length > 0" class="message-images">
-          <img
-            v-for="(img, j) in msg.images"
-            :key="j"
-            :src="imageDataUri(img)"
-            :alt="img.filename || 'attached image'"
-            class="inline-image"
-          />
-        </div>
-        <div
-          v-else-if="msg.role === 'assistant'"
-          class="message-content markdown-body"
-          v-html="renderMarkdown(msg.content)"
-        ></div>
-        <div v-else class="message-content">{{ msg.content }}</div>
+        <!-- System messages: centered, no avatar -->
+        <template v-if="msg.role === 'system'">
+          <div class="system-divider">
+            <span class="system-text">{{ msg.content }}</span>
+          </div>
+        </template>
+
+        <!-- User messages: right-aligned with avatar -->
+        <template v-else-if="msg.role === 'user'">
+          <div class="message-bubble user-bubble">
+            <ApprovalCard
+              v-if="getApprovalRequestId(msg.metadata)"
+              :requestId="getApprovalRequestId(msg.metadata)!"
+            />
+            <div v-else-if="msg.images && msg.images.length > 0" class="message-images">
+              <img
+                v-for="(img, j) in msg.images"
+                :key="j"
+                :src="imageDataUri(img)"
+                :alt="img.filename || 'attached image'"
+                class="inline-image"
+              />
+            </div>
+            <div v-else class="message-content">{{ msg.content }}</div>
+          </div>
+          <span class="msg-avatar user-avatar">U</span>
+        </template>
+
+        <!-- Assistant messages: left-aligned with avatar -->
+        <template v-else>
+          <span class="msg-avatar assistant-avatar">{{ agentName.charAt(0).toUpperCase() }}</span>
+          <div class="message-bubble assistant-bubble">
+            <div
+              class="message-content markdown-body"
+              v-html="renderMarkdown(msg.content)"
+            ></div>
+          </div>
+        </template>
       </div>
     </div>
 
@@ -574,17 +592,22 @@ watch(
         @select="handleSlashSelect"
         @close="inputText = ''"
       />
-      <textarea
-        ref="textareaEl"
-        v-model="inputText"
-        :placeholder="`Send to ${agentName}...`"
-        :disabled="status === 'active'"
-        rows="1"
-        @keydown="handleKeydown"
-        @input="resizeTextarea"
-        @paste="handlePaste"
-        @focus="handleTextareaFocus"
-      ></textarea>
+      <div class="input-row">
+        <!-- Inline status indicator: only shown when active -->
+        <span v-if="status === 'active'" class="inline-status" title="Agent is working...">
+          <span class="status-spinner-sm"></span>
+        </span>
+        <textarea
+          ref="textareaEl"
+          v-model="inputText"
+          :placeholder="status === 'active' ? `${agentName} is working... (type to queue)` : `Send to ${agentName}...`"
+          rows="1"
+          @keydown="handleKeydown"
+          @input="resizeTextarea"
+          @paste="handlePaste"
+          @focus="handleTextareaFocus"
+        ></textarea>
+      </div>
     </div>
 
     <!-- Drag overlay -->
@@ -844,33 +867,89 @@ watch(
   opacity: 0.6;
 }
 
-.message {
-  margin-bottom: 8px;
-  padding: 8px 10px;
-  border-radius: var(--radius);
+/* Message row layout — controls alignment per role */
+.message-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin-bottom: 10px;
   font-size: 12px;
   line-height: 1.5;
   word-break: break-word;
 }
 
-.message.user {
-  background: rgba(0, 212, 255, 0.08);
-  border-left: 2px solid var(--accent-main);
-  font-family: var(--font-mono);
-  white-space: pre-wrap;
+.message-row.user {
+  justify-content: flex-end;
 }
 
-.message.assistant {
-  background: rgba(123, 104, 238, 0.08);
-  border-left: 2px solid var(--accent-sub);
+.message-row.assistant {
+  justify-content: flex-start;
 }
 
-.message.system {
-  background: rgba(255, 82, 82, 0.08);
-  border-left: 2px solid var(--accent-error);
-  color: var(--accent-error);
+.message-row.system {
+  justify-content: center;
+}
+
+/* Avatar badges */
+.msg-avatar {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  font-weight: 700;
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.user-avatar {
+  background: rgba(0, 212, 255, 0.2);
+  color: var(--accent-main);
+}
+
+.assistant-avatar {
+  background: rgba(123, 104, 238, 0.2);
+  color: var(--accent-sub);
+}
+
+/* Message bubbles */
+.message-bubble {
+  max-width: 85%;
+  padding: 8px 12px;
+  border-radius: var(--radius);
+}
+
+.user-bubble {
+  background: rgba(0, 212, 255, 0.1);
+  border: 1px solid rgba(0, 212, 255, 0.15);
   font-family: var(--font-mono);
   white-space: pre-wrap;
+  border-radius: var(--radius) var(--radius) 2px var(--radius);
+}
+
+.assistant-bubble {
+  background: rgba(123, 104, 238, 0.06);
+  border: 1px solid rgba(123, 104, 238, 0.1);
+  border-radius: var(--radius) var(--radius) var(--radius) 2px;
+}
+
+/* System messages — centered divider style */
+.system-divider {
+  width: 100%;
+  text-align: center;
+  padding: 4px 0;
+}
+
+.system-text {
+  font-size: 10px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  background: var(--bg-secondary);
+  padding: 2px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
 }
 
 /* Inline images in messages */
@@ -1142,7 +1221,33 @@ watch(
   flex-shrink: 0;
 }
 
+.input-row {
+  display: flex;
+  align-items: flex-end;
+  gap: 6px;
+}
+
+.inline-status {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  margin-bottom: 8px;
+}
+
+.status-spinner-sm {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 1.5px solid var(--accent-main);
+  border-right-color: transparent;
+  animation: status-spin 0.85s linear infinite;
+}
+
 .panel-input textarea {
+  flex: 1;
   width: 100%;
   padding: 8px 12px;
   background: var(--bg-input);
@@ -1166,10 +1271,7 @@ watch(
   color: var(--text-muted);
 }
 
-.panel-input textarea:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
+/* Textarea no longer disabled during active — user can queue messages */
 
 @media (max-width: 720px) {
   .panel-header {


### PR DESCRIPTION
## Summary
- **UI-6**: Move active status indicator inline next to textarea; remove input disabled during active state (users can queue messages); spinner shows in input area
- **UI-7**: Visual message differentiation — user messages right-aligned with avatar (U), assistant messages left-aligned with agent initial avatar, system messages centered as dividers

## Test plan
- [ ] Verify active status spinner appears left of textarea (not in header)
- [ ] Verify textarea is NOT disabled when agent is active
- [ ] Verify placeholder shows "working... (type to queue)" when active
- [ ] Verify user messages are right-aligned with cyan bubbles and U avatar
- [ ] Verify assistant messages are left-aligned with purple cards and agent initial avatar
- [ ] Verify system messages are centered divider style
- [ ] Type check passes: `vue-tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **用户界面改进**
  * 重新设计消息行布局：系统消息为居中分隔样式，用户消息右对齐带“U”头像与气泡（支持审批卡与内嵌图片），助理消息左对齐带基于名称首字母的头像与富文本气泡。
  * 面板状态与操作：状态区域仅在错误时显示错误标识，“开始新会话”按钮仅在空闲时可见；移除活动状态的头部加载指示。
  * 输入交互改进：活动时显示小型内联加载指示，活动时占位文本为“正在处理...（输入可排队）”，输入框在活动时仍可编辑。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->