### PR TITLE
fix(TASK-BUGFIX-001): UTF-8 encoding hardening for CJK Windows

### DIFF
--- a/packages/gui/src-tauri/src/sidecar.rs
+++ b/packages/gui/src-tauri/src/sidecar.rs
@@ -40,7 +40,13 @@ impl SidecarManager {
             c
         };
 
-        cmd.current_dir(&project_dir)
+        // Force UTF-8 encoding to prevent codepage 936/GBK garbling on CJK Windows.
+        // LANG/LC_ALL: effective on Unix; NODE_ICU_DATA + CHCP side: handled by Node.js W1/W2.
+        // PYTHONIOENCODING: protects any Python subprocess spawned downstream.
+        cmd.env("LANG", "en_US.UTF-8")
+            .env("LC_ALL", "en_US.UTF-8")
+            .env("PYTHONIOENCODING", "utf-8")
+            .current_dir(&project_dir)
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped());

--- a/packages/gui/src-tauri/src/sidecar.rs
+++ b/packages/gui/src-tauri/src/sidecar.rs
@@ -29,6 +29,11 @@ impl SidecarManager {
             c.args(["/c", "pnpm", "exec", "tsx"]);
             c.arg(&orchestrator_entry);
             c.creation_flags(0x08000000); // CREATE_NO_WINDOW
+            // Force UTF-8 encoding to prevent codepage 936/GBK garbling on CJK Windows.
+            // PYTHONIOENCODING: protects any Python subprocess spawned downstream.
+            c.env("LANG", "en_US.UTF-8");
+            c.env("LC_ALL", "en_US.UTF-8");
+            c.env("PYTHONIOENCODING", "utf-8");
             c
         };
 
@@ -40,13 +45,7 @@ impl SidecarManager {
             c
         };
 
-        // Force UTF-8 encoding to prevent codepage 936/GBK garbling on CJK Windows.
-        // LANG/LC_ALL: effective on Unix; NODE_ICU_DATA + CHCP side: handled by Node.js W1/W2.
-        // PYTHONIOENCODING: protects any Python subprocess spawned downstream.
-        cmd.env("LANG", "en_US.UTF-8")
-            .env("LC_ALL", "en_US.UTF-8")
-            .env("PYTHONIOENCODING", "utf-8")
-            .current_dir(&project_dir)
+        cmd.current_dir(&project_dir)
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped());

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -5,6 +5,11 @@
  * Communicates via JSON-RPC 2.0 over stdin/stdout.
  */
 
+// ─── Force UTF-8 on stdio (defense against Windows codepage 936/GBK) ───
+process.stdin.setEncoding("utf-8");
+process.stdout.setDefaultEncoding("utf-8");
+process.stderr.setDefaultEncoding("utf-8");
+
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, isAbsolute, resolve } from "node:path";

--- a/packages/orchestrator/src/rpc-transport.ts
+++ b/packages/orchestrator/src/rpc-transport.ts
@@ -90,14 +90,14 @@ export class RpcTransport {
 
   sendNotification(method: string, params: Record<string, unknown>): void {
     const msg: RpcNotification = { jsonrpc: "2.0", method, params };
-    process.stdout.write(JSON.stringify(msg) + "\n");
+    process.stdout.write(JSON.stringify(msg) + "\n", "utf-8");
   }
 
   private sendResponse(response: RpcResponse): void {
-    process.stdout.write(JSON.stringify(response) + "\n");
+    process.stdout.write(JSON.stringify(response) + "\n", "utf-8");
   }
 
   log(message: string): void {
-    process.stderr.write(`[orchestrator] ${message}\n`);
+    process.stderr.write(`[orchestrator] ${message}\n`, "utf-8");
   }
 }


### PR DESCRIPTION
## Summary

- **C1**: Force UTF-8 on `process.stdin/stdout/stderr` in orchestrator entry point
- **C2**: Explicit `'utf-8'` encoding on all `rpc-transport.ts` write calls
- **C3**: Inject `LANG/LC_ALL/PYTHONIOENCODING` env vars in Tauri sidecar spawn (**Windows-only** per CodeRabbit feedback)

Prevents codepage 936 (GBK) garbling of Chinese text on Windows.

Supersedes #41 (clean rebase after #40 merge).
Closes #32

## Test plan

- [x] `pnpm typecheck` passes
- [x] `cargo check` passes
- [ ] Manual: Chinese text in orchestrator→GUI displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)