### PR TITLE
refactor: KB system docs migration + generic framework cleanup

### DIFF
--- a/.mercury/docs/kb-structure.md
+++ b/.mercury/docs/kb-structure.md
@@ -17,3 +17,10 @@ Obsidian vault 命名约定: `{Project}_KB`（如 `Mercury_KB`）。路径由项
 | `archive/` | 已归档制品（过期handoff、旧研究） | Main only |
 
 KB 路径通过 orchestrator 启动配置注入，各 Agent 指令文件中引用相对路径 `{Project}_KB/{子目录}/`。
+
+## 目录编号约定
+
+- `00-09`: 元数据层（导航、注册表、研究、上下文、决策）— `01-registry` 和 `01-research` 共享前缀是有意设计，二者均属「只读参考数据」类别
+- `10-19`: 工作制品层（tasks、issues、acceptances、handoffs）— 由 orchestrator 读写
+- `99`: 模板层（只读参考）
+- `archive/`: 已过期制品归档

--- a/.mercury/docs/kb-structure.md
+++ b/.mercury/docs/kb-structure.md
@@ -4,10 +4,16 @@ Obsidian vault 命名约定: `{Project}_KB`（如 `Mercury_KB`）。路径由项
 
 | 路径 | 内容 | 写权限 |
 |------|------|--------|
+| `00-index/` | 导航、仪表盘、handoff指南、决策索引 | Main only |
+| `01-registry/` | 全局索引、阶段注册表、策略 | Main only |
+| `01-research/` | 研究文档与分析 | Research agent / Main |
+| `02-context/` | 当前session账本、checkpoint、计划 | Main only |
+| `03-decisions/` | 架构决策记录 (ADR) | Main only |
 | `10-tasks/` | TaskBundle JSON | Main 创建, Dev 填 receipt |
 | `11-issues/` | IssueBundle JSON | 任意角色创建, Main triage |
 | `12-acceptances/` | AcceptanceBundle JSON | Main 创建, Acceptance 填结果 |
 | `13-handoff/` | Handoff packets, session context | Main + 发起方 |
 | `99-templates/` | Bundle 模板（只读参考） | Main only |
+| `archive/` | 已归档制品（过期handoff、旧研究） | Main only |
 
-KB 路径通过 orchestrator 启动配置注入，各 Agent 指令文件中引用相对路径 `Mercury_KB/{子目录}/`。
+KB 路径通过 orchestrator 启动配置注入，各 Agent 指令文件中引用相对路径 `{Project}_KB/{子目录}/`。

--- a/.mercury/docs/roles/dev.md
+++ b/.mercury/docs/roles/dev.md
@@ -17,7 +17,7 @@ Read TaskBundle, implement within allowedWriteScope, fill implementationReceipt,
 - Perform Acceptance testing
 - Modify files outside `allowedWriteScope`
 - Modify agent instruction files (CLAUDE.md/AGENTS.md/OPENCODE.md/GEMINI.md)
-- Modify `Mercury_KB/templates/` or `Mercury_KB/acceptances/`
+- Modify `{Project}_KB/99-templates/` or `{Project}_KB/12-acceptances/`
 - Generate intermediate scripts to indirectly write project files
 - `git switch`/`checkout`/`branch -d`/`reset`/`stash`/`rebase`/`merge`
 - `git add -A` or `git add .`

--- a/.mercury/docs/sot-workflow.md
+++ b/.mercury/docs/sot-workflow.md
@@ -20,11 +20,11 @@ Main 创建 Task → 派发
 
 | 步骤 | 角色 | 操作 | 输出 |
 |------|------|------|------|
-| 1. Create | Main | 创建 TaskBundle，保存到 KB | `tasks/TASK-{phase}-{nnn}.json` |
+| 1. Create | Main | 创建 TaskBundle，保存到 KB | `10-tasks/TASK-{phase}-{nnn}.json` |
 | 2. Dispatch | Main | 创建 feature branch，派发给 dev | agent session |
 | 3. Implement | Dev | 在 scope 内实现，填写 receipt | 更新 TaskBundle |
 | 4. Main Review | Main | Receipt 完整性检查 | 更新 mainReview |
-| 5. Acceptance | Acceptance | 盲审，输出 verdict | `acceptances/ACC-{phase}-{nnn}.json` |
+| 5. Acceptance | Acceptance | 盲审，输出 verdict | `12-acceptances/ACC-{phase}-{nnn}.json` |
 | 6. Close/Rework | Main | 关闭 task 或触发 rework | 更新 task + issue 状态 |
 
 ## Issue 登记

--- a/.mercury/docs/sot-workflow.md
+++ b/.mercury/docs/sot-workflow.md
@@ -42,4 +42,4 @@ Main 创建 Task → 派发
 | `session-context.template.json` | Milestone 快照 |
 | `dispatch-prompt.template.md` | 派发 prompt 模板 |
 
-模板位置: `Mercury_KB/99-templates/`
+模板位置: `{Project}_KB/99-templates/`


### PR DESCRIPTION
## Summary
- Migrate Mercury-specific KB docs to archive, generalize framework docs for project-agnostic reuse
- Update `.mercury/docs/` references from hardcoded `Mercury_KB` to `{Project}_KB` placeholders
- Part of Session 6 C-task (KB cleanup), driven by multi-agent research findings

## Changes in this PR (Mercury project)
- `.mercury/docs/sot-workflow.md`: template path → `{Project}_KB/99-templates/`
- `.mercury/docs/kb-structure.md`: complete rewrite with all directories, `{Project}_KB` placeholders
- `.mercury/docs/roles/dev.md`: forbidden paths → `{Project}_KB/99-templates/` and `{Project}_KB/12-acceptances/`

## Changes in Mercury_KB repo (separate commits, already pushed)
- Created `archive/` structure (handoffs, context, research)
- Created `00-index/decisions-index.md` for quick ADR lookup
- Archived 12 expired Mercury-specific files (handoffs + research)
- Generalized all framework docs: README, AI-Handoff-Guide, 6 templates, issue-triage-policy
- Upgraded templates to v2: added complexity, verifyGate, resilience, contextInjection fields
- Updated dispatch-prompt template with execution protocol and escalation rules

## Verification
- Dual-round validation passed (consecutive 2 rounds, 0 issues)
- All JSON templates validated
- No broken references in global-index.json
- No Mercury-specific content in framework docs (grep verified)
- TypeScript code unaffected (all KB paths config-driven)

## Test plan
- [ ] Verify `.mercury/docs/` renders correctly in agent context
- [ ] Confirm orchestrator task dispatch still works with updated paths
- [ ] Verify KB templates are valid and usable for new task creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **文档更新**
  * 标准化知识库顶层目录，新增 00/01/02/03 与 archive 分区并说明写权限标签
  * 将示例路径由固定项目名替换为项目占位符 {Project}_KB/...，提高项目级配置灵活性
  * 新增目录编号约定，说明编号范围与前缀映射
  * 收窄权限规则中禁止修改的模板/验收路径为项目作用域目录
  * 调整 SoT 工作流文档中产出文件的示例输出路径以匹配新的目录约定
<!-- end of auto-generated comment: release notes by coderabbit.ai -->