### PR TITLE
feat(gui): Remote Control GUI integration (#55)

### DIFF
--- a/packages/gui/src-tauri/Cargo.toml
+++ b/packages/gui/src-tauri/Cargo.toml
@@ -20,5 +20,5 @@ tauri-plugin-single-instance = "2"
 tauri-plugin-window-state = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["process", "io-util", "rt-multi-thread", "sync", "macros"] }
+tokio = { version = "1", features = ["process", "io-util", "rt-multi-thread", "sync", "macros", "time"] }
 dirs = "6"

--- a/packages/gui/src-tauri/Cargo.toml
+++ b/packages/gui/src-tauri/Cargo.toml
@@ -21,4 +21,5 @@ tauri-plugin-window-state = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["process", "io-util", "rt-multi-thread", "sync", "macros", "time"] }
+url = "2"
 dirs = "6"

--- a/packages/gui/src-tauri/src/commands.rs
+++ b/packages/gui/src-tauri/src/commands.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 use tauri::State;
 
 use crate::sidecar::SidecarManager;
-use crate::{ProjectRoot, SharedSidecar};
+use crate::{ProjectRoot, SharedRemoteControl, SharedSidecar};
 
 // ─── Project Info (direct, no sidecar) ───
 
@@ -769,4 +769,36 @@ fn extract_message_from_jsonl(obj: &serde_json::Value, cli_type: &str) -> Option
         }
         _ => None,
     }
+}
+
+// ─── Remote Control Commands ───
+
+#[tauri::command]
+pub async fn start_remote_control(
+    app: tauri::AppHandle,
+    rc: State<'_, SharedRemoteControl>,
+    root: State<'_, ProjectRoot>,
+    session_name: Option<String>,
+) -> Result<serde_json::Value, String> {
+    let mgr = rc.lock().await;
+    mgr.start(app, root.0.clone(), session_name).await?;
+    Ok(serde_json::json!({ "ok": true }))
+}
+
+#[tauri::command]
+pub async fn stop_remote_control(
+    rc: State<'_, SharedRemoteControl>,
+) -> Result<serde_json::Value, String> {
+    let mgr = rc.lock().await;
+    mgr.stop().await?;
+    Ok(serde_json::json!({ "ok": true }))
+}
+
+#[tauri::command]
+pub async fn get_remote_control_status(
+    rc: State<'_, SharedRemoteControl>,
+) -> Result<serde_json::Value, String> {
+    let mgr = rc.lock().await;
+    let state = mgr.get_state(None).await;
+    serde_json::to_value(&state).map_err(|e| e.to_string())
 }

--- a/packages/gui/src-tauri/src/commands.rs
+++ b/packages/gui/src-tauri/src/commands.rs
@@ -799,6 +799,6 @@ pub async fn get_remote_control_status(
     rc: State<'_, SharedRemoteControl>,
 ) -> Result<serde_json::Value, String> {
     let mgr = rc.lock().await;
-    let state = mgr.get_state(None).await;
+    let state = mgr.get_state().await;
     serde_json::to_value(&state).map_err(|e| e.to_string())
 }

--- a/packages/gui/src-tauri/src/lib.rs
+++ b/packages/gui/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod commands;
+mod remote_control;
 mod sidecar;
 mod types;
 
@@ -7,10 +8,14 @@ use std::sync::Arc;
 use tauri::{Emitter, Manager};
 use tokio::sync::Mutex;
 
+use remote_control::RemoteControlManager;
 use sidecar::SidecarManager;
 
 /// Shared sidecar handle — `None` until the sidecar finishes spawning.
 pub type SharedSidecar = Arc<Mutex<Option<SidecarManager>>>;
+
+/// Shared remote control manager.
+pub type SharedRemoteControl = Arc<Mutex<RemoteControlManager>>;
 
 /// Project root path — available immediately (no sidecar dependency).
 pub struct ProjectRoot(pub String);
@@ -65,6 +70,10 @@ pub fn run() {
             // Register shared sidecar state synchronously (avoids race condition)
             let shared: SharedSidecar = Arc::new(Mutex::new(None));
             app.manage(shared.clone());
+
+            // Register remote control manager
+            let rc: SharedRemoteControl = Arc::new(Mutex::new(RemoteControlManager::new()));
+            app.manage(rc.clone());
 
             // Resolve the monorepo root (where mercury.config.json lives)
             let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -138,13 +147,26 @@ pub fn run() {
             commands::list_models,
             commands::set_model,
             commands::read_session_history,
+            commands::start_remote_control,
+            commands::stop_remote_control,
+            commands::get_remote_control_status,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")
         .run(|app, event| {
             if let tauri::RunEvent::Exit = event {
                 let shared = app.state::<SharedSidecar>().inner().clone();
+                let rc = app.state::<SharedRemoteControl>().inner().clone();
                 tauri::async_runtime::block_on(async {
+                    // Shutdown remote control first
+                    {
+                        let mgr = rc.lock().await;
+                        if mgr.is_running().await {
+                            eprintln!("[tauri] Shutting down remote control");
+                            let _ = mgr.stop().await;
+                        }
+                    }
+                    // Then shutdown sidecar
                     let guard = shared.lock().await;
                     if let Some(mgr) = guard.as_ref() {
                         eprintln!("[tauri] Shutting down orchestrator sidecar");

--- a/packages/gui/src-tauri/src/remote_control.rs
+++ b/packages/gui/src-tauri/src/remote_control.rs
@@ -162,10 +162,13 @@ impl RemoteControlManager {
                     }
                 }
 
-                // Detect connection established
-                if trimmed.to_lowercase().contains("connected")
-                    || trimmed.to_lowercase().contains("session active")
-                {
+                // Detect connection established.
+                // Pattern list centralised here for maintainability if CLI output changes.
+                let lower = trimmed.to_lowercase();
+                let is_connected = lower.contains("connected")
+                    || lower.contains("session active")
+                    || lower.contains("connection established");
+                if is_connected {
                     {
                         let mut status_guard = status_clone.lock().await;
                         *status_guard = RemoteControlStatus::Connected;
@@ -214,15 +217,19 @@ impl RemoteControlManager {
                 }
                 eprintln!("[remote-control stderr] {}", trimmed);
 
-                // Detect fatal errors
-                if trimmed.to_lowercase().contains("error")
-                    && !trimmed.to_lowercase().contains("error handler")
-                {
-                    let _ = app_stderr.emit("remote-control-log", serde_json::json!({
-                        "level": "error",
-                        "message": trimmed,
-                    }));
-                }
+                // Classify and forward all stderr lines to the GUI log panel.
+                let lower = trimmed.to_lowercase();
+                let level = if lower.contains("error") && !lower.contains("error handler") {
+                    "error"
+                } else if lower.contains("warn") {
+                    "warn"
+                } else {
+                    "info"
+                };
+                let _ = app_stderr.emit("remote-control-log", serde_json::json!({
+                    "level": level,
+                    "message": trimmed,
+                }));
             }
 
             // stderr closed — only the first task to reach here runs cleanup
@@ -291,18 +298,23 @@ impl RemoteControlManager {
     }
 }
 
-/// Extract a URL from a line of text.
+/// Extract and validate a URL from a line of text.
+/// Only accepts well-formed HTTPS URLs on expected domains (claude.ai, anthropic.com).
+/// Uses the `url` crate (https://crates.io/crates/url) for robust parsing.
 fn extract_url(line: &str) -> Option<String> {
-    // Find the start of https://
     if let Some(start) = line.find("https://") {
-        // Find the end of the URL (space, newline, or end of string)
         let rest = &line[start..];
         let end = rest
             .find(|c: char| c.is_whitespace() || c == '"' || c == '\'' || c == '>' || c == ')')
             .unwrap_or(rest.len());
-        let url = &rest[..end];
-        if url.len() > 10 {
-            return Some(url.to_string());
+        let candidate = &rest[..end];
+        // Structural validation: must parse as a URL with a recognised host.
+        if let Ok(parsed) = url::Url::parse(candidate) {
+            if let Some(host) = parsed.host_str() {
+                if host.ends_with("claude.ai") || host.ends_with("anthropic.com") {
+                    return Some(candidate.to_string());
+                }
+            }
         }
     }
     None

--- a/packages/gui/src-tauri/src/remote_control.rs
+++ b/packages/gui/src-tauri/src/remote_control.rs
@@ -189,12 +189,20 @@ impl RemoteControlManager {
                     return;
                 }
 
+                // Forward the raw line (preserving whitespace for QR/ASCII art) to the GUI.
+                let _ = app_stdout.emit("remote-control-log", serde_json::json!({
+                    "level": "stdout",
+                    "message": &line,
+                }));
+
                 let trimmed = line.trim().to_string();
                 if trimmed.is_empty() {
                     continue;
                 }
 
-                eprintln!("[remote-control stdout] {}", trimmed);
+                // Debug logging — redact session URLs to avoid leaking pairing credentials.
+                #[cfg(debug_assertions)]
+                eprintln!("[remote-control stdout] {}", redact_url(&trimmed));
 
                 // Detect session URL (typically contains claude.ai/code or a URL pattern)
                 if trimmed.contains("https://") {
@@ -287,7 +295,9 @@ impl RemoteControlManager {
                 if trimmed.is_empty() {
                     continue;
                 }
-                eprintln!("[remote-control stderr] {}", trimmed);
+
+                #[cfg(debug_assertions)]
+                eprintln!("[remote-control stderr] {}", redact_url(&trimmed));
 
                 // Classify and forward all stderr lines to the GUI log panel.
                 let lower = trimmed.to_lowercase();
@@ -400,4 +410,21 @@ fn extract_url(line: &str) -> Option<String> {
         }
     }
     None
+}
+
+/// Replace any `https://...` URL in the line with a redacted placeholder.
+/// Used for debug logging to avoid leaking session pairing credentials.
+/// Only compiled in debug builds via `#[cfg(debug_assertions)]`.
+/// See: https://doc.rust-lang.org/reference/conditional-compilation.html
+#[cfg(debug_assertions)]
+fn redact_url(line: &str) -> String {
+    if let Some(start) = line.find("https://") {
+        let rest = &line[start..];
+        let end = rest
+            .find(|c: char| c.is_whitespace())
+            .unwrap_or(rest.len());
+        format!("{}[REDACTED_URL]{}", &line[..start], &line[start + end..])
+    } else {
+        line.to_string()
+    }
 }

--- a/packages/gui/src-tauri/src/remote_control.rs
+++ b/packages/gui/src-tauri/src/remote_control.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use tauri::Emitter;
 use tokio::io::{AsyncBufReadExt, BufReader};
@@ -7,14 +7,27 @@ use tokio::sync::Mutex;
 
 /// Manages a `claude remote-control` child process.
 /// Parses stdout for session URL, emits Tauri events for GUI updates.
+///
+/// Thread-safety design:
+/// - `start()` holds the child lock across the entire spawn to prevent concurrent spawns.
+/// - A monotonic `generation` counter ties each spawn's cleanup tasks to the correct session,
+///   so stale stdout/stderr watchers from a previous process cannot corrupt the current state.
+///
+/// References:
+/// - AtomicU64: https://docs.rs/rustc-std-workspace-std/latest/std/sync/atomic/struct.AtomicU64.html
+/// - tokio Child: https://docs.rs/tokio/latest/tokio/process/struct.Child.html
+/// - url crate: https://crates.io/crates/url
 #[derive(Clone)]
 pub struct RemoteControlManager {
     child: Arc<Mutex<Option<Child>>>,
     session_url: Arc<Mutex<Option<String>>>,
     status: Arc<Mutex<RemoteControlStatus>>,
     session_name: Arc<Mutex<Option<String>>>,
-    /// Ensures cleanup logic runs exactly once when stdout/stderr tasks race.
+    /// Ensures cleanup logic runs exactly once per generation.
     cleanup_done: Arc<AtomicBool>,
+    /// Monotonic counter incremented on every `start()`. Cleanup tasks compare their
+    /// captured generation against the current value to avoid cross-session corruption.
+    generation: Arc<AtomicU64>,
 }
 
 #[derive(Clone, Debug, serde::Serialize)]
@@ -42,31 +55,39 @@ impl RemoteControlManager {
             status: Arc::new(Mutex::new(RemoteControlStatus::Stopped)),
             session_name: Arc::new(Mutex::new(None)),
             cleanup_done: Arc::new(AtomicBool::new(false)),
+            generation: Arc::new(AtomicU64::new(0)),
         }
     }
 
+    /// Start a `claude remote-control` session.
+    ///
+    /// The child lock is held across the entire spawn to guarantee atomicity:
+    /// no concurrent `start()` can slip through between the "is running?" check and
+    /// the child handle being stored.
     pub async fn start(
         &self,
         app_handle: tauri::AppHandle,
         project_dir: String,
         session_name: Option<String>,
     ) -> Result<(), String> {
-        // Check if already running
-        {
-            let child = self.child.lock().await;
-            if child.is_some() {
-                return Err("Remote control is already running".to_string());
-            }
+        // Hold the child lock for the ENTIRE start sequence to prevent concurrent spawns.
+        let mut child_guard = self.child.lock().await;
+
+        if child_guard.is_some() {
+            return Err("Remote control is already running".to_string());
         }
 
-        // Persist session name and reset cleanup flag
+        // Bump generation so any lingering cleanup tasks from a previous session become no-ops.
+        let gen = self.generation.fetch_add(1, Ordering::SeqCst) + 1;
+        self.cleanup_done.store(false, Ordering::SeqCst);
+
+        // Persist session name
         {
             let mut name = self.session_name.lock().await;
             *name = session_name.clone();
         }
-        self.cleanup_done.store(false, Ordering::SeqCst);
 
-        // Update status
+        // Update status to Starting
         {
             let mut status = self.status.lock().await;
             *status = RemoteControlStatus::Starting;
@@ -107,24 +128,41 @@ impl RemoteControlManager {
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped());
 
-        let mut child = cmd
-            .spawn()
-            .map_err(|e| format!("Failed to spawn claude remote-control: {}", e))?;
+        let mut child = match cmd.spawn() {
+            Ok(c) => c,
+            Err(e) => {
+                // Rollback status on spawn failure so the state machine stays clean.
+                {
+                    let mut status = self.status.lock().await;
+                    *status = RemoteControlStatus::Stopped;
+                }
+                {
+                    let mut name = self.session_name.lock().await;
+                    *name = None;
+                }
+                let _ = app_handle.emit("remote-control-status", RemoteControlState {
+                    status: RemoteControlStatus::Stopped,
+                    session_url: None,
+                    session_name: None,
+                });
+                return Err(format!("Failed to spawn claude remote-control: {}", e));
+            }
+        };
 
         let stdout = child.stdout.take().ok_or("Failed to get stdout")?;
         let stderr = child.stderr.take().ok_or("Failed to get stderr")?;
 
-        // Store child process
-        {
-            let mut guard = self.child.lock().await;
-            *guard = Some(child);
-        }
+        // Store child process (still under the same lock — atomic).
+        *child_guard = Some(child);
+        // Release the child lock now.
+        drop(child_guard);
 
         // Monitor stdout for session URL and status changes
         let url_clone = self.session_url.clone();
         let status_clone = self.status.clone();
         let child_clone = self.child.clone();
         let cleanup_flag_stdout = self.cleanup_done.clone();
+        let generation_stdout = self.generation.clone();
         let app_stdout = app_handle.clone();
         let name_for_stdout = session_name.clone();
         tokio::spawn(async move {
@@ -132,6 +170,11 @@ impl RemoteControlManager {
             let mut lines = reader.lines();
 
             while let Ok(Some(line)) = lines.next_line().await {
+                // If a newer generation has started, this task is stale — bail out.
+                if generation_stdout.load(Ordering::SeqCst) != gen {
+                    return;
+                }
+
                 let trimmed = line.trim().to_string();
                 if trimmed.is_empty() {
                     continue;
@@ -141,7 +184,6 @@ impl RemoteControlManager {
 
                 // Detect session URL (typically contains claude.ai/code or a URL pattern)
                 if trimmed.contains("https://") {
-                    // Extract URL from the line
                     if let Some(url) = extract_url(&trimmed) {
                         {
                             let mut url_guard = url_clone.lock().await;
@@ -182,11 +224,18 @@ impl RemoteControlManager {
                 }
             }
 
-            // Process exited — only the first task to reach here runs cleanup
-            if !cleanup_flag_stdout.swap(true, Ordering::SeqCst) {
+            // Process exited — only the first task to reach here runs cleanup,
+            // and only if this is still the current generation.
+            if generation_stdout.load(Ordering::SeqCst) == gen
+                && !cleanup_flag_stdout.swap(true, Ordering::SeqCst)
+            {
                 {
                     let mut status_guard = status_clone.lock().await;
                     *status_guard = RemoteControlStatus::Stopped;
+                }
+                {
+                    let mut url_guard = url_clone.lock().await;
+                    *url_guard = None;
                 }
                 {
                     let mut child_guard = child_clone.lock().await;
@@ -202,8 +251,10 @@ impl RemoteControlManager {
 
         // Monitor stderr for errors and logs
         let status_stderr = self.status.clone();
+        let url_stderr = self.session_url.clone();
         let child_stderr = self.child.clone();
         let cleanup_flag_stderr = self.cleanup_done.clone();
+        let generation_stderr = self.generation.clone();
         let app_stderr = app_handle.clone();
         let name_for_stderr = session_name;
         tokio::spawn(async move {
@@ -211,6 +262,10 @@ impl RemoteControlManager {
             let mut lines = reader.lines();
 
             while let Ok(Some(line)) = lines.next_line().await {
+                if generation_stderr.load(Ordering::SeqCst) != gen {
+                    return;
+                }
+
                 let trimmed = line.trim().to_string();
                 if trimmed.is_empty() {
                     continue;
@@ -233,10 +288,16 @@ impl RemoteControlManager {
             }
 
             // stderr closed — only the first task to reach here runs cleanup
-            if !cleanup_flag_stderr.swap(true, Ordering::SeqCst) {
+            if generation_stderr.load(Ordering::SeqCst) == gen
+                && !cleanup_flag_stderr.swap(true, Ordering::SeqCst)
+            {
                 {
                     let mut status_guard = status_stderr.lock().await;
                     *status_guard = RemoteControlStatus::Stopped;
+                }
+                {
+                    let mut url_guard = url_stderr.lock().await;
+                    *url_guard = None;
                 }
                 {
                     let mut child_guard = child_stderr.lock().await;
@@ -253,12 +314,12 @@ impl RemoteControlManager {
         Ok(())
     }
 
+    /// Stop the remote-control session, killing the child process and resetting all state.
     pub async fn stop(&self) -> Result<(), String> {
         let mut child = self.child.lock().await;
         if let Some(ref mut c) = *child {
             let _ = c.kill().await;
             // Wait for the child process to fully exit (timeout 5s) to avoid zombies.
-            // See: https://docs.rs/tokio/latest/tokio/process/struct.Child.html
             let _ = tokio::time::timeout(
                 std::time::Duration::from_secs(5),
                 c.wait(),
@@ -292,6 +353,7 @@ impl RemoteControlManager {
         }
     }
 
+    /// Returns whether a child process is currently held.
     pub async fn is_running(&self) -> bool {
         let child = self.child.lock().await;
         child.is_some()
@@ -299,8 +361,8 @@ impl RemoteControlManager {
 }
 
 /// Extract and validate a URL from a line of text.
-/// Only accepts well-formed HTTPS URLs on expected domains (claude.ai, anthropic.com).
-/// Uses the `url` crate (https://crates.io/crates/url) for robust parsing.
+/// Only accepts well-formed HTTPS URLs on the exact `claude.ai` domain (or subdomains).
+/// Uses the `url` crate (<https://crates.io/crates/url>) for robust parsing.
 fn extract_url(line: &str) -> Option<String> {
     if let Some(start) = line.find("https://") {
         let rest = &line[start..];
@@ -311,7 +373,8 @@ fn extract_url(line: &str) -> Option<String> {
         // Structural validation: must parse as a URL with a recognised host.
         if let Ok(parsed) = url::Url::parse(candidate) {
             if let Some(host) = parsed.host_str() {
-                if host.ends_with("claude.ai") || host.ends_with("anthropic.com") {
+                // Exact match or subdomain — rejects lookalikes like "evilclaude.ai".
+                if host == "claude.ai" || host.ends_with(".claude.ai") {
                     return Some(candidate.to_string());
                 }
             }

--- a/packages/gui/src-tauri/src/remote_control.rs
+++ b/packages/gui/src-tauri/src/remote_control.rs
@@ -30,6 +30,9 @@ pub struct RemoteControlManager {
     generation: Arc<AtomicU64>,
 }
 
+/// Remote control session status.
+/// All variants are unit variants so they serialise as plain strings
+/// (e.g. `"stopped"`, `"error"`), matching the front-end TypeScript union type.
 #[derive(Clone, Debug, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum RemoteControlStatus {
@@ -37,7 +40,7 @@ pub enum RemoteControlStatus {
     Starting,
     WaitingForConnection,
     Connected,
-    Error(String),
+    Error,
 }
 
 #[derive(Clone, Debug, serde::Serialize)]
@@ -45,6 +48,9 @@ pub struct RemoteControlState {
     pub status: RemoteControlStatus,
     pub session_url: Option<String>,
     pub session_name: Option<String>,
+    /// Present only when `status == "error"`; carries the error description.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_message: Option<String>,
 }
 
 impl RemoteControlManager {
@@ -96,6 +102,7 @@ impl RemoteControlManager {
             status: RemoteControlStatus::Starting,
             session_url: None,
             session_name: session_name.clone(),
+        error_message: None,
         });
 
         // Build command: `claude remote-control --verbose`
@@ -109,6 +116,11 @@ impl RemoteControlManager {
             }
             c.arg("--verbose");
             c.creation_flags(0x08000000); // CREATE_NO_WINDOW
+            // Force UTF-8 encoding to prevent codepage 936/GBK garbling on CJK Windows.
+            // Mirrors sidecar.rs environment setup for consistency.
+            c.env("LANG", "en_US.UTF-8");
+            c.env("LC_ALL", "en_US.UTF-8");
+            c.env("PYTHONIOENCODING", "utf-8");
             c
         };
 
@@ -140,12 +152,14 @@ impl RemoteControlManager {
                     let mut name = self.session_name.lock().await;
                     *name = None;
                 }
+                let err_msg = format!("Failed to spawn claude remote-control: {}", e);
                 let _ = app_handle.emit("remote-control-status", RemoteControlState {
-                    status: RemoteControlStatus::Stopped,
+                    status: RemoteControlStatus::Error,
                     session_url: None,
                     session_name: None,
+                    error_message: Some(err_msg.clone()),
                 });
-                return Err(format!("Failed to spawn claude remote-control: {}", e));
+                return Err(err_msg);
             }
         };
 
@@ -197,6 +211,7 @@ impl RemoteControlManager {
                             status: RemoteControlStatus::WaitingForConnection,
                             session_url: Some(url.clone()),
                             session_name: name_for_stdout.clone(),
+                        error_message: None,
                         });
                         let _ = app_stdout.emit("remote-control-url", serde_json::json!({
                             "url": url,
@@ -220,6 +235,7 @@ impl RemoteControlManager {
                         status: RemoteControlStatus::Connected,
                         session_url: url_val,
                         session_name: name_for_stdout.clone(),
+                    error_message: None,
                     });
                 }
             }
@@ -245,6 +261,7 @@ impl RemoteControlManager {
                     status: RemoteControlStatus::Stopped,
                     session_url: None,
                     session_name: name_for_stdout.clone(),
+                error_message: None,
                 });
             }
         });
@@ -307,6 +324,7 @@ impl RemoteControlManager {
                     status: RemoteControlStatus::Stopped,
                     session_url: None,
                     session_name: name_for_stderr,
+                error_message: None,
                 });
             }
         });
@@ -350,6 +368,7 @@ impl RemoteControlManager {
             status,
             session_url,
             session_name,
+        error_message: None,
         }
     }
 

--- a/packages/gui/src-tauri/src/remote_control.rs
+++ b/packages/gui/src-tauri/src/remote_control.rs
@@ -1,0 +1,280 @@
+use std::sync::Arc;
+use tauri::Emitter;
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::{Child, Command};
+use tokio::sync::Mutex;
+
+/// Manages a `claude remote-control` child process.
+/// Parses stdout for session URL, emits Tauri events for GUI updates.
+#[derive(Clone)]
+pub struct RemoteControlManager {
+    child: Arc<Mutex<Option<Child>>>,
+    session_url: Arc<Mutex<Option<String>>>,
+    status: Arc<Mutex<RemoteControlStatus>>,
+}
+
+#[derive(Clone, Debug, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RemoteControlStatus {
+    Stopped,
+    Starting,
+    WaitingForConnection,
+    Connected,
+    Error(String),
+}
+
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct RemoteControlState {
+    pub status: RemoteControlStatus,
+    pub session_url: Option<String>,
+    pub session_name: Option<String>,
+}
+
+impl RemoteControlManager {
+    pub fn new() -> Self {
+        Self {
+            child: Arc::new(Mutex::new(None)),
+            session_url: Arc::new(Mutex::new(None)),
+            status: Arc::new(Mutex::new(RemoteControlStatus::Stopped)),
+        }
+    }
+
+    pub async fn start(
+        &self,
+        app_handle: tauri::AppHandle,
+        project_dir: String,
+        session_name: Option<String>,
+    ) -> Result<(), String> {
+        // Check if already running
+        {
+            let child = self.child.lock().await;
+            if child.is_some() {
+                return Err("Remote control is already running".to_string());
+            }
+        }
+
+        // Update status
+        {
+            let mut status = self.status.lock().await;
+            *status = RemoteControlStatus::Starting;
+        }
+        let _ = app_handle.emit("remote-control-status", RemoteControlState {
+            status: RemoteControlStatus::Starting,
+            session_url: None,
+            session_name: session_name.clone(),
+        });
+
+        // Build command: `claude remote-control --verbose`
+        // On Windows, claude is a .cmd script so we must run via cmd.exe.
+        #[cfg(target_os = "windows")]
+        let mut cmd = {
+            let mut c = Command::new("cmd");
+            c.args(["/c", "claude", "remote-control"]);
+            if let Some(ref name) = session_name {
+                c.args(["--name", name]);
+            }
+            c.arg("--verbose");
+            c.creation_flags(0x08000000); // CREATE_NO_WINDOW
+            c
+        };
+
+        #[cfg(not(target_os = "windows"))]
+        let mut cmd = {
+            let mut c = Command::new("claude");
+            c.arg("remote-control");
+            if let Some(ref name) = session_name {
+                c.args(["--name", name]);
+            }
+            c.arg("--verbose");
+            c
+        };
+
+        cmd.current_dir(&project_dir)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped());
+
+        let mut child = cmd
+            .spawn()
+            .map_err(|e| format!("Failed to spawn claude remote-control: {}", e))?;
+
+        let stdout = child.stdout.take().ok_or("Failed to get stdout")?;
+        let stderr = child.stderr.take().ok_or("Failed to get stderr")?;
+
+        // Store child process
+        {
+            let mut guard = self.child.lock().await;
+            *guard = Some(child);
+        }
+
+        // Monitor stdout for session URL and status changes
+        let url_clone = self.session_url.clone();
+        let status_clone = self.status.clone();
+        let child_clone = self.child.clone();
+        let app_stdout = app_handle.clone();
+        let name_for_stdout = session_name.clone();
+        tokio::spawn(async move {
+            let reader = BufReader::new(stdout);
+            let mut lines = reader.lines();
+
+            while let Ok(Some(line)) = lines.next_line().await {
+                let trimmed = line.trim().to_string();
+                if trimmed.is_empty() {
+                    continue;
+                }
+
+                eprintln!("[remote-control stdout] {}", trimmed);
+
+                // Detect session URL (typically contains claude.ai/code or a URL pattern)
+                if trimmed.contains("https://") {
+                    // Extract URL from the line
+                    if let Some(url) = extract_url(&trimmed) {
+                        {
+                            let mut url_guard = url_clone.lock().await;
+                            *url_guard = Some(url.clone());
+                        }
+                        {
+                            let mut status_guard = status_clone.lock().await;
+                            *status_guard = RemoteControlStatus::WaitingForConnection;
+                        }
+                        let _ = app_stdout.emit("remote-control-status", RemoteControlState {
+                            status: RemoteControlStatus::WaitingForConnection,
+                            session_url: Some(url.clone()),
+                            session_name: name_for_stdout.clone(),
+                        });
+                        let _ = app_stdout.emit("remote-control-url", serde_json::json!({
+                            "url": url,
+                        }));
+                    }
+                }
+
+                // Detect connection established
+                if trimmed.to_lowercase().contains("connected")
+                    || trimmed.to_lowercase().contains("session active")
+                {
+                    {
+                        let mut status_guard = status_clone.lock().await;
+                        *status_guard = RemoteControlStatus::Connected;
+                    }
+                    let url_val = url_clone.lock().await.clone();
+                    let _ = app_stdout.emit("remote-control-status", RemoteControlState {
+                        status: RemoteControlStatus::Connected,
+                        session_url: url_val,
+                        session_name: name_for_stdout.clone(),
+                    });
+                }
+            }
+
+            // Process exited
+            {
+                let mut status_guard = status_clone.lock().await;
+                *status_guard = RemoteControlStatus::Stopped;
+            }
+            {
+                let mut child_guard = child_clone.lock().await;
+                *child_guard = None;
+            }
+            let _ = app_stdout.emit("remote-control-status", RemoteControlState {
+                status: RemoteControlStatus::Stopped,
+                session_url: None,
+                session_name: name_for_stdout.clone(),
+            });
+        });
+
+        // Monitor stderr for errors and logs
+        let status_stderr = self.status.clone();
+        let child_stderr = self.child.clone();
+        let app_stderr = app_handle.clone();
+        let name_for_stderr = session_name;
+        tokio::spawn(async move {
+            let reader = BufReader::new(stderr);
+            let mut lines = reader.lines();
+
+            while let Ok(Some(line)) = lines.next_line().await {
+                let trimmed = line.trim().to_string();
+                if trimmed.is_empty() {
+                    continue;
+                }
+                eprintln!("[remote-control stderr] {}", trimmed);
+
+                // Detect fatal errors
+                if trimmed.to_lowercase().contains("error")
+                    && !trimmed.to_lowercase().contains("error handler")
+                {
+                    let _ = app_stderr.emit("remote-control-log", serde_json::json!({
+                        "level": "error",
+                        "message": trimmed,
+                    }));
+                }
+            }
+
+            // stderr closed — process likely exited
+            {
+                let mut status_guard = status_stderr.lock().await;
+                if !matches!(*status_guard, RemoteControlStatus::Stopped) {
+                    *status_guard = RemoteControlStatus::Stopped;
+                }
+            }
+            {
+                let mut child_guard = child_stderr.lock().await;
+                *child_guard = None;
+            }
+            let _ = app_stderr.emit("remote-control-status", RemoteControlState {
+                status: RemoteControlStatus::Stopped,
+                session_url: None,
+                session_name: name_for_stderr,
+            });
+        });
+
+        Ok(())
+    }
+
+    pub async fn stop(&self) -> Result<(), String> {
+        let mut child = self.child.lock().await;
+        if let Some(ref mut c) = *child {
+            let _ = c.kill().await;
+            *child = None;
+        }
+        {
+            let mut status = self.status.lock().await;
+            *status = RemoteControlStatus::Stopped;
+        }
+        {
+            let mut url = self.session_url.lock().await;
+            *url = None;
+        }
+        Ok(())
+    }
+
+    pub async fn get_state(&self, session_name: Option<String>) -> RemoteControlState {
+        let status = self.status.lock().await.clone();
+        let session_url = self.session_url.lock().await.clone();
+        RemoteControlState {
+            status,
+            session_url,
+            session_name,
+        }
+    }
+
+    pub async fn is_running(&self) -> bool {
+        let child = self.child.lock().await;
+        child.is_some()
+    }
+}
+
+/// Extract a URL from a line of text.
+fn extract_url(line: &str) -> Option<String> {
+    // Find the start of https://
+    if let Some(start) = line.find("https://") {
+        // Find the end of the URL (space, newline, or end of string)
+        let rest = &line[start..];
+        let end = rest
+            .find(|c: char| c.is_whitespace() || c == '"' || c == '\'' || c == '>' || c == ')')
+            .unwrap_or(rest.len());
+        let url = &rest[..end];
+        if url.len() > 10 {
+            return Some(url.to_string());
+        }
+    }
+    None
+}

--- a/packages/gui/src-tauri/src/remote_control.rs
+++ b/packages/gui/src-tauri/src/remote_control.rs
@@ -1,3 +1,4 @@
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tauri::Emitter;
 use tokio::io::{AsyncBufReadExt, BufReader};
@@ -11,6 +12,9 @@ pub struct RemoteControlManager {
     child: Arc<Mutex<Option<Child>>>,
     session_url: Arc<Mutex<Option<String>>>,
     status: Arc<Mutex<RemoteControlStatus>>,
+    session_name: Arc<Mutex<Option<String>>>,
+    /// Ensures cleanup logic runs exactly once when stdout/stderr tasks race.
+    cleanup_done: Arc<AtomicBool>,
 }
 
 #[derive(Clone, Debug, serde::Serialize)]
@@ -36,6 +40,8 @@ impl RemoteControlManager {
             child: Arc::new(Mutex::new(None)),
             session_url: Arc::new(Mutex::new(None)),
             status: Arc::new(Mutex::new(RemoteControlStatus::Stopped)),
+            session_name: Arc::new(Mutex::new(None)),
+            cleanup_done: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -52,6 +58,13 @@ impl RemoteControlManager {
                 return Err("Remote control is already running".to_string());
             }
         }
+
+        // Persist session name and reset cleanup flag
+        {
+            let mut name = self.session_name.lock().await;
+            *name = session_name.clone();
+        }
+        self.cleanup_done.store(false, Ordering::SeqCst);
 
         // Update status
         {
@@ -111,6 +124,7 @@ impl RemoteControlManager {
         let url_clone = self.session_url.clone();
         let status_clone = self.status.clone();
         let child_clone = self.child.clone();
+        let cleanup_flag_stdout = self.cleanup_done.clone();
         let app_stdout = app_handle.clone();
         let name_for_stdout = session_name.clone();
         tokio::spawn(async move {
@@ -165,25 +179,28 @@ impl RemoteControlManager {
                 }
             }
 
-            // Process exited
-            {
-                let mut status_guard = status_clone.lock().await;
-                *status_guard = RemoteControlStatus::Stopped;
+            // Process exited — only the first task to reach here runs cleanup
+            if !cleanup_flag_stdout.swap(true, Ordering::SeqCst) {
+                {
+                    let mut status_guard = status_clone.lock().await;
+                    *status_guard = RemoteControlStatus::Stopped;
+                }
+                {
+                    let mut child_guard = child_clone.lock().await;
+                    *child_guard = None;
+                }
+                let _ = app_stdout.emit("remote-control-status", RemoteControlState {
+                    status: RemoteControlStatus::Stopped,
+                    session_url: None,
+                    session_name: name_for_stdout.clone(),
+                });
             }
-            {
-                let mut child_guard = child_clone.lock().await;
-                *child_guard = None;
-            }
-            let _ = app_stdout.emit("remote-control-status", RemoteControlState {
-                status: RemoteControlStatus::Stopped,
-                session_url: None,
-                session_name: name_for_stdout.clone(),
-            });
         });
 
         // Monitor stderr for errors and logs
         let status_stderr = self.status.clone();
         let child_stderr = self.child.clone();
+        let cleanup_flag_stderr = self.cleanup_done.clone();
         let app_stderr = app_handle.clone();
         let name_for_stderr = session_name;
         tokio::spawn(async move {
@@ -208,22 +225,22 @@ impl RemoteControlManager {
                 }
             }
 
-            // stderr closed — process likely exited
-            {
-                let mut status_guard = status_stderr.lock().await;
-                if !matches!(*status_guard, RemoteControlStatus::Stopped) {
+            // stderr closed — only the first task to reach here runs cleanup
+            if !cleanup_flag_stderr.swap(true, Ordering::SeqCst) {
+                {
+                    let mut status_guard = status_stderr.lock().await;
                     *status_guard = RemoteControlStatus::Stopped;
                 }
+                {
+                    let mut child_guard = child_stderr.lock().await;
+                    *child_guard = None;
+                }
+                let _ = app_stderr.emit("remote-control-status", RemoteControlState {
+                    status: RemoteControlStatus::Stopped,
+                    session_url: None,
+                    session_name: name_for_stderr,
+                });
             }
-            {
-                let mut child_guard = child_stderr.lock().await;
-                *child_guard = None;
-            }
-            let _ = app_stderr.emit("remote-control-status", RemoteControlState {
-                status: RemoteControlStatus::Stopped,
-                session_url: None,
-                session_name: name_for_stderr,
-            });
         });
 
         Ok(())
@@ -233,6 +250,12 @@ impl RemoteControlManager {
         let mut child = self.child.lock().await;
         if let Some(ref mut c) = *child {
             let _ = c.kill().await;
+            // Wait for the child process to fully exit (timeout 5s) to avoid zombies.
+            // See: https://docs.rs/tokio/latest/tokio/process/struct.Child.html
+            let _ = tokio::time::timeout(
+                std::time::Duration::from_secs(5),
+                c.wait(),
+            ).await;
             *child = None;
         }
         {
@@ -243,12 +266,18 @@ impl RemoteControlManager {
             let mut url = self.session_url.lock().await;
             *url = None;
         }
+        {
+            let mut name = self.session_name.lock().await;
+            *name = None;
+        }
         Ok(())
     }
 
-    pub async fn get_state(&self, session_name: Option<String>) -> RemoteControlState {
+    /// Returns the current state, reading `session_name` from internal storage.
+    pub async fn get_state(&self) -> RemoteControlState {
         let status = self.status.lock().await.clone();
         let session_url = self.session_url.lock().await.clone();
+        let session_name = self.session_name.lock().await.clone();
         RemoteControlState {
             status,
             session_url,

--- a/packages/gui/src/App.vue
+++ b/packages/gui/src/App.vue
@@ -11,6 +11,7 @@ import ApprovalQueue from "./components/ApprovalQueue.vue";
 import BookmarkRail from "./components/BookmarkRail.vue";
 import FloatingPanel from "./components/FloatingPanel.vue";
 import AgentRoleSelector from "./components/AgentRoleSelector.vue";
+import RemoteControlPanel from "./components/RemoteControlPanel.vue";
 import { useAgentStore } from "./stores/agents";
 import { useApprovalStore } from "./stores/approvals";
 import { useMessageStore } from "./stores/messages";
@@ -27,6 +28,7 @@ const { initEventListeners } = useEventStore();
 const { loadTasks, initTaskListeners } = useTaskStore();
 
 const showSettings = ref(false);
+const showRemoteControl = ref(false);
 const activeView = ref<"agents" | "tasks">("agents");
 const showEventLog = ref(false);
 const showAgentRoleSelector = ref(false);
@@ -55,6 +57,7 @@ onMounted(async () => {
       :activeView="activeView"
       :eventLogOpen="showEventLog"
       @open-settings="showSettings = true"
+      @open-remote-control="showRemoteControl = true"
       @switch-view="(v) => activeView = v"
       @toggle-event-log="showEventLog = !showEventLog"
     />
@@ -101,6 +104,10 @@ onMounted(async () => {
       <EventLog v-if="showEventLog" />
     </div>
 
+    <RemoteControlPanel
+      v-if="showRemoteControl"
+      @close="showRemoteControl = false"
+    />
     <SessionPicker />
     <HistoryPanel />
     <ApprovalQueue />

--- a/packages/gui/src/components/RemoteControlPanel.vue
+++ b/packages/gui/src/components/RemoteControlPanel.vue
@@ -1,0 +1,356 @@
+<script setup lang="ts">
+import { onMounted } from "vue";
+import { useRemoteControlStore } from "../stores/remote-control";
+
+const emit = defineEmits<{ close: [] }>();
+
+const {
+  status,
+  sessionUrl,
+  error,
+  logs,
+  isRunning,
+  start,
+  stop,
+  initRemoteControlListeners,
+} = useRemoteControlStore();
+
+async function handleStart() {
+  await start("Mercury");
+}
+
+async function handleStop() {
+  await stop();
+}
+
+function copyUrl() {
+  if (sessionUrl.value) {
+    navigator.clipboard.writeText(sessionUrl.value);
+  }
+}
+
+function openInBrowser() {
+  if (sessionUrl.value) {
+    window.open(sessionUrl.value, "_blank");
+  }
+}
+
+const statusLabels: Record<string, string> = {
+  stopped: "Stopped",
+  starting: "Starting...",
+  waiting_for_connection: "Waiting for connection",
+  connected: "Connected",
+  error: "Error",
+};
+
+const statusColors: Record<string, string> = {
+  stopped: "var(--text-muted)",
+  starting: "var(--accent-warn)",
+  waiting_for_connection: "var(--accent-main)",
+  connected: "var(--accent-success)",
+  error: "var(--accent-error)",
+};
+
+onMounted(async () => {
+  await initRemoteControlListeners();
+});
+</script>
+
+<template>
+  <div class="rc-overlay" @click.self="emit('close')">
+    <div class="rc-panel">
+      <!-- Header -->
+      <div class="rc-header">
+        <div class="rc-title">
+          <span class="rc-icon">📡</span>
+          Remote Control
+        </div>
+        <button class="rc-close" @click="emit('close')" title="Close">×</button>
+      </div>
+
+      <!-- Status -->
+      <div class="rc-status-row">
+        <span
+          class="rc-status-dot"
+          :style="{ background: statusColors[status] ?? 'var(--text-muted)' }"
+        ></span>
+        <span class="rc-status-label">{{ statusLabels[status] ?? status }}</span>
+      </div>
+
+      <!-- Error -->
+      <div v-if="error" class="rc-error">{{ error }}</div>
+
+      <!-- Session URL display -->
+      <div v-if="sessionUrl" class="rc-url-section">
+        <div class="rc-url-label">Session URL</div>
+        <div class="rc-url-box">
+          <code class="rc-url-text">{{ sessionUrl }}</code>
+          <div class="rc-url-actions">
+            <button class="rc-btn rc-btn-small" @click="copyUrl" title="Copy URL">
+              Copy
+            </button>
+            <button class="rc-btn rc-btn-small" @click="openInBrowser" title="Open in browser">
+              Open
+            </button>
+          </div>
+        </div>
+        <p class="rc-hint">
+          Open this URL on your phone or another device to control this session remotely.
+          You can also scan the QR code shown in the terminal.
+        </p>
+      </div>
+
+      <!-- Info when not running -->
+      <div v-if="!isRunning && !error" class="rc-info">
+        <p>Start a Remote Control session to continue working from your phone, tablet, or another browser.</p>
+        <p class="rc-hint">
+          Requires Claude Code v2.1.51+ and a Pro/Max subscription with claude.ai OAuth.
+          API keys are not supported.
+        </p>
+      </div>
+
+      <!-- Actions -->
+      <div class="rc-actions">
+        <button
+          v-if="!isRunning"
+          class="rc-btn rc-btn-primary"
+          @click="handleStart"
+        >
+          Start Remote Control
+        </button>
+        <button
+          v-if="isRunning"
+          class="rc-btn rc-btn-danger"
+          @click="handleStop"
+        >
+          Stop
+        </button>
+      </div>
+
+      <!-- Logs -->
+      <div v-if="logs.length > 0" class="rc-logs">
+        <div class="rc-logs-label">Logs</div>
+        <div class="rc-logs-content">
+          <div v-for="(log, i) in logs" :key="i" class="rc-log-line">{{ log }}</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.rc-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(4px);
+}
+
+.rc-panel {
+  width: 480px;
+  max-width: 90vw;
+  max-height: 80vh;
+  overflow-y: auto;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.rc-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.rc-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text-primary);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.rc-icon {
+  font-size: 18px;
+}
+
+.rc-close {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 20px;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 4px;
+  line-height: 1;
+}
+
+.rc-close:hover {
+  color: var(--text-primary);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.rc-status-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.rc-status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.rc-status-label {
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.rc-error {
+  padding: 8px 12px;
+  background: rgba(255, 82, 82, 0.1);
+  border: 1px solid rgba(255, 82, 82, 0.3);
+  border-radius: var(--radius);
+  color: var(--accent-error);
+  font-size: 12px;
+  font-family: var(--font-mono);
+}
+
+.rc-url-section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.rc-url-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-muted);
+}
+
+.rc-url-box {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
+.rc-url-text {
+  flex: 1;
+  font-size: 12px;
+  font-family: var(--font-mono);
+  color: var(--accent-main);
+  word-break: break-all;
+  user-select: all;
+}
+
+.rc-url-actions {
+  display: flex;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.rc-info {
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.rc-hint {
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.4;
+  margin-top: 4px;
+}
+
+.rc-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.rc-btn {
+  padding: 8px 16px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-input);
+  color: var(--text-primary);
+  font-size: 13px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.rc-btn:hover {
+  border-color: var(--accent-main);
+  background: rgba(0, 212, 255, 0.05);
+}
+
+.rc-btn-small {
+  padding: 4px 10px;
+  font-size: 11px;
+}
+
+.rc-btn-primary {
+  background: rgba(0, 212, 255, 0.1);
+  border-color: var(--accent-main);
+  color: var(--accent-main);
+}
+
+.rc-btn-primary:hover {
+  background: rgba(0, 212, 255, 0.2);
+}
+
+.rc-btn-danger {
+  background: rgba(255, 82, 82, 0.1);
+  border-color: var(--accent-error);
+  color: var(--accent-error);
+}
+
+.rc-btn-danger:hover {
+  background: rgba(255, 82, 82, 0.2);
+}
+
+.rc-logs {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.rc-logs-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-muted);
+}
+
+.rc-logs-content {
+  max-height: 120px;
+  overflow-y: auto;
+  padding: 8px;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.rc-log-line {
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+</style>

--- a/packages/gui/src/components/RemoteControlPanel.vue
+++ b/packages/gui/src/components/RemoteControlPanel.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted } from "vue";
+import { ref, onMounted, onUnmounted } from "vue";
 import { useRemoteControlStore } from "../stores/remote-control";
 
 const emit = defineEmits<{ close: [] }>();
@@ -15,6 +15,9 @@ const {
   initRemoteControlListeners,
 } = useRemoteControlStore();
 
+const copyFeedback = ref<string | null>(null);
+const unlistenFns: Array<() => void> = [];
+
 async function handleStart() {
   await start("Mercury");
 }
@@ -25,7 +28,15 @@ async function handleStop() {
 
 function copyUrl() {
   if (sessionUrl.value) {
-    navigator.clipboard.writeText(sessionUrl.value);
+    navigator.clipboard.writeText(sessionUrl.value)
+      .then(() => {
+        copyFeedback.value = "Copied";
+        setTimeout(() => (copyFeedback.value = null), 2000);
+      })
+      .catch(() => {
+        copyFeedback.value = "Failed";
+        setTimeout(() => (copyFeedback.value = null), 2000);
+      });
   }
 }
 
@@ -52,7 +63,12 @@ const statusColors: Record<string, string> = {
 };
 
 onMounted(async () => {
-  await initRemoteControlListeners();
+  const fns = await initRemoteControlListeners();
+  unlistenFns.push(...fns);
+});
+
+onUnmounted(() => {
+  unlistenFns.forEach((fn) => fn());
 });
 </script>
 
@@ -87,7 +103,7 @@ onMounted(async () => {
           <code class="rc-url-text">{{ sessionUrl }}</code>
           <div class="rc-url-actions">
             <button class="rc-btn rc-btn-small" @click="copyUrl" title="Copy URL">
-              Copy
+              {{ copyFeedback ?? "Copy" }}
             </button>
             <button class="rc-btn rc-btn-small" @click="openInBrowser" title="Open in browser">
               Open

--- a/packages/gui/src/components/RemoteControlPanel.vue
+++ b/packages/gui/src/components/RemoteControlPanel.vue
@@ -16,14 +16,25 @@ const {
 } = useRemoteControlStore();
 
 const copyFeedback = ref<string | null>(null);
+const isLoading = ref(false);
 const unlistenFns: Array<() => void> = [];
 
 async function handleStart() {
-  await start("Mercury");
+  isLoading.value = true;
+  try {
+    await start("Mercury");
+  } finally {
+    isLoading.value = false;
+  }
 }
 
 async function handleStop() {
-  await stop();
+  isLoading.value = true;
+  try {
+    await stop();
+  } finally {
+    isLoading.value = false;
+  }
 }
 
 function copyUrl() {
@@ -42,7 +53,11 @@ function copyUrl() {
 
 function openInBrowser() {
   if (sessionUrl.value) {
-    window.open(sessionUrl.value, "_blank");
+    const win = window.open(sessionUrl.value, "_blank");
+    if (!win) {
+      // Popup blocked — fall back to clipboard copy
+      copyUrl();
+    }
   }
 }
 
@@ -130,16 +145,18 @@ onUnmounted(() => {
         <button
           v-if="!isRunning"
           class="rc-btn rc-btn-primary"
+          :disabled="isLoading"
           @click="handleStart"
         >
-          Start Remote Control
+          {{ isLoading ? "Starting..." : "Start Remote Control" }}
         </button>
         <button
           v-if="isRunning"
           class="rc-btn rc-btn-danger"
+          :disabled="isLoading"
           @click="handleStop"
         >
-          Stop
+          {{ isLoading ? "Stopping..." : "Stop" }}
         </button>
       </div>
 

--- a/packages/gui/src/components/RemoteControlPanel.vue
+++ b/packages/gui/src/components/RemoteControlPanel.vue
@@ -18,6 +18,9 @@ const {
 const copyFeedback = ref<string | null>(null);
 const isLoading = ref(false);
 const unlistenFns: Array<() => void> = [];
+/** Guard: if the component unmounts before the async init resolves,
+ *  any returned UnlistenFns are executed immediately. */
+let disposed = false;
 
 async function handleStart() {
   isLoading.value = true;
@@ -79,10 +82,16 @@ const statusColors: Record<string, string> = {
 
 onMounted(async () => {
   const fns = await initRemoteControlListeners();
-  unlistenFns.push(...fns);
+  if (disposed) {
+    // Component was unmounted while we were awaiting — clean up immediately.
+    fns.forEach((fn) => fn());
+  } else {
+    unlistenFns.push(...fns);
+  }
 });
 
 onUnmounted(() => {
+  disposed = true;
   unlistenFns.forEach((fn) => fn());
 });
 </script>

--- a/packages/gui/src/components/TitleBar.vue
+++ b/packages/gui/src/components/TitleBar.vue
@@ -8,6 +8,7 @@ const props = defineProps<{
 }>();
 const emit = defineEmits<{
   "open-settings": [];
+  "open-remote-control": [];
   "switch-view": [view: "agents" | "tasks"];
   "toggle-event-log": [];
 }>();
@@ -64,6 +65,11 @@ onUnmounted(() => {
     </div>
     <div class="titlebar-center" data-tauri-drag-region></div>
     <div class="titlebar-right">
+      <button
+        class="titlebar-btn"
+        title="Remote Control"
+        @click="emit('open-remote-control')"
+      >📡</button>
       <button
         class="titlebar-btn"
         :class="{ 'btn-active': props.eventLogOpen }"

--- a/packages/gui/src/lib/tauri-bridge.ts
+++ b/packages/gui/src/lib/tauri-bridge.ts
@@ -563,6 +563,59 @@ export async function getContextStatus(): Promise<ContextStatus> {
   return invoke<ContextStatus>("get_context_status");
 }
 
+// ─── Remote Control Operations ───
+
+export type RemoteControlStatus =
+  | "stopped"
+  | "starting"
+  | "waiting_for_connection"
+  | "connected"
+  | "error";
+
+export interface RemoteControlState {
+  status: RemoteControlStatus;
+  session_url: string | null;
+  session_name: string | null;
+}
+
+export async function startRemoteControl(
+  sessionName?: string,
+): Promise<{ ok: true }> {
+  return invoke("start_remote_control", { sessionName: sessionName ?? null });
+}
+
+export async function stopRemoteControl(): Promise<{ ok: true }> {
+  return invoke("stop_remote_control");
+}
+
+export async function getRemoteControlStatus(): Promise<RemoteControlState> {
+  return invoke<RemoteControlState>("get_remote_control_status");
+}
+
+export function onRemoteControlStatus(
+  handler: (data: RemoteControlState) => void,
+): Promise<UnlistenFn> {
+  return listen<RemoteControlState>("remote-control-status", (event) =>
+    handler(event.payload),
+  );
+}
+
+export function onRemoteControlUrl(
+  handler: (data: { url: string }) => void,
+): Promise<UnlistenFn> {
+  return listen<{ url: string }>("remote-control-url", (event) =>
+    handler(event.payload),
+  );
+}
+
+export function onRemoteControlLog(
+  handler: (data: { level: string; message: string }) => void,
+): Promise<UnlistenFn> {
+  return listen<{ level: string; message: string }>("remote-control-log", (event) =>
+    handler(event.payload),
+  );
+}
+
 // Events (sidecar → Rust → frontend)
 
 export interface AgentMessageEvent {

--- a/packages/gui/src/lib/tauri-bridge.ts
+++ b/packages/gui/src/lib/tauri-bridge.ts
@@ -86,6 +86,7 @@ export interface ProjectInfo {
   gitBranch: string | null;
 }
 
+/** Retrieve the current project root path and git branch via Rust. */
 export async function getProjectInfo(): Promise<ProjectInfo> {
   return invoke<ProjectInfo>("get_project_info");
 }
@@ -97,6 +98,7 @@ export interface GitInfo {
   gitBranch: string | null;
 }
 
+/** Get git information (branch name) for an arbitrary directory path. */
 export async function getGitInfo(path: string): Promise<GitInfo> {
   return invoke<GitInfo>("get_git_info", { path });
 }
@@ -107,16 +109,19 @@ export interface GitBranchList {
   remote: string[];
 }
 
+/** List local and remote git branches for the repository at the given path. */
 export async function listGitBranches(path: string): Promise<GitBranchList> {
   return invoke<GitBranchList>("list_git_branches", { path });
 }
 
+/** Switch the repository at `path` to the specified git branch. */
 export async function checkoutBranch(path: string, branch: string): Promise<{ ok: boolean; branch: string }> {
   return invoke<{ ok: boolean; branch: string }>("checkout_branch", { path, branch });
 }
 
 // Agent workspace (frontend → Rust → sidecar)
 
+/** Set the working directory for an agent via the sidecar. */
 export async function setAgentCwd(
   agentId: string,
   cwd: string,
@@ -126,10 +131,12 @@ export async function setAgentCwd(
 
 // Commands (frontend → Rust → sidecar)
 
+/** Retrieve the list of configured agents from the sidecar. */
 export async function getAgents(): Promise<AgentConfig[]> {
   return invoke<AgentConfig[]>("get_agents");
 }
 
+/** Send a prompt (with optional images and role) to an agent session. */
 export async function sendPrompt(
   agentId: string,
   prompt: string,
@@ -150,6 +157,7 @@ export async function startSession(
   return invoke("start_session", { agentId, role: role ?? null });
 }
 
+/** Stop an active agent session by ID. */
 export async function stopSession(
   agentId: string,
   sessionId: string,
@@ -157,6 +165,7 @@ export async function stopSession(
   return invoke("stop_session", { agentId, sessionId });
 }
 
+/** Delete a terminated session and its associated resources. */
 export async function deleteSession(
   agentId: string,
   sessionId: string,
@@ -164,10 +173,12 @@ export async function deleteSession(
   return invoke("delete_session", { agentId, sessionId });
 }
 
+/** Update an agent's configuration in the sidecar runtime. */
 export async function configureAgent(config: AgentConfig): Promise<void> {
   return invoke("configure_agent", { config });
 }
 
+/** Dispatch a task prompt from one agent to another, creating a new session. */
 export async function dispatchTask(
   fromAgentId: string,
   toAgentId: string,
@@ -204,10 +215,12 @@ export interface MercuryProjectConfig {
   obsidian?: ObsidianConfig;
 }
 
+/** Retrieve the current Mercury project configuration. */
 export async function getConfig(): Promise<MercuryProjectConfig> {
   return invoke<MercuryProjectConfig>("get_config");
 }
 
+/** Persist an updated Mercury project configuration. */
 export async function updateConfig(
   config: MercuryProjectConfig,
 ): Promise<{ ok: true }> {
@@ -313,14 +326,17 @@ export interface CreateTaskParams {
   maxReworks?: number;
 }
 
+/** Create a new task bundle from the provided parameters. */
 export async function createTask(params: CreateTaskParams): Promise<TaskBundle> {
   return invoke<TaskBundle>("create_task", { params });
 }
 
+/** Fetch a single task bundle by its ID, or null if not found. */
 export async function getTask(taskId: string): Promise<TaskBundle | null> {
   return invoke<TaskBundle | null>("get_task", { taskId });
 }
 
+/** List task bundles, optionally filtered by status and/or assignee. */
 export async function listTasks(
   status?: TaskStatus,
   assignedTo?: string,
@@ -328,12 +344,14 @@ export async function listTasks(
   return invoke<TaskBundle[]>("list_tasks", { status: status ?? null, assignedTo: assignedTo ?? null });
 }
 
+/** Dispatch a task bundle to the assigned agent for execution. */
 export async function dispatchBundleTask(
   taskId: string,
 ): Promise<{ sessionId: string; taskId: string }> {
   return invoke("dispatch_task", { params: { taskId } });
 }
 
+/** Record an implementation receipt for a completed task. */
 export async function recordReceipt(
   taskId: string,
   receipt: Record<string, unknown>,
@@ -341,6 +359,7 @@ export async function recordReceipt(
   return invoke<TaskBundle>("record_receipt", { taskId, receipt });
 }
 
+/** Create an acceptance test session for a task, assigning the given acceptor. */
 export async function createAcceptance(
   taskId: string,
   acceptorId: string,
@@ -348,6 +367,7 @@ export async function createAcceptance(
   return invoke("create_acceptance", { taskId, acceptorId });
 }
 
+/** Record the acceptance test verdict and findings for a task. */
 export async function recordAcceptanceResult(
   acceptanceId: string,
   results: { verdict: AcceptanceVerdict; findings: string[]; recommendations: string[] },
@@ -355,12 +375,14 @@ export async function recordAcceptanceResult(
   return invoke("record_acceptance_result", { acceptanceId, results });
 }
 
+/** Create a new issue in the Mercury issue tracker. */
 export async function createIssue(
   params: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
   return invoke("create_issue", { params });
 }
 
+/** Mark an issue as resolved with a summary and resolution metadata. */
 export async function resolveIssue(
   issueId: string,
   resolution: { resolvedBy: string; summary: string; resolvedAt: number },
@@ -368,6 +390,7 @@ export async function resolveIssue(
   return invoke("resolve_issue", { issueId, resolution });
 }
 
+/** Summarize and close the current session, returning the new session ID. */
 export async function summarizeSession(
   agentId: string,
   summary: string,
@@ -377,10 +400,12 @@ export async function summarizeSession(
 
 // ─── Model Listing & Switching ───
 
+/** List available models for the specified agent. */
 export async function listModels(agentId: string): Promise<{ id: string; name: string }[]> {
   return invoke<{ id: string; name: string }[]>("list_models", { agentId });
 }
 
+/** Switch an agent to a different model at runtime. */
 export async function setModel(agentId: string, model: string): Promise<{ ok: boolean }> {
   return invoke<{ ok: boolean }>("set_model", { agentId, model });
 }
@@ -402,28 +427,33 @@ export interface SlashCommand {
   category?: string;
 }
 
+/** Retrieve the list of slash commands supported by an agent. */
 export async function getSlashCommands(agentId: string): Promise<SlashCommand[]> {
   return invoke<SlashCommand[]>("get_slash_commands", { agentId });
 }
 
 // ─── Knowledge Base Operations (optional, requires obsidian enabled) ───
 
+/** Read a file from the Obsidian knowledge base. */
 export async function kbRead(file: string): Promise<{ content: string }> {
   return invoke("kb_read", { file });
 }
 
+/** Search the knowledge base for files matching the given query. */
 export async function kbSearch(
   query: string,
 ): Promise<Array<{ file: string; matches: string[] }>> {
   return invoke("kb_search", { query });
 }
 
+/** List files and folders in the knowledge base, optionally within a subfolder. */
 export async function kbList(
   folder?: string,
 ): Promise<Array<{ path: string; name: string; folder: string; kind: "file" | "folder" }>> {
   return invoke("kb_list", { folder: folder ?? null });
 }
 
+/** Write (create or overwrite) a file in the knowledge base. */
 export async function kbWrite(
   name: string,
   content: string,
@@ -431,6 +461,7 @@ export async function kbWrite(
   return invoke("kb_write", { name, content });
 }
 
+/** Append content to an existing knowledge base file. */
 export async function kbAppend(
   file: string,
   content: string,
@@ -454,6 +485,7 @@ export interface SessionListItem {
   promptHash?: string;
 }
 
+/** List sessions, optionally filtered by agent, role, or terminal status. */
 export async function listSessions(
   agentId?: string,
   role?: string,
@@ -466,6 +498,7 @@ export async function listSessions(
   });
 }
 
+/** Resume a previously paused or overflow session for an agent. */
 export async function resumeSession(
   agentId: string,
   sessionId: string,
@@ -486,6 +519,7 @@ export interface TranscriptMessage {
   metadata?: Record<string, unknown>;
 }
 
+/** Retrieve paginated transcript messages for a given session. */
 export async function getSessionMessages(
   sessionId: string,
   offset?: number,
@@ -517,20 +551,24 @@ export async function readSessionHistory(
 
 // ─── Approval Control Plane ───
 
+/** Get the current approval mode (main_agent_review or auto_accept). */
 export async function getApprovalMode(): Promise<{ mode: ApprovalMode }> {
   return invoke<{ mode: ApprovalMode }>("get_approval_mode");
 }
 
+/** Set the approval mode for incoming agent requests. */
 export async function setApprovalMode(mode: ApprovalMode): Promise<{ mode: ApprovalMode }> {
   return invoke<{ mode: ApprovalMode }>("set_approval_mode", { mode });
 }
 
+/** List approval requests, optionally filtered by status. */
 export async function listApprovalRequests(
   status?: ApprovalRequestStatus,
 ): Promise<ApprovalRequest[]> {
   return invoke<ApprovalRequest[]>("list_approval_requests", { status: status ?? null });
 }
 
+/** Approve a pending approval request with an optional reason. */
 export async function approveRequest(
   requestId: string,
   reason?: string,
@@ -538,6 +576,7 @@ export async function approveRequest(
   return invoke("approve_request", { requestId, reason: reason ?? null });
 }
 
+/** Deny a pending approval request with an optional reason. */
 export async function denyRequest(
   requestId: string,
   reason?: string,
@@ -555,10 +594,12 @@ export interface ContextStatus {
   roleContextFiles?: ObsidianConfig["roleContextFiles"];
 }
 
+/** Re-inject shared context into all active agent sessions. */
 export async function refreshContext(): Promise<{ injected: boolean; agentCount: number; contextLength: number }> {
   return invoke("refresh_context");
 }
 
+/** Get the current shared context injection status and configuration. */
 export async function getContextStatus(): Promise<ContextStatus> {
   return invoke<ContextStatus>("get_context_status");
 }
@@ -578,20 +619,24 @@ export interface RemoteControlState {
   session_name: string | null;
 }
 
+/** Start a `claude remote-control` subprocess with an optional session name. */
 export async function startRemoteControl(
   sessionName?: string,
 ): Promise<{ ok: true }> {
   return invoke("start_remote_control", { sessionName: sessionName ?? null });
 }
 
+/** Stop the running `claude remote-control` subprocess. */
 export async function stopRemoteControl(): Promise<{ ok: true }> {
   return invoke("stop_remote_control");
 }
 
+/** Query the current remote control subprocess state from the backend. */
 export async function getRemoteControlStatus(): Promise<RemoteControlState> {
   return invoke<RemoteControlState>("get_remote_control_status");
 }
 
+/** Listen for remote control status change events from the backend. */
 export function onRemoteControlStatus(
   handler: (data: RemoteControlState) => void,
 ): Promise<UnlistenFn> {
@@ -600,6 +645,7 @@ export function onRemoteControlStatus(
   );
 }
 
+/** Listen for remote control session URL events. */
 export function onRemoteControlUrl(
   handler: (data: { url: string }) => void,
 ): Promise<UnlistenFn> {
@@ -608,6 +654,7 @@ export function onRemoteControlUrl(
   );
 }
 
+/** Listen for remote control log messages (stdout/stderr). */
 export function onRemoteControlLog(
   handler: (data: { level: string; message: string }) => void,
 ): Promise<UnlistenFn> {
@@ -666,6 +713,7 @@ export interface SidecarReadyEvent {
   timestamp: number;
 }
 
+/** Listen for complete agent response messages. */
 export function onAgentMessage(
   handler: (data: AgentMessageEvent) => void,
 ): Promise<UnlistenFn> {
@@ -674,6 +722,7 @@ export function onAgentMessage(
   );
 }
 
+/** Listen for the end-of-stream signal from an agent session. */
 export function onAgentStreamEnd(
   handler: (data: AgentStreamEndEvent) => void,
 ): Promise<UnlistenFn> {
@@ -682,6 +731,7 @@ export function onAgentStreamEnd(
   );
 }
 
+/** Listen for incremental streaming token events from an agent. */
 export function onAgentStreaming(
   handler: (data: AgentStreamingEvent) => void,
 ): Promise<UnlistenFn> {
@@ -690,6 +740,7 @@ export function onAgentStreaming(
   );
 }
 
+/** Listen for agent working-state notifications (session started processing). */
 export function onAgentWorking(
   handler: (data: AgentWorkingEvent) => void,
 ): Promise<UnlistenFn> {
@@ -698,6 +749,7 @@ export function onAgentWorking(
   );
 }
 
+/** Listen for agent error events. */
 export function onAgentError(
   handler: (data: AgentErrorEvent) => void,
 ): Promise<UnlistenFn> {
@@ -706,6 +758,7 @@ export function onAgentError(
   );
 }
 
+/** Listen for generic Mercury platform events. */
 export function onMercuryEvent(
   handler: (data: MercuryEvent) => void,
 ): Promise<UnlistenFn> {
@@ -714,6 +767,7 @@ export function onMercuryEvent(
   );
 }
 
+/** Listen for the sidecar ready event after initial bootstrap. */
 export function onSidecarReady(
   handler: (data: SidecarReadyEvent) => void,
 ): Promise<UnlistenFn> {
@@ -722,6 +776,7 @@ export function onSidecarReady(
   );
 }
 
+/** Listen for fatal sidecar error events. */
 export function onSidecarError(
   handler: (data: { error: string }) => void,
 ): Promise<UnlistenFn> {

--- a/packages/gui/src/lib/tauri-bridge.ts
+++ b/packages/gui/src/lib/tauri-bridge.ts
@@ -617,6 +617,8 @@ export interface RemoteControlState {
   status: RemoteControlStatus;
   session_url: string | null;
   session_name: string | null;
+  /** Present only when `status === "error"`; carries the error description. */
+  error_message?: string | null;
 }
 
 /** Start a `claude remote-control` subprocess with an optional session name. */

--- a/packages/gui/src/stores/remote-control.ts
+++ b/packages/gui/src/stores/remote-control.ts
@@ -85,37 +85,50 @@ function applyState(state: RemoteControlState) {
 let listenersInitialized = false;
 
 /** Register Tauri event listeners for remote control status, URL, and log updates.
- *  Returns an array of unlisten functions for cleanup on component unmount. */
+ *  Returns an array of unlisten functions for cleanup on component unmount.
+ *  The `listenersInitialized` flag is only set after ALL listeners succeed;
+ *  on partial failure the already-registered listeners are cleaned up. */
 async function initRemoteControlListeners(): Promise<Array<() => void>> {
   if (listenersInitialized) {
     console.warn("[remote-control] Listeners already initialized");
     return [];
   }
+
+  const collected: Array<() => void> = [];
+  try {
+    const unlistenStatus = await onRemoteControlStatus((state) => {
+      applyState(state);
+    });
+    collected.push(unlistenStatus);
+
+    const unlistenUrl = await onRemoteControlUrl((data) => {
+      sessionUrl.value = data.url;
+    });
+    collected.push(unlistenUrl);
+
+    const unlistenLog = await onRemoteControlLog((data) => {
+      logs.value = [...logs.value.slice(-99), `[${data.level}] ${data.message}`];
+      if (data.level === "error") {
+        error.value = data.message;
+      }
+    });
+    collected.push(unlistenLog);
+  } catch (e) {
+    // Partial failure — clean up any listeners that were registered.
+    collected.forEach((fn) => fn());
+    console.error("[remote-control] Failed to init listeners:", e);
+    return [];
+  }
+
+  // All listeners registered successfully — mark as initialised.
   listenersInitialized = true;
-
-  const unlistenStatus = await onRemoteControlStatus((state) => {
-    /** Update store from status event. */
-    applyState(state);
-  });
-
-  const unlistenUrl = await onRemoteControlUrl((data) => {
-    sessionUrl.value = data.url;
-  });
-
-  const unlistenLog = await onRemoteControlLog((data) => {
-    logs.value = [...logs.value.slice(-99), `[${data.level}] ${data.message}`];
-    if (data.level === "error") {
-      error.value = data.message;
-    }
-  });
 
   // Fetch initial status
   await refreshStatus();
 
   return [
-    () => { unlistenStatus(); listenersInitialized = false; },
-    unlistenUrl,
-    unlistenLog,
+    () => { collected[0](); listenersInitialized = false; },
+    ...collected.slice(1),
   ];
 }
 

--- a/packages/gui/src/stores/remote-control.ts
+++ b/packages/gui/src/stores/remote-control.ts
@@ -27,6 +27,7 @@ const isRunning = computed(() =>
 
 const isConnected = computed(() => status.value === "connected");
 
+/** Start a remote control session, spawning the `claude remote-control` subprocess. */
 async function start(name?: string) {
   error.value = null;
   logs.value = [];
@@ -39,25 +40,30 @@ async function start(name?: string) {
   }
 }
 
+/** Stop the running remote control subprocess and reset state. */
 async function stop() {
   try {
     await invokeStop();
+    status.value = "stopped";
+    sessionUrl.value = null;
   } catch (e) {
     error.value = String(e);
+    status.value = "error";
   }
-  status.value = "stopped";
-  sessionUrl.value = null;
 }
 
+/** Fetch the current remote control status from the Tauri backend. */
 async function refreshStatus() {
   try {
     const state = await invokeGetStatus();
+    /** Sync reactive store with fetched backend state. */
     applyState(state);
   } catch {
     // Ignore — sidecar may not be ready yet
   }
 }
 
+/** Apply a backend RemoteControlState snapshot to the reactive store values. */
 function applyState(state: RemoteControlState) {
   // Map snake_case enum variants to our TS type
   const statusMap: Record<string, RemoteControlStatus> = {
@@ -82,16 +88,27 @@ function applyState(state: RemoteControlState) {
   }
 }
 
-async function initRemoteControlListeners() {
-  await onRemoteControlStatus((state) => {
+let listenersInitialized = false;
+
+/** Register Tauri event listeners for remote control status, URL, and log updates.
+ *  Returns an array of unlisten functions for cleanup on component unmount. */
+async function initRemoteControlListeners(): Promise<Array<() => void>> {
+  if (listenersInitialized) {
+    console.warn("[remote-control] Listeners already initialized");
+    return [];
+  }
+  listenersInitialized = true;
+
+  const unlistenStatus = await onRemoteControlStatus((state) => {
+    /** Update store from status event. */
     applyState(state);
   });
 
-  await onRemoteControlUrl((data) => {
+  const unlistenUrl = await onRemoteControlUrl((data) => {
     sessionUrl.value = data.url;
   });
 
-  await onRemoteControlLog((data) => {
+  const unlistenLog = await onRemoteControlLog((data) => {
     logs.value = [...logs.value.slice(-99), `[${data.level}] ${data.message}`];
     if (data.level === "error") {
       error.value = data.message;
@@ -100,8 +117,15 @@ async function initRemoteControlListeners() {
 
   // Fetch initial status
   await refreshStatus();
+
+  return [
+    () => { unlistenStatus(); listenersInitialized = false; },
+    unlistenUrl,
+    unlistenLog,
+  ];
 }
 
+/** Composable that exposes remote control reactive state and actions. */
 export function useRemoteControlStore() {
   return {
     status,

--- a/packages/gui/src/stores/remote-control.ts
+++ b/packages/gui/src/stores/remote-control.ts
@@ -1,0 +1,119 @@
+/**
+ * Remote Control state store.
+ * Manages the lifecycle of a `claude remote-control` subprocess
+ * and exposes reactive state for the GUI.
+ */
+
+import { ref, computed } from "vue";
+import type { RemoteControlState, RemoteControlStatus } from "../lib/tauri-bridge";
+import {
+  startRemoteControl as invokeStart,
+  stopRemoteControl as invokeStop,
+  getRemoteControlStatus as invokeGetStatus,
+  onRemoteControlStatus,
+  onRemoteControlUrl,
+  onRemoteControlLog,
+} from "../lib/tauri-bridge";
+
+const status = ref<RemoteControlStatus>("stopped");
+const sessionUrl = ref<string | null>(null);
+const sessionName = ref<string | null>(null);
+const error = ref<string | null>(null);
+const logs = ref<string[]>([]);
+
+const isRunning = computed(() =>
+  status.value !== "stopped" && status.value !== "error",
+);
+
+const isConnected = computed(() => status.value === "connected");
+
+async function start(name?: string) {
+  error.value = null;
+  logs.value = [];
+  sessionName.value = name ?? "Mercury";
+  try {
+    await invokeStart(sessionName.value);
+  } catch (e) {
+    error.value = String(e);
+    status.value = "error";
+  }
+}
+
+async function stop() {
+  try {
+    await invokeStop();
+  } catch (e) {
+    error.value = String(e);
+  }
+  status.value = "stopped";
+  sessionUrl.value = null;
+}
+
+async function refreshStatus() {
+  try {
+    const state = await invokeGetStatus();
+    applyState(state);
+  } catch {
+    // Ignore — sidecar may not be ready yet
+  }
+}
+
+function applyState(state: RemoteControlState) {
+  // Map snake_case enum variants to our TS type
+  const statusMap: Record<string, RemoteControlStatus> = {
+    stopped: "stopped",
+    starting: "starting",
+    waiting_for_connection: "waiting_for_connection",
+    connected: "connected",
+  };
+  if (typeof state.status === "string") {
+    status.value = statusMap[state.status] ?? "stopped";
+  } else if (typeof state.status === "object" && state.status !== null) {
+    // Rust enum serialization: { "error": "message" }
+    const errObj = state.status as Record<string, string>;
+    if ("error" in errObj) {
+      status.value = "error";
+      error.value = errObj.error;
+    }
+  }
+  sessionUrl.value = state.session_url;
+  if (state.session_name) {
+    sessionName.value = state.session_name;
+  }
+}
+
+async function initRemoteControlListeners() {
+  await onRemoteControlStatus((state) => {
+    applyState(state);
+  });
+
+  await onRemoteControlUrl((data) => {
+    sessionUrl.value = data.url;
+  });
+
+  await onRemoteControlLog((data) => {
+    logs.value = [...logs.value.slice(-99), `[${data.level}] ${data.message}`];
+    if (data.level === "error") {
+      error.value = data.message;
+    }
+  });
+
+  // Fetch initial status
+  await refreshStatus();
+}
+
+export function useRemoteControlStore() {
+  return {
+    status,
+    sessionUrl,
+    sessionName,
+    error,
+    logs,
+    isRunning,
+    isConnected,
+    start,
+    stop,
+    refreshStatus,
+    initRemoteControlListeners,
+  };
+}

--- a/packages/gui/src/stores/remote-control.ts
+++ b/packages/gui/src/stores/remote-control.ts
@@ -63,24 +63,18 @@ async function refreshStatus() {
   }
 }
 
-/** Apply a backend RemoteControlState snapshot to the reactive store values. */
+/** Apply a backend RemoteControlState snapshot to the reactive store values.
+ *  All status variants are now unit variants (plain strings), so no object
+ *  parsing is needed. Error details arrive in the separate `error_message` field. */
 function applyState(state: RemoteControlState) {
-  // Map snake_case enum variants to our TS type
-  const statusMap: Record<string, RemoteControlStatus> = {
-    stopped: "stopped",
-    starting: "starting",
-    waiting_for_connection: "waiting_for_connection",
-    connected: "connected",
-  };
-  if (typeof state.status === "string") {
-    status.value = statusMap[state.status] ?? "stopped";
-  } else if (typeof state.status === "object" && state.status !== null) {
-    // Rust enum serialization: { "error": "message" }
-    const errObj = state.status as Record<string, string>;
-    if ("error" in errObj) {
-      status.value = "error";
-      error.value = errObj.error;
-    }
+  const validStatuses: RemoteControlStatus[] = [
+    "stopped", "starting", "waiting_for_connection", "connected", "error",
+  ];
+  status.value = validStatuses.includes(state.status as RemoteControlStatus)
+    ? (state.status as RemoteControlStatus)
+    : "stopped";
+  if (state.status === "error" && state.error_message) {
+    error.value = state.error_message;
   }
   sessionUrl.value = state.session_url;
   if (state.session_name) {


### PR DESCRIPTION
## Summary
- Add full-stack GUI integration for `claude remote-control` CLI command
- New `RemoteControlManager` (Rust) spawns and manages the `claude remote-control` subprocess
- New `RemoteControlPanel.vue` provides a modal UI with session URL display, copy/open actions, status indicator, and error/log display
- New `remote-control.ts` store manages reactive state across the GUI
- TitleBar gains a 📡 button to open the Remote Control panel
- Graceful shutdown of RC process on app exit

### Architecture
```
[GUI 📡 Button] → RemoteControlPanel.vue
    ↓ tauri-bridge.ts invoke
[commands.rs] → start_remote_control / stop_remote_control / get_remote_control_status
    ↓
[remote_control.rs] → spawn `claude remote-control --name Mercury --verbose`
    ↓ parse stdout for URL
[Tauri events] → remote-control-status / remote-control-url / remote-control-log
    ↓
[remote-control.ts store] → reactive state → RemoteControlPanel.vue renders
```

### Files Changed
| File | Change |
|------|--------|
| `remote_control.rs` | **New** — Child process manager |
| `commands.rs` | 3 new Tauri commands |
| `lib.rs` | SharedRemoteControl state + shutdown |
| `tauri-bridge.ts` | TS types + invoke/listen wrappers |
| `remote-control.ts` | **New** — Vue reactive store |
| `RemoteControlPanel.vue` | **New** — Modal component |
| `TitleBar.vue` | 📡 button |
| `App.vue` | Panel integration |

### Requirements
- Claude Code v2.1.51+
- Pro/Max subscription with claude.ai OAuth (API keys not supported)
- Source: [Official docs](https://code.claude.com/docs/en/remote-control)

Closes #55

## Test plan
- [ ] Click 📡 in titlebar → Remote Control panel opens
- [ ] Click "Start Remote Control" → status changes to "Starting..."
- [ ] Verify session URL appears once process outputs it
- [ ] Copy and Open buttons work correctly
- [ ] Click "Stop" → process terminates, status returns to "Stopped"
- [ ] Close GUI → RC process gracefully shut down
- [ ] Error case: no claude CLI → error message displayed
- [ ] Rust: `cargo check` passes with 0 warnings
- [ ] TypeScript: `vue-tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)