### PR TITLE
feat(TASK-CRITIC-001): Critic Agent spec-driven verification layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,5 +50,8 @@ CLAUDE.md
 .mercury/sessions.json
 .mercury/transcripts/
 .mercury/backups/
+.mercury/mercury.db
+.mercury/mercury.db-wal
+.mercury/mercury.db-shm
 mercury.config.json
 .claude/current-session.md

--- a/.mercury/roles/critic.yaml
+++ b/.mercury/roles/critic.yaml
@@ -1,0 +1,61 @@
+role: critic
+description: "Spec-driven verifier: validates implementation against Definition of Done checklist."
+canExecuteCode: true
+canDelegateToRoles: []
+inputBoundary:
+  - TaskBundle (definitionOfDone, codeScope, context)
+  - git diff (code changes)
+  - pre-check results (build, lint, test)
+outputBoundary:
+  - CriticResult (per-item verdict with evidence)
+instructions: |
+  # Role: Critic Agent
+
+  ## Responsibility
+  Independent spec-driven verification. For each item in the Definition of Done,
+  verify whether the implementation satisfies it. Use a different analytical
+  perspective than the dev agent (who implemented) or the main agent (who reviewed).
+
+  ## Verification Protocol
+  For each DoD item:
+  1. **Parse** — understand what the DoD item requires
+  2. **Locate** — find the relevant code changes in the diff
+  3. **Verify** — check if the implementation satisfies the requirement
+  4. **Evidence** — cite specific file:line or test output as proof
+  5. **Verdict** — PASS / FAIL / PARTIAL / SKIP (if not verifiable from code alone)
+
+  ## Allowed Actions
+  - Read TaskBundle fields: definitionOfDone, context, codeScope, requiredEvidence
+  - Read git diff and pre-check results
+  - Execute code, run tests, inspect build output
+  - Read changed files for verification
+
+  ## Forbidden Actions
+  - Read dev agent's conversation or reasoning
+  - Modify source code or create commits
+  - Create new Tasks or Issues
+  - Communicate directly with dev agent
+  - Override main_review decision
+
+  ## Model Separation
+  This role MUST be assigned to a different model than the dev agent to avoid
+  self-congratulation bias. If dev used claude-sonnet, critic should use
+  claude-haiku or a different provider.
+
+  ## Output Format
+  ```json
+  {
+    "overallVerdict": "pass|partial|fail",
+    "completeness": 0.0-1.0,
+    "items": [
+      {
+        "dodItem": "the DoD checklist item text",
+        "verdict": "pass|fail|partial|skip",
+        "evidence": "file:line or test output citation",
+        "detail": "explanation of verification result"
+      }
+    ],
+    "blockers": ["critical issues that must be fixed"],
+    "suggestions": ["optional improvements"]
+  }
+  ```

--- a/.mercury/roles/main.yaml
+++ b/.mercury/roles/main.yaml
@@ -4,6 +4,7 @@ canExecuteCode: false
 canDelegateToRoles:
   - dev
   - acceptance
+  - critic
   - research
   - design
 inputBoundary:

--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.76",
     "@openai/codex-sdk": "^0.114.0"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": ["better-sqlite3"]
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,5 @@
 export { EventBus } from "./event-bus.js";
-export { ROLE_CARDS, makeRoleSlotKey, parseRoleSlotKey, isStreamingEvent } from "./types.js";
+export { ROLE_CARDS, makeRoleSlotKey, parseRoleSlotKey, isStreamingEvent, normalizePriority } from "./types.js";
 export type {
   AcceptanceBundle,
   AcceptanceVerdict,
@@ -39,5 +39,6 @@ export type {
   SlashCommandArg,
   TaskAssignee,
   TaskBundle,
+  TaskPriority,
   TaskStatus,
 } from "./types.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,10 @@ export { ROLE_CARDS, makeRoleSlotKey, parseRoleSlotKey, isStreamingEvent, normal
 export type {
   AcceptanceBundle,
   AcceptanceVerdict,
+  CriticItemResult,
+  CriticItemVerdict,
+  CriticResult,
+  CriticVerdict,
   AdapterYield,
   AgentAdapter,
   AgentApprovalRequest,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -10,7 +10,7 @@
 
 // ─── Agent Identity ───
 
-export type AgentRole = "main" | "dev" | "acceptance" | "research" | "design";
+export type AgentRole = "main" | "dev" | "acceptance" | "critic" | "research" | "design";
 
 export type IntegrationType = "sdk" | "mcp" | "http" | "pty" | "rpc";
 
@@ -193,6 +193,7 @@ export type EventType =
   | "orchestrator.session.handoff"
   | "orchestrator.task.main_review"
   | "orchestrator.task.callback"
+  | "orchestrator.critic.result"
   | "orchestrator.scope.violation"
   | "human.intervention";
 
@@ -325,6 +326,13 @@ export interface TaskBundle {
     reviewedAt?: number;
   };
 
+  // Critic review (spec-driven verification, parallel to main_review)
+  criticReview?: {
+    result?: CriticResult;
+    reviewedAt?: number;
+    criticAgent?: string; // agentId of the critic
+  };
+
   // Dispatch retry tracking
   dispatchAttempts: number;
   maxDispatchAttempts: number;
@@ -392,6 +400,28 @@ export interface AcceptanceBundle {
     recommendations: string[];
   };
   completedAt?: number;
+}
+
+// ─── Critic Result ───
+
+export type CriticVerdict = "pass" | "partial" | "fail";
+export type CriticItemVerdict = "pass" | "fail" | "partial" | "skip";
+
+/** Per-item verification result from the Critic Agent. */
+export interface CriticItemResult {
+  dodItem: string;
+  verdict: CriticItemVerdict;
+  evidence: string;
+  detail: string;
+}
+
+/** Structured output from the Critic Agent's spec-driven verification. */
+export interface CriticResult {
+  overallVerdict: CriticVerdict;
+  completeness: number; // 0.0 – 1.0
+  items: CriticItemResult[];
+  blockers: string[];
+  suggestions: string[];
 }
 
 // ─── Issue Bundle ───

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -216,6 +216,8 @@ export interface TaskAssignee {
   sessionId?: string; // populated when task is dispatched
 }
 
+export type TaskPriority = "P0" | "P1" | "P2" | "P3";
+
 export type TaskStatus =
   | "drafted"
   | "dispatched"
@@ -227,6 +229,16 @@ export type TaskStatus =
   | "closed"
   | "failed"
   | "blocked";
+
+/** Normalize legacy priority formats (sev-0..sev-3) to canonical P0..P3. */
+export function normalizePriority(raw: string): TaskPriority {
+  const map: Record<string, TaskPriority> = {
+    "sev-0": "P0", "sev-1": "P1", "sev-2": "P2", "sev-3": "P3",
+    "P0": "P0", "P1": "P1", "P2": "P2", "P3": "P3",
+    "p0": "P0", "p1": "P1", "p2": "P2", "p3": "P3",
+  };
+  return map[raw] ?? "P3";
+}
 
 export interface PreCheckConfig {
   name: string;
@@ -275,7 +287,7 @@ export interface TaskBundle {
   taskId: string;
   title: string;
   phaseId?: string;
-  priority: "sev-0" | "sev-1" | "sev-2" | "sev-3";
+  priority: TaskPriority;
   status: TaskStatus;
   createdAt?: string; // ISO 8601, set by TaskManager when task is created (optional for legacy compat)
   closedAt: string | null; // ISO 8601, set by TaskManager when status → closed/verified
@@ -391,7 +403,7 @@ export interface IssueBundle {
   title: string;
   status: "open" | "resolved" | "deferred";
   type: IssueType;
-  priority: "sev-0" | "sev-1" | "sev-2" | "sev-3";
+  priority: TaskPriority;
   source: {
     reporterType: AgentRole;
     reporterId: string;

--- a/packages/gui/src-tauri/src/sidecar.rs
+++ b/packages/gui/src-tauri/src/sidecar.rs
@@ -40,7 +40,13 @@ impl SidecarManager {
             c
         };
 
-        cmd.current_dir(&project_dir)
+        // Force UTF-8 encoding to prevent codepage 936/GBK garbling on CJK Windows.
+        // LANG/LC_ALL: effective on Unix; NODE_ICU_DATA + CHCP side: handled by Node.js W1/W2.
+        // PYTHONIOENCODING: protects any Python subprocess spawned downstream.
+        cmd.env("LANG", "en_US.UTF-8")
+            .env("LC_ALL", "en_US.UTF-8")
+            .env("PYTHONIOENCODING", "utf-8")
+            .current_dir(&project_dir)
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped());

--- a/packages/gui/src/components/TaskDashboard.vue
+++ b/packages/gui/src/components/TaskDashboard.vue
@@ -50,7 +50,7 @@ function statusColor(status: TaskStatus): string {
   return STATUS_LABELS.find((s) => s.status === status)?.color ?? "var(--text-muted)";
 }
 
-/** Convert a priority slug (e.g. "sev-1") to an uppercase display label. */
+/** Convert a priority slug (e.g. "P1") to an uppercase display label. */
 function priorityLabel(p: string): string {
   return p.toUpperCase();
 }
@@ -364,10 +364,10 @@ async function handleCreateAcceptance(taskId: string) {
   border-radius: 3px;
 }
 
-.task-priority.sev-0 { background: rgba(255, 82, 82, 0.2); color: var(--accent-error); }
-.task-priority.sev-1 { background: rgba(251, 146, 60, 0.2); color: #fb923c; }
-.task-priority.sev-2 { background: rgba(250, 204, 21, 0.2); color: #facc15; }
-.task-priority.sev-3 { background: rgba(148, 163, 184, 0.2); color: var(--text-muted); }
+.task-priority.P0 { background: rgba(255, 82, 82, 0.2); color: var(--accent-error); }
+.task-priority.P1 { background: rgba(251, 146, 60, 0.2); color: #fb923c; }
+.task-priority.P2 { background: rgba(250, 204, 21, 0.2); color: #facc15; }
+.task-priority.P3 { background: rgba(148, 163, 184, 0.2); color: var(--text-muted); }
 
 .empty-state {
   display: flex;

--- a/packages/gui/src/lib/tauri-bridge.ts
+++ b/packages/gui/src/lib/tauri-bridge.ts
@@ -208,7 +208,7 @@ export async function updateConfig(
 
 // ─── Task Orchestration Operations ───
 
-export type TaskPriority = "sev-0" | "sev-1" | "sev-2" | "sev-3";
+export type TaskPriority = "P0" | "P1" | "P2" | "P3";
 /** Task lifecycle status. SYNC: mirrors @mercury/core TaskStatus. */
 export type TaskStatus =
   | "drafted" | "dispatched" | "in_progress" | "implementation_done"

--- a/packages/orchestrator/package.json
+++ b/packages/orchestrator/package.json
@@ -8,10 +8,12 @@
     "@mercury/core": "workspace:*",
     "@mercury/sdk-adapters": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.27.1",
+    "better-sqlite3": "12.8.0",
     "js-yaml": "^4.1.1",
     "zod": "^4.0.0"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "7.6.13",
     "@types/js-yaml": "^4.0.9"
   }
 }

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -5,6 +5,11 @@
  * Communicates via JSON-RPC 2.0 over stdin/stdout.
  */
 
+// ─── Force UTF-8 on stdio (defense against Windows codepage 936/GBK) ───
+process.stdin.setEncoding("utf-8");
+process.stdout.setDefaultEncoding("utf-8");
+process.stderr.setDefaultEncoding("utf-8");
+
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, isAbsolute, resolve } from "node:path";

--- a/packages/orchestrator/src/mcp-server.ts
+++ b/packages/orchestrator/src/mcp-server.ts
@@ -153,7 +153,7 @@ export function createMcpServer(orchestrator: Orchestrator, transport: RpcTransp
     "Create a new TaskBundle", {
       taskId: taskId.optional().describe("Custom task ID (auto-generated if omitted)"),
       title: z.string().describe("Short task title"),
-      priority: z.string().optional().describe("sev-0 | sev-1 | sev-2 | sev-3"),
+      priority: z.string().optional().describe("P0 | P1 | P2 | P3"),
       assignedTo: agentId.describe("Agent to assign the task to"),
       description: z.string().optional().describe("Detailed task description"),
       context: z.string().describe("Task context for dev agent"),
@@ -228,7 +228,7 @@ export function createMcpServer(orchestrator: Orchestrator, transport: RpcTransp
     "Create a new issue (params passed to CreateIssueParams)", {
       title: z.string().describe("Issue title"),
       type: z.string().describe("bug | enhancement | task"),
-      priority: z.string().describe("sev-0 | sev-1 | sev-2 | sev-3"),
+      priority: z.string().describe("P0 | P1 | P2 | P3"),
       description: z.string().describe("Issue description"),
       source: z.string().optional().describe("Source context"),
       linkedTaskIds: z.array(z.string()).optional().describe("Related task IDs"),

--- a/packages/orchestrator/src/mcp-server.ts
+++ b/packages/orchestrator/src/mcp-server.ts
@@ -222,6 +222,30 @@ export function createMcpServer(orchestrator: Orchestrator, transport: RpcTransp
       }).describe("Acceptance results object"),
     });
 
+  // ─── Critic Verification ───
+
+  rpcTool(server, orchestrator, "get_critic_prompt",
+    "Generate the critic verification prompt for a task (spec-driven DoD validation)", {
+      taskId,
+    });
+
+  rpcTool(server, orchestrator, "record_critic_result",
+    "Record the critic agent's verification result on a task", {
+      taskId,
+      result: z.object({
+        overallVerdict: z.string().describe("pass | partial | fail"),
+        completeness: z.number().describe("0.0 – 1.0"),
+        items: z.array(z.object({
+          dodItem: z.string(),
+          verdict: z.string().describe("pass | fail | partial | skip"),
+          evidence: z.string(),
+          detail: z.string(),
+        })),
+        blockers: z.array(z.string()),
+        suggestions: z.array(z.string()),
+      }).describe("Critic verification result"),
+    });
+
   // ─── Issue Management ───
 
   rpcTool(server, orchestrator, "create_issue",

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -4,6 +4,7 @@
 
 import { spawn } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
+import { mkdirSync } from "node:fs";
 import { copyFile, mkdir, readdir, writeFile, rename, unlink } from "node:fs/promises";
 import { dirname, join, relative, resolve } from "node:path";
 import { EventBus, isStreamingEvent, makeRoleSlotKey } from "@mercury/core";
@@ -41,6 +42,8 @@ import {
 } from "./task-manager.js";
 import type { CreateTaskParams, CreateIssueParams } from "./task-manager.js";
 import { TaskPersistenceKB } from "./task-persistence-kb.js";
+import { TaskPersistenceSqlite } from "./task-persistence-sqlite.js";
+import { TaskPersistenceDual } from "./task-persistence-dual.js";
 import {
   buildRoleSystemPrompt,
   buildAcceptanceRolePrompt,
@@ -105,6 +108,7 @@ export class Orchestrator {
     }
   >();
   private kb: KnowledgeService | null = null;
+  private sqliteDb: TaskPersistenceSqlite | null = null;
   private projectConfig: MercuryConfig | null = null;
   private configFilePath: string | null = null;
   private taskManager: TaskManager;
@@ -140,14 +144,29 @@ export class Orchestrator {
     });
   }
 
-  /** Inject optional knowledge service + wire up task persistence. */
+  /** Inject optional knowledge service + wire up task persistence (with optional SQLite dual-write). */
   setKnowledgeService(kb: KnowledgeService) {
     this.kb = kb;
-    // Wire KB persistence into TaskManager
-    const persistence = new TaskPersistenceKB(kb, (msg) =>
-      this.transport.sendNotification("log", { message: msg }),
-    );
-    this.taskManager.setPersistence(persistence);
+    const logFn = (msg: string) => this.transport.sendNotification("log", { message: msg });
+
+    // KB persistence (always available as secondary / fallback)
+    const kbPersistence = new TaskPersistenceKB(kb, logFn);
+
+    // Try to initialize SQLite as primary persistence with dual-write to KB
+    try {
+      const mercuryDir = join(this.getProjectRoot(), ".mercury");
+      try { mkdirSync(mercuryDir, { recursive: true }); } catch { /* already exists */ }
+      const dbPath = join(mercuryDir, "mercury.db");
+      this.sqliteDb = new TaskPersistenceSqlite(dbPath, logFn);
+      const dualPersistence = new TaskPersistenceDual(this.sqliteDb, kbPersistence, logFn);
+      this.taskManager.setPersistence(dualPersistence);
+      logFn("[orchestrator] Persistence: SQLite (primary) + KB (sync)");
+    } catch (err) {
+      // Fallback to KB-only if SQLite fails to initialize
+      logFn(`[orchestrator] SQLite init failed, falling back to KB-only: ${err instanceof Error ? err.message : err}`);
+      this.taskManager.setPersistence(kbPersistence);
+    }
+
     // Wire agent config lookup for Agents First assignee.model
     this.taskManager.setAgentConfigLookup((agentId) =>
       this.registry.listAgents().find((a) => a.id === agentId),
@@ -165,6 +184,23 @@ export class Orchestrator {
   async init(): Promise<void> {
     this.syncRTKCommandWrapper();
     await this.validateRTKConfiguration();
+
+    // If SQLite is empty and KB has data, do one-time migration
+    if (this.sqliteDb?.isEmpty() && this.kb) {
+      try {
+        const logFn = (msg: string) => this.transport.sendNotification("log", { message: msg });
+        const kbOnly = new TaskPersistenceKB(this.kb, logFn);
+        const kbData = await kbOnly.loadAll();
+        if (kbData.tasks.length > 0 || kbData.issues.length > 0 || kbData.acceptances.length > 0) {
+          logFn(`[orchestrator] Migrating KB data to SQLite (${kbData.tasks.length} tasks, ${kbData.issues.length} issues, ${kbData.acceptances.length} acceptances)`);
+          this.sqliteDb.importFromKB(kbData);
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        this.transport.sendNotification("log", { message: `[orchestrator] KB→SQLite migration failed: ${msg}` });
+      }
+    }
+
     await this.taskManager.init();
     await this.restoreSessions();
     // Build and inject shared context from KB if autoInjectContext is enabled

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -39,6 +39,7 @@ import {
   buildAcceptancePrompt,
   buildReworkPrompt,
   buildMainReviewPrompt,
+  buildCriticPrompt,
 } from "./task-manager.js";
 import type { CreateTaskParams, CreateIssueParams } from "./task-manager.js";
 import { TaskPersistenceKB } from "./task-persistence-kb.js";
@@ -662,6 +663,13 @@ export class Orchestrator {
           params.decision as string,
           (params.reason as string | null) ?? undefined,
           (params.acceptorId as string | null) ?? undefined,
+        );
+      case "get_critic_prompt":
+        return this.getCriticPrompt(params.taskId as string);
+      case "record_critic_result":
+        return this.recordCriticResult(
+          params.taskId as string,
+          params.result as import("@mercury/core").CriticResult,
         );
       case "create_acceptance":
         return this.createAcceptanceFlow(
@@ -2530,6 +2538,39 @@ export class Orchestrator {
     }
 
     throw new Error(`Invalid review decision: "${decision}". Expected APPROVE_FOR_ACCEPTANCE or SEND_BACK.`);
+  }
+
+  // ─── Critic Agent Integration ───
+
+  /** Generate the critic verification prompt for a task. */
+  private getCriticPrompt(taskId: string): { prompt: string } {
+    const task = this.taskManager.getTask(taskId);
+    if (!task) throw new Error(`Task not found: ${taskId}`);
+    if (task.status !== "main_review" && task.status !== "implementation_done") {
+      throw new Error(`Task ${taskId} is not in reviewable state (current: ${task.status})`);
+    }
+    const prompt = buildCriticPrompt(task, this.getProjectRoot());
+    return { prompt };
+  }
+
+  /** Record the critic agent's verification result on a task. */
+  private recordCriticResult(
+    taskId: string,
+    result: import("@mercury/core").CriticResult,
+  ): { recorded: true; overallVerdict: string } {
+    this.taskManager.updateTaskField(taskId, "criticReview", {
+      result,
+      reviewedAt: Date.now(),
+    });
+
+    this.bus.emit("orchestrator.critic.result", "orchestrator", "", {
+      taskId,
+      overallVerdict: result.overallVerdict,
+      completeness: result.completeness,
+      blockerCount: result.blockers.length,
+    });
+
+    return { recorded: true, overallVerdict: result.overallVerdict };
   }
 
   /** Find an agent with the "acceptance" role. */

--- a/packages/orchestrator/src/rpc-transport.ts
+++ b/packages/orchestrator/src/rpc-transport.ts
@@ -90,14 +90,14 @@ export class RpcTransport {
 
   sendNotification(method: string, params: Record<string, unknown>): void {
     const msg: RpcNotification = { jsonrpc: "2.0", method, params };
-    process.stdout.write(JSON.stringify(msg) + "\n");
+    process.stdout.write(JSON.stringify(msg) + "\n", "utf-8");
   }
 
   private sendResponse(response: RpcResponse): void {
-    process.stdout.write(JSON.stringify(response) + "\n");
+    process.stdout.write(JSON.stringify(response) + "\n", "utf-8");
   }
 
   log(message: string): void {
-    process.stderr.write(`[orchestrator] ${message}\n`);
+    process.stderr.write(`[orchestrator] ${message}\n`, "utf-8");
   }
 }

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -1039,3 +1039,95 @@ export function buildMainReviewPrompt(task: TaskBundle): string {
 
   return lines.join("\n");
 }
+
+/** Build the Critic Agent verification prompt — spec-driven DoD validation. */
+export function buildCriticPrompt(task: TaskBundle, _projectRoot?: string): string {
+  const lines: string[] = [];
+
+  lines.push(`# Critic Verification: ${task.title} [${task.taskId}]`);
+  lines.push("");
+
+  // Definition of Done — the "spec" to verify against
+  lines.push("## Definition of Done (verify each item)");
+  for (const [i, item] of task.definitionOfDone.entries()) {
+    lines.push(`${i + 1}. ${item}`);
+  }
+  lines.push("");
+
+  // Task context
+  lines.push("## Task Context");
+  lines.push(task.context || "(no context provided)");
+  lines.push("");
+
+  // Code scope
+  lines.push("## Code Scope");
+  lines.push("```json");
+  lines.push(JSON.stringify(task.codeScope, null, 2));
+  lines.push("```");
+  lines.push("");
+
+  // Pre-check results (if available)
+  if (task.mainReview?.preChecks?.length) {
+    lines.push("## Pre-Check Results");
+    for (const pc of task.mainReview.preChecks) {
+      const icon = pc.success ? "PASS" : "FAIL";
+      lines.push(`- [${icon}] ${pc.name}: exit=${pc.exitCode}, ${pc.durationMs}ms`);
+      if (!pc.success && pc.stdout) {
+        lines.push("  ```");
+        lines.push("  " + truncate(pc.stdout, 500));
+        lines.push("  ```");
+      }
+    }
+    lines.push("");
+  }
+
+  // Git diff (if available)
+  if (task.mainReview?.gitDiff) {
+    lines.push("## Git Diff");
+    lines.push("```diff");
+    lines.push(sanitizeFenceContent(truncate(task.mainReview.gitDiff, MAX_DIFF_CHARS)));
+    lines.push("```");
+    lines.push("");
+  }
+
+  // Changed files list from receipt
+  if (task.implementationReceipt?.changedFiles?.length) {
+    lines.push("## Changed Files");
+    for (const f of task.implementationReceipt.changedFiles) {
+      lines.push(`- ${f}`);
+    }
+    lines.push("");
+  }
+
+  // Instructions
+  lines.push("## Instructions");
+  lines.push("");
+  lines.push("For EACH Definition of Done item above:");
+  lines.push("1. Locate the relevant code changes in the diff");
+  lines.push("2. Verify the implementation satisfies the requirement");
+  lines.push("3. Cite specific evidence (file:line or test output)");
+  lines.push("4. Assign a verdict: pass / fail / partial / skip");
+  lines.push("");
+  lines.push("Return your result as JSON:");
+  lines.push("```json");
+  lines.push(JSON.stringify({
+    overallVerdict: "pass|partial|fail",
+    completeness: 0.85,
+    items: [
+      {
+        dodItem: "the DoD checklist item text",
+        verdict: "pass|fail|partial|skip",
+        evidence: "file:line or test output citation",
+        detail: "explanation of verification result",
+      },
+    ],
+    blockers: ["critical issues that must be fixed"],
+    suggestions: ["optional improvements"],
+  }, null, 2));
+  lines.push("```");
+  lines.push("");
+  lines.push("Any item with verdict `fail` should appear in `blockers`.");
+  lines.push("Set `overallVerdict` to `fail` if any blocker exists, `partial` if any item is partial/skip, `pass` if all pass.");
+
+  return lines.join("\n");
+}

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -9,6 +9,7 @@ import { randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import type { EventBus } from "@mercury/core";
+import { normalizePriority } from "@mercury/core";
 import type {
   TaskBundle,
   TaskStatus,
@@ -149,9 +150,9 @@ export class TaskManager {
     if (!params.definitionOfDone?.length) errors.push("definitionOfDone must have at least 1 item");
     if (!params.codeScope) errors.push("codeScope is required");
     if (!params.readScope) errors.push("readScope is required");
-    const validPriorities = ["sev-0", "sev-1", "sev-2", "sev-3"];
+    const validPriorities = ["P0", "P1", "P2", "P3", "sev-0", "sev-1", "sev-2", "sev-3"];
     if (!validPriorities.includes(params.priority)) {
-      errors.push(`priority must be one of ${validPriorities.join(", ")}, got "${params.priority}"`);
+      errors.push(`priority must be one of P0, P1, P2, P3, got "${params.priority}"`);
     }
     if (params.maxDispatchAttempts !== undefined &&
         (!Number.isInteger(params.maxDispatchAttempts) || params.maxDispatchAttempts < 1)) {
@@ -177,7 +178,7 @@ export class TaskManager {
       taskId,
       title: params.title,
       phaseId: params.phaseId,
-      priority: params.priority,
+      priority: normalizePriority(params.priority),
       status: "drafted",
       createdAt: new Date().toISOString(),
       closedAt: null,

--- a/packages/orchestrator/src/task-persistence-dual.ts
+++ b/packages/orchestrator/src/task-persistence-dual.ts
@@ -1,0 +1,70 @@
+/**
+ * Task Persistence — Dual-write layer.
+ *
+ * Writes to SQLite (primary) first, then asynchronously syncs to KB (secondary).
+ * Reads always come from SQLite for speed and indexed queries.
+ * Git sync is delegated to the KB layer.
+ */
+
+import type { TaskBundle, AcceptanceBundle, IssueBundle, TaskStatus } from "@mercury/core";
+import type { TaskPersistence } from "./task-persistence-kb.js";
+
+type Log = (msg: string) => void;
+
+/** Dual-write persistence: writes to primary (SQLite) first, then async-syncs to secondary (KB). Reads from primary only. */
+export class TaskPersistenceDual implements TaskPersistence {
+  constructor(
+    private primary: TaskPersistence,
+    private secondary: TaskPersistence,
+    private log: Log = () => {},
+  ) {}
+
+  /** Save task to primary (SQLite), then fire-and-forget to secondary (KB). */
+  async saveTask(task: TaskBundle): Promise<void> {
+    await this.primary.saveTask(task);
+    // Fire-and-forget to secondary (KB)
+    this.secondary.saveTask(task).catch((err) => {
+      this.log(`[dual] Secondary saveTask failed: ${err instanceof Error ? err.message : err}`);
+    });
+  }
+
+  /** Save acceptance to primary, then fire-and-forget to secondary. */
+  async saveAcceptance(acc: AcceptanceBundle): Promise<void> {
+    await this.primary.saveAcceptance(acc);
+    this.secondary.saveAcceptance(acc).catch((err) => {
+      this.log(`[dual] Secondary saveAcceptance failed: ${err instanceof Error ? err.message : err}`);
+    });
+  }
+
+  /** Save issue to primary, then fire-and-forget to secondary. */
+  async saveIssue(issue: IssueBundle): Promise<void> {
+    await this.primary.saveIssue(issue);
+    this.secondary.saveIssue(issue).catch((err) => {
+      this.log(`[dual] Secondary saveIssue failed: ${err instanceof Error ? err.message : err}`);
+    });
+  }
+
+  /** Load all entities from primary (SQLite). */
+  async loadAll(): Promise<{
+    tasks: TaskBundle[];
+    acceptances: AcceptanceBundle[];
+    issues: IssueBundle[];
+  }> {
+    return this.primary.loadAll();
+  }
+
+  /** Load a single task from primary. */
+  async loadTask(taskId: string): Promise<TaskBundle | null> {
+    return this.primary.loadTask(taskId);
+  }
+
+  /** Load tasks with optional filter from primary. */
+  async loadTaskList(filter?: { status?: TaskStatus; assignedTo?: string }): Promise<TaskBundle[]> {
+    return this.primary.loadTaskList(filter);
+  }
+
+  /** Delegate git sync to KB (secondary) layer. */
+  async gitSync(message: string): Promise<void> {
+    return this.secondary.gitSync(message);
+  }
+}

--- a/packages/orchestrator/src/task-persistence-kb.ts
+++ b/packages/orchestrator/src/task-persistence-kb.ts
@@ -13,6 +13,7 @@
  * falls back to in-memory Map as write-through cache.
  */
 
+import { normalizePriority } from "@mercury/core";
 import type { TaskBundle, AcceptanceBundle, IssueBundle, TaskStatus } from "@mercury/core";
 import type { KnowledgeService } from "./knowledge-service.js";
 
@@ -59,7 +60,7 @@ function resolveKbPaths(paths?: Partial<TaskPersistenceKBPaths>): TaskPersistenc
 /** Default createdAt value for tasks migrated before timestamps were added. */
 const LEGACY_CREATED_AT = "2026-03-18T00:00:00+09:00";
 
-/** Backfill missing timestamp fields for legacy KB data. Mutates and returns the input. */
+/** Backfill missing timestamp fields and normalize priority for legacy KB data. Mutates and returns the input. */
 function backfillTimestamps(task: TaskBundle): TaskBundle {
   if (!task.createdAt) {
     task.createdAt = LEGACY_CREATED_AT;
@@ -70,6 +71,8 @@ function backfillTimestamps(task: TaskBundle): TaskBundle {
   if (task.failedAt === undefined) {
     task.failedAt = null;
   }
+  // Normalize legacy sev-X priorities to P0-P3
+  task.priority = normalizePriority(task.priority);
   return task;
 }
 

--- a/packages/orchestrator/src/task-persistence-sqlite.ts
+++ b/packages/orchestrator/src/task-persistence-sqlite.ts
@@ -1,0 +1,338 @@
+/**
+ * Task Persistence — SQLite storage via better-sqlite3.
+ *
+ * Implements the same TaskPersistence interface as the KB variant.
+ * SQLite is the primary data store; reads are indexed, writes are synchronous.
+ *
+ * Schema enforces CHECK constraints on status/priority/type enums.
+ * Each entity also stores a raw_json column as a complete JSON backup for
+ * forward-compatible fields not yet modelled as columns.
+ */
+
+import Database from "better-sqlite3";
+import { normalizePriority } from "@mercury/core";
+import type {
+  TaskBundle,
+  AcceptanceBundle,
+  IssueBundle,
+  TaskStatus,
+  TaskPriority,
+} from "@mercury/core";
+import type { TaskPersistence } from "./task-persistence-kb.js";
+
+type Log = (msg: string) => void;
+
+// ─── Schema & Migrations ───
+
+const MIGRATIONS = [
+  {
+    version: 1,
+    description: "initial_schema",
+    sql: `
+      CREATE TABLE IF NOT EXISTS tasks (
+        task_id TEXT PRIMARY KEY,
+        title TEXT NOT NULL,
+        status TEXT NOT NULL CHECK(status IN ('drafted','dispatched','in_progress','implementation_done','main_review','acceptance','verified','closed','failed','blocked')),
+        priority TEXT NOT NULL CHECK(priority IN ('P0','P1','P2','P3')),
+        phase_id TEXT,
+        created_at TEXT,
+        closed_at TEXT,
+        failed_at TEXT,
+        assigned_to TEXT,
+        branch TEXT,
+        context TEXT,
+        dispatch_attempts INTEGER DEFAULT 0,
+        max_dispatch_attempts INTEGER DEFAULT 5,
+        last_dispatch_error TEXT,
+        rework_count INTEGER DEFAULT 0,
+        max_reworks INTEGER DEFAULT 2,
+        originator_session_id TEXT,
+        raw_json TEXT NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS issues (
+        issue_id TEXT PRIMARY KEY,
+        title TEXT NOT NULL,
+        status TEXT NOT NULL CHECK(status IN ('open','resolved','deferred')),
+        type TEXT NOT NULL CHECK(type IN ('bug','scope_creep','blocker','question')),
+        priority TEXT NOT NULL CHECK(priority IN ('P0','P1','P2','P3')),
+        raw_json TEXT NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS acceptances (
+        acceptance_id TEXT PRIMARY KEY,
+        linked_task_id TEXT NOT NULL,
+        status TEXT NOT NULL CHECK(status IN ('pending','in_progress','completed')),
+        acceptor TEXT,
+        completed_at INTEGER,
+        raw_json TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status);
+      CREATE INDEX IF NOT EXISTS idx_tasks_priority ON tasks(priority);
+      CREATE INDEX IF NOT EXISTS idx_tasks_assigned ON tasks(assigned_to);
+      CREATE INDEX IF NOT EXISTS idx_issues_status ON issues(status);
+
+      CREATE TABLE IF NOT EXISTS _migrations (
+        version INTEGER PRIMARY KEY,
+        description TEXT,
+        applied_at TEXT DEFAULT (datetime('now'))
+      );
+    `,
+  },
+];
+
+function applyMigrations(db: Database.Database, log: Log): void {
+  db.exec("CREATE TABLE IF NOT EXISTS _migrations (version INTEGER PRIMARY KEY, description TEXT, applied_at TEXT DEFAULT (datetime('now')))");
+  const applied = new Set(
+    db.prepare("SELECT version FROM _migrations").all().map((r: unknown) => (r as { version: number }).version),
+  );
+
+  for (const m of MIGRATIONS) {
+    if (applied.has(m.version)) continue;
+    log(`[sqlite] Applying migration v${m.version}: ${m.description}`);
+    db.exec(m.sql);
+    db.prepare("INSERT INTO _migrations (version, description) VALUES (?, ?)").run(m.version, m.description);
+  }
+}
+
+// ─── Persistence Implementation ───
+
+/** SQLite-backed task persistence using better-sqlite3 with indexed columns and CHECK constraints. */
+export class TaskPersistenceSqlite implements TaskPersistence {
+  private db: Database.Database;
+  private log: Log;
+
+  // Prepared statements (lazy-init after DB open)
+  private stmts!: {
+    upsertTask: Database.Statement;
+    upsertIssue: Database.Statement;
+    upsertAcceptance: Database.Statement;
+    selectAllTasks: Database.Statement;
+    selectAllIssues: Database.Statement;
+    selectAllAcceptances: Database.Statement;
+    selectTask: Database.Statement;
+    selectTasksByStatus: Database.Statement;
+    selectTasksByAssigned: Database.Statement;
+    selectTasksByBoth: Database.Statement;
+    selectAllTasksList: Database.Statement;
+  };
+
+  constructor(dbPath: string, log: Log = () => {}) {
+    this.log = log;
+    this.db = new Database(dbPath);
+    // WAL mode for better concurrent read performance
+    this.db.pragma("journal_mode = WAL");
+    this.db.pragma("foreign_keys = ON");
+
+    applyMigrations(this.db, log);
+    this.prepareStatements();
+    log(`[sqlite] Database opened: ${dbPath}`);
+  }
+
+  private prepareStatements(): void {
+    this.stmts = {
+      upsertTask: this.db.prepare(`
+        INSERT OR REPLACE INTO tasks (
+          task_id, title, status, priority, phase_id,
+          created_at, closed_at, failed_at, assigned_to, branch,
+          context, dispatch_attempts, max_dispatch_attempts,
+          last_dispatch_error, rework_count, max_reworks,
+          originator_session_id, raw_json
+        ) VALUES (
+          @task_id, @title, @status, @priority, @phase_id,
+          @created_at, @closed_at, @failed_at, @assigned_to, @branch,
+          @context, @dispatch_attempts, @max_dispatch_attempts,
+          @last_dispatch_error, @rework_count, @max_reworks,
+          @originator_session_id, @raw_json
+        )
+      `),
+
+      upsertIssue: this.db.prepare(`
+        INSERT OR REPLACE INTO issues (
+          issue_id, title, status, type, priority, raw_json
+        ) VALUES (
+          @issue_id, @title, @status, @type, @priority, @raw_json
+        )
+      `),
+
+      upsertAcceptance: this.db.prepare(`
+        INSERT OR REPLACE INTO acceptances (
+          acceptance_id, linked_task_id, status, acceptor, completed_at, raw_json
+        ) VALUES (
+          @acceptance_id, @linked_task_id, @status, @acceptor, @completed_at, @raw_json
+        )
+      `),
+
+      selectAllTasks: this.db.prepare("SELECT raw_json FROM tasks"),
+      selectAllIssues: this.db.prepare("SELECT raw_json FROM issues"),
+      selectAllAcceptances: this.db.prepare("SELECT raw_json FROM acceptances"),
+      selectTask: this.db.prepare("SELECT raw_json FROM tasks WHERE task_id = ?"),
+      selectTasksByStatus: this.db.prepare("SELECT raw_json FROM tasks WHERE status = ?"),
+      selectTasksByAssigned: this.db.prepare("SELECT raw_json FROM tasks WHERE assigned_to = ?"),
+      selectTasksByBoth: this.db.prepare("SELECT raw_json FROM tasks WHERE status = ? AND assigned_to = ?"),
+      selectAllTasksList: this.db.prepare("SELECT raw_json FROM tasks"),
+    };
+  }
+
+  // ─── TaskPersistence interface ───
+
+  /** Persist a task bundle to SQLite — INSERT OR REPLACE with indexed columns + raw_json backup. */
+  async saveTask(task: TaskBundle): Promise<void> {
+    try {
+      const priority = normalizePriority(task.priority);
+      this.stmts.upsertTask.run({
+        task_id: task.taskId,
+        title: task.title,
+        status: task.status,
+        priority,
+        phase_id: task.phaseId ?? null,
+        created_at: task.createdAt ?? null,
+        closed_at: task.closedAt ?? null,
+        failed_at: task.failedAt ?? null,
+        assigned_to: task.assignedTo ?? null,
+        branch: task.branch ?? null,
+        context: task.context ?? null,
+        dispatch_attempts: task.dispatchAttempts ?? 0,
+        max_dispatch_attempts: task.maxDispatchAttempts ?? 5,
+        last_dispatch_error: task.lastDispatchError ?? null,
+        rework_count: task.reworkCount ?? 0,
+        max_reworks: task.maxReworks ?? 2,
+        originator_session_id: task.originatorSessionId ?? null,
+        raw_json: JSON.stringify({ ...task, priority }),
+      });
+    } catch (err) {
+      this.log(`[sqlite] Failed to save task ${task.taskId}: ${err instanceof Error ? err.message : err}`);
+    }
+  }
+
+  /** Persist an acceptance bundle to SQLite. */
+  async saveAcceptance(acc: AcceptanceBundle): Promise<void> {
+    try {
+      this.stmts.upsertAcceptance.run({
+        acceptance_id: acc.acceptanceId,
+        linked_task_id: acc.linkedTaskId,
+        status: acc.status,
+        acceptor: acc.acceptor ?? null,
+        completed_at: acc.completedAt ?? null,
+        raw_json: JSON.stringify(acc),
+      });
+    } catch (err) {
+      this.log(`[sqlite] Failed to save acceptance ${acc.acceptanceId}: ${err instanceof Error ? err.message : err}`);
+    }
+  }
+
+  /** Persist an issue bundle to SQLite. */
+  async saveIssue(issue: IssueBundle): Promise<void> {
+    try {
+      const priority = normalizePriority(issue.priority);
+      this.stmts.upsertIssue.run({
+        issue_id: issue.issueId,
+        title: issue.title,
+        status: issue.status,
+        type: issue.type,
+        priority,
+        raw_json: JSON.stringify({ ...issue, priority }),
+      });
+    } catch (err) {
+      this.log(`[sqlite] Failed to save issue ${issue.issueId}: ${err instanceof Error ? err.message : err}`);
+    }
+  }
+
+  /** Load all tasks, acceptances, and issues from SQLite. */
+  async loadAll(): Promise<{
+    tasks: TaskBundle[];
+    acceptances: AcceptanceBundle[];
+    issues: IssueBundle[];
+  }> {
+    const tasks = this.stmts.selectAllTasks.all()
+      .map((r: unknown) => this.parseJson<TaskBundle>((r as { raw_json: string }).raw_json))
+      .filter((t): t is TaskBundle => t !== null);
+
+    const acceptances = this.stmts.selectAllAcceptances.all()
+      .map((r: unknown) => this.parseJson<AcceptanceBundle>((r as { raw_json: string }).raw_json))
+      .filter((a): a is AcceptanceBundle => a !== null);
+
+    const issues = this.stmts.selectAllIssues.all()
+      .map((r: unknown) => this.parseJson<IssueBundle>((r as { raw_json: string }).raw_json))
+      .filter((i): i is IssueBundle => i !== null);
+
+    this.log(`[sqlite] Loaded: ${tasks.length} tasks, ${acceptances.length} acceptances, ${issues.length} issues`);
+    return { tasks, acceptances, issues };
+  }
+
+  /** Load a single task by ID from SQLite. */
+  async loadTask(taskId: string): Promise<TaskBundle | null> {
+    const row = this.stmts.selectTask.get(taskId) as { raw_json: string } | undefined;
+    if (!row) return null;
+    return this.parseJson<TaskBundle>(row.raw_json);
+  }
+
+  /** Load tasks with optional status/assignedTo filter — uses indexed queries. */
+  async loadTaskList(filter?: { status?: TaskStatus; assignedTo?: string }): Promise<TaskBundle[]> {
+    let rows: unknown[];
+    if (filter?.status && filter?.assignedTo) {
+      rows = this.stmts.selectTasksByBoth.all(filter.status, filter.assignedTo);
+    } else if (filter?.status) {
+      rows = this.stmts.selectTasksByStatus.all(filter.status);
+    } else if (filter?.assignedTo) {
+      rows = this.stmts.selectTasksByAssigned.all(filter.assignedTo);
+    } else {
+      rows = this.stmts.selectAllTasksList.all();
+    }
+    return rows
+      .map((r: unknown) => this.parseJson<TaskBundle>((r as { raw_json: string }).raw_json))
+      .filter((t): t is TaskBundle => t !== null);
+  }
+
+  /** SQLite does not need git sync — no-op. */
+  async gitSync(_message: string): Promise<void> {
+    // no-op: DB changes are persisted immediately
+  }
+
+  // ─── Migration helper: bulk import from KB data ───
+
+  /** Bulk import all entities from KB data in a single transaction. */
+  importFromKB(data: {
+    tasks: TaskBundle[];
+    acceptances: AcceptanceBundle[];
+    issues: IssueBundle[];
+  }): void {
+    const importAll = this.db.transaction(() => {
+      for (const task of data.tasks) {
+        this.saveTask(task); // async wrapper but actually sync inside
+      }
+      for (const acc of data.acceptances) {
+        this.saveAcceptance(acc);
+      }
+      for (const issue of data.issues) {
+        this.saveIssue(issue);
+      }
+    });
+
+    importAll();
+    this.log(`[sqlite] Imported from KB: ${data.tasks.length} tasks, ${data.acceptances.length} acceptances, ${data.issues.length} issues`);
+  }
+
+  /** Check if DB has any data (used to detect first-run migration need). */
+  isEmpty(): boolean {
+    const row = this.db.prepare("SELECT COUNT(*) as cnt FROM tasks").get() as { cnt: number };
+    return row.cnt === 0;
+  }
+
+  /** Close the database connection. */
+  close(): void {
+    this.db.close();
+  }
+
+  // ─── Internal ───
+
+  private parseJson<T>(raw: string): T | null {
+    try {
+      return JSON.parse(raw) as T;
+    } catch {
+      this.log(`[sqlite] Failed to parse JSON record`);
+      return null;
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.27.1
         version: 1.27.1(zod@4.3.6)
+      better-sqlite3:
+        specifier: 12.8.0
+        version: 12.8.0
       js-yaml:
         specifier: ^4.1.1
         version: 4.1.1
@@ -88,6 +91,9 @@ importers:
         specifier: ^4.0.0
         version: 4.3.6
     devDependencies:
+      '@types/better-sqlite3':
+        specifier: 7.6.13
+        version: 7.6.13
       '@types/js-yaml':
         specifier: ^4.0.9
         version: 4.0.9
@@ -833,6 +839,9 @@ packages:
   '@tauri-apps/plugin-opener@2.5.3':
     resolution: {integrity: sha512-CCcUltXMOfUEArbf3db3kCE7Ggy1ExBEBl51Ko2ODJ6GDYHRp1nSNlQm5uNCFY5k7/ufaK5Ib3Du/Zir19IYQQ==}
 
+  '@types/better-sqlite3@7.6.13':
+    resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -925,12 +934,28 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  better-sqlite3@12.8.0:
+    resolution: {integrity: sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
 
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -943,6 +968,9 @@ packages:
   call-bound@1.0.4:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   content-disposition@1.0.1:
     resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
@@ -983,9 +1011,21 @@ packages:
       supports-color:
         optional: true
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
+
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
 
   dompurify@3.3.3:
     resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
@@ -1000,6 +1040,9 @@ packages:
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
@@ -1045,6 +1088,10 @@ packages:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
 
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
   express-rate-limit@8.3.1:
     resolution: {integrity: sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==}
     engines: {node: '>= 16'}
@@ -1070,6 +1117,9 @@ packages:
       picomatch:
         optional: true
 
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
@@ -1081,6 +1131,9 @@ packages:
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
+
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1100,6 +1153,9 @@ packages:
 
   get-tsconfig@4.13.6:
     resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -1129,8 +1185,14 @@ packages:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
@@ -1187,9 +1249,19 @@ packages:
     resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
     engines: {node: '>=18'}
 
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
   minimatch@9.0.9:
     resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -1202,9 +1274,16 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
+
+  node-abi@3.89.0:
+    resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
+    engines: {node: '>=10'}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -1250,9 +1329,18 @@ packages:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
+
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
   qs@6.15.0:
     resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
@@ -1265,6 +1353,14 @@ packages:
   raw-body@3.0.2:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
+
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
 
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
@@ -1282,8 +1378,16 @@ packages:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
 
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
@@ -1320,6 +1424,12 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -1327,6 +1437,20 @@ packages:
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
+
+  tar-fs@2.1.4:
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
@@ -1340,6 +1464,9 @@ packages:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
+
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
@@ -1361,6 +1488,9 @@ packages:
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -1877,6 +2007,10 @@ snapshots:
     dependencies:
       '@tauri-apps/api': 2.10.1
 
+  '@types/better-sqlite3@7.6.13':
+    dependencies:
+      '@types/node': 25.5.0
+
   '@types/estree@1.0.8': {}
 
   '@types/js-yaml@4.0.9': {}
@@ -1999,6 +2133,23 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  base64-js@1.5.1: {}
+
+  better-sqlite3@12.8.0:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
   body-parser@2.2.2:
     dependencies:
       bytes: 3.1.2
@@ -2017,6 +2168,11 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
   bytes@3.1.2: {}
 
   call-bind-apply-helpers@1.0.2:
@@ -2028,6 +2184,8 @@ snapshots:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
+
+  chownr@1.1.4: {}
 
   content-disposition@1.0.1: {}
 
@@ -2056,7 +2214,15 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
+  deep-extend@0.6.0: {}
+
   depd@2.0.0: {}
+
+  detect-libc@2.1.2: {}
 
   dompurify@3.3.3:
     optionalDependencies:
@@ -2071,6 +2237,10 @@ snapshots:
   ee-first@1.1.1: {}
 
   encodeurl@2.0.0: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   entities@7.0.1: {}
 
@@ -2152,6 +2322,8 @@ snapshots:
     dependencies:
       eventsource-parser: 3.0.6
 
+  expand-template@2.0.3: {}
+
   express-rate-limit@8.3.1(express@5.2.1):
     dependencies:
       express: 5.2.1
@@ -2198,6 +2370,8 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  file-uri-to-path@1.0.0: {}
+
   finalhandler@2.1.1:
     dependencies:
       debug: 4.4.3
@@ -2212,6 +2386,8 @@ snapshots:
   forwarded@0.2.0: {}
 
   fresh@2.0.0: {}
+
+  fs-constants@1.0.0: {}
 
   fsevents@2.3.3:
     optional: true
@@ -2240,6 +2416,8 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  github-from-package@0.0.0: {}
+
   gopd@1.2.0: {}
 
   has-symbols@1.1.0: {}
@@ -2264,7 +2442,11 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  ieee754@1.2.1: {}
+
   inherits@2.0.4: {}
+
+  ini@1.3.8: {}
 
   ip-address@10.1.0: {}
 
@@ -2302,9 +2484,15 @@ snapshots:
     dependencies:
       mime-db: 1.54.0
 
+  mimic-response@3.1.0: {}
+
   minimatch@9.0.9:
     dependencies:
       brace-expansion: 2.0.2
+
+  minimist@1.2.8: {}
+
+  mkdirp-classic@0.5.3: {}
 
   ms@2.1.3: {}
 
@@ -2312,7 +2500,13 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  napi-build-utils@2.0.0: {}
+
   negotiator@1.0.0: {}
+
+  node-abi@3.89.0:
+    dependencies:
+      semver: 7.7.4
 
   object-assign@4.1.1: {}
 
@@ -2346,10 +2540,30 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.89.0
+      pump: 3.0.4
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.4
+      tunnel-agent: 0.6.0
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
 
   qs@6.15.0:
     dependencies:
@@ -2363,6 +2577,19 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       unpipe: 1.0.0
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
 
   require-from-string@2.0.2: {}
 
@@ -2409,7 +2636,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  safe-buffer@5.2.1: {}
+
   safer-buffer@2.1.2: {}
+
+  semver@7.7.4: {}
 
   send@1.2.1:
     dependencies:
@@ -2472,9 +2703,38 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+
   source-map-js@1.2.1: {}
 
   statuses@2.0.2: {}
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  strip-json-comments@2.0.1: {}
+
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   tinyglobby@0.2.15:
     dependencies:
@@ -2490,6 +2750,10 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   type-is@2.0.1:
     dependencies:
       content-type: 1.0.5
@@ -2503,6 +2767,8 @@ snapshots:
   undici-types@7.18.2: {}
 
   unpipe@1.0.0: {}
+
+  util-deprecate@1.0.2: {}
 
   vary@1.1.2: {}
 


### PR DESCRIPTION
## Summary

- **W1**: New `critic.yaml` role definition with spec-driven verification protocol (independent model requirement)
- **W2**: `CriticResult`/`CriticItemResult` types + `buildCriticPrompt()` with GIVEN→LOCATE→VERIFY→EVIDENCE protocol
- **W3**: Integration as parallel sub-step of `main_review` via `get_critic_prompt` and `record_critic_result` RPC + MCP tools

### Architecture

```
main_review phase
  ├─ Main Agent review (existing)
  └─ Critic Agent verification (NEW, parallel)
       ├─ get_critic_prompt → DoD-based verification prompt
       ├─ critic runs verification (different model than dev)
       └─ record_critic_result → stored in task.criticReview
```

### Key Design Decisions

- Critic operates **parallel to** main_review, not as a new state machine phase (avoids state machine complexity)
- Uses DoD checklist as "spec" (DEC-1 rejected formal GIVEN/WHEN/THEN in TaskBundle)
- Requires different model than dev agent to prevent self-congratulation bias
- Results stored but do not auto-block transitions (Main Agent decides based on critic findings)

Depends on: #40 (TASK-DB-001), #41 (TASK-BUGFIX-001)

## Test plan

- [x] `pnpm typecheck` passes
- [x] Manual: `get_critic_prompt` returns properly formatted prompt
- [x] Manual: `record_critic_result` stores CriticResult on task

🤖 Generated with [Claude Code](https://claude.com/claude-code)