### PR TITLE
feat(TASK-CRITIC-001): Critic Agent spec-driven verification layer

### DIFF
--- a/.mercury/roles/critic.yaml
+++ b/.mercury/roles/critic.yaml
@@ -1,0 +1,61 @@
+role: critic
+description: "Spec-driven verifier: validates implementation against Definition of Done checklist."
+canExecuteCode: true
+canDelegateToRoles: []
+inputBoundary:
+  - TaskBundle (definitionOfDone, codeScope, context)
+  - git diff (code changes)
+  - pre-check results (build, lint, test)
+outputBoundary:
+  - CriticResult (per-item verdict with evidence)
+instructions: |
+  # Role: Critic Agent
+
+  ## Responsibility
+  Independent spec-driven verification. For each item in the Definition of Done,
+  verify whether the implementation satisfies it. Use a different analytical
+  perspective than the dev agent (who implemented) or the main agent (who reviewed).
+
+  ## Verification Protocol
+  For each DoD item:
+  1. **Parse** — understand what the DoD item requires
+  2. **Locate** — find the relevant code changes in the diff
+  3. **Verify** — check if the implementation satisfies the requirement
+  4. **Evidence** — cite specific file:line or test output as proof
+  5. **Verdict** — PASS / FAIL / PARTIAL / SKIP (if not verifiable from code alone)
+
+  ## Allowed Actions
+  - Read TaskBundle fields: definitionOfDone, context, codeScope, requiredEvidence
+  - Read git diff and pre-check results
+  - Execute code, run tests, inspect build output
+  - Read changed files for verification
+
+  ## Forbidden Actions
+  - Read dev agent's conversation or reasoning
+  - Modify source code or create commits
+  - Create new Tasks or Issues
+  - Communicate directly with dev agent
+  - Override main_review decision
+
+  ## Model Separation
+  This role MUST be assigned to a different model than the dev agent to avoid
+  self-congratulation bias. If dev used claude-sonnet, critic should use
+  claude-haiku or a different provider.
+
+  ## Output Format
+  ```json
+  {
+    "overallVerdict": "pass|partial|fail",
+    "completeness": 0.0-1.0,
+    "items": [
+      {
+        "dodItem": "the DoD checklist item text",
+        "verdict": "pass|fail|partial|skip",
+        "evidence": "file:line or test output citation",
+        "detail": "explanation of verification result"
+      }
+    ],
+    "blockers": ["critical issues that must be fixed"],
+    "suggestions": ["optional improvements"]
+  }
+  ```

--- a/.mercury/roles/main.yaml
+++ b/.mercury/roles/main.yaml
@@ -4,6 +4,7 @@ canExecuteCode: false
 canDelegateToRoles:
   - dev
   - acceptance
+  - critic
   - research
   - design
 inputBoundary:

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,10 @@ export { ROLE_CARDS, makeRoleSlotKey, parseRoleSlotKey, isStreamingEvent, normal
 export type {
   AcceptanceBundle,
   AcceptanceVerdict,
+  CriticItemResult,
+  CriticItemVerdict,
+  CriticResult,
+  CriticVerdict,
   AdapterYield,
   AgentAdapter,
   AgentApprovalRequest,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -10,7 +10,7 @@
 
 // ─── Agent Identity ───
 
-export type AgentRole = "main" | "dev" | "acceptance" | "research" | "design";
+export type AgentRole = "main" | "dev" | "acceptance" | "critic" | "research" | "design";
 
 export type IntegrationType = "sdk" | "mcp" | "http" | "pty" | "rpc";
 
@@ -193,6 +193,7 @@ export type EventType =
   | "orchestrator.session.handoff"
   | "orchestrator.task.main_review"
   | "orchestrator.task.callback"
+  | "orchestrator.critic.result"
   | "orchestrator.scope.violation"
   | "human.intervention";
 
@@ -325,6 +326,13 @@ export interface TaskBundle {
     reviewedAt?: number;
   };
 
+  // Critic review (spec-driven verification, parallel to main_review)
+  criticReview?: {
+    result?: CriticResult;
+    reviewedAt?: number;
+    criticAgent?: string; // agentId of the critic
+  };
+
   // Dispatch retry tracking
   dispatchAttempts: number;
   maxDispatchAttempts: number;
@@ -392,6 +400,28 @@ export interface AcceptanceBundle {
     recommendations: string[];
   };
   completedAt?: number;
+}
+
+// ─── Critic Result ───
+
+export type CriticVerdict = "pass" | "partial" | "fail";
+export type CriticItemVerdict = "pass" | "fail" | "partial" | "skip";
+
+/** Per-item verification result from the Critic Agent. */
+export interface CriticItemResult {
+  dodItem: string;
+  verdict: CriticItemVerdict;
+  evidence: string;
+  detail: string;
+}
+
+/** Structured output from the Critic Agent's spec-driven verification. */
+export interface CriticResult {
+  overallVerdict: CriticVerdict;
+  completeness: number; // 0.0 – 1.0
+  items: CriticItemResult[];
+  blockers: string[];
+  suggestions: string[];
 }
 
 // ─── Issue Bundle ───

--- a/packages/gui/src/lib/tauri-bridge.ts
+++ b/packages/gui/src/lib/tauri-bridge.ts
@@ -262,6 +262,22 @@ export interface TaskBundle {
     residualRisks: string[];
     completedAt: number;
   };
+  criticReview?: {
+    result?: {
+      overallVerdict: "pass" | "partial" | "fail";
+      completeness: number;
+      items: Array<{
+        dodItem: string;
+        verdict: "pass" | "fail" | "partial" | "skip";
+        evidence: string;
+        detail: string;
+      }>;
+      blockers: string[];
+      suggestions: string[];
+    };
+    reviewedAt?: number;
+    criticAgent?: string;
+  };
   reworkCount: number;
   maxReworks: number;
   linkedIssueIds: string[];

--- a/packages/orchestrator/src/mcp-server.ts
+++ b/packages/orchestrator/src/mcp-server.ts
@@ -233,17 +233,18 @@ export function createMcpServer(orchestrator: Orchestrator, transport: RpcTransp
     "Record the critic agent's verification result on a task", {
       taskId,
       result: z.object({
-        overallVerdict: z.string().describe("pass | partial | fail"),
+        overallVerdict: z.enum(["pass", "partial", "fail"]).describe("Overall critic verdict"),
         completeness: z.number().describe("0.0 – 1.0"),
         items: z.array(z.object({
           dodItem: z.string(),
-          verdict: z.string().describe("pass | fail | partial | skip"),
+          verdict: z.enum(["pass", "fail", "partial", "skip"]).describe("Per-item verdict"),
           evidence: z.string(),
           detail: z.string(),
         })),
         blockers: z.array(z.string()),
         suggestions: z.array(z.string()),
       }).describe("Critic verification result"),
+      criticAgentId: z.string().optional().describe("Agent ID of the critic that performed verification"),
     });
 
   // ─── Issue Management ───

--- a/packages/orchestrator/src/mcp-server.ts
+++ b/packages/orchestrator/src/mcp-server.ts
@@ -222,6 +222,30 @@ export function createMcpServer(orchestrator: Orchestrator, transport: RpcTransp
       }).describe("Acceptance results object"),
     });
 
+  // ─── Critic Verification ───
+
+  rpcTool(server, orchestrator, "get_critic_prompt",
+    "Generate the critic verification prompt for a task (spec-driven DoD validation)", {
+      taskId,
+    });
+
+  rpcTool(server, orchestrator, "record_critic_result",
+    "Record the critic agent's verification result on a task", {
+      taskId,
+      result: z.object({
+        overallVerdict: z.string().describe("pass | partial | fail"),
+        completeness: z.number().describe("0.0 – 1.0"),
+        items: z.array(z.object({
+          dodItem: z.string(),
+          verdict: z.string().describe("pass | fail | partial | skip"),
+          evidence: z.string(),
+          detail: z.string(),
+        })),
+        blockers: z.array(z.string()),
+        suggestions: z.array(z.string()),
+      }).describe("Critic verification result"),
+    });
+
   // ─── Issue Management ───
 
   rpcTool(server, orchestrator, "create_issue",

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -683,6 +683,7 @@ export class Orchestrator {
         return this.recordCriticResult(
           params.taskId as string,
           params.result as import("@mercury/core").CriticResult,
+          (params.criticAgentId as string | undefined),
         );
       case "create_acceptance":
         return this.createAcceptanceFlow(
@@ -2570,13 +2571,15 @@ export class Orchestrator {
   private recordCriticResult(
     taskId: string,
     result: import("@mercury/core").CriticResult,
+    criticAgentId?: string,
   ): { recorded: true; overallVerdict: string } {
     this.taskManager.updateTaskField(taskId, "criticReview", {
       result,
       reviewedAt: Date.now(),
+      criticAgent: criticAgentId,
     });
 
-    this.bus.emit("orchestrator.critic.result", "orchestrator", "", {
+    this.bus.emit("orchestrator.critic.result", "orchestrator", "orchestrator", {
       taskId,
       overallVerdict: result.overallVerdict,
       completeness: result.completeness,

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -39,6 +39,7 @@ import {
   buildAcceptancePrompt,
   buildReworkPrompt,
   buildMainReviewPrompt,
+  buildCriticPrompt,
 } from "./task-manager.js";
 import type { CreateTaskParams, CreateIssueParams } from "./task-manager.js";
 import { TaskPersistenceKB } from "./task-persistence-kb.js";
@@ -675,6 +676,13 @@ export class Orchestrator {
           params.decision as string,
           (params.reason as string | null) ?? undefined,
           (params.acceptorId as string | null) ?? undefined,
+        );
+      case "get_critic_prompt":
+        return this.getCriticPrompt(params.taskId as string);
+      case "record_critic_result":
+        return this.recordCriticResult(
+          params.taskId as string,
+          params.result as import("@mercury/core").CriticResult,
         );
       case "create_acceptance":
         return this.createAcceptanceFlow(
@@ -2543,6 +2551,39 @@ export class Orchestrator {
     }
 
     throw new Error(`Invalid review decision: "${decision}". Expected APPROVE_FOR_ACCEPTANCE or SEND_BACK.`);
+  }
+
+  // ─── Critic Agent Integration ───
+
+  /** Generate the critic verification prompt for a task. */
+  private getCriticPrompt(taskId: string): { prompt: string } {
+    const task = this.taskManager.getTask(taskId);
+    if (!task) throw new Error(`Task not found: ${taskId}`);
+    if (task.status !== "main_review" && task.status !== "implementation_done") {
+      throw new Error(`Task ${taskId} is not in reviewable state (current: ${task.status})`);
+    }
+    const prompt = buildCriticPrompt(task, this.getProjectRoot());
+    return { prompt };
+  }
+
+  /** Record the critic agent's verification result on a task. */
+  private recordCriticResult(
+    taskId: string,
+    result: import("@mercury/core").CriticResult,
+  ): { recorded: true; overallVerdict: string } {
+    this.taskManager.updateTaskField(taskId, "criticReview", {
+      result,
+      reviewedAt: Date.now(),
+    });
+
+    this.bus.emit("orchestrator.critic.result", "orchestrator", "", {
+      taskId,
+      overallVerdict: result.overallVerdict,
+      completeness: result.completeness,
+      blockerCount: result.blockers.length,
+    });
+
+    return { recorded: true, overallVerdict: result.overallVerdict };
   }
 
   /** Find an agent with the "acceptance" role. */

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -1039,3 +1039,95 @@ export function buildMainReviewPrompt(task: TaskBundle): string {
 
   return lines.join("\n");
 }
+
+/** Build the Critic Agent verification prompt — spec-driven DoD validation. */
+export function buildCriticPrompt(task: TaskBundle, _projectRoot?: string): string {
+  const lines: string[] = [];
+
+  lines.push(`# Critic Verification: ${task.title} [${task.taskId}]`);
+  lines.push("");
+
+  // Definition of Done — the "spec" to verify against
+  lines.push("## Definition of Done (verify each item)");
+  for (const [i, item] of task.definitionOfDone.entries()) {
+    lines.push(`${i + 1}. ${item}`);
+  }
+  lines.push("");
+
+  // Task context
+  lines.push("## Task Context");
+  lines.push(task.context || "(no context provided)");
+  lines.push("");
+
+  // Code scope
+  lines.push("## Code Scope");
+  lines.push("```json");
+  lines.push(JSON.stringify(task.codeScope, null, 2));
+  lines.push("```");
+  lines.push("");
+
+  // Pre-check results (if available)
+  if (task.mainReview?.preChecks?.length) {
+    lines.push("## Pre-Check Results");
+    for (const pc of task.mainReview.preChecks) {
+      const icon = pc.success ? "PASS" : "FAIL";
+      lines.push(`- [${icon}] ${pc.name}: exit=${pc.exitCode}, ${pc.durationMs}ms`);
+      if (!pc.success && pc.stdout) {
+        lines.push("  ```");
+        lines.push("  " + truncate(pc.stdout, 500));
+        lines.push("  ```");
+      }
+    }
+    lines.push("");
+  }
+
+  // Git diff (if available)
+  if (task.mainReview?.gitDiff) {
+    lines.push("## Git Diff");
+    lines.push("```diff");
+    lines.push(sanitizeFenceContent(truncate(task.mainReview.gitDiff, MAX_DIFF_CHARS)));
+    lines.push("```");
+    lines.push("");
+  }
+
+  // Changed files list from receipt
+  if (task.implementationReceipt?.changedFiles?.length) {
+    lines.push("## Changed Files");
+    for (const f of task.implementationReceipt.changedFiles) {
+      lines.push(`- ${f}`);
+    }
+    lines.push("");
+  }
+
+  // Instructions
+  lines.push("## Instructions");
+  lines.push("");
+  lines.push("For EACH Definition of Done item above:");
+  lines.push("1. Locate the relevant code changes in the diff");
+  lines.push("2. Verify the implementation satisfies the requirement");
+  lines.push("3. Cite specific evidence (file:line or test output)");
+  lines.push("4. Assign a verdict: pass / fail / partial / skip");
+  lines.push("");
+  lines.push("Return your result as JSON:");
+  lines.push("```json");
+  lines.push(JSON.stringify({
+    overallVerdict: "pass|partial|fail",
+    completeness: 0.85,
+    items: [
+      {
+        dodItem: "the DoD checklist item text",
+        verdict: "pass|fail|partial|skip",
+        evidence: "file:line or test output citation",
+        detail: "explanation of verification result",
+      },
+    ],
+    blockers: ["critical issues that must be fixed"],
+    suggestions: ["optional improvements"],
+  }, null, 2));
+  lines.push("```");
+  lines.push("");
+  lines.push("Any item with verdict `fail` should appear in `blockers`.");
+  lines.push("Set `overallVerdict` to `fail` if any blocker exists, `partial` if any item is partial/skip, `pass` if all pass.");
+
+  return lines.join("\n");
+}


### PR DESCRIPTION
## Summary

- **W1**: New `critic.yaml` role definition with spec-driven verification protocol
- **W2**: `CriticResult`/`CriticItemResult` types + `buildCriticPrompt()` with DoD verification
- **W3**: `get_critic_prompt` and `record_critic_result` RPC + MCP tools

Supersedes #42 (clean rebase after #40, #43 merge).

## Test plan

- [x] `pnpm typecheck` passes
- [ ] Manual: `get_critic_prompt` returns properly formatted prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)