### PR TITLE
fix(tauri): improve single-instance focus callback, fix dev mode crash

### DIFF
--- a/packages/gui/src-tauri/src/lib.rs
+++ b/packages/gui/src-tauri/src/lib.rs
@@ -46,6 +46,8 @@ pub fn run() {
                 if let Err(e) = w.show() { eprintln!("[single-instance] show failed: {e}"); }
                 if let Err(e) = w.unminimize() { eprintln!("[single-instance] unminimize failed: {e}"); }
                 if let Err(e) = w.set_focus() { eprintln!("[single-instance] set_focus failed: {e}"); }
+            } else {
+                eprintln!("[single-instance] main window not found");
             }
         }))
     };

--- a/packages/gui/src-tauri/src/lib.rs
+++ b/packages/gui/src-tauri/src/lib.rs
@@ -35,12 +35,16 @@ fn find_project_root(start: PathBuf) -> Option<PathBuf> {
 pub fn run() {
     #[cfg(not(debug_assertions))]
     let builder = {
-        // Keep single-instance enforcement out of `tauri dev`, which may restart/spawn
-        // the app process during development.
+        // Single-instance is disabled during `tauri dev` (debug_assertions enabled)
+        // because the dev runner may spawn multiple cargo processes, causing the
+        // second instance to exit and kill the dev pipeline.
+        // In release builds, the second instance notifies the first and exits with code 0.
         tauri::Builder::default().plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
+            // Restore and focus the existing window regardless of its current state
+            // (minimized, hidden, or normal). Order matters: show → unminimize → focus.
             if let Some(w) = app.get_webview_window("main") {
+                let _ = w.show();
                 let _ = w.unminimize();
-                let _ = w.maximize();
                 let _ = w.set_focus();
             }
         }))

--- a/packages/gui/src-tauri/src/lib.rs
+++ b/packages/gui/src-tauri/src/lib.rs
@@ -43,9 +43,9 @@ pub fn run() {
             // Restore and focus the existing window regardless of its current state
             // (minimized, hidden, or normal). Order matters: show → unminimize → focus.
             if let Some(w) = app.get_webview_window("main") {
-                let _ = w.show();
-                let _ = w.unminimize();
-                let _ = w.set_focus();
+                if let Err(e) = w.show() { eprintln!("[single-instance] show failed: {e}"); }
+                if let Err(e) = w.unminimize() { eprintln!("[single-instance] unminimize failed: {e}"); }
+                if let Err(e) = w.set_focus() { eprintln!("[single-instance] set_focus failed: {e}"); }
             }
         }))
     };


### PR DESCRIPTION
## Summary
- Fix single-instance plugin focus callback: replace `maximize()` with `show()` + `unminimize()` + `set_focus()` for proper window restoration
- The `cfg(not(debug_assertions))` guard for dev mode was already in place — this PR improves the release-mode behavior

## Context (TASK-SB-FIX-001)
- **Original issue**: `tauri dev` double-launch triggers single-instance exit crash (Sev-1)
- **Root cause**: Already fixed in commit ddc46e2 via `cfg(not(debug_assertions))`
- **This PR**: Improves the release-mode callback (remove inappropriate maximize, add show for hidden windows per [tauri#12936](https://github.com/tauri-apps/tauri/issues/12936))

## Test plan
- [ ] `cargo check` passes (dev profile)
- [ ] `pnpm tauri dev` starts cleanly without ELIFECYCLE error
- [ ] Double-launch of compiled exe: second instance focuses first window without maximizing

## References
- [Tauri Single Instance Plugin docs](https://v2.tauri.app/plugin/single-instance/)
- [tauri#12936: Can't set focus when window hidden](https://github.com/tauri-apps/tauri/issues/12936)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **改进**
  * 开发模式下不启用单实例；发布版再次启动时会将焦点交回已有窗口并退出，避免启动冲突。
  * 优化了窗口恢复与聚焦顺序：现有窗口会先显示、再恢复最小化状态，随后获得焦点，提升可见性与一致性。
  * 改进了异常上报与可观察性，便于更快定位窗口聚焦或显示问题。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->