### PR TITLE
fix(TASK-CALLBACK-001): route acceptance callbacks to Main Agent

### DIFF
--- a/packages/orchestrator/src/mcp-server.ts
+++ b/packages/orchestrator/src/mcp-server.ts
@@ -167,6 +167,9 @@ export function createMcpServer(orchestrator: Orchestrator, transport: RpcTransp
   rpcTool(server, orchestrator, "get_task",
     "Get a task by ID", { taskId });
 
+  rpcTool(server, orchestrator, "get_task_result",
+    "Get task result with acceptance verdict and findings (for polling task completion)", { taskId });
+
   rpcTool(server, orchestrator, "list_tasks",
     "List all tasks, optionally filtered by status", {
       status: z.string().optional().describe("Filter by task status"),

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -143,6 +143,19 @@ export class Orchestrator {
         parentEventId: event.parentEventId,
       });
     });
+
+    // Route task completion callbacks to Internal Main Agent session
+    this.bus.on("orchestrator.task.callback", (event) => {
+      const payload = event.payload as {
+        taskId: string;
+        originatorSessionId?: string;
+        verdict: string;
+        findings?: string[];
+        recommendations?: string[];
+      };
+      // Fire-and-forget: deliver callback to Main Agent
+      void this.deliverTaskCallback(payload);
+    });
   }
 
   /** Inject optional knowledge service + wire up task persistence (with optional SQLite dual-write). */
@@ -663,6 +676,8 @@ export class Orchestrator {
         return this.taskManager.createTask(params as unknown as CreateTaskParams);
       case "get_task":
         return (await this.taskManager.getTaskAsync(params.taskId as string)) ?? null;
+      case "get_task_result":
+        return this.getTaskResult(params.taskId as string);
       case "list_tasks":
         return this.taskManager.listTasksAsync(params as { status?: TaskStatus; assignedTo?: string });
       case "record_receipt":
@@ -2331,6 +2346,83 @@ export class Orchestrator {
     return this.registry.listAgents().find((a) => a.roles.includes("main"))?.id;
   }
 
+  /**
+   * Deliver task completion callback to Internal Main Agent session.
+   * Called when acceptance result (pass/fail/partial/blocked) is recorded.
+   */
+  private async deliverTaskCallback(payload: {
+    taskId: string;
+    originatorSessionId?: string;
+    verdict: string;
+    findings?: string[];
+    recommendations?: string[];
+  }): Promise<void> {
+    const mainAgentId = this.findMainAgentId();
+    if (!mainAgentId) return;
+
+    const task = this.taskManager.getTask(payload.taskId);
+    const taskTitle = task?.title ?? payload.taskId;
+    const findings = payload.findings?.length
+      ? `\nFindings:\n${payload.findings.map((f) => `- ${f}`).join("\n")}`
+      : "";
+    const recommendations = payload.recommendations?.length
+      ? `\nRecommendations:\n${payload.recommendations.map((r) => `- ${r}`).join("\n")}`
+      : "";
+
+    const callbackPrompt = [
+      `[Task Callback] ${taskTitle}`,
+      `Task ID: ${payload.taskId}`,
+      `Acceptance Verdict: ${payload.verdict.toUpperCase()}`,
+      findings,
+      recommendations,
+      payload.verdict === "pass"
+        ? "Task has been verified and closed."
+        : payload.verdict === "blocked"
+          ? "Task is blocked. Manual intervention required."
+          : "Rework has been triggered. Dev agent will receive updated instructions.",
+    ].filter(Boolean).join("\n");
+
+    try {
+      await this.sendPrompt(mainAgentId, callbackPrompt, undefined, "main");
+    } catch (err) {
+      // Non-fatal: callback delivery is best-effort
+      this.transport.sendNotification("log", {
+        message: `[orchestrator] Failed to deliver task callback to Main Agent: ${err instanceof Error ? err.message : err}`,
+      });
+    }
+  }
+
+  /**
+   * Get task result — returns task status, acceptance verdict, and findings.
+   * Designed for external callers to poll task completion.
+   */
+  private async getTaskResult(taskId: string): Promise<{
+    taskId: string;
+    status: TaskStatus;
+    title: string;
+    verdict: AcceptanceVerdict | null;
+    findings: string[];
+    recommendations: string[];
+    closedAt: string | null;
+  }> {
+    const task = await this.taskManager.getTaskAsync(taskId);
+    if (!task) throw new Error(`Task not found: ${taskId}`);
+
+    // Find latest acceptance result for this task
+    const acceptance = this.taskManager.getAcceptanceByTaskId(taskId);
+    const latestResult = acceptance?.results;
+
+    return {
+      taskId: task.taskId,
+      status: task.status,
+      title: task.title,
+      verdict: latestResult?.verdict ?? null,
+      findings: latestResult?.findings ?? [],
+      recommendations: latestResult?.recommendations ?? [],
+      closedAt: task.closedAt,
+    };
+  }
+
   private async createAcceptanceFlow(
     taskId: string,
     acceptorId: string,
@@ -2414,6 +2506,20 @@ export class Orchestrator {
         results.findings,
       );
 
+      // Callback to Main Agent for fail/partial
+      this.bus.emit(
+        "orchestrator.task.callback",
+        acceptance.acceptor,
+        "orchestrator",
+        {
+          taskId: task.taskId,
+          originatorSessionId: task.originatorSessionId,
+          verdict: results.verdict,
+          findings: results.findings,
+          recommendations: results.recommendations,
+        },
+      );
+
       if (!newSession) {
         // Send rework prompt to existing dev session
         const reworkPrompt = buildReworkPrompt(task, acceptance);
@@ -2434,6 +2540,21 @@ export class Orchestrator {
     // verdict === "blocked" → create issue (caller handles specifics)
     if (results.verdict === "blocked") {
       this.taskManager.transitionTask(task.taskId, "blocked", acceptance.acceptor);
+
+      // Callback to Main Agent for blocked
+      this.bus.emit(
+        "orchestrator.task.callback",
+        acceptance.acceptor,
+        "orchestrator",
+        {
+          taskId: task.taskId,
+          originatorSessionId: task.originatorSessionId,
+          verdict: "blocked",
+          findings: results.findings,
+          recommendations: results.recommendations,
+        },
+      );
+
       return { verdict: "blocked", reworkTriggered: false, newSession: false };
     }
 

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -2516,20 +2516,6 @@ export class Orchestrator {
         results.findings,
       );
 
-      // Callback to Main Agent for fail/partial
-      this.bus.emit(
-        "orchestrator.task.callback",
-        acceptance.acceptor,
-        "orchestrator",
-        {
-          taskId: task.taskId,
-          originatorSessionId: task.originatorSessionId,
-          verdict: results.verdict,
-          findings: results.findings,
-          recommendations: results.recommendations,
-        },
-      );
-
       if (!newSession) {
         // Send rework prompt to existing dev session
         const reworkPrompt = buildReworkPrompt(task, acceptance);
@@ -2543,6 +2529,20 @@ export class Orchestrator {
           task.taskId,
         );
       }
+
+      // Callback to Main Agent for fail/partial (after rework dispatch to avoid premature notification)
+      this.bus.emit(
+        "orchestrator.task.callback",
+        acceptance.acceptor,
+        "orchestrator",
+        {
+          taskId: task.taskId,
+          originatorSessionId: task.originatorSessionId,
+          verdict: results.verdict,
+          findings: results.findings,
+          recommendations: results.recommendations,
+        },
+      );
 
       return { verdict: results.verdict, reworkTriggered: true, newSession };
     }

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -79,6 +79,15 @@ type ParsedMainReviewDecision = {
   structured: StructuredReviewResult;
 };
 
+/** Shared type for orchestrator.task.callback event payload. */
+type TaskCallbackPayload = {
+  taskId: string;
+  originatorSessionId?: string;
+  verdict: AcceptanceVerdict;
+  findings?: string[];
+  recommendations?: string[];
+};
+
 const ROLE_CONTEXT_ROLES = ["main", "dev", "acceptance"] as const;
 type RoleContextKey = (typeof ROLE_CONTEXT_ROLES)[number];
 
@@ -146,13 +155,7 @@ export class Orchestrator {
 
     // Route task completion callbacks to Internal Main Agent session
     this.bus.on("orchestrator.task.callback", (event) => {
-      const payload = event.payload as {
-        taskId: string;
-        originatorSessionId?: string;
-        verdict: string;
-        findings?: string[];
-        recommendations?: string[];
-      };
+      const payload = event.payload as TaskCallbackPayload;
       // Fire-and-forget: deliver callback to Main Agent
       void this.deliverTaskCallback(payload);
     });
@@ -2350,15 +2353,19 @@ export class Orchestrator {
    * Deliver task completion callback to Internal Main Agent session.
    * Called when acceptance result (pass/fail/partial/blocked) is recorded.
    */
-  private async deliverTaskCallback(payload: {
-    taskId: string;
-    originatorSessionId?: string;
-    verdict: string;
-    findings?: string[];
-    recommendations?: string[];
-  }): Promise<void> {
+  private async deliverTaskCallback(payload: TaskCallbackPayload): Promise<void> {
     const mainAgentId = this.findMainAgentId();
     if (!mainAgentId) return;
+
+    // Only deliver if there's an active Main Agent session (avoid spawning new session)
+    const mainSlot = makeRoleSlotKey("main", mainAgentId);
+    const activeSessionId = this.roleSessions.get(mainSlot);
+    if (!activeSessionId) {
+      this.transport.sendNotification("log", {
+        message: `[orchestrator] No active Main Agent session for callback delivery (task: ${payload.taskId})`,
+      });
+      return;
+    }
 
     const task = this.taskManager.getTask(payload.taskId);
     const taskTitle = task?.title ?? payload.taskId;
@@ -2408,8 +2415,11 @@ export class Orchestrator {
     const task = await this.taskManager.getTaskAsync(taskId);
     if (!task) throw new Error(`Task not found: ${taskId}`);
 
-    // Find latest acceptance result for this task
-    const acceptance = this.taskManager.getAcceptanceByTaskId(taskId);
+    // Find acceptance result: prefer persisted reference, fall back to memory scan
+    const acceptanceBundleId = task.handoffToAcceptance?.acceptanceBundleId;
+    const acceptance = acceptanceBundleId
+      ? this.taskManager.getAcceptance(acceptanceBundleId)
+      : this.taskManager.getAcceptanceByTaskId(taskId);
     const latestResult = acceptance?.results;
 
     return {

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -520,6 +520,19 @@ export class TaskManager {
     return this.acceptances.get(acceptanceId);
   }
 
+  /** Find the latest acceptance for a given task ID. */
+  getAcceptanceByTaskId(taskId: string): AcceptanceBundle | undefined {
+    let latest: AcceptanceBundle | undefined;
+    for (const a of this.acceptances.values()) {
+      if (a.linkedTaskId === taskId) {
+        if (!latest || (a.completedAt ?? 0) > (latest.completedAt ?? 0)) {
+          latest = a;
+        }
+      }
+    }
+    return latest;
+  }
+
   recordAcceptanceResult(
     acceptanceId: string,
     results: { verdict: AcceptanceVerdict; findings: string[]; recommendations: string[] },


### PR DESCRIPTION
## Summary
- **Internal callback (#33)**: Add `orchestrator.task.callback` EventBus listener that delivers acceptance results (pass/fail/partial/blocked) to Internal Main Agent session via `sendPrompt()`
- **External callback (#34)**: Add `get_task_result` RPC method + MCP tool for external callers to poll task completion status with verdict and findings
- Emit callback events for ALL acceptance verdicts (previously only "pass" emitted)
- Add `TaskManager.getAcceptanceByTaskId()` helper for acceptance result lookup

## Changes
| File | Change |
|------|--------|
| `orchestrator.ts` | Bus listener + `deliverTaskCallback()` + `getTaskResult()` + emit for fail/partial/blocked |
| `task-manager.ts` | `getAcceptanceByTaskId()` method |
| `mcp-server.ts` | Register `get_task_result` tool |

## Test plan
- [ ] Type-check passes (`tsc --noEmit` clean)
- [ ] Internal Main Agent receives callback after acceptance pass
- [ ] Internal Main Agent receives callback after acceptance fail/partial (with findings)
- [ ] External caller can poll `get_task_result` for task status
- [ ] Callback delivery failure is non-fatal (best-effort with log)

Closes #33, Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)