### PR TITLE
fix(TASK-SESSION-ISOLATION-001): enforce agent+role isolation on session history

### DIFF
--- a/packages/gui/src-tauri/src/commands.rs
+++ b/packages/gui/src-tauri/src/commands.rs
@@ -512,6 +512,8 @@ pub async fn get_session_messages(
     session_id: String,
     offset: Option<usize>,
     limit: Option<usize>,
+    agent_id: Option<String>,
+    role: Option<String>,
 ) -> Result<serde_json::Value, String> {
     let mgr = get_sidecar(&sidecar).await?;
     mgr.send_request(
@@ -519,7 +521,9 @@ pub async fn get_session_messages(
         serde_json::json!({
             "sessionId": session_id,
             "offset": offset,
-            "limit": limit
+            "limit": limit,
+            "agentId": agent_id,
+            "role": role
         }),
     )
     .await

--- a/packages/gui/src/lib/tauri-bridge.ts
+++ b/packages/gui/src/lib/tauri-bridge.ts
@@ -477,11 +477,15 @@ export async function getSessionMessages(
   sessionId: string,
   offset?: number,
   limit?: number,
+  agentId?: string,
+  role?: string,
 ): Promise<{ messages: TranscriptMessage[]; total: number }> {
   return invoke("get_session_messages", {
     sessionId,
     offset: offset ?? null,
     limit: limit ?? null,
+    agentId: agentId ?? null,
+    role: role ?? null,
   });
 }
 

--- a/packages/gui/src/stores/messages.ts
+++ b/packages/gui/src/stores/messages.ts
@@ -414,7 +414,23 @@ async function loadSessionHistory(panelKey: string, sessionId: string): Promise<
 
   try {
     // Primary: orchestrator transcript (with agent+role isolation)
-    const result = await bridgeGetSessionMessages(sessionId, undefined, undefined, agentId, role);
+    const result = await bridgeGetSessionMessages(sessionId, undefined, undefined, agentId, role) as {
+      messages: TranscriptMessage[];
+      total: number;
+      accessDenied?: boolean;
+    };
+
+    // If access was denied by isolation, do NOT fall back to native files
+    if (result.accessDenied) {
+      clearMessages(panelKey);
+      appendMessage(panelKey, {
+        role: "system",
+        content: "Access denied: this session belongs to a different agent/role.",
+        timestamp: Date.now(),
+      });
+      return;
+    }
+
     if (result.messages && result.messages.length > 0) {
       const batch: DisplayMessage[] = result.messages.map((msg) => ({
         role: msg.role,
@@ -430,7 +446,7 @@ async function loadSessionHistory(panelKey: string, sessionId: string): Promise<
     // Orchestrator doesn't have this session — try native CLI files
   }
 
-  // Fallback: native CLI JSONL files
+  // Fallback: native CLI JSONL files (only reached when orchestrator has no transcript, NOT access denied)
   const agent = agentStore.agents.value.find((a) => a.id === agentId);
   const cliType = agent?.cli === "codex" ? "codex" as const : "claude" as const;
 

--- a/packages/gui/src/stores/messages.ts
+++ b/packages/gui/src/stores/messages.ts
@@ -60,6 +60,7 @@ const pendingSessionPick = ref<{
 const pendingHistoryView = ref<{
   panelKey: string;
   agentId: string;
+  role?: string;
   sessions: SessionListItem[];
   selectedSessionId: string | null;
   messages: TranscriptMessage[];
@@ -408,9 +409,12 @@ async function loadSessionHistory(panelKey: string, sessionId: string): Promise<
     timestamp: Date.now(),
   });
 
+  const agentStore = useAgentStore();
+  const { agentId, role } = agentStore.parsePanelKey(panelKey);
+
   try {
-    // Primary: orchestrator transcript
-    const result = await bridgeGetSessionMessages(sessionId);
+    // Primary: orchestrator transcript (with agent+role isolation)
+    const result = await bridgeGetSessionMessages(sessionId, undefined, undefined, agentId, role);
     if (result.messages && result.messages.length > 0) {
       const batch: DisplayMessage[] = result.messages.map((msg) => ({
         role: msg.role,
@@ -427,8 +431,6 @@ async function loadSessionHistory(panelKey: string, sessionId: string): Promise<
   }
 
   // Fallback: native CLI JSONL files
-  const agentStore = useAgentStore();
-  const { agentId } = agentStore.parsePanelKey(panelKey);
   const agent = agentStore.agents.value.find((a) => a.id === agentId);
   const cliType = agent?.cli === "codex" ? "codex" as const : "claude" as const;
 
@@ -481,15 +483,17 @@ async function openSessionPicker(panelKey: string): Promise<void> {
   }
 }
 
-/** Open the history panel showing all sessions for this panel's agent. */
+/** Open the history panel showing sessions filtered by agent+role for isolation. */
 async function openHistory(panelKey: string): Promise<void> {
-  const { agentId } = useAgentStore().parsePanelKey(panelKey);
+  const { agentId, role } = useAgentStore().parsePanelKey(panelKey);
 
   try {
-    const sessions = await bridgeListSessions(agentId, undefined, true);
+    // Filter sessions by agent + role for proper isolation
+    const sessions = await bridgeListSessions(agentId, role, true);
     pendingHistoryView.value = {
       panelKey,
       agentId,
+      role,
       sessions,
       selectedSessionId: null,
       messages: [],
@@ -507,7 +511,7 @@ async function openHistory(panelKey: string): Promise<void> {
   }
 }
 
-/** Load transcript messages for a session into the history viewer. */
+/** Load transcript messages for a session into the history viewer (with agent+role isolation). */
 async function selectHistorySession(sessionId: string): Promise<void> {
   const current = pendingHistoryView.value;
   if (!current) return;
@@ -516,7 +520,14 @@ async function selectHistorySession(sessionId: string): Promise<void> {
   pendingHistoryView.value = { ...current, selectedSessionId: sessionId, messages: [] };
 
   try {
-    const result = await bridgeGetSessionMessages(sessionId);
+    // Pass agentId + role for server-side ownership validation
+    const result = await bridgeGetSessionMessages(
+      sessionId,
+      undefined,
+      undefined,
+      current.agentId,
+      current.role,
+    );
     // Guard against stale response: only apply if this session is still selected
     if (pendingHistoryView.value?.selectedSessionId !== sessionId) return;
     pendingHistoryView.value = {

--- a/packages/orchestrator/src/mcp-server.ts
+++ b/packages/orchestrator/src/mcp-server.ts
@@ -135,10 +135,12 @@ export function createMcpServer(orchestrator: Orchestrator, transport: RpcTransp
     });
 
   rpcTool(server, orchestrator, "get_session_messages",
-    "Get message history for a session", {
+    "Get message history for a session (filtered by agent+role when provided)", {
       sessionId,
       offset: z.number().optional().describe("Start offset"),
       limit: z.number().optional().describe("Max messages to return"),
+      agentId: agentId.optional().describe("Filter: only return messages if session belongs to this agent"),
+      role: z.string().optional().describe("Filter: only return messages if session has this role"),
     });
 
   rpcTool(server, orchestrator, "summarize_session",

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -841,6 +841,8 @@ export class Orchestrator {
           params.sessionId as string,
           (params.offset as number | null) ?? undefined,
           (params.limit as number | null) ?? undefined,
+          (params.agentId as string | null) ?? undefined,
+          (params.role as AgentRole | null) ?? undefined,
         );
       case "get_approval_mode":
         return { mode: this.approvalMode };
@@ -1068,7 +1070,25 @@ export class Orchestrator {
     sessionId: string,
     offset?: number,
     limit?: number,
+    requestingAgentId?: string,
+    requestingRole?: AgentRole,
   ): Promise<{ messages: TranscriptMessage[]; total: number }> {
+    // Validate session ownership if requesting context is provided
+    if (requestingAgentId || requestingRole) {
+      const sessionInfo = this.sessions.get(sessionId);
+      if (sessionInfo) {
+        if (requestingAgentId && sessionInfo.agentId !== requestingAgentId) {
+          return { messages: [], total: 0 };
+        }
+        if (requestingRole) {
+          const sessionRole = this.getSessionRole(sessionInfo, sessionInfo.agentId);
+          if (sessionRole && sessionRole !== requestingRole) {
+            return { messages: [], total: 0 };
+          }
+        }
+      }
+    }
+
     const safeOffset = Math.max(0, offset ?? 0);
 
     if (this.transcripts) {
@@ -1079,6 +1099,8 @@ export class Orchestrator {
     }
 
     for (const agent of this.registry.listAgents()) {
+      // When requesting agent is specified, only try that agent's adapter
+      if (requestingAgentId && agent.id !== requestingAgentId) continue;
       const nativeAdapter = this.asNativeSessionBridge(agent.id);
       if (!nativeAdapter.readNativeMessages) continue;
       try {

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -1068,23 +1068,42 @@ export class Orchestrator {
 
   private async getSessionMessages(
     sessionId: string,
-    offset?: number,
-    limit?: number,
+    offset: number | undefined,
+    limit: number | undefined,
     requestingAgentId?: string,
     requestingRole?: AgentRole,
-  ): Promise<{ messages: TranscriptMessage[]; total: number }> {
-    // Validate session ownership if requesting context is provided
-    if (requestingAgentId || requestingRole) {
+  ): Promise<{ messages: TranscriptMessage[]; total: number; accessDenied?: boolean }> {
+    // Enforce agent+role isolation: validate session ownership
+    if (requestingAgentId) {
       const sessionInfo = this.sessions.get(sessionId);
       if (sessionInfo) {
-        if (requestingAgentId && sessionInfo.agentId !== requestingAgentId) {
-          return { messages: [], total: 0 };
+        // Session found in memory — validate ownership
+        if (sessionInfo.agentId !== requestingAgentId) {
+          return { messages: [], total: 0, accessDenied: true };
         }
         if (requestingRole) {
           const sessionRole = this.getSessionRole(sessionInfo, sessionInfo.agentId);
-          if (sessionRole && sessionRole !== requestingRole) {
-            return { messages: [], total: 0 };
+          if (!sessionRole || sessionRole !== requestingRole) {
+            return { messages: [], total: 0, accessDenied: true };
           }
+        }
+      } else {
+        // Session not in memory — deny by default (unknown session = no access)
+        // Exception: allow if session can be found via native adapter for the requesting agent
+        const nativeAdapter = this.asNativeSessionBridge(requestingAgentId);
+        if (!nativeAdapter.getNativeSessionInfo) {
+          return { messages: [], total: 0, accessDenied: true };
+        }
+        try {
+          const nativeInfo = await nativeAdapter.getNativeSessionInfo(
+            sessionId,
+            this.agentCwds.get(requestingAgentId),
+          );
+          if (!nativeInfo || nativeInfo.agentId !== requestingAgentId) {
+            return { messages: [], total: 0, accessDenied: true };
+          }
+        } catch {
+          return { messages: [], total: 0, accessDenied: true };
         }
       }
     }


### PR DESCRIPTION
## Summary
- **Backend**: Add agentId/role ownership validation to `getSessionMessages()` — returns empty if session doesn't belong to requesting agent+role
- **Frontend**: `openHistory()` now passes role filter; `selectHistorySession()` passes agentId+role for server-side validation
- **Tauri**: Updated Rust command with `agent_id`/`role` parameters
- **MCP**: Updated `get_session_messages` schema with optional agentId/role params

## Changes
| File | Change |
|------|--------|
| `orchestrator.ts` | `getSessionMessages()` ownership validation + RPC handler update |
| `mcp-server.ts` | Schema: add agentId/role to `get_session_messages` |
| `tauri-bridge.ts` | Pass agentId/role params |
| `messages.ts` | Filter by role in `openHistory()`, pass context in `selectHistorySession()` + `loadSessionHistory()` |
| `commands.rs` | Add `agent_id`/`role` params to Rust command |

## Test plan
- [ ] Type-check passes (tsc + cargo check)
- [ ] Main Agent `/history` shows only main-role sessions
- [ ] Dev Agent `/history` shows only dev-role sessions
- [ ] Cross-role session transcript reads return empty

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)