### PR TITLE
feat(gui): PR Monitor panel with CodeRabbit status tracking (#58)

### DIFF
--- a/packages/gui/src-tauri/Cargo.lock
+++ b/packages/gui/src-tauri/Cargo.lock
@@ -2057,6 +2057,7 @@ dependencies = [
  "tauri-plugin-single-instance",
  "tauri-plugin-window-state",
  "tokio",
+ "url",
 ]
 
 [[package]]

--- a/packages/gui/src-tauri/src/commands.rs
+++ b/packages/gui/src-tauri/src/commands.rs
@@ -809,8 +809,7 @@ pub async fn get_remote_control_status(
 pub async fn get_open_prs(
     pm: State<'_, SharedPrMonitor>,
 ) -> Result<serde_json::Value, String> {
-    let monitor = pm.lock().await;
-    let prs = monitor.fetch_prs().await?;
+    let prs = pm.fetch_prs().await?;
     Ok(serde_json::json!({ "prs": prs }))
 }
 
@@ -818,8 +817,7 @@ pub async fn get_open_prs(
 pub async fn get_pr_monitor_state(
     pm: State<'_, SharedPrMonitor>,
 ) -> Result<serde_json::Value, String> {
-    let monitor = pm.lock().await;
-    let state = monitor.get_state().await;
+    let state = pm.get_state().await;
     serde_json::to_value(&state).map_err(|e| e.to_string())
 }
 
@@ -829,8 +827,7 @@ pub async fn start_pr_polling(
     pm: State<'_, SharedPrMonitor>,
     interval_secs: Option<u64>,
 ) -> Result<serde_json::Value, String> {
-    let monitor = pm.lock().await;
-    monitor.start_polling(app, interval_secs).await?;
+    pm.start_polling(app, interval_secs).await?;
     Ok(serde_json::json!({ "ok": true }))
 }
 
@@ -838,8 +835,7 @@ pub async fn start_pr_polling(
 pub async fn stop_pr_polling(
     pm: State<'_, SharedPrMonitor>,
 ) -> Result<serde_json::Value, String> {
-    let monitor = pm.lock().await;
-    monitor.stop_polling();
+    pm.stop_polling();
     Ok(serde_json::json!({ "ok": true }))
 }
 

--- a/packages/gui/src-tauri/src/commands.rs
+++ b/packages/gui/src-tauri/src/commands.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 use tauri::State;
 
 use crate::sidecar::SidecarManager;
-use crate::{ProjectRoot, SharedRemoteControl, SharedSidecar};
+use crate::{ProjectRoot, SharedPrMonitor, SharedRemoteControl, SharedSidecar};
 
 // ─── Project Info (direct, no sidecar) ───
 
@@ -801,4 +801,78 @@ pub async fn get_remote_control_status(
     let mgr = rc.lock().await;
     let state = mgr.get_state().await;
     serde_json::to_value(&state).map_err(|e| e.to_string())
+}
+
+// ─── PR Monitor Commands ───
+
+#[tauri::command]
+pub async fn get_open_prs(
+    pm: State<'_, SharedPrMonitor>,
+) -> Result<serde_json::Value, String> {
+    let monitor = pm.lock().await;
+    let prs = monitor.fetch_prs().await?;
+    Ok(serde_json::json!({ "prs": prs }))
+}
+
+#[tauri::command]
+pub async fn get_pr_monitor_state(
+    pm: State<'_, SharedPrMonitor>,
+) -> Result<serde_json::Value, String> {
+    let monitor = pm.lock().await;
+    let state = monitor.get_state().await;
+    serde_json::to_value(&state).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn start_pr_polling(
+    app: tauri::AppHandle,
+    pm: State<'_, SharedPrMonitor>,
+    interval_secs: Option<u64>,
+) -> Result<serde_json::Value, String> {
+    let monitor = pm.lock().await;
+    monitor.start_polling(app, interval_secs).await?;
+    Ok(serde_json::json!({ "ok": true }))
+}
+
+#[tauri::command]
+pub async fn stop_pr_polling(
+    pm: State<'_, SharedPrMonitor>,
+) -> Result<serde_json::Value, String> {
+    let monitor = pm.lock().await;
+    monitor.stop_polling();
+    Ok(serde_json::json!({ "ok": true }))
+}
+
+#[tauri::command]
+pub async fn trigger_coderabbit_review(
+    root: State<'_, ProjectRoot>,
+    pr_number: u32,
+) -> Result<serde_json::Value, String> {
+    if pr_number == 0 {
+        return Err("Invalid PR number".to_string());
+    }
+    let project_root = root.0.clone();
+    tokio::task::spawn_blocking(move || {
+        crate::pr_monitor::trigger_coderabbit_review_blocking(&project_root, pr_number)
+    })
+    .await
+    .map_err(|e| format!("Task join error: {}", e))??;
+    Ok(serde_json::json!({ "ok": true }))
+}
+
+#[tauri::command]
+pub async fn merge_pr(
+    root: State<'_, ProjectRoot>,
+    pr_number: u32,
+) -> Result<serde_json::Value, String> {
+    if pr_number == 0 {
+        return Err("Invalid PR number".to_string());
+    }
+    let project_root = root.0.clone();
+    tokio::task::spawn_blocking(move || {
+        crate::pr_monitor::merge_pr_blocking(&project_root, pr_number)
+    })
+    .await
+    .map_err(|e| format!("Task join error: {}", e))??;
+    Ok(serde_json::json!({ "ok": true }))
 }

--- a/packages/gui/src-tauri/src/lib.rs
+++ b/packages/gui/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod commands;
+mod pr_monitor;
 mod remote_control;
 mod sidecar;
 mod types;
@@ -8,6 +9,7 @@ use std::sync::Arc;
 use tauri::{Emitter, Manager};
 use tokio::sync::Mutex;
 
+use pr_monitor::PrMonitor;
 use remote_control::RemoteControlManager;
 use sidecar::SidecarManager;
 
@@ -16,6 +18,9 @@ pub type SharedSidecar = Arc<Mutex<Option<SidecarManager>>>;
 
 /// Shared remote control manager.
 pub type SharedRemoteControl = Arc<Mutex<RemoteControlManager>>;
+
+/// Shared PR monitor.
+pub type SharedPrMonitor = Arc<Mutex<PrMonitor>>;
 
 /// Project root path — available immediately (no sidecar dependency).
 pub struct ProjectRoot(pub String);
@@ -75,6 +80,10 @@ pub fn run() {
             let rc: SharedRemoteControl = Arc::new(Mutex::new(RemoteControlManager::new()));
             app.manage(rc.clone());
 
+            // Register PR monitor
+            let pm: SharedPrMonitor = Arc::new(Mutex::new(PrMonitor::new()));
+            app.manage(pm.clone());
+
             // Resolve the monorepo root (where mercury.config.json lives)
             let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
             let cwd = std::env::current_dir().unwrap_or_else(|_| manifest_dir.clone());
@@ -86,6 +95,16 @@ pub fn run() {
 
             app.manage(ProjectRoot(project_dir.clone()));
             eprintln!("[tauri] Project root: {}", project_dir);
+
+            // Set project root on PR monitor
+            {
+                let pm_clone = pm.clone();
+                let dir = project_dir.clone();
+                tauri::async_runtime::spawn(async move {
+                    let monitor = pm_clone.lock().await;
+                    monitor.set_project_root(dir).await;
+                });
+            }
 
             // Spawn the Node.js orchestrator sidecar
             tauri::async_runtime::spawn(async move {
@@ -150,6 +169,12 @@ pub fn run() {
             commands::start_remote_control,
             commands::stop_remote_control,
             commands::get_remote_control_status,
+            commands::get_open_prs,
+            commands::get_pr_monitor_state,
+            commands::start_pr_polling,
+            commands::stop_pr_polling,
+            commands::trigger_coderabbit_review,
+            commands::merge_pr,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")
@@ -157,7 +182,16 @@ pub fn run() {
             if let tauri::RunEvent::Exit = event {
                 let shared = app.state::<SharedSidecar>().inner().clone();
                 let rc = app.state::<SharedRemoteControl>().inner().clone();
+                let pm = app.state::<SharedPrMonitor>().inner().clone();
                 tauri::async_runtime::block_on(async {
+                    // Stop PR monitor polling
+                    {
+                        let monitor = pm.lock().await;
+                        if monitor.is_polling() {
+                            eprintln!("[tauri] Stopping PR monitor polling");
+                            monitor.stop_polling();
+                        }
+                    }
                     // Shutdown remote control first
                     {
                         let mgr = rc.lock().await;

--- a/packages/gui/src-tauri/src/lib.rs
+++ b/packages/gui/src-tauri/src/lib.rs
@@ -19,8 +19,8 @@ pub type SharedSidecar = Arc<Mutex<Option<SidecarManager>>>;
 /// Shared remote control manager.
 pub type SharedRemoteControl = Arc<Mutex<RemoteControlManager>>;
 
-/// Shared PR monitor.
-pub type SharedPrMonitor = Arc<Mutex<PrMonitor>>;
+/// Shared PR monitor — no outer Mutex needed; PrMonitor has internal fine-grained locking.
+pub type SharedPrMonitor = Arc<PrMonitor>;
 
 /// Project root path — available immediately (no sidecar dependency).
 pub struct ProjectRoot(pub String);
@@ -80,10 +80,6 @@ pub fn run() {
             let rc: SharedRemoteControl = Arc::new(Mutex::new(RemoteControlManager::new()));
             app.manage(rc.clone());
 
-            // Register PR monitor
-            let pm: SharedPrMonitor = Arc::new(Mutex::new(PrMonitor::new()));
-            app.manage(pm.clone());
-
             // Resolve the monorepo root (where mercury.config.json lives)
             let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
             let cwd = std::env::current_dir().unwrap_or_else(|_| manifest_dir.clone());
@@ -96,15 +92,9 @@ pub fn run() {
             app.manage(ProjectRoot(project_dir.clone()));
             eprintln!("[tauri] Project root: {}", project_dir);
 
-            // Set project root on PR monitor
-            {
-                let pm_clone = pm.clone();
-                let dir = project_dir.clone();
-                tauri::async_runtime::spawn(async move {
-                    let monitor = pm_clone.lock().await;
-                    monitor.set_project_root(dir).await;
-                });
-            }
+            // Register PR monitor with project root available immediately
+            let pm: SharedPrMonitor = Arc::new(PrMonitor::new(project_dir.clone()));
+            app.manage(pm.clone());
 
             // Spawn the Node.js orchestrator sidecar
             tauri::async_runtime::spawn(async move {
@@ -185,12 +175,9 @@ pub fn run() {
                 let pm = app.state::<SharedPrMonitor>().inner().clone();
                 tauri::async_runtime::block_on(async {
                     // Stop PR monitor polling
-                    {
-                        let monitor = pm.lock().await;
-                        if monitor.is_polling() {
-                            eprintln!("[tauri] Stopping PR monitor polling");
-                            monitor.stop_polling();
-                        }
+                    if pm.is_polling() {
+                        eprintln!("[tauri] Stopping PR monitor polling");
+                        pm.stop_polling();
                     }
                     // Shutdown remote control first
                     {

--- a/packages/gui/src-tauri/src/pr_monitor.rs
+++ b/packages/gui/src-tauri/src/pr_monitor.rs
@@ -59,9 +59,9 @@ pub struct PrMonitor {
 }
 
 impl PrMonitor {
-    pub fn new() -> Self {
+    pub fn new(project_root: String) -> Self {
         Self {
-            project_root: Arc::new(Mutex::new(String::new())),
+            project_root: Arc::new(Mutex::new(project_root)),
             polling: Arc::new(AtomicBool::new(false)),
             generation: Arc::new(AtomicU64::new(0)),
             interval_secs: Arc::new(Mutex::new(60)),
@@ -259,6 +259,8 @@ fn fetch_prs_blocking(project_root: &str) -> Result<Vec<PullRequest>, String> {
             "list",
             "--state",
             "open",
+            "--limit",
+            "100",
             "--json",
             "number,title,headRefName,author,createdAt,updatedAt,url,reviewDecision,reviews",
         ])
@@ -365,8 +367,45 @@ pub fn trigger_coderabbit_review_blocking(
     Ok(())
 }
 
-/// Squash merge a PR.
+/// Squash merge a PR after verifying it is approved and not a draft.
 pub fn merge_pr_blocking(project_root: &str, pr_number: u32) -> Result<(), String> {
+    // Gate: verify PR is approved and not a draft before merging
+    let check = Command::new("gh")
+        .args([
+            "pr",
+            "view",
+            &pr_number.to_string(),
+            "--json",
+            "reviewDecision,isDraft",
+        ])
+        .current_dir(project_root)
+        .env("LANG", "en_US.UTF-8")
+        .env("LC_ALL", "en_US.UTF-8")
+        .output()
+        .map_err(|e| format!("Failed to check PR state: {}", e))?;
+
+    if check.status.success() {
+        let check_json: serde_json::Value =
+            serde_json::from_slice(&check.stdout).unwrap_or_default();
+        let decision = check_json
+            .get("reviewDecision")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let is_draft = check_json
+            .get("isDraft")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        if is_draft {
+            return Err("Cannot merge: PR is still a draft".to_string());
+        }
+        if decision != "APPROVED" {
+            return Err(format!(
+                "Cannot merge: review decision is '{}', expected 'APPROVED'",
+                decision
+            ));
+        }
+    }
+
     let output = Command::new("gh")
         .args([
             "pr",

--- a/packages/gui/src-tauri/src/pr_monitor.rs
+++ b/packages/gui/src-tauri/src/pr_monitor.rs
@@ -114,7 +114,7 @@ impl PrMonitor {
             return Err("Polling already active".to_string());
         }
 
-        let interval = interval_secs.unwrap_or(60);
+        let interval = interval_secs.unwrap_or(60).max(10);
         {
             let mut guard = self.interval_secs.lock().await;
             *guard = interval;

--- a/packages/gui/src-tauri/src/pr_monitor.rs
+++ b/packages/gui/src-tauri/src/pr_monitor.rs
@@ -1,0 +1,441 @@
+use serde::{Deserialize, Serialize};
+use std::process::Command;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+use tauri::Emitter;
+use tokio::sync::Mutex;
+
+// ─── Data Model ───
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PrReview {
+    pub author: String,
+    pub state: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CodeRabbitStatus {
+    Pending,
+    Commented,
+    Approved,
+    ChangesRequested,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PullRequest {
+    pub number: u32,
+    pub title: String,
+    pub head_ref_name: String,
+    pub author: String,
+    pub created_at: String,
+    pub updated_at: String,
+    pub url: String,
+    pub review_decision: Option<String>,
+    pub coderabbit_status: CodeRabbitStatus,
+    pub timeout_alert: bool,
+    pub reviews: Vec<PrReview>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PrMonitorState {
+    pub polling: bool,
+    pub interval_secs: u64,
+    pub prs: Vec<PullRequest>,
+    pub last_error: Option<String>,
+    pub last_fetched_at: Option<String>,
+}
+
+// ─── Monitor Implementation ───
+
+pub struct PrMonitor {
+    project_root: Arc<Mutex<String>>,
+    polling: Arc<AtomicBool>,
+    generation: Arc<AtomicU64>,
+    interval_secs: Arc<Mutex<u64>>,
+    prs: Arc<Mutex<Vec<PullRequest>>>,
+    last_error: Arc<Mutex<Option<String>>>,
+    last_fetched_at: Arc<Mutex<Option<String>>>,
+}
+
+impl PrMonitor {
+    pub fn new() -> Self {
+        Self {
+            project_root: Arc::new(Mutex::new(String::new())),
+            polling: Arc::new(AtomicBool::new(false)),
+            generation: Arc::new(AtomicU64::new(0)),
+            interval_secs: Arc::new(Mutex::new(60)),
+            prs: Arc::new(Mutex::new(Vec::new())),
+            last_error: Arc::new(Mutex::new(None)),
+            last_fetched_at: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    pub async fn set_project_root(&self, root: String) {
+        let mut guard = self.project_root.lock().await;
+        *guard = root;
+    }
+
+    /// Fetch open PRs once via `gh pr list --json ...`.
+    pub async fn fetch_prs(&self) -> Result<Vec<PullRequest>, String> {
+        let root = self.project_root.lock().await.clone();
+        if root.is_empty() {
+            return Err("Project root not set".to_string());
+        }
+
+        let prs = tokio::task::spawn_blocking(move || fetch_prs_blocking(&root))
+            .await
+            .map_err(|e| format!("Task join error: {}", e))??;
+
+        // Update cached state
+        {
+            let mut guard = self.prs.lock().await;
+            *guard = prs.clone();
+        }
+        {
+            let mut guard = self.last_error.lock().await;
+            *guard = None;
+        }
+        {
+            let mut guard = self.last_fetched_at.lock().await;
+            *guard = Some(now_unix_ms());
+        }
+
+        Ok(prs)
+    }
+
+    /// Start background polling. Emits `pr-list-updated` events on changes.
+    pub async fn start_polling(
+        &self,
+        app: tauri::AppHandle,
+        interval_secs: Option<u64>,
+    ) -> Result<(), String> {
+        if self.polling.load(Ordering::SeqCst) {
+            return Err("Polling already active".to_string());
+        }
+
+        let interval = interval_secs.unwrap_or(60);
+        {
+            let mut guard = self.interval_secs.lock().await;
+            *guard = interval;
+        }
+
+        self.polling.store(true, Ordering::SeqCst);
+        let gen = self.generation.fetch_add(1, Ordering::SeqCst) + 1;
+
+        let polling_flag = self.polling.clone();
+        let generation = self.generation.clone();
+        let project_root = self.project_root.clone();
+        let prs_cache = self.prs.clone();
+        let last_error = self.last_error.clone();
+        let last_fetched_at = self.last_fetched_at.clone();
+
+        tokio::spawn(async move {
+            loop {
+                // Check if this generation is still current
+                if generation.load(Ordering::SeqCst) != gen
+                    || !polling_flag.load(Ordering::SeqCst)
+                {
+                    break;
+                }
+
+                let root = project_root.lock().await.clone();
+                if root.is_empty() {
+                    tokio::time::sleep(std::time::Duration::from_secs(interval)).await;
+                    continue;
+                }
+
+                let root_clone = root.clone();
+                let result =
+                    tokio::task::spawn_blocking(move || fetch_prs_blocking(&root_clone)).await;
+
+                // Check generation again after blocking work
+                if generation.load(Ordering::SeqCst) != gen
+                    || !polling_flag.load(Ordering::SeqCst)
+                {
+                    break;
+                }
+
+                match result {
+                    Ok(Ok(new_prs)) => {
+                        let changed = {
+                            let mut guard = prs_cache.lock().await;
+                            let changed = *guard != new_prs;
+                            *guard = new_prs.clone();
+                            changed
+                        };
+                        {
+                            let mut guard = last_error.lock().await;
+                            *guard = None;
+                        }
+                        {
+                            let mut guard = last_fetched_at.lock().await;
+                            *guard = Some(now_unix_ms());
+                        }
+
+                        if changed {
+                            let _ = app.emit(
+                                "pr-list-updated",
+                                serde_json::json!({
+                                    "prs": new_prs,
+                                    "timestamp": now_unix_ms(),
+                                }),
+                            );
+                        }
+                    }
+                    Ok(Err(e)) => {
+                        let mut guard = last_error.lock().await;
+                        *guard = Some(e.clone());
+                        eprintln!("[pr-monitor] fetch error: {}", e);
+                    }
+                    Err(e) => {
+                        let mut guard = last_error.lock().await;
+                        *guard = Some(format!("Task panic: {}", e));
+                    }
+                }
+
+                tokio::time::sleep(std::time::Duration::from_secs(interval)).await;
+            }
+            eprintln!("[pr-monitor] polling loop exited (gen={})", gen);
+        });
+
+        Ok(())
+    }
+
+    pub fn stop_polling(&self) {
+        self.polling.store(false, Ordering::SeqCst);
+    }
+
+    pub fn is_polling(&self) -> bool {
+        self.polling.load(Ordering::SeqCst)
+    }
+
+    pub async fn get_state(&self) -> PrMonitorState {
+        PrMonitorState {
+            polling: self.polling.load(Ordering::SeqCst),
+            interval_secs: *self.interval_secs.lock().await,
+            prs: self.prs.lock().await.clone(),
+            last_error: self.last_error.lock().await.clone(),
+            last_fetched_at: self.last_fetched_at.lock().await.clone(),
+        }
+    }
+}
+
+// ─── Blocking helpers (run via spawn_blocking) ───
+
+/// Raw JSON shape returned by `gh pr list --json ...`.
+#[derive(Deserialize)]
+struct GhPr {
+    number: u32,
+    title: String,
+    #[serde(rename = "headRefName")]
+    head_ref_name: String,
+    author: GhAuthor,
+    #[serde(rename = "createdAt")]
+    created_at: String,
+    #[serde(rename = "updatedAt")]
+    updated_at: String,
+    url: String,
+    #[serde(rename = "reviewDecision")]
+    review_decision: Option<String>,
+    reviews: Vec<GhReview>,
+}
+
+#[derive(Deserialize)]
+struct GhAuthor {
+    login: String,
+}
+
+#[derive(Deserialize)]
+struct GhReview {
+    author: GhAuthor,
+    state: String,
+}
+
+fn fetch_prs_blocking(project_root: &str) -> Result<Vec<PullRequest>, String> {
+    let output = Command::new("gh")
+        .args([
+            "pr",
+            "list",
+            "--state",
+            "open",
+            "--json",
+            "number,title,headRefName,author,createdAt,updatedAt,url,reviewDecision,reviews",
+        ])
+        .current_dir(project_root)
+        .env("LANG", "en_US.UTF-8")
+        .env("LC_ALL", "en_US.UTF-8")
+        .output()
+        .map_err(|e| format!("Failed to run gh: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("gh pr list failed: {}", stderr.trim()));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let gh_prs: Vec<GhPr> =
+        serde_json::from_str(&stdout).map_err(|e| format!("JSON parse error: {}", e))?;
+
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64;
+
+    let prs = gh_prs
+        .into_iter()
+        .map(|pr| {
+            let coderabbit_reviews: Vec<&GhReview> = pr
+                .reviews
+                .iter()
+                .filter(|r| r.author.login == "coderabbitai")
+                .collect();
+
+            let coderabbit_status = if let Some(latest) = coderabbit_reviews.last() {
+                match latest.state.as_str() {
+                    "APPROVED" => CodeRabbitStatus::Approved,
+                    "CHANGES_REQUESTED" => CodeRabbitStatus::ChangesRequested,
+                    "COMMENTED" => CodeRabbitStatus::Commented,
+                    _ => CodeRabbitStatus::Pending,
+                }
+            } else {
+                CodeRabbitStatus::Pending
+            };
+
+            // Timeout alert: PR created > 10min ago and still no CodeRabbit review
+            let timeout_alert = if coderabbit_reviews.is_empty() {
+                parse_iso_to_ms(&pr.created_at)
+                    .map(|created_ms| now_ms.saturating_sub(created_ms) > 10 * 60 * 1000)
+                    .unwrap_or(false)
+            } else {
+                false
+            };
+
+            let reviews = pr
+                .reviews
+                .iter()
+                .map(|r| PrReview {
+                    author: r.author.login.clone(),
+                    state: r.state.clone(),
+                })
+                .collect();
+
+            PullRequest {
+                number: pr.number,
+                title: pr.title,
+                head_ref_name: pr.head_ref_name,
+                author: pr.author.login,
+                created_at: pr.created_at,
+                updated_at: pr.updated_at,
+                url: pr.url,
+                review_decision: pr.review_decision,
+                coderabbit_status,
+                timeout_alert,
+                reviews,
+            }
+        })
+        .collect();
+
+    Ok(prs)
+}
+
+/// Post a comment on a PR to trigger CodeRabbit review.
+pub fn trigger_coderabbit_review_blocking(
+    project_root: &str,
+    pr_number: u32,
+) -> Result<(), String> {
+    let output = Command::new("gh")
+        .args([
+            "pr",
+            "comment",
+            &pr_number.to_string(),
+            "--body",
+            "@coderabbitai review",
+        ])
+        .current_dir(project_root)
+        .env("LANG", "en_US.UTF-8")
+        .env("LC_ALL", "en_US.UTF-8")
+        .output()
+        .map_err(|e| format!("Failed to run gh: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("gh pr comment failed: {}", stderr.trim()));
+    }
+    Ok(())
+}
+
+/// Squash merge a PR.
+pub fn merge_pr_blocking(project_root: &str, pr_number: u32) -> Result<(), String> {
+    let output = Command::new("gh")
+        .args([
+            "pr",
+            "merge",
+            &pr_number.to_string(),
+            "--squash",
+            "--delete-branch",
+        ])
+        .current_dir(project_root)
+        .env("LANG", "en_US.UTF-8")
+        .env("LC_ALL", "en_US.UTF-8")
+        .output()
+        .map_err(|e| format!("Failed to run gh: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("gh pr merge failed: {}", stderr.trim()));
+    }
+    Ok(())
+}
+
+// ─── Utility ───
+
+/// Return current time as Unix milliseconds string (JS-compatible).
+fn now_unix_ms() -> String {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .to_string()
+}
+
+/// Parse ISO 8601 UTC timestamp to Unix milliseconds.
+/// Handles GitHub's format: "2026-03-23T05:00:36Z" or "2026-03-23T05:00:36+00:00".
+fn parse_iso_to_ms(iso: &str) -> Option<u64> {
+    let iso = iso.trim();
+    let parts: Vec<&str> = iso.split('T').collect();
+    if parts.len() != 2 {
+        return None;
+    }
+    let date_parts: Vec<u64> = parts[0].split('-').filter_map(|s| s.parse().ok()).collect();
+    let time_str = parts[1].trim_end_matches('Z').trim_end_matches("+00:00");
+    let time_parts: Vec<u64> = time_str.split(':').filter_map(|s| s.parse().ok()).collect();
+
+    if date_parts.len() != 3 || time_parts.len() < 2 {
+        return None;
+    }
+
+    let (year, month, day) = (date_parts[0], date_parts[1], date_parts[2]);
+    let (hour, min) = (time_parts[0], time_parts[1]);
+    let sec = time_parts.get(2).copied().unwrap_or(0);
+
+    // Cumulative days to start of each month (non-leap year)
+    const MONTH_DAYS: [u64; 12] = [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334];
+    if month < 1 || month > 12 {
+        return None;
+    }
+
+    // Days from epoch (1970-01-01) to start of `year`
+    let years_since = year - 1970;
+    let leap_years = (year - 1) / 4 - (year - 1) / 100 + (year - 1) / 400
+        - (1969 / 4 - 1969 / 100 + 1969 / 400);
+    let days_to_year = years_since * 365 + leap_years;
+
+    // Days within the year
+    let is_leap = (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0);
+    let leap_day = if is_leap && month > 2 { 1 } else { 0 };
+    let day_of_year = MONTH_DAYS[(month - 1) as usize] + leap_day + (day - 1);
+
+    let total_secs = (days_to_year + day_of_year) * 86400 + hour * 3600 + min * 60 + sec;
+    Some(total_secs * 1000)
+}

--- a/packages/gui/src/App.vue
+++ b/packages/gui/src/App.vue
@@ -12,6 +12,7 @@ import BookmarkRail from "./components/BookmarkRail.vue";
 import FloatingPanel from "./components/FloatingPanel.vue";
 import AgentRoleSelector from "./components/AgentRoleSelector.vue";
 import RemoteControlPanel from "./components/RemoteControlPanel.vue";
+import PRMonitorPanel from "./components/PRMonitorPanel.vue";
 import { useAgentStore } from "./stores/agents";
 import { useApprovalStore } from "./stores/approvals";
 import { useMessageStore } from "./stores/messages";
@@ -29,6 +30,7 @@ const { loadTasks, initTaskListeners } = useTaskStore();
 
 const showSettings = ref(false);
 const showRemoteControl = ref(false);
+const showPrMonitor = ref(false);
 const activeView = ref<"agents" | "tasks">("agents");
 const showEventLog = ref(false);
 const showAgentRoleSelector = ref(false);
@@ -58,6 +60,7 @@ onMounted(async () => {
       :eventLogOpen="showEventLog"
       @open-settings="showSettings = true"
       @open-remote-control="showRemoteControl = true"
+      @open-pr-monitor="showPrMonitor = true"
       @switch-view="(v) => activeView = v"
       @toggle-event-log="showEventLog = !showEventLog"
     />
@@ -107,6 +110,10 @@ onMounted(async () => {
     <RemoteControlPanel
       v-if="showRemoteControl"
       @close="showRemoteControl = false"
+    />
+    <PRMonitorPanel
+      v-if="showPrMonitor"
+      @close="showPrMonitor = false"
     />
     <SessionPicker />
     <HistoryPanel />

--- a/packages/gui/src/components/PRMonitorPanel.vue
+++ b/packages/gui/src/components/PRMonitorPanel.vue
@@ -1,0 +1,514 @@
+<script setup lang="ts">
+import { onMounted, onUnmounted, ref } from "vue";
+import { usePrMonitorStore } from "../stores/pr-monitor";
+import type { PullRequest, CodeRabbitStatus } from "../lib/tauri-bridge";
+
+const emit = defineEmits<{ close: [] }>();
+const {
+  prs,
+  polling,
+  lastError,
+  loading,
+  hasAlerts,
+  fetchPrs,
+  startPolling,
+  stopPolling,
+  requestCoderabbitReview,
+  requestMerge,
+  syncState,
+  initPrMonitorListeners,
+  resetListeners,
+} = usePrMonitorStore();
+
+const disposed = ref(false);
+const unlistenFns: Array<() => void> = [];
+const confirmMerge = ref<number | null>(null);
+
+onMounted(async () => {
+  // Reset listener flag so re-mount can re-register
+  resetListeners();
+  const fns = await initPrMonitorListeners();
+  if (disposed.value) {
+    fns.forEach((fn) => fn());
+  } else {
+    unlistenFns.push(...fns);
+  }
+  // Sync backend state first, then fetch + start polling if not active
+  await syncState();
+  await fetchPrs();
+  if (!polling.value) {
+    await startPolling(60);
+  }
+});
+
+onUnmounted(() => {
+  disposed.value = true;
+  unlistenFns.forEach((fn) => fn());
+  resetListeners();
+});
+
+function codeRabbitLabel(status: CodeRabbitStatus): string {
+  const labels: Record<CodeRabbitStatus, string> = {
+    pending: "Pending",
+    commented: "Reviewing",
+    approved: "Approved",
+    changes_requested: "Changes Requested",
+  };
+  return labels[status] ?? "Unknown";
+}
+
+function codeRabbitColor(status: CodeRabbitStatus): string {
+  const colors: Record<CodeRabbitStatus, string> = {
+    pending: "var(--text-muted)",
+    commented: "var(--accent-main)",
+    approved: "var(--accent-success)",
+    changes_requested: "var(--accent-error)",
+  };
+  return colors[status] ?? "var(--text-muted)";
+}
+
+function reviewDecisionLabel(decision: string | null): string {
+  if (!decision) return "No reviews";
+  const map: Record<string, string> = {
+    APPROVED: "Approved",
+    CHANGES_REQUESTED: "Changes Requested",
+    REVIEW_REQUIRED: "Review Required",
+  };
+  return map[decision] ?? decision;
+}
+
+function timeAgo(isoString: string): string {
+  const created = new Date(isoString).getTime();
+  const now = Date.now();
+  const diffMin = Math.floor((now - created) / 60000);
+  if (diffMin < 1) return "just now";
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffH = Math.floor(diffMin / 60);
+  if (diffH < 24) return `${diffH}h ago`;
+  return `${Math.floor(diffH / 24)}d ago`;
+}
+
+async function handleTriggerReview(pr: PullRequest) {
+  await requestCoderabbitReview(pr.number);
+  await fetchPrs();
+}
+
+async function handleMerge(prNumber: number) {
+  confirmMerge.value = null;
+  await requestMerge(prNumber);
+}
+</script>
+
+<template>
+  <div class="pr-overlay" @click.self="emit('close')">
+    <div class="pr-panel">
+      <div class="pr-header">
+        <div class="pr-title-row">
+          <span class="pr-icon">🔀</span>
+          <h3>PR Monitor</h3>
+          <span v-if="hasAlerts" class="alert-badge">!</span>
+        </div>
+        <div class="pr-controls">
+          <button
+            class="ctrl-btn"
+            :class="{ active: polling }"
+            :title="polling ? 'Stop auto-refresh' : 'Start auto-refresh (60s)'"
+            @click="polling ? stopPolling() : startPolling(60)"
+          >
+            {{ polling ? "⏸" : "▶" }}
+          </button>
+          <button
+            class="ctrl-btn"
+            title="Refresh now"
+            :disabled="loading"
+            @click="fetchPrs()"
+          >🔄</button>
+          <button class="ctrl-btn close-btn" title="Close" @click="emit('close')">✕</button>
+        </div>
+      </div>
+
+      <div v-if="lastError" class="pr-error">{{ lastError }}</div>
+
+      <div v-if="loading && prs.length === 0" class="pr-loading">
+        Loading PRs...
+      </div>
+
+      <div v-else-if="prs.length === 0" class="pr-empty">
+        No open pull requests
+      </div>
+
+      <div v-else class="pr-list">
+        <div
+          v-for="pr in prs"
+          :key="pr.number"
+          class="pr-card"
+          :class="{ 'pr-alert': pr.timeout_alert }"
+        >
+          <div class="pr-card-header">
+            <a
+              class="pr-number"
+              :href="pr.url"
+              target="_blank"
+              rel="noopener noreferrer"
+              title="Open in browser"
+            >#{{ pr.number }}</a>
+            <span class="pr-card-title">{{ pr.title }}</span>
+          </div>
+          <div class="pr-card-meta">
+            <span class="pr-branch">{{ pr.head_ref_name }}</span>
+            <span class="pr-author">{{ pr.author }}</span>
+            <span class="pr-time">{{ timeAgo(pr.created_at) }}</span>
+          </div>
+          <div class="pr-card-status">
+            <div class="status-row">
+              <span class="status-label">CodeRabbit:</span>
+              <span
+                class="status-value"
+                :style="{ color: codeRabbitColor(pr.coderabbit_status) }"
+              >
+                <span class="status-dot" :style="{ background: codeRabbitColor(pr.coderabbit_status) }"></span>
+                {{ codeRabbitLabel(pr.coderabbit_status) }}
+              </span>
+              <span v-if="pr.timeout_alert" class="timeout-badge">TIMEOUT</span>
+            </div>
+            <div class="status-row">
+              <span class="status-label">Decision:</span>
+              <span class="status-value">{{ reviewDecisionLabel(pr.review_decision) }}</span>
+            </div>
+          </div>
+          <div class="pr-card-actions">
+            <button
+              class="action-btn review-btn"
+              title="@coderabbitai review"
+              @click="handleTriggerReview(pr)"
+            >🐰 Request Review</button>
+            <button
+              v-if="confirmMerge !== pr.number"
+              class="action-btn merge-btn"
+              :disabled="pr.review_decision !== 'APPROVED'"
+              :title="pr.review_decision === 'APPROVED' ? 'Squash merge' : 'Not yet approved'"
+              @click="confirmMerge = pr.number"
+            >Merge</button>
+            <div v-else class="merge-confirm">
+              <span>Confirm merge?</span>
+              <button class="action-btn confirm-yes" @click="handleMerge(pr.number)">Yes</button>
+              <button class="action-btn confirm-no" @click="confirmMerge = null">No</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="pr-footer">
+        <span v-if="polling" class="poll-indicator">
+          <span class="poll-dot"></span> Auto-refresh active
+        </span>
+        <span v-else class="poll-indicator poll-off">Auto-refresh off</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.pr-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.pr-panel {
+  background: var(--bg-primary);
+  border: 1px solid rgba(0, 212, 255, 0.15);
+  border-radius: 12px;
+  width: min(560px, 90vw);
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+}
+
+.pr-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px;
+  border-bottom: 1px solid rgba(0, 212, 255, 0.08);
+}
+
+.pr-title-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.pr-icon {
+  font-size: 18px;
+}
+
+.pr-title-row h3 {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.alert-badge {
+  background: var(--accent-error);
+  color: #fff;
+  font-size: 10px;
+  font-weight: 700;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
+.pr-controls {
+  display: flex;
+  gap: 4px;
+}
+
+.ctrl-btn {
+  background: none;
+  border: 1px solid rgba(0, 212, 255, 0.12);
+  color: var(--text-secondary);
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 13px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.ctrl-btn:hover {
+  background: var(--bg-panel);
+  color: var(--text-primary);
+}
+
+.ctrl-btn.active {
+  background: rgba(0, 212, 255, 0.15);
+  color: var(--accent-main);
+  border-color: var(--accent-main);
+}
+
+.ctrl-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.close-btn {
+  font-size: 14px;
+}
+
+.pr-error {
+  padding: 8px 16px;
+  background: rgba(255, 82, 82, 0.1);
+  color: var(--accent-error);
+  font-size: 12px;
+  border-bottom: 1px solid rgba(255, 82, 82, 0.15);
+}
+
+.pr-loading,
+.pr-empty {
+  padding: 40px 16px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.pr-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.pr-card {
+  background: var(--bg-secondary);
+  border: 1px solid rgba(0, 212, 255, 0.06);
+  border-radius: 8px;
+  padding: 12px;
+}
+
+.pr-card.pr-alert {
+  border-color: rgba(255, 170, 0, 0.4);
+  background: rgba(255, 170, 0, 0.04);
+}
+
+.pr-card-header {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.pr-number {
+  color: var(--accent-main);
+  font-weight: 600;
+  font-size: 13px;
+  text-decoration: none;
+}
+
+.pr-number:hover {
+  text-decoration: underline;
+}
+
+.pr-card-title {
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pr-card-meta {
+  display: flex;
+  gap: 12px;
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-bottom: 8px;
+}
+
+.pr-branch {
+  font-family: monospace;
+  background: var(--bg-panel);
+  padding: 1px 5px;
+  border-radius: 3px;
+}
+
+.pr-card-status {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 8px;
+}
+
+.status-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+}
+
+.status-label {
+  color: var(--text-muted);
+  min-width: 80px;
+}
+
+.status-value {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.status-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+.timeout-badge {
+  background: rgba(255, 170, 0, 0.2);
+  color: #ffaa00;
+  font-size: 10px;
+  font-weight: 700;
+  padding: 1px 6px;
+  border-radius: 3px;
+  margin-left: 8px;
+  animation: pulse 2s infinite;
+}
+
+.pr-card-actions {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.action-btn {
+  background: var(--bg-panel);
+  border: 1px solid rgba(0, 212, 255, 0.1);
+  color: var(--text-secondary);
+  font-size: 11px;
+  padding: 4px 10px;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.action-btn:hover {
+  background: rgba(0, 212, 255, 0.1);
+  color: var(--text-primary);
+}
+
+.action-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.review-btn:hover {
+  border-color: var(--accent-main);
+}
+
+.merge-btn {
+  color: var(--accent-success);
+}
+
+.merge-confirm {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.confirm-yes {
+  color: var(--accent-success) !important;
+  border-color: var(--accent-success) !important;
+}
+
+.confirm-no {
+  color: var(--accent-error) !important;
+}
+
+.pr-footer {
+  padding: 8px 16px;
+  border-top: 1px solid rgba(0, 212, 255, 0.06);
+  font-size: 11px;
+}
+
+.poll-indicator {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--accent-success);
+}
+
+.poll-indicator.poll-off {
+  color: var(--text-muted);
+}
+
+.poll-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent-success);
+  animation: pulse 2s infinite;
+}
+</style>

--- a/packages/gui/src/components/PRMonitorPanel.vue
+++ b/packages/gui/src/components/PRMonitorPanel.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted, ref } from "vue";
+import { onMounted, onUnmounted, ref, reactive } from "vue";
 import { usePrMonitorStore } from "../stores/pr-monitor";
 import type { PullRequest, CodeRabbitStatus } from "../lib/tauri-bridge";
 
@@ -23,6 +23,7 @@ const {
 const disposed = ref(false);
 const unlistenFns: Array<() => void> = [];
 const confirmMerge = ref<number | null>(null);
+const pending = reactive<Record<number, boolean>>({});
 
 onMounted(async () => {
   // Reset listener flag so re-mount can re-register
@@ -30,12 +31,14 @@ onMounted(async () => {
   const fns = await initPrMonitorListeners();
   if (disposed.value) {
     fns.forEach((fn) => fn());
-  } else {
-    unlistenFns.push(...fns);
+    return;
   }
+  unlistenFns.push(...fns);
   // Sync backend state first, then fetch + start polling if not active
   await syncState();
+  if (disposed.value) return;
   await fetchPrs();
+  if (disposed.value) return;
   if (!polling.value) {
     await startPolling(60);
   }
@@ -45,6 +48,7 @@ onUnmounted(() => {
   disposed.value = true;
   unlistenFns.forEach((fn) => fn());
   resetListeners();
+  stopPolling();
 });
 
 function codeRabbitLabel(status: CodeRabbitStatus): string {
@@ -89,13 +93,25 @@ function timeAgo(isoString: string): string {
 }
 
 async function handleTriggerReview(pr: PullRequest) {
-  await requestCoderabbitReview(pr.number);
-  await fetchPrs();
+  if (pending[pr.number]) return;
+  pending[pr.number] = true;
+  try {
+    await requestCoderabbitReview(pr.number);
+    await fetchPrs();
+  } finally {
+    pending[pr.number] = false;
+  }
 }
 
 async function handleMerge(prNumber: number) {
+  if (pending[prNumber]) return;
   confirmMerge.value = null;
-  await requestMerge(prNumber);
+  pending[prNumber] = true;
+  try {
+    await requestMerge(prNumber);
+  } finally {
+    pending[prNumber] = false;
+  }
 }
 </script>
 
@@ -179,13 +195,14 @@ async function handleMerge(prNumber: number) {
           <div class="pr-card-actions">
             <button
               class="action-btn review-btn"
+              :disabled="pending[pr.number]"
               title="@coderabbitai review"
               @click="handleTriggerReview(pr)"
             >🐰 Request Review</button>
             <button
               v-if="confirmMerge !== pr.number"
               class="action-btn merge-btn"
-              :disabled="pr.review_decision !== 'APPROVED'"
+              :disabled="pr.review_decision !== 'APPROVED' || pending[pr.number]"
               :title="pr.review_decision === 'APPROVED' ? 'Squash merge' : 'Not yet approved'"
               @click="confirmMerge = pr.number"
             >Merge</button>

--- a/packages/gui/src/components/PRMonitorPanel.vue
+++ b/packages/gui/src/components/PRMonitorPanel.vue
@@ -117,10 +117,21 @@ async function handleMerge(prNumber: number) {
     pending[prNumber] = false;
   }
 }
+
+function onKeydown(e: KeyboardEvent) {
+  if (e.key === "Escape") emit("close");
+}
 </script>
 
 <template>
-  <div class="pr-overlay" @click.self="emit('close')">
+  <div
+    class="pr-overlay"
+    role="dialog"
+    aria-modal="true"
+    aria-label="PR Monitor"
+    @click.self="emit('close')"
+    @keydown="onKeydown"
+  >
     <div class="pr-panel">
       <div class="pr-header">
         <div class="pr-title-row">
@@ -132,6 +143,7 @@ async function handleMerge(prNumber: number) {
           <button
             class="ctrl-btn"
             :class="{ active: polling }"
+            :aria-label="polling ? 'Stop auto-refresh' : 'Start auto-refresh'"
             :title="polling ? 'Stop auto-refresh' : 'Start auto-refresh (60s)'"
             @click="polling ? stopPolling() : startPolling(60)"
           >
@@ -139,11 +151,12 @@ async function handleMerge(prNumber: number) {
           </button>
           <button
             class="ctrl-btn"
+            aria-label="Refresh now"
             title="Refresh now"
             :disabled="loading"
             @click="fetchPrs()"
           >🔄</button>
-          <button class="ctrl-btn close-btn" title="Close" @click="emit('close')">✕</button>
+          <button class="ctrl-btn close-btn" aria-label="Close" title="Close" @click="emit('close')">✕</button>
         </div>
       </div>
 

--- a/packages/gui/src/components/PRMonitorPanel.vue
+++ b/packages/gui/src/components/PRMonitorPanel.vue
@@ -98,6 +98,8 @@ async function handleTriggerReview(pr: PullRequest) {
   try {
     await requestCoderabbitReview(pr.number);
     await fetchPrs();
+  } catch {
+    // Error already stored in lastError by the store
   } finally {
     pending[pr.number] = false;
   }
@@ -105,10 +107,12 @@ async function handleTriggerReview(pr: PullRequest) {
 
 async function handleMerge(prNumber: number) {
   if (pending[prNumber]) return;
-  confirmMerge.value = null;
   pending[prNumber] = true;
   try {
     await requestMerge(prNumber);
+    confirmMerge.value = null;
+  } catch {
+    // Error already stored in lastError by the store; keep confirm dialog visible
   } finally {
     pending[prNumber] = false;
   }

--- a/packages/gui/src/components/TitleBar.vue
+++ b/packages/gui/src/components/TitleBar.vue
@@ -9,6 +9,7 @@ const props = defineProps<{
 const emit = defineEmits<{
   "open-settings": [];
   "open-remote-control": [];
+  "open-pr-monitor": [];
   "switch-view": [view: "agents" | "tasks"];
   "toggle-event-log": [];
 }>();
@@ -65,6 +66,11 @@ onUnmounted(() => {
     </div>
     <div class="titlebar-center" data-tauri-drag-region></div>
     <div class="titlebar-right">
+      <button
+        class="titlebar-btn"
+        title="PR Monitor"
+        @click="emit('open-pr-monitor')"
+      >🔀</button>
       <button
         class="titlebar-btn"
         title="Remote Control"

--- a/packages/gui/src/lib/tauri-bridge.ts
+++ b/packages/gui/src/lib/tauri-bridge.ts
@@ -665,6 +665,76 @@ export function onRemoteControlLog(
   );
 }
 
+// ─── PR Monitor Operations ───
+
+export type CodeRabbitStatus = "pending" | "commented" | "approved" | "changes_requested";
+
+export interface PrReview {
+  author: string;
+  state: string;
+}
+
+export interface PullRequest {
+  number: number;
+  title: string;
+  head_ref_name: string;
+  author: string;
+  created_at: string;
+  updated_at: string;
+  url: string;
+  review_decision: string | null;
+  coderabbit_status: CodeRabbitStatus;
+  timeout_alert: boolean;
+  reviews: PrReview[];
+}
+
+export interface PrMonitorState {
+  polling: boolean;
+  interval_secs: number;
+  prs: PullRequest[];
+  last_error: string | null;
+  last_fetched_at: string | null;
+}
+
+/** Fetch all open PRs from GitHub (one-shot). */
+export async function getOpenPrs(): Promise<{ prs: PullRequest[] }> {
+  return invoke<{ prs: PullRequest[] }>("get_open_prs");
+}
+
+/** Get the current PR monitor state (cached PRs + polling status). */
+export async function getPrMonitorState(): Promise<PrMonitorState> {
+  return invoke<PrMonitorState>("get_pr_monitor_state");
+}
+
+/** Start background polling for PR status updates. */
+export async function startPrPolling(intervalSecs?: number): Promise<{ ok: true }> {
+  return invoke("start_pr_polling", { intervalSecs: intervalSecs ?? null });
+}
+
+/** Stop background PR status polling. */
+export async function stopPrPolling(): Promise<{ ok: true }> {
+  return invoke("stop_pr_polling");
+}
+
+/** Post "@coderabbitai review" comment on a PR. */
+export async function triggerCoderabbitReview(prNumber: number): Promise<{ ok: true }> {
+  return invoke("trigger_coderabbit_review", { prNumber });
+}
+
+/** Squash-merge a PR (with delete-branch). */
+export async function mergePr(prNumber: number): Promise<{ ok: true }> {
+  return invoke("merge_pr", { prNumber });
+}
+
+/** Listen for PR list update events from background polling. */
+export function onPrListUpdated(
+  handler: (data: { prs: PullRequest[]; timestamp: string }) => void,
+): Promise<UnlistenFn> {
+  return listen<{ prs: PullRequest[]; timestamp: string }>("pr-list-updated", (event) =>
+    handler(event.payload),
+  );
+}
+
 // Events (sidecar → Rust → frontend)
 
 export interface AgentMessageEvent {

--- a/packages/gui/src/stores/pr-monitor.ts
+++ b/packages/gui/src/stores/pr-monitor.ts
@@ -1,0 +1,140 @@
+import { ref, computed } from "vue";
+import {
+  getOpenPrs,
+  getPrMonitorState,
+  startPrPolling,
+  stopPrPolling,
+  triggerCoderabbitReview,
+  mergePr,
+  onPrListUpdated,
+  type PullRequest,
+} from "../lib/tauri-bridge";
+
+const prs = ref<PullRequest[]>([]);
+const polling = ref(false);
+const intervalSecs = ref(60);
+const lastError = ref<string | null>(null);
+const lastFetchedAt = ref<string | null>(null);
+const loading = ref(false);
+
+let listenersInitialized = false;
+
+const alertCount = computed(() => prs.value.filter((pr) => pr.timeout_alert).length);
+const hasAlerts = computed(() => alertCount.value > 0);
+
+/** Convert Unix-ms string from backend to ISO display string. */
+function msToIso(ms: string): string {
+  const num = Number(ms);
+  return Number.isFinite(num) ? new Date(num).toISOString() : ms;
+}
+
+async function fetchPrs() {
+  loading.value = true;
+  lastError.value = null;
+  try {
+    const result = await getOpenPrs();
+    prs.value = result.prs;
+    lastFetchedAt.value = new Date().toISOString();
+  } catch (e) {
+    lastError.value = String(e);
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function startPolling(interval?: number) {
+  lastError.value = null;
+  try {
+    await startPrPolling(interval);
+    polling.value = true;
+    if (interval) intervalSecs.value = interval;
+  } catch (e) {
+    // "Polling already active" is not a real error — just sync state
+    polling.value = true;
+  }
+}
+
+async function stopPollingAction() {
+  try {
+    await stopPrPolling();
+    polling.value = false;
+  } catch (e) {
+    lastError.value = String(e);
+  }
+}
+
+async function requestCoderabbitReview(prNumber: number) {
+  try {
+    await triggerCoderabbitReview(prNumber);
+  } catch (e) {
+    lastError.value = String(e);
+  }
+}
+
+async function requestMerge(prNumber: number) {
+  try {
+    await mergePr(prNumber);
+    // Refresh after merge
+    await fetchPrs();
+  } catch (e) {
+    lastError.value = String(e);
+  }
+}
+
+async function syncState() {
+  try {
+    const state = await getPrMonitorState();
+    prs.value = state.prs;
+    polling.value = state.polling;
+    intervalSecs.value = state.interval_secs;
+    lastError.value = state.last_error;
+    lastFetchedAt.value = state.last_fetched_at ? msToIso(state.last_fetched_at) : null;
+  } catch (e) {
+    lastError.value = String(e);
+  }
+}
+
+async function initPrMonitorListeners(): Promise<Array<() => void>> {
+  if (listenersInitialized) return [];
+
+  const collected: Array<() => void> = [];
+  try {
+    const unlisten = await onPrListUpdated((data) => {
+      prs.value = data.prs;
+      lastFetchedAt.value = msToIso(data.timestamp);
+      lastError.value = null;
+    });
+    collected.push(unlisten);
+  } catch (e) {
+    collected.forEach((fn) => fn());
+    return [];
+  }
+  listenersInitialized = true;
+  return collected;
+}
+
+/** Reset listener flag so listeners can be re-registered on next mount. */
+function resetListeners() {
+  listenersInitialized = false;
+}
+
+export function usePrMonitorStore() {
+  return {
+    prs,
+    polling,
+    intervalSecs,
+    lastError,
+    lastFetchedAt,
+    loading,
+    alertCount,
+    hasAlerts,
+    fetchPrs,
+    startPolling,
+    stopPolling: stopPollingAction,
+    requestCoderabbitReview,
+    requestMerge,
+    syncState,
+    initPrMonitorListeners,
+    resetListeners,
+  };
+}

--- a/packages/gui/src/stores/pr-monitor.ts
+++ b/packages/gui/src/stores/pr-monitor.ts
@@ -72,6 +72,7 @@ async function requestCoderabbitReview(prNumber: number) {
     await triggerCoderabbitReview(prNumber);
   } catch (e) {
     lastError.value = String(e);
+    throw e;
   }
 }
 
@@ -82,6 +83,7 @@ async function requestMerge(prNumber: number) {
     await fetchPrs();
   } catch (e) {
     lastError.value = String(e);
+    throw e;
   }
 }
 

--- a/packages/gui/src/stores/pr-monitor.ts
+++ b/packages/gui/src/stores/pr-monitor.ts
@@ -49,8 +49,12 @@ async function startPolling(interval?: number) {
     polling.value = true;
     if (interval) intervalSecs.value = interval;
   } catch (e) {
-    // "Polling already active" is not a real error — just sync state
-    polling.value = true;
+    const msg = String(e);
+    if (msg.includes("Polling already active")) {
+      polling.value = true;
+    } else {
+      lastError.value = msg;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- **PR Monitor panel** — real-time tracking of all open PRs with CodeRabbit review status
- **Backend**: Rust `PrMonitor` with `gh` CLI integration, generation-counter polling (60s default), timeout alerts (10min without CodeRabbit response)
- **Frontend**: Vue overlay panel with PR cards showing CodeRabbit status (pending/reviewing/approved/changes_requested), one-click review trigger (`@coderabbitai review`), merge confirmation dialog
- **6 Tauri commands**: `get_open_prs`, `start_pr_polling`, `stop_pr_polling`, `get_pr_monitor_state`, `trigger_coderabbit_review`, `merge_pr`

## Key Design Decisions

- Uses `gh` CLI (not direct HTTP API) — consistent with existing `sidecar.rs` / `remote_control.rs` subprocess pattern
- Generation counter pattern from `remote_control.rs` prevents stale polling loop cleanup
- `listenersInitialized` flag with `resetListeners()` handles component remount lifecycle correctly
- ISO 8601 parser uses proper leap year + cumulative month calculation for accurate timeout detection
- Backend emits Unix-ms timestamps; frontend converts via `msToIso()` helper

## Files Changed

| Layer | File | Role |
|-------|------|------|
| Rust backend | `src-tauri/src/pr_monitor.rs` | PrMonitor struct + gh CLI helpers |
| Rust commands | `src-tauri/src/commands.rs` | 6 new Tauri commands |
| Rust setup | `src-tauri/src/lib.rs` | SharedPrMonitor registration + shutdown |
| TS bridge | `src/lib/tauri-bridge.ts` | Types + invoke/listen wrappers |
| Vue store | `src/stores/pr-monitor.ts` | Reactive state + actions |
| Vue component | `src/components/PRMonitorPanel.vue` | Overlay panel UI |
| Integration | `src/components/TitleBar.vue` | 🔀 button |
| Integration | `src/App.vue` | Panel mounting |

## Test plan

- [ ] Open PR Monitor panel via 🔀 button in title bar
- [ ] Verify "No open pull requests" shown when no open PRs exist
- [ ] Create a test PR and verify it appears in the panel
- [ ] Verify CodeRabbit status shows correctly (pending → reviewing → approved)
- [ ] Test "Request Review" button posts `@coderabbitai review` comment
- [ ] Test auto-refresh (60s polling) shows updated status
- [ ] Test panel close/reopen preserves polling state
- [ ] Verify merge button is disabled when not APPROVED
- [ ] Verify merge confirmation dialog works

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)