### PR TITLE
docs(TASK-DOCS-001): core docs refresh post-Codex MCP migration

### DIFF
--- a/.mercury/docs/guides/architecture.md
+++ b/.mercury/docs/guides/architecture.md
@@ -7,7 +7,7 @@
 - **Frontend**: Vue 3 (Tauri 2 desktop app)
 - **Shell**: Rust (Tauri)
 - **Orchestrator**: Node.js sidecar (JSON-RPC 2.0 over stdio)
-- **SDK Adapters**: 包装 Agent CLI (Claude Code, Codex, opencode, Gemini CLI)
+- **SDK Adapters**: 包装 Agent CLI (Claude Code, Codex, opencode, Gemini CLI)。Codex 使用 MCP 协议 (`codex mcp-server`)，其他 adapter 使用各自的 CLI 集成方式
 - **Task Flow**: SoT (Ship of Theseus) orchestration pattern
 
 ## 数据流
@@ -28,7 +28,13 @@ packages/
       role-loader.ts      # 运行时从 YAML 加载角色定义
       role-prompt-builder.ts  # 生成 role-scoped system prompt
       task-manager.ts     # TaskBundle 状态机 + 基于模板的 prompt 构建
-  sdk-adapters/       # Agent CLI wrappers
+  sdk-adapters/       # Agent CLI adapters
+    src/
+      claude-adapter.ts       # Claude Code CLI adapter
+      codex-mcp-adapter.ts    # Codex MCP adapter (via codex mcp-server)
+      codex-mcp-transport.ts  # Codex MCP transport layer
+      gemini-adapter.ts       # Gemini CLI adapter
+      opencode-adapter.ts     # opencode CLI adapter
   core/               # Shared TypeScript types (RoleCard interface, AgentRole)
 ```
 

--- a/.mercury/docs/guides/git-flow.md
+++ b/.mercury/docs/guides/git-flow.md
@@ -32,7 +32,7 @@ Both `develop` and `master` have branch protection rules enabled:
 | Required approving reviews | 1 | 1 |
 | Dismiss stale reviews | Yes | Yes |
 
-PRs must receive at least one approved review (typically CodeRabbit) before merging.
+PRs must receive at least one approved review (from CodeRabbit or an authorized human reviewer) before merging.
 
 ## Commit Format
 

--- a/.mercury/docs/guides/git-flow.md
+++ b/.mercury/docs/guides/git-flow.md
@@ -22,6 +22,18 @@
 
 **Direct push to develop is forbidden.** All code enters develop through PRs.
 
+## Branch Protection (GitHub)
+
+Both `develop` and `master` have branch protection rules enabled:
+
+| Rule | develop | master |
+|------|---------|--------|
+| Require PR before merge | Yes | Yes |
+| Required approving reviews | 1 | 1 |
+| Dismiss stale reviews | Yes | Yes |
+
+PRs must receive at least one approved review (typically CodeRabbit) before merging.
+
 ## Commit Format
 
 `{type}({task_id}): {summary}`

--- a/.mercury/docs/guides/sot-workflow.md
+++ b/.mercury/docs/guides/sot-workflow.md
@@ -24,6 +24,7 @@ drafted → dispatched → in_progress → implementation_done → main_review �
                             └────────────── rework ──────────────┘              |
                             ↑                                                   |
                             └──────────────── rework ───────────────────────────┘
+                       in_progress → blocked (when blocked)
                        blocked → in_progress (after unblock)
                        failed (terminal)
 ```

--- a/.mercury/docs/guides/sot-workflow.md
+++ b/.mercury/docs/guides/sot-workflow.md
@@ -16,6 +16,18 @@ Main 创建 Task → 派发
 
 **Issue 和 Task 是独立实体**：Issue 记录"发生了什么"，Task 记录"要做什么"。
 
+## Task 状态机
+
+```text
+drafted → dispatched → in_progress → implementation_done → main_review → acceptance → verified → closed
+                            ↑                                    |              |
+                            └────────────── rework ──────────────┘              |
+                            ↑                                                   |
+                            └──────────────── rework ───────────────────────────┘
+                       blocked → in_progress (after unblock)
+                       failed (terminal)
+```
+
 ## Task 执行流程
 
 | 步骤 | 角色 | 操作 | 输出 |

--- a/.mercury/docs/guides/sot-workflow.md
+++ b/.mercury/docs/guides/sot-workflow.md
@@ -18,16 +18,46 @@ Main 创建 Task → 派发
 
 ## Task 状态机
 
-```text
-drafted → dispatched → in_progress → implementation_done → main_review → acceptance → verified → closed
-                            ↑                                    |              |
-                            └────────────── rework ──────────────┘              |
-                            ↑                                                   |
-                            └──────────────── rework ───────────────────────────┘
-                       in_progress → blocked (when blocked)
-                       blocked → in_progress (after unblock)
-                       failed (terminal)
+> 代码实现: `packages/orchestrator/src/task-manager.ts` — `VALID_TRANSITIONS` 常量
+
+```mermaid
+stateDiagram-v2
+    [*] --> drafted
+    drafted --> dispatched
+    dispatched --> in_progress
+    in_progress --> implementation_done
+    implementation_done --> main_review
+    main_review --> acceptance
+    main_review --> in_progress : rework
+    acceptance --> verified
+    acceptance --> in_progress : rework
+    verified --> closed
+    closed --> [*]
+
+    in_progress --> blocked : when blocked
+    in_progress --> failed : unrecoverable
+    blocked --> in_progress : after unblock
+    blocked --> failed : unrecoverable
+
+    failed --> [*]
 ```
+
+**转换说明**:
+
+| 转换 | 触发方式 | 说明 |
+|------|----------|------|
+| `drafted → dispatched` | Main 派发 | 创建分支，发送 dispatch prompt |
+| `dispatched → in_progress` | 系统自动 | Dev agent 开始执行 |
+| `in_progress → implementation_done` | Dev 提交 receipt | Dev 填写 implementationReceipt |
+| `implementation_done → main_review` | 系统自动 | 进入 Main 审核队列 |
+| `main_review → acceptance` | Main 人工审核 | Receipt 完整性检查通过 |
+| `main_review → in_progress` | Main 人工审核 | Rework: receipt 不完整或实现有误 |
+| `acceptance → verified` | Acceptance 盲审 | Verdict: pass |
+| `acceptance → in_progress` | Acceptance 盲审 | Rework: verdict fail/partial |
+| `verified → closed` | Main 关闭 | 合并 PR，归档 |
+| `in_progress → blocked` | Dev/Main 标记 | 外部依赖阻塞 |
+| `blocked → in_progress` | Main 解除阻塞 | 阻塞条件消除 |
+| `in_progress/blocked → failed` | Main 标记 | 不可恢复的失败（终态） |
 
 ## Task 执行流程
 


### PR DESCRIPTION
## Summary

- **architecture.md**: Updated SDK Adapters description to reflect Codex MCP adapter migration (`codex mcp-server`), added detailed adapter file listing replacing generic "Agent CLI wrappers"
- **git-flow.md**: Added Branch Protection section documenting GitHub rules (both `develop` and `master` require 1 approved review, dismiss stale reviews)
- **sot-workflow.md**: Added explicit Task state machine diagram matching `task-manager.ts` implementation (states: drafted → dispatched → in_progress → implementation_done → main_review → acceptance → verified → closed, plus blocked/failed)
- **kb-structure.md**: Verified clean — no `specs` field references found, no changes needed

## Verification

| Doc | Check | Result |
|-----|-------|--------|
| architecture.md | Codex MCP adapter files exist | codex-mcp-adapter.ts + codex-mcp-transport.ts confirmed |
| architecture.md | Old app-server files deleted | codex-adapter.ts, codex-app-server-*.ts not found |
| git-flow.md | Branch protection rules | Verified via `gh api` — both branches require 1 approved review |
| kb-structure.md | specs field removed | No references found in kb-structure.md |
| sot-workflow.md | State machine matches code | Verified against task-manager.ts state transitions |

## Test plan

- [ ] Review each doc change against the actual codebase state
- [ ] Verify no stale references to old Codex app-server architecture remain in guides

🤖 Generated with [Claude Code](https://claude.com/claude-code)