### PR TITLE
feat(gui): Batch 3 session infrastructure — history backfill, slash commands

### DIFF
--- a/packages/gui/src/components/AgentPanel.vue
+++ b/packages/gui/src/components/AgentPanel.vue
@@ -246,11 +246,19 @@ function getApprovalRequestId(metadata?: Record<string, unknown>): string | null
  * - "passthrough": forwarded to backend CLI as-is (palette entry for discoverability)
  */
 const BUILTIN_COMMANDS: SlashCommand[] = [
+  // GUI-intercepted commands
   { name: "/new", description: "Start a new session (clears current context)", category: "built-in" },
   { name: "/clear", description: "Clear messages and stop current session", category: "built-in" },
   { name: "/resume", description: "Resume a previous session", category: "built-in", args: [{ name: "sessionId", description: "Session ID to resume", required: false, type: "string" }] },
   { name: "/history", description: "View session history", category: "built-in" },
+  // Passthrough: forwarded to backend CLI (palette entry for discoverability)
   { name: "/compact", description: "Compact conversation context", category: "passthrough" },
+  { name: "/doctor", description: "Check CLI installation and configuration", category: "passthrough" },
+  { name: "/status", description: "Show current session status", category: "passthrough" },
+  { name: "/cost", description: "Show token usage and cost for this session", category: "passthrough" },
+  { name: "/config", description: "Show or modify configuration", category: "passthrough" },
+  { name: "/login", description: "Authenticate with the CLI provider", category: "passthrough" },
+  { name: "/logout", description: "Sign out of the CLI provider", category: "passthrough" },
 ];
 
 const backendCommands = ref<SlashCommand[]>([]);

--- a/packages/gui/src/stores/messages.ts
+++ b/packages/gui/src/stores/messages.ts
@@ -152,6 +152,8 @@ async function sendPrompt(panelKey: string, prompt: string, images?: ImageAttach
           lastActiveAt: Date.now(),
         });
         sessionToPanelKey.set(result.sessionId, panelKey);
+        // Backfill history from the resumed session
+        await loadSessionHistory(panelKey, result.sessionId);
         appendMessage(panelKey, {
           role: "system",
           content: `Resumed session ${result.sessionId.slice(0, 8)}`,
@@ -303,6 +305,8 @@ async function pickSession(sessionId: string): Promise<void> {
       lastActiveAt: Date.now(),
     });
     sessionToPanelKey.set(result.sessionId, panelKey);
+    // Backfill history from the resumed session
+    await loadSessionHistory(panelKey, result.sessionId);
     appendMessage(panelKey, {
       role: "system",
       content: `Resumed session ${result.sessionId.slice(0, 8)}`,
@@ -315,6 +319,31 @@ async function pickSession(sessionId: string): Promise<void> {
       content: `Resume failed: ${error}`,
       timestamp: Date.now(),
     });
+  }
+}
+
+/**
+ * Load historical messages from a session into the panel's message store.
+ * Clears existing messages and backfills from the backend transcript.
+ */
+async function loadSessionHistory(panelKey: string, sessionId: string): Promise<void> {
+  try {
+    const result = await bridgeGetSessionMessages(sessionId);
+    if (!result.messages || result.messages.length === 0) return;
+
+    // Clear current messages and backfill with historical ones
+    clearMessages(panelKey);
+    for (const msg of result.messages) {
+      appendMessage(panelKey, {
+        role: msg.role,
+        content: msg.content,
+        timestamp: msg.timestamp,
+        images: msg.images,
+        metadata: msg.metadata,
+      });
+    }
+  } catch (e) {
+    console.debug("loadSessionHistory: failed to load history", e);
   }
 }
 

--- a/packages/gui/src/stores/messages.ts
+++ b/packages/gui/src/stores/messages.ts
@@ -110,6 +110,12 @@ function clearMessages(panelKey: string) {
   saveToStorage();
 }
 
+/** Replace all messages for a panel in a single reactive update. */
+function setMessages(panelKey: string, msgs: DisplayMessage[]) {
+  messages.value = new Map(messages.value).set(panelKey, msgs);
+  saveToStorage();
+}
+
 /**
  * Send a prompt from a specific role panel.
  * @param panelKey - roleSlotKey "{role}:{agentId}"
@@ -331,17 +337,15 @@ async function loadSessionHistory(panelKey: string, sessionId: string): Promise<
     const result = await bridgeGetSessionMessages(sessionId);
     if (!result.messages || result.messages.length === 0) return;
 
-    // Clear current messages and backfill with historical ones
-    clearMessages(panelKey);
-    for (const msg of result.messages) {
-      appendMessage(panelKey, {
-        role: msg.role,
-        content: msg.content,
-        timestamp: msg.timestamp,
-        images: msg.images,
-        metadata: msg.metadata,
-      });
-    }
+    // Batch-set all messages in a single reactive update
+    const batch: DisplayMessage[] = result.messages.map((msg) => ({
+      role: msg.role,
+      content: msg.content,
+      timestamp: msg.timestamp,
+      images: msg.images,
+      metadata: msg.metadata,
+    }));
+    setMessages(panelKey, batch);
   } catch (e) {
     console.debug("loadSessionHistory: failed to load history", e);
   }

--- a/packages/gui/src/stores/messages.ts
+++ b/packages/gui/src/stores/messages.ts
@@ -333,6 +333,9 @@ async function pickSession(sessionId: string): Promise<void> {
  * Clears existing messages and backfills from the backend transcript.
  */
 async function loadSessionHistory(panelKey: string, sessionId: string): Promise<void> {
+  // Always clear old messages to prevent cross-session leakage
+  clearMessages(panelKey);
+
   try {
     const result = await bridgeGetSessionMessages(sessionId);
     if (!result.messages || result.messages.length === 0) return;
@@ -348,6 +351,7 @@ async function loadSessionHistory(panelKey: string, sessionId: string): Promise<
     setMessages(panelKey, batch);
   } catch (e) {
     console.debug("loadSessionHistory: failed to load history", e);
+    // Panel is already cleared — empty state is safe
   }
 }
 


### PR DESCRIPTION
## Summary
- **UI-3**: Resume sessions now backfill historical messages from backend transcript into the message panel
- **UI-8**: Session history reads from backend authoritative source (via bridgeGetSessionMessages), not just localStorage
- **UI-4**: Add passthrough slash commands to palette (/doctor, /status, /cost, /config, /login, /logout)

## Test plan
- [ ] Verify /resume <id> loads historical messages before showing "Resumed" message
- [ ] Verify SessionPicker resume loads historical messages
- [ ] Verify passthrough commands (/doctor, /status, etc.) appear in palette
- [ ] Verify passthrough commands are forwarded to CLI when selected
- [ ] Type check passes: `vue-tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发行说明

* **New Features**
  * 在界面调色板中新增多项斜杠命令以支持更多操作（登录/登出、配置、状态、计费、医生助手等）。
  * 改进会话恢复流程：恢复时会回填并替换面板的历史消息，确保恢复后能完整显示会话记录。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->