### PR TITLE
feat(TASK-AUTO-TRIAGE-001): G9 modelRecommendation auto-routing

### DIFF
--- a/.claude/hooks/pr-create-guard.sh
+++ b/.claude/hooks/pr-create-guard.sh
@@ -11,11 +11,11 @@
 INPUT=$(cat)
 
 # Only intercept gh pr create commands
-echo "$INPUT" | grep -qE 'gh\s+pr\s+create' || exit 0
+echo "$INPUT" | grep -qE 'gh[[:space:]]+pr[[:space:]]+create' || exit 0
 
 MISSING=""
 
-# Check --assignee or --add-assignee (match word boundary to avoid substring false positives)
+# Check --assignee or --add-assignee
 echo "$INPUT" | grep -qE '(--assignee|--add-assignee)' || MISSING="${MISSING}  - --assignee (required: who owns this PR)\n"
 
 # Check --label or --add-label

--- a/.claude/hooks/pr-create-guard.sh
+++ b/.claude/hooks/pr-create-guard.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # GATE: block `gh pr create` unless --assignee and --label are present.
 # Ensures all PRs follow Mercury standard flow with proper metadata.
 #
@@ -25,7 +25,7 @@ if [ -n "$MISSING" ]; then
   cat >&2 <<MSG
 BLOCKED: PR creation missing required metadata (Mercury standard flow).
 Missing flags:
-$(echo -e "$MISSING")
+$(printf '%b' "$MISSING")
 All PRs must include assignee and label. Use pr-flow skill or add flags manually.
 Example: gh pr create --title "..." --body "..." --assignee 392fyc --label enhancement
 MSG

--- a/.claude/hooks/pr-create-guard.sh
+++ b/.claude/hooks/pr-create-guard.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# GATE: block `gh pr create` unless --assignee and --label are present.
+# Ensures all PRs follow Mercury standard flow with proper metadata.
+#
+# Pattern: PreToolUse(Bash) → detect "gh pr create" → check flags → block/allow
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+
+# Only intercept gh pr create commands
+echo "$COMMAND" | grep -qE 'gh[[:space:]]+pr[[:space:]]+create' || exit 0
+
+MISSING=""
+
+# Check --assignee or --add-assignee
+echo "$COMMAND" | grep -qE '\-\-assignee|\-\-add-assignee' || MISSING="${MISSING}  - --assignee (required: who owns this PR)\n"
+
+# Check --label or --add-label
+echo "$COMMAND" | grep -qE '\-\-label|\-\-add-label' || MISSING="${MISSING}  - --label (required: bug/enhancement/etc.)\n"
+
+if [ -n "$MISSING" ]; then
+  cat >&2 <<MSG
+BLOCKED: PR creation missing required metadata (Mercury standard flow).
+Missing flags:
+$(echo -e "$MISSING")
+All PRs must include assignee and label. Use pr-flow skill or add flags manually.
+Example: gh pr create --title "..." --body "..." --assignee 392fyc --label enhancement
+MSG
+  exit 2
+fi
+
+exit 0

--- a/.claude/hooks/pr-create-guard.sh
+++ b/.claude/hooks/pr-create-guard.sh
@@ -3,20 +3,23 @@
 # Ensures all PRs follow Mercury standard flow with proper metadata.
 #
 # Pattern: PreToolUse(Bash) → detect "gh pr create" → check flags → block/allow
+#
+# NOTE: We match against raw INPUT (not parsed COMMAND) to avoid JSON escaping
+# issues with sed/grep. The flags --assignee/--label won't appear in title/body
+# content, so raw matching is safe and robust.
 
 INPUT=$(cat)
-COMMAND=$(echo "$INPUT" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
 
 # Only intercept gh pr create commands
-echo "$COMMAND" | grep -qE 'gh[[:space:]]+pr[[:space:]]+create' || exit 0
+echo "$INPUT" | grep -qE 'gh\s+pr\s+create' || exit 0
 
 MISSING=""
 
-# Check --assignee or --add-assignee
-echo "$COMMAND" | grep -qE '\-\-assignee|\-\-add-assignee' || MISSING="${MISSING}  - --assignee (required: who owns this PR)\n"
+# Check --assignee or --add-assignee (match word boundary to avoid substring false positives)
+echo "$INPUT" | grep -qE '(--assignee|--add-assignee)' || MISSING="${MISSING}  - --assignee (required: who owns this PR)\n"
 
 # Check --label or --add-label
-echo "$COMMAND" | grep -qE '\-\-label|\-\-add-label' || MISSING="${MISSING}  - --label (required: bug/enhancement/etc.)\n"
+echo "$INPUT" | grep -qE '(--label|--add-label)' || MISSING="${MISSING}  - --label (required: bug/enhancement/etc.)\n"
 
 if [ -n "$MISSING" ]; then
   cat >&2 <<MSG

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -26,6 +26,11 @@
           },
           {
             "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/pr-create-guard.sh\"",
+            "timeout": 5
+          },
+          {
+            "type": "command",
             "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/pr-merge-guard.sh\"",
             "timeout": 15
           }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -43,6 +43,8 @@ export type {
   SlashCommandArg,
   TaskAssignee,
   TaskBundle,
+  TaskComplexity,
   TaskPriority,
   TaskStatus,
+  ModelRecommendation,
 } from "./types.js";

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -219,6 +219,16 @@ export interface TaskAssignee {
 
 export type TaskPriority = "P0" | "P1" | "P2" | "P3";
 
+/** G9: Model recommendation for automatic task routing. */
+export type TaskComplexity = "low" | "medium" | "high";
+
+export interface ModelRecommendation {
+  complexity: TaskComplexity;
+  requiredCapabilities?: string[];
+  preferredModel?: string; // hint: e.g. "claude-opus-4-6", "o3"
+  reason?: string;
+}
+
 export type TaskStatus =
   | "drafted"
   | "dispatched"
@@ -346,6 +356,9 @@ export interface TaskBundle {
 
   // Callback routing: Main Agent session that dispatched this task
   originatorSessionId?: string;
+
+  // G9: Auto-triage model recommendation
+  modelRecommendation?: ModelRecommendation;
 
   // Rework history: accumulated across attempts for iterative context
   reworkHistory: ReworkHistoryEntry[];

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -182,6 +182,7 @@ export type EventType =
   | "orchestrator.task.complete"
   | "orchestrator.task.fail"
   | "orchestrator.task.created"
+  | "orchestrator.routing.debug"
   | "orchestrator.task.status_change"
   | "orchestrator.task.rework"
   | "orchestrator.acceptance.created"

--- a/packages/gui/src/lib/tauri-bridge.ts
+++ b/packages/gui/src/lib/tauri-bridge.ts
@@ -298,9 +298,9 @@ export interface CreateTaskParams {
   requiredEvidence?: string[];
   context: string;
   modelRecommendation?: {
+    complexity: "low" | "medium" | "high"; // Required per core ModelRecommendation
     preferredModel?: string;
     requiredCapabilities?: string[];
-    complexity?: "low" | "medium" | "high";
   };
   maxReworks?: number;
 }

--- a/packages/gui/src/lib/tauri-bridge.ts
+++ b/packages/gui/src/lib/tauri-bridge.ts
@@ -287,7 +287,7 @@ export interface CreateTaskParams {
   title: string;
   phaseId?: string;
   priority: TaskPriority;
-  assignedTo: string;
+  assignedTo?: string; // Optional: auto-assigned via G9 modelRecommendation if omitted
   branch?: string;
   codeScope: { include: string[]; exclude: string[] };
   readScope: { requiredDocs: string[]; optionalDocs: string[] };
@@ -297,6 +297,11 @@ export interface CreateTaskParams {
   definitionOfDone: string[];
   requiredEvidence?: string[];
   context: string;
+  modelRecommendation?: {
+    preferredModel?: string;
+    requiredCapabilities?: string[];
+    complexity?: "low" | "medium" | "high";
+  };
   maxReworks?: number;
 }
 

--- a/packages/orchestrator/src/mcp-server.ts
+++ b/packages/orchestrator/src/mcp-server.ts
@@ -150,11 +150,11 @@ export function createMcpServer(orchestrator: Orchestrator, transport: RpcTransp
   // ─── Task Management ───
 
   rpcTool(server, orchestrator, "create_task",
-    "Create a new TaskBundle", {
+    "Create a new TaskBundle (assignedTo is auto-selected via G9 if omitted)", {
       taskId: taskId.optional().describe("Custom task ID (auto-generated if omitted)"),
       title: z.string().describe("Short task title"),
       priority: z.enum(["P0", "P1", "P2", "P3"]).optional().describe("Task priority level"),
-      assignedTo: agentId.describe("Agent to assign the task to"),
+      assignedTo: agentId.optional().describe("Agent to assign (auto-selected if omitted)"),
       description: z.string().optional().describe("Detailed task description"),
       context: z.string().describe("Task context for dev agent"),
       codeScope: z.record(z.string(), z.unknown()).optional().describe("Code scope boundaries"),
@@ -162,6 +162,12 @@ export function createMcpServer(orchestrator: Orchestrator, transport: RpcTransp
       allowedWriteScope: z.record(z.string(), z.unknown()).describe("Allowed write paths"),
       definitionOfDone: z.array(z.string()).optional().describe("DoD checklist items"),
       branch: z.string().optional().describe("Git branch name"),
+      modelRecommendation: z.object({
+        complexity: z.enum(["low", "medium", "high"]).describe("Task complexity"),
+        requiredCapabilities: z.array(z.string()).optional().describe("Required agent capabilities"),
+        preferredModel: z.string().optional().describe("Preferred model hint (e.g. claude-opus-4-6)"),
+        reason: z.string().optional().describe("Reason for recommendation"),
+      }).optional().describe("G9: model recommendation for auto-routing"),
     });
 
   rpcTool(server, orchestrator, "get_task",

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -195,6 +195,8 @@ export class Orchestrator {
     this.taskManager.setAgentConfigLookup((agentId) =>
       this.registry.listAgents().find((a) => a.id === agentId),
     );
+    // Wire agent list lookup for G9 auto-triage agent selection
+    this.taskManager.setAgentListLookup(() => this.registry.listAgents());
   }
 
   /** Wire agent config lookup for Agents First assignee.model (works with or without KB). */
@@ -202,6 +204,7 @@ export class Orchestrator {
     this.taskManager.setAgentConfigLookup((agentId) =>
       this.registry.listAgents().find((a) => a.id === agentId),
     );
+    this.taskManager.setAgentListLookup(() => this.registry.listAgents());
   }
 
   /** Rehydrate task state from KB persistence + build shared context + restore sessions. */

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -199,7 +199,11 @@ export class Orchestrator {
     this.taskManager.setAgentListLookup(() => this.registry.listAgents());
   }
 
-  /** Wire agent config lookup for Agents First assignee.model (works with or without KB). */
+  /**
+   * Wire agent config lookup for Agents First assignee.model (works with or without KB).
+   * NOTE: Both this method AND setKnowledgeService() wire agentListLookup — this is
+   * intentional to ensure G9 auto-triage works regardless of initialization path.
+   */
   setAgentConfigLookup(): void {
     this.taskManager.setAgentConfigLookup((agentId) =>
       this.registry.listAgents().find((a) => a.id === agentId),

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -140,10 +140,14 @@ export class TaskManager {
     const scored = devAgents.map((agent) => {
       let score = 0;
 
-      // Preferred model match (highest weight)
+      // Preferred model match: exact or normalized comparison (avoids "o3" matching "o3-mini" etc.)
       if (rec.preferredModel && agent.model) {
-        if (agent.model.includes(rec.preferredModel) || rec.preferredModel.includes(agent.model)) {
-          score += 100;
+        const preferred = rec.preferredModel.toLowerCase();
+        const agentModel = agent.model.toLowerCase();
+        if (agentModel === preferred) {
+          score += 100; // Exact match
+        } else if (agentModel.startsWith(preferred + "-") || preferred.startsWith(agentModel + "-")) {
+          score += 50; // Family match (e.g. "claude-opus-4-6" matches "claude-opus-4-6-xxx")
         }
       }
 
@@ -155,7 +159,9 @@ export class TaskManager {
         score += matched * 20;
       }
 
-      // Complexity-based preference: high → prefer agents with more capabilities
+      // Complexity-based preference:
+      // - high: prefer agents with more capabilities (stronger models)
+      // - medium/low: no capability bias (any dev agent is suitable)
       if (rec.complexity === "high") {
         score += agent.capabilities.length * 5;
       }
@@ -163,8 +169,8 @@ export class TaskManager {
       return { agent, score };
     });
 
-    // Sort by score descending, return best match
-    scored.sort((a, b) => b.score - a.score);
+    // Sort by score descending; tiebreak by agent ID for deterministic selection
+    scored.sort((a, b) => b.score - a.score || a.agent.id.localeCompare(b.agent.id));
     return scored[0].agent.id;
   }
 

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -127,9 +127,7 @@ export class TaskManager {
     // Only consider agents with "dev" role
     const devAgents = agents.filter((a) => a.roles.includes("dev"));
     if (devAgents.length === 0) {
-      // Last resort: any agent
-      if (agents.length > 0) return agents[0].id;
-      throw new Error("No agents registered — cannot auto-assign task");
+      throw new Error("No agents with 'dev' role registered — cannot auto-assign task");
     }
     if (devAgents.length === 1) return devAgents[0].id;
 
@@ -239,6 +237,11 @@ export class TaskManager {
 
     // G9: Auto-assign agent if not provided — use modelRecommendation routing
     const assignedTo = params.assignedTo?.trim() || this.autoSelectAgent(params);
+
+    // Validate assignedTo references a registered agent
+    if (this.agentConfigLookup && !this.agentConfigLookup(assignedTo)) {
+      throw new Error(`createTask validation failed: agent "${assignedTo}" is not registered`);
+    }
 
     const taskId = `TASK-${shortId()}`;
     const task: TaskBundle = {

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -152,7 +152,7 @@ export class TaskManager {
       // Capability matching
       if (rec.requiredCapabilities?.length) {
         const matched = rec.requiredCapabilities.filter((cap) =>
-          agent.capabilities.some((ac) => ac.toLowerCase().includes(cap.toLowerCase())),
+          agent.capabilities.some((ac) => ac.toLowerCase() === cap.toLowerCase()),
         ).length;
         score += matched * 20;
       }
@@ -238,9 +238,15 @@ export class TaskManager {
     // G9: Auto-assign agent if not provided — use modelRecommendation routing
     const assignedTo = params.assignedTo?.trim() || this.autoSelectAgent(params);
 
-    // Validate assignedTo references a registered agent
-    if (this.agentConfigLookup && !this.agentConfigLookup(assignedTo)) {
-      throw new Error(`createTask validation failed: agent "${assignedTo}" is not registered`);
+    // Validate assignedTo references a registered agent with 'dev' role
+    if (this.agentConfigLookup) {
+      const agentConfig = this.agentConfigLookup(assignedTo);
+      if (!agentConfig) {
+        throw new Error(`createTask validation failed: agent "${assignedTo}" is not registered`);
+      }
+      if (!agentConfig.roles.includes("dev")) {
+        throw new Error(`createTask validation failed: agent "${assignedTo}" does not have 'dev' role`);
+      }
     }
 
     const taskId = `TASK-${shortId()}`;

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -51,7 +51,7 @@ export interface CreateTaskParams {
   title: string;
   phaseId?: string;
   priority: TaskBundle["priority"];
-  assignedTo: string;
+  assignedTo?: string; // Optional: auto-assigned via G9 modelRecommendation if omitted
   branch?: string;
   codeScope: TaskBundle["codeScope"];
   readScope: TaskBundle["readScope"];
@@ -63,6 +63,7 @@ export interface CreateTaskParams {
   context: string;
   reviewConfig?: TaskBundle["reviewConfig"];
   handoffToAcceptance?: TaskBundle["handoffToAcceptance"];
+  modelRecommendation?: TaskBundle["modelRecommendation"];
   maxReworks?: number;
   maxDispatchAttempts?: number;
 }
@@ -89,6 +90,7 @@ export class TaskManager {
 
   private persistence: TaskPersistence | null = null;
   private agentConfigLookup: ((agentId: string) => AgentConfig | undefined) | null = null;
+  private agentListLookup: (() => AgentConfig[]) | null = null;
 
   constructor(private bus: EventBus) {}
 
@@ -102,10 +104,68 @@ export class TaskManager {
     this.agentConfigLookup = lookup;
   }
 
+  /** Inject agent list lookup for G9 auto-triage agent selection. */
+  setAgentListLookup(lookup: () => AgentConfig[]): void {
+    this.agentListLookup = lookup;
+  }
+
   /** Build a TaskAssignee struct from agentId, enriching with model from agent config if available. */
   private buildTaskAssignee(agentId: string): TaskAssignee {
     const model = this.agentConfigLookup?.(agentId)?.model;
     return model === undefined ? { agentId } : { agentId, model };
+  }
+
+  /**
+   * G9 Auto-triage: select the best agent for a task based on:
+   * 1. modelRecommendation.preferredModel → match agent.model
+   * 2. modelRecommendation.requiredCapabilities → match agent.capabilities
+   * 3. modelRecommendation.complexity → prefer more capable agents for high complexity
+   * 4. Fallback: first agent with "dev" role
+   */
+  private autoSelectAgent(params: CreateTaskParams): string {
+    const agents = this.agentListLookup?.() ?? [];
+    // Only consider agents with "dev" role
+    const devAgents = agents.filter((a) => a.roles.includes("dev"));
+    if (devAgents.length === 0) {
+      // Last resort: any agent
+      if (agents.length > 0) return agents[0].id;
+      throw new Error("No agents registered — cannot auto-assign task");
+    }
+    if (devAgents.length === 1) return devAgents[0].id;
+
+    const rec = params.modelRecommendation;
+    if (!rec) return devAgents[0].id;
+
+    // Score each dev agent
+    const scored = devAgents.map((agent) => {
+      let score = 0;
+
+      // Preferred model match (highest weight)
+      if (rec.preferredModel && agent.model) {
+        if (agent.model.includes(rec.preferredModel) || rec.preferredModel.includes(agent.model)) {
+          score += 100;
+        }
+      }
+
+      // Capability matching
+      if (rec.requiredCapabilities?.length) {
+        const matched = rec.requiredCapabilities.filter((cap) =>
+          agent.capabilities.some((ac) => ac.toLowerCase().includes(cap.toLowerCase())),
+        ).length;
+        score += matched * 20;
+      }
+
+      // Complexity-based preference: high → prefer agents with more capabilities
+      if (rec.complexity === "high") {
+        score += agent.capabilities.length * 5;
+      }
+
+      return { agent, score };
+    });
+
+    // Sort by score descending, return best match
+    scored.sort((a, b) => b.score - a.score);
+    return scored[0].agent.id;
   }
 
   /** Rehydrate task state from persistence (call before RPC starts). */
@@ -145,7 +205,6 @@ export class TaskManager {
     // ─── Input Validation + Normalization ───
     const errors: string[] = [];
     if (!params.title?.trim()) errors.push("title is required");
-    if (!params.assignedTo?.trim()) errors.push("assignedTo is required");
     if (!params.context?.trim()) errors.push("context is required");
     if (!params.definitionOfDone?.length) errors.push("definitionOfDone must have at least 1 item");
     if (!params.codeScope) errors.push("codeScope is required");
@@ -170,8 +229,10 @@ export class TaskManager {
 
     // Normalize string inputs
     params.title = params.title.trim();
-    params.assignedTo = params.assignedTo.trim();
     params.context = params.context.trim();
+
+    // G9: Auto-assign agent if not provided — use modelRecommendation routing
+    const assignedTo = params.assignedTo?.trim() || this.autoSelectAgent(params);
 
     const taskId = `TASK-${shortId()}`;
     const task: TaskBundle = {
@@ -183,7 +244,7 @@ export class TaskManager {
       createdAt: new Date().toISOString(),
       closedAt: null,
       failedAt: null,
-      assignedTo: params.assignedTo,
+      assignedTo,
       branch: params.branch,
       codeScope: params.codeScope,
       readScope: params.readScope,
@@ -195,6 +256,7 @@ export class TaskManager {
       context: params.context,
       reviewConfig: params.reviewConfig,
       handoffToAcceptance: params.handoffToAcceptance,
+      modelRecommendation: params.modelRecommendation,
       dispatchAttempts: 0,
       maxDispatchAttempts: params.maxDispatchAttempts ?? 5,
       reworkCount: 0,
@@ -204,14 +266,14 @@ export class TaskManager {
     };
 
     // Agents First: populate structured assignee from agent config
-    task.assignee = this.buildTaskAssignee(params.assignedTo);
+    task.assignee = this.buildTaskAssignee(assignedTo);
 
     this.tasks.set(taskId, task);
     this.persistTask(task);
 
     this.bus.emit(
       "orchestrator.task.created",
-      params.assignedTo,
+      assignedTo,
       "orchestrator",
       { taskId, title: task.title, assignedTo: task.assignedTo, priority: task.priority },
     );

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -290,7 +290,14 @@ export class TaskManager {
       "orchestrator.task.created",
       assignedTo,
       "orchestrator",
-      { taskId, title: task.title, assignedTo: task.assignedTo, priority: task.priority },
+      {
+        taskId,
+        title: task.title,
+        assignedTo: task.assignedTo,
+        priority: task.priority,
+        modelRecommendation: task.modelRecommendation,
+        routingMethod: params.assignedTo ? "explicit" : "auto-triage",
+      },
     );
 
     return task;

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -149,10 +149,11 @@ export class TaskManager {
         }
       }
 
-      // Capability matching
+      // Capability matching (deduplicated to prevent repeated scoring)
       if (rec.requiredCapabilities?.length) {
-        const matched = rec.requiredCapabilities.filter((cap) =>
-          agent.capabilities.some((ac) => ac.toLowerCase() === cap.toLowerCase()),
+        const uniqueCaps = [...new Set(rec.requiredCapabilities.map((c) => c.toLowerCase()))];
+        const matched = uniqueCaps.filter((cap) =>
+          agent.capabilities.some((ac) => ac.toLowerCase() === cap),
         ).length;
         score += matched * 20;
       }
@@ -236,7 +237,8 @@ export class TaskManager {
     params.context = params.context.trim();
 
     // G9: Auto-assign agent if not provided — use modelRecommendation routing
-    const assignedTo = params.assignedTo?.trim() || this.autoSelectAgent(params);
+    const explicitAssignedTo = params.assignedTo?.trim();
+    const assignedTo = explicitAssignedTo || this.autoSelectAgent(params);
 
     // Validate assignedTo references a registered agent with 'dev' role
     if (this.agentConfigLookup) {
@@ -296,7 +298,7 @@ export class TaskManager {
         assignedTo: task.assignedTo,
         priority: task.priority,
         modelRecommendation: task.modelRecommendation,
-        routingMethod: params.assignedTo ? "explicit" : "auto-triage",
+        routingMethod: explicitAssignedTo ? "explicit" : "auto-triage",
       },
     );
 

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -123,11 +123,16 @@ export class TaskManager {
    * 4. Fallback: first agent with "dev" role
    */
   private autoSelectAgent(params: CreateTaskParams): string {
-    const agents = this.agentListLookup?.() ?? [];
+    if (!this.agentListLookup) {
+      throw new Error("agentListLookup not injected — Orchestrator wiring incomplete");
+    }
+    const agents = this.agentListLookup();
     // Only consider agents with "dev" role
     const devAgents = agents.filter((a) => a.roles.includes("dev"));
     if (devAgents.length === 0) {
-      throw new Error("No agents with 'dev' role registered — cannot auto-assign task");
+      throw new Error(
+        `No agents with 'dev' role in registry (${agents.length} total agents) — cannot auto-assign task`,
+      );
     }
     if (devAgents.length === 1) return devAgents[0].id;
 
@@ -170,6 +175,14 @@ export class TaskManager {
 
     // Sort by score descending; tiebreak by agent ID for deterministic selection
     scored.sort((a, b) => b.score - a.score || a.agent.id.localeCompare(b.agent.id));
+
+    // Debug: emit routing snapshot for observability
+    this.bus.emit("orchestrator.routing.debug", "orchestrator", "orchestrator", {
+      taskTitle: params.title,
+      candidates: scored.slice(0, 3).map((s) => ({ agentId: s.agent.id, score: s.score })),
+      selected: scored[0].agent.id,
+    });
+
     return scored[0].agent.id;
   }
 

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -122,7 +122,7 @@ export class TaskManager {
    * 3. modelRecommendation.complexity → prefer more capable agents for high complexity
    * 4. Fallback: first agent with "dev" role
    */
-  private autoSelectAgent(params: CreateTaskParams): string {
+  private autoSelectAgent(params: CreateTaskParams, taskId: string): string {
     if (!this.agentListLookup) {
       throw new Error("agentListLookup not injected — Orchestrator wiring incomplete");
     }
@@ -142,6 +142,7 @@ export class TaskManager {
       candidates?: { agentId: string; score: number }[],
     ): string => {
       this.bus.emit("orchestrator.routing.debug", "orchestrator", "orchestrator", {
+        taskId,
         taskTitle: params.title,
         reason,
         candidates: candidates ?? [{ agentId, score: 0 }],
@@ -154,10 +155,15 @@ export class TaskManager {
       return selectAndEmit(devAgents[0].id, "single-dev-agent");
     }
 
-    const rec = params.modelRecommendation;
-    if (!rec) {
+    const rawRec = params.modelRecommendation;
+    // Normalize: treat recommendation with only whitespace values as absent
+    const hasModel = !!rawRec?.preferredModel?.trim();
+    const hasCaps = !!rawRec?.requiredCapabilities?.some((c) => c.trim().length > 0);
+    const hasComplexity = !!rawRec?.complexity;
+    if (!rawRec || (!hasModel && !hasCaps && !hasComplexity)) {
       return selectAndEmit(devAgents[0].id, "no-recommendation-fallback");
     }
+    const rec = rawRec;
 
     // Score each dev agent
     const scored = devAgents.map((agent) => {
@@ -274,9 +280,12 @@ export class TaskManager {
     params.title = params.title.trim();
     params.context = params.context.trim();
 
+    // Generate taskId early so it can be included in routing debug events
+    const taskId = `TASK-${shortId()}`;
+
     // G9: Auto-assign agent if not provided — use modelRecommendation routing
     const explicitAssignedTo = params.assignedTo?.trim();
-    const assignedTo = explicitAssignedTo || this.autoSelectAgent(params);
+    const assignedTo = explicitAssignedTo || this.autoSelectAgent(params, taskId);
 
     // Validate assignedTo references a registered agent with 'dev' role
     if (this.agentConfigLookup) {
@@ -289,7 +298,6 @@ export class TaskManager {
       }
     }
 
-    const taskId = `TASK-${shortId()}`;
     const task: TaskBundle = {
       taskId,
       title: params.title,

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -134,31 +134,59 @@ export class TaskManager {
         `No agents with 'dev' role in registry (${agents.length} total agents) — cannot auto-assign task`,
       );
     }
-    if (devAgents.length === 1) return devAgents[0].id;
+
+    // Helper: emit debug event and return selected agent
+    const selectAndEmit = (
+      agentId: string,
+      reason: string,
+      candidates?: { agentId: string; score: number }[],
+    ): string => {
+      this.bus.emit("orchestrator.routing.debug", "orchestrator", "orchestrator", {
+        taskTitle: params.title,
+        reason,
+        candidates: candidates ?? [{ agentId, score: 0 }],
+        selected: agentId,
+      });
+      return agentId;
+    };
+
+    if (devAgents.length === 1) {
+      return selectAndEmit(devAgents[0].id, "single-dev-agent");
+    }
 
     const rec = params.modelRecommendation;
-    if (!rec) return devAgents[0].id;
+    if (!rec) {
+      return selectAndEmit(devAgents[0].id, "no-recommendation-fallback");
+    }
 
     // Score each dev agent
     const scored = devAgents.map((agent) => {
       let score = 0;
 
-      // Preferred model match: exact or normalized comparison (avoids "o3" matching "o3-mini" etc.)
+      // Preferred model match: trim + lowercase to handle whitespace in MCP/JSON inputs
       if (rec.preferredModel && agent.model) {
-        const preferred = rec.preferredModel.toLowerCase();
-        const agentModel = agent.model.toLowerCase();
-        if (agentModel === preferred) {
-          score += 100; // Exact match
-        } else if (agentModel.startsWith(preferred + "-") || preferred.startsWith(agentModel + "-")) {
-          score += 50; // Family match (e.g. "claude-opus-4-6" matches "claude-opus-4-6-xxx")
+        const preferred = rec.preferredModel.trim().toLowerCase();
+        const agentModel = agent.model.trim().toLowerCase();
+        if (preferred && agentModel) {
+          if (agentModel === preferred) {
+            score += 100; // Exact match
+          } else if (agentModel.startsWith(preferred + "-") || preferred.startsWith(agentModel + "-")) {
+            score += 50; // Family match (e.g. "claude-opus-4-6" matches "claude-opus-4-6-xxx")
+          }
         }
       }
 
-      // Capability matching (deduplicated to prevent repeated scoring)
+      // Capability matching (deduplicated, trimmed to prevent whitespace/repeated scoring)
       if (rec.requiredCapabilities?.length) {
-        const uniqueCaps = [...new Set(rec.requiredCapabilities.map((c) => c.toLowerCase()))];
+        const uniqueCaps = [
+          ...new Set(
+            rec.requiredCapabilities
+              .map((c) => c.trim().toLowerCase())
+              .filter((c) => c.length > 0),
+          ),
+        ];
         const matched = uniqueCaps.filter((cap) =>
-          agent.capabilities.some((ac) => ac.toLowerCase() === cap),
+          agent.capabilities.some((ac) => ac.trim().toLowerCase() === cap),
         ).length;
         score += matched * 20;
       }
@@ -176,14 +204,11 @@ export class TaskManager {
     // Sort by score descending; tiebreak by agent ID for deterministic selection
     scored.sort((a, b) => b.score - a.score || a.agent.id.localeCompare(b.agent.id));
 
-    // Debug: emit routing snapshot for observability
-    this.bus.emit("orchestrator.routing.debug", "orchestrator", "orchestrator", {
-      taskTitle: params.title,
-      candidates: scored.slice(0, 3).map((s) => ({ agentId: s.agent.id, score: s.score })),
-      selected: scored[0].agent.id,
-    });
-
-    return scored[0].agent.id;
+    return selectAndEmit(
+      scored[0].agent.id,
+      "scored-selection",
+      scored.slice(0, 3).map((s) => ({ agentId: s.agent.id, score: s.score })),
+    );
   }
 
   /** Rehydrate task state from persistence (call before RPC starts). */


### PR DESCRIPTION
## Summary
- **New types**: `ModelRecommendation` with complexity/requiredCapabilities/preferredModel fields
- **Auto-assignment**: `assignedTo` now optional in `createTask` — auto-selected via scoring algorithm when omitted
- **Scoring**: `autoSelectAgent()` scores agents by model match (100), capability match (20/each), complexity preference
- **MCP**: Updated `create_task` schema with optional `modelRecommendation` parameter

## Changes
| File | Change |
|------|--------|
| `types.ts` | `TaskComplexity`, `ModelRecommendation` types + field on TaskBundle |
| `index.ts` | Export new types |
| `task-manager.ts` | `autoSelectAgent()` + optional assignedTo + agentListLookup |
| `orchestrator.ts` | Wire agentListLookup from registry |
| `mcp-server.ts` | Optional assignedTo + modelRecommendation in create_task schema |

## Test plan
- [ ] Type-check passes
- [ ] createTask with assignedTo works as before (backward compat)
- [ ] createTask without assignedTo auto-selects dev agent
- [ ] modelRecommendation.preferredModel influences agent selection
- [ ] Capability matching scores higher for matching agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)