### PR TITLE
feat(gui): Agent streaming display, resume history backfill, session cleanup

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,13 +1,16 @@
 export { EventBus } from "./event-bus.js";
-export { makeRoleSlotKey, parseRoleSlotKey, ROLE_CARDS } from "./types.js";
+export { makeRoleSlotKey, parseRoleSlotKey, ROLE_CARDS, isStreamingEvent } from "./types.js";
 export type {
   AcceptanceBundle,
   AcceptanceVerdict,
+  AdapterYield,
   AgentAdapter,
   AgentApprovalRequest,
   AgentConfig,
   AgentMessage,
   AgentRole,
+  AgentStreamingEvent,
+  AgentStreamingEventKind,
   AgentSendHooks,
   ApprovalDecision,
   ApprovalDecisionSource,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -503,6 +503,42 @@ export interface AgentMessage {
   metadata?: Record<string, unknown>;
 }
 
+// ─── Streaming Events ───
+
+export type AgentStreamingEventKind =
+  | "text_delta"
+  | "tool_start"
+  | "tool_delta"
+  | "tool_end";
+
+/**
+ * Incremental streaming event yielded by adapters when streaming is enabled.
+ * Unlike AgentMessage (complete turns), streaming events represent partial content
+ * arriving token-by-token from the LLM.
+ *
+ * Claude SDK: includePartialMessages → content_block_delta (text_delta / input_json_delta)
+ * Codex app-server: item/agentMessage/delta, item/commandExecution/outputDelta
+ */
+export interface AgentStreamingEvent {
+  type: "streaming";
+  eventKind: AgentStreamingEventKind;
+  /** Incremental text content (for text_delta, tool_delta) */
+  content?: string;
+  /** Tool name (for tool_start) */
+  toolName?: string;
+  /** Partial JSON input for tool call (for tool_delta) */
+  toolInput?: string;
+  timestamp: number;
+}
+
+/** Union type yielded by adapter sendPrompt generators. */
+export type AdapterYield = AgentMessage | AgentStreamingEvent;
+
+/** Type guard: is the yielded value a streaming event? */
+export function isStreamingEvent(value: AdapterYield): value is AgentStreamingEvent {
+  return "type" in value && (value as AgentStreamingEvent).type === "streaming";
+}
+
 export interface AgentOneShotOptions {
   model?: string;
   sandbox?: string;
@@ -525,7 +561,7 @@ export interface AgentAdapter {
     prompt: string,
     images?: ImageAttachment[],
     hooks?: AgentSendHooks,
-  ): AsyncGenerator<AgentMessage>;
+  ): AsyncGenerator<AdapterYield>;
   resumeSession(sessionId: string, persistedInfo?: SessionInfo, cwd?: string): Promise<SessionInfo>;
   endSession(sessionId: string): Promise<void>;
   executeOneShot?(

--- a/packages/gui/src-tauri/Cargo.lock
+++ b/packages/gui/src-tauri/Cargo.lock
@@ -2047,6 +2047,7 @@ dependencies = [
 name = "mercury-gui"
 version = "0.1.0"
 dependencies = [
+ "dirs",
  "serde",
  "serde_json",
  "tauri",

--- a/packages/gui/src-tauri/Cargo.toml
+++ b/packages/gui/src-tauri/Cargo.toml
@@ -21,3 +21,4 @@ tauri-plugin-window-state = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["process", "io-util", "rt-multi-thread", "sync", "macros"] }
+dirs = "6"

--- a/packages/gui/src-tauri/src/commands.rs
+++ b/packages/gui/src-tauri/src/commands.rs
@@ -1,3 +1,5 @@
+use std::fs;
+use std::path::PathBuf;
 use std::process::Command;
 use tauri::State;
 
@@ -603,4 +605,140 @@ pub async fn get_context_status(
     let mgr = get_sidecar(&sidecar).await?;
     mgr.send_request("get_context_status", serde_json::json!({}))
         .await
+}
+
+// ─── Session History Commands (direct filesystem, no sidecar) ───
+
+/// Read native CLI session history from JSONL files.
+///
+/// Claude Code: ~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl
+/// Codex CLI:   ~/.codex/sessions/<threadId>.jsonl (via app-server)
+///
+/// Returns parsed messages from the JSONL file for history backfill on resume.
+#[tauri::command]
+pub fn read_session_history(
+    root: State<'_, ProjectRoot>,
+    cli_type: String,
+    session_id: String,
+    cwd: Option<String>,
+) -> Result<serde_json::Value, String> {
+    let effective_cwd = cwd.unwrap_or_else(|| root.0.clone());
+    let jsonl_path = match cli_type.as_str() {
+        "claude" => resolve_claude_session_path(&effective_cwd, &session_id),
+        "codex" => resolve_codex_session_path(&session_id),
+        _ => return Err(format!("Unknown CLI type: {}", cli_type)),
+    };
+
+    let path = jsonl_path?;
+    if !path.exists() {
+        return Ok(serde_json::json!({ "messages": [], "source": path.display().to_string() }));
+    }
+
+    let content = fs::read_to_string(&path)
+        .map_err(|e| format!("Failed to read session file: {}", e))?;
+
+    let mut messages = Vec::new();
+    for line in content.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        if let Ok(obj) = serde_json::from_str::<serde_json::Value>(line) {
+            if let Some(msg) = extract_message_from_jsonl(&obj, &cli_type) {
+                messages.push(msg);
+            }
+        }
+    }
+
+    Ok(serde_json::json!({
+        "messages": messages,
+        "source": path.display().to_string(),
+        "total": messages.len(),
+    }))
+}
+
+/// Resolve Claude Code session JSONL path.
+/// Claude encodes the cwd in the path: ~/.claude/projects/<hex-encoded-cwd>/<sessionId>.jsonl
+fn resolve_claude_session_path(cwd: &str, session_id: &str) -> Result<PathBuf, String> {
+    let home = dirs::home_dir().ok_or("Cannot determine home directory")?;
+    // Claude Code encodes the cwd as a hex string for the directory name
+    let encoded_cwd = cwd.as_bytes().iter().map(|b| format!("{:02x}", b)).collect::<String>();
+    let path = home
+        .join(".claude")
+        .join("projects")
+        .join(&encoded_cwd)
+        .join(format!("{}.jsonl", session_id));
+    Ok(path)
+}
+
+/// Resolve Codex CLI session JSONL path.
+/// Codex stores sessions at: ~/.codex/sessions/<threadId>.jsonl
+fn resolve_codex_session_path(session_id: &str) -> Result<PathBuf, String> {
+    let home = dirs::home_dir().ok_or("Cannot determine home directory")?;
+    let path = home
+        .join(".codex")
+        .join("sessions")
+        .join(format!("{}.jsonl", session_id));
+    Ok(path)
+}
+
+/// Extract a user/assistant message from a JSONL line object.
+/// Claude: { "role": "user"|"assistant", "content": "..." }
+/// Codex:  { "type": "agentMessage"|"userMessage", "text": "...", "content": [...] }
+fn extract_message_from_jsonl(obj: &serde_json::Value, cli_type: &str) -> Option<serde_json::Value> {
+    match cli_type {
+        "claude" => {
+            let role = obj.get("role")?.as_str()?;
+            if role != "user" && role != "assistant" {
+                return None;
+            }
+            // Content can be string or array of blocks
+            let content = if let Some(s) = obj.get("content").and_then(|v| v.as_str()) {
+                s.to_string()
+            } else if let Some(arr) = obj.get("content").and_then(|v| v.as_array()) {
+                arr.iter()
+                    .filter_map(|block| block.get("text").and_then(|t| t.as_str()))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            } else {
+                return None;
+            };
+            if content.is_empty() {
+                return None;
+            }
+            Some(serde_json::json!({
+                "role": role,
+                "content": content,
+                "timestamp": obj.get("timestamp").and_then(|t| t.as_f64()).unwrap_or(0.0) as u64,
+            }))
+        }
+        "codex" => {
+            let item_type = obj.get("type")?.as_str()?;
+            let (role, text) = match item_type {
+                "userMessage" => {
+                    let content = obj.get("content").and_then(|v| v.as_array())?;
+                    let text: String = content
+                        .iter()
+                        .filter_map(|c| c.get("text").and_then(|t| t.as_str()))
+                        .collect::<Vec<_>>()
+                        .join("\n");
+                    ("user", text)
+                }
+                "agentMessage" => {
+                    let text = obj.get("text").and_then(|t| t.as_str())?.to_string();
+                    ("assistant", text)
+                }
+                _ => return None,
+            };
+            if text.is_empty() {
+                return None;
+            }
+            Some(serde_json::json!({
+                "role": role,
+                "content": text,
+                "timestamp": 0,
+            }))
+        }
+        _ => None,
+    }
 }

--- a/packages/gui/src-tauri/src/commands.rs
+++ b/packages/gui/src-tauri/src/commands.rs
@@ -622,6 +622,16 @@ pub fn read_session_history(
     session_id: String,
     cwd: Option<String>,
 ) -> Result<serde_json::Value, String> {
+    // Validate session_id to prevent path traversal attacks
+    if session_id.contains("..")
+        || session_id.contains('/')
+        || session_id.contains('\\')
+        || session_id.contains('\0')
+        || session_id.is_empty()
+    {
+        return Err(format!("Invalid session ID: {}", session_id));
+    }
+
     let effective_cwd = cwd.unwrap_or_else(|| root.0.clone());
     let jsonl_path = match cli_type.as_str() {
         "claude" => resolve_claude_session_path(&effective_cwd, &session_id),

--- a/packages/gui/src-tauri/src/lib.rs
+++ b/packages/gui/src-tauri/src/lib.rs
@@ -136,6 +136,7 @@ pub fn run() {
             commands::get_context_status,
             commands::list_models,
             commands::set_model,
+            commands::read_session_history,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/packages/gui/src/components/AgentPanel.vue
+++ b/packages/gui/src/components/AgentPanel.vue
@@ -21,7 +21,7 @@ const props = defineProps<{
 }>();
 
 const { agents, getStatus, getSession, getSessionInfo, getWorkDir, setWorkDir, getGitBranch, setGitBranch, clearSession, defaultWorkDir, getModelCache, setModelCache } = useAgentStore();
-const { getMessages, sendPrompt, clearMessages, openSessionPicker, openHistory, archiveSession, newSession, getUserMessageHistory } = useMessageStore();
+const { getMessages, getStreamingState, sendPrompt, clearMessages, openSessionPicker, openHistory, archiveSession, newSession, getUserMessageHistory } = useMessageStore();
 const { approvalMode, pendingCount, openQueue, setMode: setApprovalMode } = useApprovalStore();
 
 const inputText = ref("");
@@ -39,6 +39,7 @@ const sessionId = computed(() => getSession(props.panelKey));
 const sessionInfo = computed(() => getSessionInfo(props.panelKey));
 const sessionTitle = computed(() => sessionInfo.value?.sessionName ?? null);
 const hasLegacyRoleConfig = computed(() => sessionInfo.value?.legacyRoleConfig === true);
+const streaming = computed(() => getStreamingState(props.panelKey));
 const sessionShortId = computed(() => {
   const id = sessionId.value;
   return id ? id.slice(0, 8) : null;
@@ -656,6 +657,19 @@ watch(
           </button>
         </template>
       </div>
+
+      <!-- Streaming zone: real-time token display while agent is generating -->
+      <div v-if="streaming" class="message-row assistant streaming-zone">
+        <span class="msg-avatar assistant-avatar">{{ agentName.charAt(0).toUpperCase() }}</span>
+        <div class="message-bubble assistant-bubble streaming-bubble">
+          <div v-if="streaming.activeTool" class="streaming-tool-label">
+            <span class="tool-indicator">&#9881;</span> {{ streaming.activeTool }}
+            <span v-if="streaming.toolInput" class="tool-input-preview">{{ streaming.toolInput.slice(0, 120) }}</span>
+          </div>
+          <div v-if="streaming.text" class="message-content markdown-body streaming-text" v-html="renderMarkdown(streaming.text)"></div>
+          <span v-if="!streaming.text && !streaming.activeTool" class="streaming-cursor">&#9646;</span>
+        </div>
+      </div>
     </div>
 
     <!-- Pending image previews -->
@@ -1174,6 +1188,58 @@ watch(
   background: rgba(123, 104, 238, 0.06);
   border: 1px solid rgba(123, 104, 238, 0.1);
   border-radius: var(--radius) var(--radius) var(--radius) 2px;
+}
+
+/* Streaming zone — real-time token display */
+.streaming-zone {
+  opacity: 0.9;
+}
+
+.streaming-bubble {
+  border-style: dashed;
+  min-height: 24px;
+}
+
+.streaming-tool-label {
+  font-size: 10px;
+  color: var(--accent);
+  font-family: var(--font-mono);
+  padding: 2px 0 4px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.tool-indicator {
+  animation: spin 2s linear infinite;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.tool-input-preview {
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 300px;
+}
+
+.streaming-text {
+  border-left: 2px solid var(--accent);
+  padding-left: 8px;
+}
+
+.streaming-cursor {
+  display: inline-block;
+  animation: blink 1s step-end infinite;
+  color: var(--accent);
+}
+
+@keyframes blink {
+  50% { opacity: 0; }
 }
 
 /* System messages — centered divider style */

--- a/packages/gui/src/components/AgentPanel.vue
+++ b/packages/gui/src/components/AgentPanel.vue
@@ -509,6 +509,12 @@ watch(
   () => messages.value.length,
   scrollMessagesToBottom,
 );
+
+// Also scroll when streaming text grows (incremental token display)
+watch(
+  () => streaming.value?.text.length ?? 0,
+  scrollMessagesToBottom,
+);
 </script>
 
 <template>
@@ -1240,6 +1246,12 @@ watch(
 
 @keyframes blink {
   50% { opacity: 0; }
+}
+
+/* Respect reduced-motion for streaming animations */
+@media (prefers-reduced-motion: reduce) {
+  .tool-indicator { animation: none; }
+  .streaming-cursor { animation: none; opacity: 1; }
 }
 
 /* System messages — centered divider style */

--- a/packages/gui/src/lib/tauri-bridge.ts
+++ b/packages/gui/src/lib/tauri-bridge.ts
@@ -469,6 +469,19 @@ export async function getSessionMessages(
   });
 }
 
+/** Read native CLI session history from JSONL files (direct filesystem, no sidecar). */
+export async function readSessionHistory(
+  cliType: "claude" | "codex",
+  sessionId: string,
+  cwd?: string,
+): Promise<{ messages: TranscriptMessage[]; source: string; total: number }> {
+  return invoke("read_session_history", {
+    cliType,
+    sessionId,
+    cwd: cwd ?? null,
+  });
+}
+
 // ─── Approval Control Plane ───
 
 export async function getApprovalMode(): Promise<{ mode: ApprovalMode }> {
@@ -530,6 +543,25 @@ export interface AgentStreamEndEvent {
   sessionId: string;
 }
 
+export type AgentStreamingEventKind =
+  | "text_delta"
+  | "tool_start"
+  | "tool_delta"
+  | "tool_end";
+
+/** Incremental streaming event for real-time token display. */
+export interface AgentStreamingEvent {
+  agentId: string;
+  sessionId: string;
+  event: {
+    eventKind: AgentStreamingEventKind;
+    content?: string;
+    toolName?: string;
+    toolInput?: string;
+    timestamp: number;
+  };
+}
+
 export interface AgentWorkingEvent {
   agentId: string;
   sessionId: string;
@@ -560,6 +592,14 @@ export function onAgentStreamEnd(
   handler: (data: AgentStreamEndEvent) => void,
 ): Promise<UnlistenFn> {
   return listen<AgentStreamEndEvent>("agent-stream-end", (event) =>
+    handler(event.payload),
+  );
+}
+
+export function onAgentStreaming(
+  handler: (data: AgentStreamingEvent) => void,
+): Promise<UnlistenFn> {
+  return listen<AgentStreamingEvent>("agent-streaming", (event) =>
     handler(event.payload),
   );
 }

--- a/packages/gui/src/stores/agents.ts
+++ b/packages/gui/src/stores/agents.ts
@@ -426,12 +426,25 @@ async function initAgents() {
         sessionPromptState.value = nextPromptState;
 
         clearSession(panelKey);
-        setStatus(panelKey, "idle");
 
-        // Remove bookmark for non-main sessions to prevent memory leaks
-        // from frequent sub-agent creation over long-running sessions
+        // For non-main sessions, fully remove all panel-level state to prevent
+        // memory growth from frequent sub-agent creation over long-running sessions
         if (role !== "main") {
+          const nextStatuses = new Map(statuses.value);
+          nextStatuses.delete(panelKey);
+          statuses.value = nextStatuses;
+
+          const nextWorkDirs = new Map(workDirs.value);
+          nextWorkDirs.delete(panelKey);
+          workDirs.value = nextWorkDirs;
+
+          const nextBranches = new Map(gitBranches.value);
+          nextBranches.delete(panelKey);
+          gitBranches.value = nextBranches;
+
           removeBookmark(panelKey);
+        } else {
+          setStatus(panelKey, "idle");
         }
         break;
       }

--- a/packages/gui/src/stores/agents.ts
+++ b/packages/gui/src/stores/agents.ts
@@ -418,8 +418,21 @@ async function initAgents() {
     if (event.type === "agent.session.end") {
       for (const [panelKey, sessionId] of sessions.value) {
         if (sessionId !== event.sessionId) continue;
+        const { role } = parsePanelKey(panelKey);
+
+        // Clean up sessionPromptState for this session
+        const nextPromptState = new Map(sessionPromptState.value);
+        nextPromptState.delete(sessionId);
+        sessionPromptState.value = nextPromptState;
+
         clearSession(panelKey);
         setStatus(panelKey, "idle");
+
+        // Remove bookmark for non-main sessions to prevent memory leaks
+        // from frequent sub-agent creation over long-running sessions
+        if (role !== "main") {
+          removeBookmark(panelKey);
+        }
         break;
       }
       return;

--- a/packages/gui/src/stores/messages.ts
+++ b/packages/gui/src/stores/messages.ts
@@ -427,9 +427,8 @@ async function loadSessionHistory(panelKey: string, sessionId: string): Promise<
   }
 
   // Fallback: native CLI JSONL files
-  const { parsePanelKey } = useAgentStore();
   const agentStore = useAgentStore();
-  const { agentId } = parsePanelKey(panelKey);
+  const { agentId } = agentStore.parsePanelKey(panelKey);
   const agent = agentStore.agents.value.find((a) => a.id === agentId);
   const cliType = agent?.cli === "codex" ? "codex" as const : "claude" as const;
 

--- a/packages/gui/src/stores/messages.ts
+++ b/packages/gui/src/stores/messages.ts
@@ -13,12 +13,14 @@ import {
   listSessions as bridgeListSessions,
   resumeSession as bridgeResumeSession,
   getSessionMessages as bridgeGetSessionMessages,
+  readSessionHistory as bridgeReadSessionHistory,
   onAgentMessage,
   onAgentWorking,
   onAgentStreamEnd,
   onAgentError,
+  onAgentStreaming,
 } from "../lib/tauri-bridge";
-import type { SessionListItem, TranscriptMessage } from "../lib/tauri-bridge";
+import type { AgentStreamingEventKind, SessionListItem, TranscriptMessage } from "../lib/tauri-bridge";
 import { useAgentStore } from "./agents";
 
 export interface DisplayMessage {
@@ -29,10 +31,20 @@ export interface DisplayMessage {
   metadata?: Record<string, unknown>;
 }
 
+/** Per-panel streaming state: accumulated text + active tool indicator. */
+export interface StreamingState {
+  text: string;
+  activeTool: string | null;
+  toolInput: string;
+}
+
 const STORAGE_KEY = "mercury:messages";
 const MAX_MESSAGES_PER_PANEL = 200;
 
 const messages = ref<Map<string, DisplayMessage[]>>(new Map());
+
+/** Live streaming content per panel — cleared when stream ends or full message arrives. */
+const streamingState = ref<Map<string, StreamingState>>(new Map());
 
 /** Reverse map: sessionId → panelKey, populated when we get sessionIds back */
 const sessionToPanelKey = new Map<string, string>();
@@ -95,6 +107,42 @@ function loadFromStorage(): void {
 /** Retrieve messages for a specific panel. */
 function getMessages(panelKey: string): DisplayMessage[] {
   return messages.value.get(panelKey) ?? [];
+}
+
+/** Get the current streaming state for a panel (null if not streaming). */
+function getStreamingState(panelKey: string): StreamingState | null {
+  return streamingState.value.get(panelKey) ?? null;
+}
+
+/** Process an incoming streaming event for a panel. */
+function handleStreamingEvent(panelKey: string, eventKind: AgentStreamingEventKind, content?: string, toolName?: string, toolInput?: string) {
+  const current = streamingState.value.get(panelKey) ?? { text: "", activeTool: null, toolInput: "" };
+
+  switch (eventKind) {
+    case "text_delta":
+      current.text += content ?? "";
+      break;
+    case "tool_start":
+      current.activeTool = toolName ?? null;
+      current.toolInput = "";
+      break;
+    case "tool_delta":
+      current.toolInput += toolInput ?? "";
+      break;
+    case "tool_end":
+      current.activeTool = null;
+      current.toolInput = "";
+      break;
+  }
+
+  streamingState.value = new Map(streamingState.value).set(panelKey, { ...current });
+}
+
+/** Clear streaming state for a panel (on stream end or full message arrival). */
+function clearStreamingState(panelKey: string) {
+  const next = new Map(streamingState.value);
+  next.delete(panelKey);
+  streamingState.value = next;
 }
 
 /** Append a message to a panel's history and persist to localStorage. */
@@ -253,9 +301,23 @@ async function initMessageListeners() {
 
   const { setStatus } = useAgentStore();
 
+  await onAgentStreaming((data) => {
+    const panelKey = resolvePanelKey(data.agentId, data.sessionId);
+    if (!panelKey) return;
+    handleStreamingEvent(
+      panelKey,
+      data.event.eventKind,
+      data.event.content,
+      data.event.toolName,
+      data.event.toolInput,
+    );
+  });
+
   await onAgentMessage((data) => {
     const panelKey = resolvePanelKey(data.agentId, data.sessionId);
     if (!panelKey) return;
+    // Clear streaming buffer when a complete message arrives
+    clearStreamingState(panelKey);
     appendMessage(panelKey, {
       role: data.message.role as "user" | "assistant" | "system",
       content: data.message.content,
@@ -274,6 +336,7 @@ async function initMessageListeners() {
   await onAgentStreamEnd((data) => {
     const panelKey = resolvePanelKey(data.agentId, data.sessionId);
     if (!panelKey) return;
+    clearStreamingState(panelKey);
     setStatus(panelKey, "idle");
   });
 
@@ -329,28 +392,64 @@ async function pickSession(sessionId: string): Promise<void> {
 /**
  * Load historical messages from a session into the panel's message store.
  * Clears existing messages and backfills from the backend transcript.
+ *
+ * Strategy: try orchestrator transcript first (get_session_messages), then
+ * fall back to native CLI JSONL files (read_session_history) for sessions
+ * created outside Mercury.
  */
 async function loadSessionHistory(panelKey: string, sessionId: string): Promise<void> {
   // Always clear old messages to prevent cross-session leakage
   clearMessages(panelKey);
 
-  try {
-    const result = await bridgeGetSessionMessages(sessionId);
-    if (!result.messages || result.messages.length === 0) return;
+  // Show loading indicator
+  appendMessage(panelKey, {
+    role: "system",
+    content: "Loading history...",
+    timestamp: Date.now(),
+  });
 
-    // Batch-set all messages in a single reactive update
-    const batch: DisplayMessage[] = result.messages.map((msg) => ({
-      role: msg.role,
-      content: msg.content,
-      timestamp: msg.timestamp,
-      images: msg.images,
-      metadata: msg.metadata,
-    }));
-    setMessages(panelKey, batch);
-  } catch (e) {
-    console.debug("loadSessionHistory: failed to load history", e);
-    // Panel is already cleared — empty state is safe
+  try {
+    // Primary: orchestrator transcript
+    const result = await bridgeGetSessionMessages(sessionId);
+    if (result.messages && result.messages.length > 0) {
+      const batch: DisplayMessage[] = result.messages.map((msg) => ({
+        role: msg.role,
+        content: msg.content,
+        timestamp: msg.timestamp,
+        images: msg.images,
+        metadata: msg.metadata,
+      }));
+      setMessages(panelKey, batch);
+      return;
+    }
+  } catch {
+    // Orchestrator doesn't have this session — try native CLI files
   }
+
+  // Fallback: native CLI JSONL files
+  const { parsePanelKey } = useAgentStore();
+  const agentStore = useAgentStore();
+  const { agentId } = parsePanelKey(panelKey);
+  const agent = agentStore.agents.value.find((a) => a.id === agentId);
+  const cliType = agent?.cli === "codex" ? "codex" as const : "claude" as const;
+
+  try {
+    const nativeResult = await bridgeReadSessionHistory(cliType, sessionId);
+    if (nativeResult.messages && nativeResult.messages.length > 0) {
+      const batch: DisplayMessage[] = nativeResult.messages.map((msg) => ({
+        role: msg.role,
+        content: msg.content,
+        timestamp: msg.timestamp,
+      }));
+      setMessages(panelKey, batch);
+      return;
+    }
+  } catch (e) {
+    console.debug("loadSessionHistory: native CLI history not available", e);
+  }
+
+  // No history found — clear the loading indicator
+  clearMessages(panelKey);
 }
 
 /** Close the session picker modal without selecting a session. */
@@ -505,7 +604,9 @@ function getUserMessageHistory(panelKey: string): string[] {
 export function useMessageStore() {
   return {
     messages,
+    streamingState,
     getMessages,
+    getStreamingState,
     appendMessage,
     clearMessages,
     sendPrompt,

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -1353,6 +1353,11 @@ export class Orchestrator {
       const errorMsg = err instanceof Error ? err.message : String(err);
       this.cancelPendingApprovalsForSession(sessionId, "Session failed while approval was pending");
       this.bus.emit("agent.error", agentId, sessionId, { error: errorMsg });
+      // Ensure frontend streaming state is always closed, even on errors
+      this.transport.sendNotification("agent_stream_end", {
+        agentId,
+        sessionId,
+      });
       this.transport.sendNotification("agent_error", {
         agentId,
         sessionId,

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -6,11 +6,12 @@ import { spawn } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import { copyFile, mkdir, readdir, writeFile, rename, unlink } from "node:fs/promises";
 import { dirname, join, relative, resolve } from "node:path";
-import { EventBus, makeRoleSlotKey } from "@mercury/core";
+import { EventBus, isStreamingEvent, makeRoleSlotKey } from "@mercury/core";
 import type {
   AgentConfig,
   AgentSendHooks,
   AgentRole,
+  AgentStreamingEvent,
   ApprovalDecision,
   ApprovalMode,
   ApprovalRequest,
@@ -1290,7 +1291,25 @@ export class Orchestrator {
     let lastAssistantMessage: AgentMessage | undefined;
 
     try {
-      for await (const message of adapter.sendPrompt(sessionId, prompt, images, hooks)) {
+      for await (const yielded of adapter.sendPrompt(sessionId, prompt, images, hooks)) {
+        // Streaming events are forwarded as lightweight notifications without
+        // persisting to transcript — they represent incremental token content.
+        if (isStreamingEvent(yielded)) {
+          this.transport.sendNotification("agent_streaming", {
+            agentId,
+            sessionId,
+            event: {
+              eventKind: yielded.eventKind,
+              content: yielded.content,
+              toolName: yielded.toolName,
+              toolInput: yielded.toolInput,
+              timestamp: yielded.timestamp,
+            },
+          });
+          continue;
+        }
+
+        const message = yielded as AgentMessage;
         if (message.role === "assistant" && message.content.trim().length > 0) {
           lastAssistantMessage = message;
         }

--- a/packages/sdk-adapters/src/claude-adapter.ts
+++ b/packages/sdk-adapters/src/claude-adapter.ts
@@ -12,11 +12,13 @@
 
 import { randomUUID } from "node:crypto";
 import type {
+  AdapterYield,
   AgentAdapter,
   AgentApprovalRequest,
   AgentConfig,
   AgentMessage,
   AgentSendHooks,
+  AgentStreamingEvent,
   ImageAttachment,
   SessionInfo,
   SlashCommand,
@@ -104,7 +106,7 @@ export class ClaudeAdapter implements AgentAdapter {
   private async *handleSlashCommand(
     sessionId: string,
     prompt: string,
-  ): AsyncGenerator<AgentMessage> {
+  ): AsyncGenerator<AdapterYield> {
     const trimmed = prompt.trim();
     const match = trimmed.match(/^\/(\S+)(?:\s+(.*))?$/);
     if (!match) return; // not a slash command — caller should pass through
@@ -266,7 +268,7 @@ export class ClaudeAdapter implements AgentAdapter {
     prompt: string,
     images?: ImageAttachment[],
     hooks?: AgentSendHooks,
-  ): AsyncGenerator<AgentMessage> {
+  ): AsyncGenerator<AdapterYield> {
     // Intercept slash commands before sending to SDK
     const trimmed = prompt.trim();
     if (trimmed.startsWith("/")) {
@@ -297,6 +299,10 @@ export class ClaudeAdapter implements AgentAdapter {
       permissionMode: "acceptEdits",
       maxTurns: 30,
       cwd,
+      // Enable partial message streaming — yields StreamEvent objects alongside
+      // AssistantMessage/ResultMessage for real-time token display.
+      // Ref: https://platform.claude.com/docs/en/agent-sdk/streaming-output
+      includePartialMessages: true,
     };
 
     if (this.config.model) {
@@ -424,6 +430,53 @@ export class ClaudeAdapter implements AgentAdapter {
       // Capture SDK session ID from init message
       if (msg.type === "system" && msg.subtype === "init" && msg.session_id) {
         sdkSessionId = msg.session_id as string;
+      }
+
+      // Streaming events — incremental content from includePartialMessages: true
+      // Type: SDKPartialAssistantMessage { type: "stream_event", event: RawMessageStreamEvent }
+      // Ref: https://platform.claude.com/docs/en/agent-sdk/streaming-output
+      if (msg.type === "stream_event") {
+        const event = msg.event as Record<string, unknown> | undefined;
+        if (!event) continue;
+
+        const eventType = event.type as string;
+        const now = Date.now();
+
+        if (eventType === "content_block_start") {
+          const contentBlock = event.content_block as Record<string, unknown> | undefined;
+          if (contentBlock?.type === "tool_use") {
+            yield {
+              type: "streaming",
+              eventKind: "tool_start",
+              toolName: contentBlock.name as string,
+              timestamp: now,
+            } satisfies AgentStreamingEvent;
+          }
+        } else if (eventType === "content_block_delta") {
+          const delta = event.delta as Record<string, unknown> | undefined;
+          if (delta?.type === "text_delta") {
+            yield {
+              type: "streaming",
+              eventKind: "text_delta",
+              content: delta.text as string,
+              timestamp: now,
+            } satisfies AgentStreamingEvent;
+          } else if (delta?.type === "input_json_delta") {
+            yield {
+              type: "streaming",
+              eventKind: "tool_delta",
+              toolInput: delta.partial_json as string,
+              timestamp: now,
+            } satisfies AgentStreamingEvent;
+          }
+        } else if (eventType === "content_block_stop") {
+          yield {
+            type: "streaming",
+            eventKind: "tool_end",
+            timestamp: now,
+          } satisfies AgentStreamingEvent;
+        }
+        continue;
       }
 
       // Assistant messages — content is an array of blocks [{text: "..."}, {name: "ToolName"}]

--- a/packages/sdk-adapters/src/claude-adapter.ts
+++ b/packages/sdk-adapters/src/claude-adapter.ts
@@ -414,6 +414,7 @@ export class ClaudeAdapter implements AgentAdapter {
 
     let sdkSessionId: string | undefined;
     let hasYieldedAssistant = false;
+    let inToolBlock = false; // Track whether current content block is a tool_use
 
     // sdk.query() accepts string | AsyncIterable<SDKUserMessage> — both paths converge here
     const queryIter = sdk.query(queryArgs as { prompt: string; options: Record<string, unknown> });
@@ -444,11 +445,12 @@ export class ClaudeAdapter implements AgentAdapter {
 
         if (eventType === "content_block_start") {
           const contentBlock = event.content_block as Record<string, unknown> | undefined;
-          if (contentBlock?.type === "tool_use") {
+          inToolBlock = contentBlock?.type === "tool_use";
+          if (inToolBlock) {
             yield {
               type: "streaming",
               eventKind: "tool_start",
-              toolName: contentBlock.name as string,
+              toolName: contentBlock!.name as string,
               timestamp: now,
             } satisfies AgentStreamingEvent;
           }
@@ -470,11 +472,16 @@ export class ClaudeAdapter implements AgentAdapter {
             } satisfies AgentStreamingEvent;
           }
         } else if (eventType === "content_block_stop") {
-          yield {
-            type: "streaming",
-            eventKind: "tool_end",
-            timestamp: now,
-          } satisfies AgentStreamingEvent;
+          // Only emit tool_end if the ending block was a tool_use.
+          // content_block_stop fires for all block types (text + tool_use).
+          if (inToolBlock) {
+            yield {
+              type: "streaming",
+              eventKind: "tool_end",
+              timestamp: now,
+            } satisfies AgentStreamingEvent;
+            inToolBlock = false;
+          }
         }
         continue;
       }

--- a/packages/sdk-adapters/src/codex-adapter.ts
+++ b/packages/sdk-adapters/src/codex-adapter.ts
@@ -9,11 +9,14 @@ import { randomUUID } from "node:crypto";
 import { readFile, unlink, writeFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
+import { isStreamingEvent } from "@mercury/core";
 import type {
+  AdapterYield,
   AgentAdapter,
   AgentConfig,
   AgentMessage,
   AgentRole,
+  AgentStreamingEvent,
   ImageAttachment,
   SessionInfo,
   SlashCommand,
@@ -31,6 +34,7 @@ import type {
   FileUpdateChange,
   FileChangeApprovalDecision,
   FileChangeRequestApprovalParams,
+  ItemAgentMessageDeltaNotification,
   SandboxMode,
   Thread,
   ThreadListResponse,
@@ -45,7 +49,7 @@ const DEFAULT_APPROVAL_POLICY: AskForApproval = "on-request";
 const DEFAULT_SANDBOX_MODE = "workspace-write";
 const END_OF_STREAM = Symbol("codex-turn-end");
 const NOTIFICATION_OPTOUTS: string[] = [
-  "item/agentMessage/delta",
+  // item/agentMessage/delta is NOT opted out — forwarded as streaming events
   "item/reasoning/textDelta",
   "item/reasoning/summaryTextDelta",
   "item/reasoning/summaryPartAdded",
@@ -77,8 +81,8 @@ interface NativeSession {
 }
 
 class MessageStream {
-  private queue: Array<AgentMessage | Error | typeof END_OF_STREAM> = [];
-  private waiters: Array<(value: AgentMessage | Error | typeof END_OF_STREAM) => void> = [];
+  private queue: Array<AdapterYield | Error | typeof END_OF_STREAM> = [];
+  private waiters: Array<(value: AdapterYield | Error | typeof END_OF_STREAM) => void> = [];
   private ended = false;
   private compactionNotified = false;
   readonly hooks?: LocalAgentSendHooks;
@@ -92,7 +96,7 @@ class MessageStream {
     this.turnId = turnId;
   }
 
-  push(message: AgentMessage): void {
+  push(message: AdapterYield): void {
     if (this.ended) return;
     this.deliver(message);
   }
@@ -115,7 +119,7 @@ class MessageStream {
     this.deliver(END_OF_STREAM);
   }
 
-  async *iterate(): AsyncGenerator<AgentMessage> {
+  async *iterate(): AsyncGenerator<AdapterYield> {
     while (true) {
       const next = await this.next();
       if (next === END_OF_STREAM) return;
@@ -124,7 +128,7 @@ class MessageStream {
     }
   }
 
-  private next(): Promise<AgentMessage | Error | typeof END_OF_STREAM> {
+  private next(): Promise<AdapterYield | Error | typeof END_OF_STREAM> {
     const item = this.queue.shift();
     if (item !== undefined) {
       return Promise.resolve(item);
@@ -134,7 +138,7 @@ class MessageStream {
     });
   }
 
-  private deliver(item: AgentMessage | Error | typeof END_OF_STREAM): void {
+  private deliver(item: AdapterYield | Error | typeof END_OF_STREAM): void {
     const waiter = this.waiters.shift();
     if (waiter) {
       waiter(item);
@@ -211,7 +215,7 @@ export class CodexAdapter implements AgentAdapter {
     prompt: string,
     images?: ImageAttachment[],
     hooks?: LocalAgentSendHooks,
-  ): AsyncGenerator<AgentMessage> {
+  ): AsyncGenerator<AdapterYield> {
     const trimmed = prompt.trim();
     if (trimmed.startsWith("/")) {
       let handled = false;
@@ -406,8 +410,10 @@ export class CodexAdapter implements AgentAdapter {
         stream.finish();
       }
 
-      for await (const message of stream.iterate()) {
-        messages.push(message);
+      for await (const yielded of stream.iterate()) {
+        if (!isStreamingEvent(yielded)) {
+          messages.push(yielded as AgentMessage);
+        }
       }
 
       record.info.lastActiveAt = Date.now();
@@ -739,6 +745,18 @@ export class CodexAdapter implements AgentAdapter {
         if (payload.willRetry) return;
         const turn = this.getTurnStream(payload.threadId, payload.turnId);
         turn?.fail(new Error(payload.error.message));
+        return;
+      }
+      case "item/agentMessage/delta": {
+        const payload = params as unknown as ItemAgentMessageDeltaNotification;
+        const turn = this.getTurnStream(payload.threadId, payload.turnId);
+        if (!turn || !payload.delta) return;
+        turn.push({
+          type: "streaming",
+          eventKind: "text_delta",
+          content: payload.delta,
+          timestamp: Date.now(),
+        } satisfies AgentStreamingEvent);
         return;
       }
       case "item/started":
@@ -1291,7 +1309,7 @@ export class CodexAdapter implements AgentAdapter {
   private async *handleSlashCommand(
     sessionId: string,
     prompt: string,
-  ): AsyncGenerator<AgentMessage> {
+  ): AsyncGenerator<AdapterYield> {
     const trimmed = prompt.trim();
     const match = trimmed.match(/^\/(\S+)(?:\s+(.*))?$/);
     if (!match) return;

--- a/packages/sdk-adapters/src/codex-app-server-types.ts
+++ b/packages/sdk-adapters/src/codex-app-server-types.ts
@@ -448,6 +448,14 @@ export interface ItemStartedNotification {
   turnId: string;
 }
 
+/** Incremental text delta for an agent message being streamed. */
+export interface ItemAgentMessageDeltaNotification {
+  threadId: string;
+  turnId: string;
+  itemId: string;
+  delta: string;
+}
+
 export interface ContextCompactedNotification {
   threadId: string;
   turnId: string;
@@ -492,6 +500,7 @@ export interface CodexAppServerNotificationMap {
   "turn/diff/updated": TurnDiffUpdatedNotification;
   "item/started": ItemStartedNotification;
   "item/completed": ItemCompletedNotification;
+  "item/agentMessage/delta": ItemAgentMessageDeltaNotification;
   "thread/compacted": ContextCompactedNotification;
   "serverRequest/resolved": ServerRequestResolvedNotification;
 }

--- a/packages/sdk-adapters/src/gemini-adapter.ts
+++ b/packages/sdk-adapters/src/gemini-adapter.ts
@@ -19,6 +19,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { spawn } from "node:child_process";
 import type {
+  AdapterYield,
   AgentAdapter,
   AgentConfig,
   AgentMessage,
@@ -105,7 +106,7 @@ export class GeminiAdapter implements AgentAdapter {
   private async *handleSlashCommand(
     sessionId: string,
     prompt: string,
-  ): AsyncGenerator<AgentMessage> {
+  ): AsyncGenerator<AdapterYield> {
     const trimmed = prompt.trim();
     const match = trimmed.match(/^\/(\S+)(?:\s+(.*))?$/);
     if (!match) return;
@@ -283,7 +284,7 @@ export class GeminiAdapter implements AgentAdapter {
     prompt: string,
     images?: ImageAttachment[],
     _hooks?: AgentSendHooks,
-  ): AsyncGenerator<AgentMessage> {
+  ): AsyncGenerator<AdapterYield> {
     // Intercept slash commands
     const trimmed = prompt.trim();
     if (trimmed.startsWith("/")) {

--- a/packages/sdk-adapters/src/opencode-adapter.ts
+++ b/packages/sdk-adapters/src/opencode-adapter.ts
@@ -11,6 +11,7 @@
 import { randomUUID } from "node:crypto";
 import { spawn, type ChildProcess } from "node:child_process";
 import type {
+  AdapterYield,
   AgentAdapter,
   AgentConfig,
   AgentMessage,
@@ -129,7 +130,7 @@ export class OpencodeAdapter implements AgentAdapter {
   private async *handleSlashCommand(
     sessionId: string,
     prompt: string,
-  ): AsyncGenerator<AgentMessage> {
+  ): AsyncGenerator<AdapterYield> {
     const trimmed = prompt.trim();
     const match = trimmed.match(/^\/(\S+)(?:\s+(.*))?$/);
     if (!match) return;
@@ -311,7 +312,7 @@ export class OpencodeAdapter implements AgentAdapter {
     prompt: string,
     images?: ImageAttachment[],
     _hooks?: AgentSendHooks,
-  ): AsyncGenerator<AgentMessage> {
+  ): AsyncGenerator<AdapterYield> {
     // Intercept slash commands before sending to CLI
     const trimmed = prompt.trim();
     if (trimmed.startsWith("/")) {


### PR DESCRIPTION
## Summary

- **A1 — Inline Agent Streaming Display (UI-6)**: End-to-end streaming pipeline from SDK adapters through orchestrator to GUI. Claude SDK uses `includePartialMessages: true` for `content_block_delta` events; Codex app-server forwards `item/agentMessage/delta` notifications. AgentPanel shows real-time text accumulation with tool indicators and cursor animation.

- **A2 — Resume History Backfill (UI-3)**: New Tauri `read_session_history` command reads native CLI JSONL files (Claude `~/.claude/projects/`, Codex `~/.codex/sessions/`) for sessions created outside Mercury. `loadSessionHistory` tries orchestrator transcript first, then falls back to native CLI files.

- **A3 — session.end Cleanup**: Cleans up `sessionPromptState` entries and removes bookmarks for non-main sessions on `agent.session.end`, preventing memory leaks from frequent sub-agent creation.

### Files Changed (16 files, +537/-36)

**Core types**: `AgentStreamingEvent`, `AdapterYield`, `isStreamingEvent()` type guard
**Adapters**: Claude (streaming), Codex (delta forwarding), Gemini/Opencode (type compat)
**Orchestrator**: `streamMessages()` routes streaming vs complete messages
**Rust/Tauri**: `read_session_history` command + `dirs` crate
**Frontend**: `onAgentStreaming` listener, `StreamingState` store, streaming zone UI

## Test plan

- [ ] Verify Claude adapter streaming: send prompt, observe real-time text in streaming zone
- [ ] Verify Codex adapter streaming: send prompt, observe agent message deltas
- [ ] Verify streaming zone clears when full message arrives
- [ ] Verify resume history loads from orchestrator transcript
- [ ] Verify resume fallback reads native Claude JSONL when orchestrator has no transcript
- [ ] Verify session.end removes bookmark for sub-agent sessions
- [ ] Verify session.end cleans sessionPromptState entry
- [ ] Verify no new TypeScript/Rust compile errors beyond pre-existing ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 支持代理增量流式事件（文本增量、工具启动/输入增量/结束），前后端可实时传递与订阅。
  * 增加从本地 CLI 会话读取历史记录的能力，并在界面显示来源与条数。
  * 聊天界面显示实时流式输出行、活动工具及输入预览，自动滚动以跟随生成进度。

* **修复与改进**
  * 在异常情况下保证会话流结束通知被发送，避免前端挂起。
  * 优化会话清理行为，非主面板移除更多关联状态。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->