### PR TITLE
fix(kb-path): replace hardcoded Mercury_KB/ paths with Obsidian MCP + config resolution

### DIFF
--- a/.agents/skills/pr-flow/SKILL.md
+++ b/.agents/skills/pr-flow/SKILL.md
@@ -33,9 +33,11 @@ TASK_ID=${BRANCH##*/}
 if ! [[ "$TASK_ID" =~ ^TASK- ]]; then
   TASK_ID=$(echo "$BRANCH" | grep -oE 'TASK-[A-Z][A-Z0-9-]+-[0-9]+' | head -1)
 fi
+# Resolve KB vault path from mercury.config.json (KB is outside project CWD)
+KB_VAULT_PATH=$(jq -r '.obsidian.vaultPath // empty' mercury.config.json 2>/dev/null)
 TASK_FILE=""
-if [ -n "$TASK_ID" ] && [ -f "Mercury_KB/10-tasks/$TASK_ID.json" ]; then
-  TASK_FILE="Mercury_KB/10-tasks/$TASK_ID.json"
+if [ -n "$TASK_ID" ] && [ -n "$KB_VAULT_PATH" ] && [ -f "$KB_VAULT_PATH/10-tasks/$TASK_ID.json" ]; then
+  TASK_FILE="$KB_VAULT_PATH/10-tasks/$TASK_ID.json"
 fi
 # When TASK_FILE is absent (non-task branches), ALLOWED_SCOPE stays empty → scope checks pass all files.
 declare -a ALLOWED_SCOPE=()
@@ -48,8 +50,8 @@ gh api rate_limit --jq '.resources.core.remaining'
 1. **Create or reuse the PR**
 
 ```bash
-SUMMARY=$(jq -r '.summary // "PR update"' Mercury_KB/10-tasks/"$TASK_ID".receipt.json 2>/dev/null || echo "PR update")
-DOD_COUNT=$(jq -r '(.definitionOfDone // []) | length' Mercury_KB/10-tasks/"$TASK_ID".json 2>/dev/null || echo "unknown")
+SUMMARY=$(jq -r '.summary // "PR update"' "$KB_VAULT_PATH/10-tasks/$TASK_ID.receipt.json" 2>/dev/null || echo "PR update")
+DOD_COUNT=$(jq -r '(.definitionOfDone // []) | length' "$TASK_FILE" 2>/dev/null || echo "unknown")
 PR_BODY=$(cat <<EOF
 ## Summary
 $SUMMARY

--- a/.agents/skills/pr-flow/SKILL.md
+++ b/.agents/skills/pr-flow/SKILL.md
@@ -34,7 +34,8 @@ if ! [[ "$TASK_ID" =~ ^TASK- ]]; then
   TASK_ID=$(echo "$BRANCH" | grep -oE 'TASK-[A-Z][A-Z0-9-]+-[0-9]+' | head -1)
 fi
 # Resolve KB vault path from mercury.config.json (KB is outside project CWD)
-KB_VAULT_PATH=$(jq -r '.obsidian.vaultPath // empty' mercury.config.json 2>/dev/null)
+KB_VAULT_PATH=$(jq -r '.obsidian.vaultPath // empty' mercury.config.json 2>/dev/null \
+  || node -e "try{console.log(require('./mercury.config.json').obsidian.vaultPath)}catch(e){}" 2>/dev/null)
 TASK_FILE=""
 if [ -n "$TASK_ID" ] && [ -n "$KB_VAULT_PATH" ] && [ -f "$KB_VAULT_PATH/10-tasks/$TASK_ID.json" ]; then
   TASK_FILE="$KB_VAULT_PATH/10-tasks/$TASK_ID.json"

--- a/.claude/hooks/session-init.sh
+++ b/.claude/hooks/session-init.sh
@@ -22,10 +22,12 @@ BRANCH=$(git branch --show-current 2>/dev/null || echo "unknown")
 LAST_COMMIT=$(git log -1 --oneline 2>/dev/null || echo "unknown")
 TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 GIT_STATUS=$(git status --porcelain 2>/dev/null | head -20)
+# Read vault name from config (default: Mercury_KB)
+VAULT_NAME=$(node -e "try{console.log(require('$CLAUDE_PROJECT_DIR/mercury.config.json').obsidian.vaultName||'Mercury_KB')}catch(e){console.log('Mercury_KB')}" 2>/dev/null)
 # Detect active tasks via Obsidian CLI (preferred) or config-resolved path (fallback)
 ACTIVE_TASKS=""
 if command -v obsidian &>/dev/null; then
-  ACTIVE_TASKS=$(obsidian vault="Mercury_KB" search query="in_progress" 2>/dev/null \
+  ACTIVE_TASKS=$(obsidian vault="$VAULT_NAME" search query="in_progress" 2>/dev/null \
     | grep -oE 'TASK-[A-Z][A-Z0-9-]+-[0-9]+' | head -5 | sort -u)
 else
   # Fallback: resolve vault path from mercury.config.json using node (handles JSON escaping)

--- a/.claude/hooks/session-init.sh
+++ b/.claude/hooks/session-init.sh
@@ -30,18 +30,23 @@ else
   VAULT_NAME=$(node -e "try{const c=require('$CLAUDE_PROJECT_DIR/mercury.config.json');console.log(c.obsidian.vaultName||'Mercury_KB')}catch(e){console.log('Mercury_KB')}" 2>/dev/null)
   KB_VAULT_PATH=$(node -e "try{console.log(require('$CLAUDE_PROJECT_DIR/mercury.config.json').obsidian.vaultPath)}catch(e){}" 2>/dev/null)
 fi
+# Scan a tasks directory for active task IDs
+scan_active_tasks() {
+  local tasks_dir="$1"
+  find "$tasks_dir" -name "*.json" -not -name "*.receipt.json" \
+    -exec grep -lE '"status":[[:space:]]*"(in_progress|dispatched|implementation_done)"' {} \; 2>/dev/null \
+    | head -5 | while read -r f; do basename "$f" .json; done
+}
 # Detect active tasks via Obsidian CLI (preferred) or config-resolved path (fallback)
 # Task ID formats: TASK-NAME-NNN (manual) or TASK-hexhexhex (shortId)
 ACTIVE_TASKS=""
 if command -v obsidian &>/dev/null; then
-  ACTIVE_TASKS=$(obsidian vault="$VAULT_NAME" search query="in_progress" 2>/dev/null \
+  ACTIVE_TASKS=$(obsidian vault="$VAULT_NAME" search query="in_progress" format=json 2>/dev/null \
     | grep -oE 'TASK-[A-Za-z0-9-]+' | head -5 | sort -u)
 fi
 # Fallback 1: filesystem scan using config-resolved vaultPath
 if [ -z "$ACTIVE_TASKS" ] && [ -n "$KB_VAULT_PATH" ] && [ -d "$KB_VAULT_PATH/10-tasks" ]; then
-  ACTIVE_TASKS=$(find "$KB_VAULT_PATH/10-tasks" -name "*.json" -not -name "*.receipt.json" \
-    -exec grep -lE '"status":[[:space:]]*"(in_progress|dispatched|implementation_done)"' {} \; 2>/dev/null \
-    | head -5 | while read -r f; do basename "$f" .json; done)
+  ACTIVE_TASKS=$(scan_active_tasks "$KB_VAULT_PATH/10-tasks")
 fi
 # Fallback 2: sibling vault convention ({ProjectName}_KB alongside project)
 if [ -z "$ACTIVE_TASKS" ]; then
@@ -53,9 +58,7 @@ if [ -z "$ACTIVE_TASKS" ]; then
     SIBLING_KB="$(dirname "$CLAUDE_PROJECT_DIR")/${VAULT_NAME}"
   fi
   if [ -d "$SIBLING_KB/10-tasks" ]; then
-    ACTIVE_TASKS=$(find "$SIBLING_KB/10-tasks" -name "*.json" -not -name "*.receipt.json" \
-      -exec grep -lE '"status":[[:space:]]*"(in_progress|dispatched|implementation_done)"' {} \; 2>/dev/null \
-      | head -5 | while read -r f; do basename "$f" .json; done)
+    ACTIVE_TASKS=$(scan_active_tasks "$SIBLING_KB/10-tasks")
   fi
 fi
 

--- a/.claude/hooks/session-init.sh
+++ b/.claude/hooks/session-init.sh
@@ -22,11 +22,23 @@ BRANCH=$(git branch --show-current 2>/dev/null || echo "unknown")
 LAST_COMMIT=$(git log -1 --oneline 2>/dev/null || echo "unknown")
 TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 GIT_STATUS=$(git status --porcelain 2>/dev/null | head -20)
+# Detect active tasks via Obsidian CLI (preferred) or config-resolved path (fallback)
 ACTIVE_TASKS=""
-if [ -d "Mercury_KB/10-tasks" ]; then
-  ACTIVE_TASKS=$(find Mercury_KB/10-tasks -name "*.json" -not -name "*.receipt.json" \
-    -exec grep -lE '"status":[[:space:]]*"(in_progress|dispatched|implementation_done)"' {} \; 2>/dev/null \
-    | head -5 | while read -r f; do basename "$f" .json; done)
+if command -v obsidian &>/dev/null; then
+  ACTIVE_TASKS=$(obsidian vault="Mercury_KB" search query="in_progress" 2>/dev/null \
+    | grep -oE 'TASK-[A-Z][A-Z0-9-]+-[0-9]+' | head -5 | sort -u)
+else
+  # Fallback: resolve vault path from mercury.config.json
+  KB_VAULT_PATH=""
+  if [ -f "$CLAUDE_PROJECT_DIR/mercury.config.json" ]; then
+    KB_VAULT_PATH=$(grep -o '"vaultPath"[[:space:]]*:[[:space:]]*"[^"]*"' "$CLAUDE_PROJECT_DIR/mercury.config.json" \
+      | head -1 | sed 's/.*"vaultPath"[[:space:]]*:[[:space:]]*"//' | sed 's/"$//' | tr '\\\\' '/')
+  fi
+  if [ -n "$KB_VAULT_PATH" ] && [ -d "$KB_VAULT_PATH/10-tasks" ]; then
+    ACTIVE_TASKS=$(find "$KB_VAULT_PATH/10-tasks" -name "*.json" -not -name "*.receipt.json" \
+      -exec grep -lE '"status":[[:space:]]*"(in_progress|dispatched|implementation_done)"' {} \; 2>/dev/null \
+      | head -5 | while read -r f; do basename "$f" .json; done)
+  fi
 fi
 
 # Write current-session.md (ensure directory exists)

--- a/.claude/hooks/session-init.sh
+++ b/.claude/hooks/session-init.sh
@@ -28,11 +28,10 @@ if command -v obsidian &>/dev/null; then
   ACTIVE_TASKS=$(obsidian vault="Mercury_KB" search query="in_progress" 2>/dev/null \
     | grep -oE 'TASK-[A-Z][A-Z0-9-]+-[0-9]+' | head -5 | sort -u)
 else
-  # Fallback: resolve vault path from mercury.config.json
+  # Fallback: resolve vault path from mercury.config.json using node (handles JSON escaping)
   KB_VAULT_PATH=""
   if [ -f "$CLAUDE_PROJECT_DIR/mercury.config.json" ]; then
-    KB_VAULT_PATH=$(grep -o '"vaultPath"[[:space:]]*:[[:space:]]*"[^"]*"' "$CLAUDE_PROJECT_DIR/mercury.config.json" \
-      | head -1 | sed 's/.*"vaultPath"[[:space:]]*:[[:space:]]*"//' | sed 's/"$//' | tr '\\\\' '/')
+    KB_VAULT_PATH=$(node -e "try{console.log(require('$CLAUDE_PROJECT_DIR/mercury.config.json').obsidian.vaultPath)}catch(e){}" 2>/dev/null)
   fi
   if [ -n "$KB_VAULT_PATH" ] && [ -d "$KB_VAULT_PATH/10-tasks" ]; then
     ACTIVE_TASKS=$(find "$KB_VAULT_PATH/10-tasks" -name "*.json" -not -name "*.receipt.json" \

--- a/.claude/hooks/session-init.sh
+++ b/.claude/hooks/session-init.sh
@@ -22,19 +22,21 @@ BRANCH=$(git branch --show-current 2>/dev/null || echo "unknown")
 LAST_COMMIT=$(git log -1 --oneline 2>/dev/null || echo "unknown")
 TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 GIT_STATUS=$(git status --porcelain 2>/dev/null | head -20)
-# Read vault name from config (default: Mercury_KB)
-VAULT_NAME=$(node -e "try{console.log(require('$CLAUDE_PROJECT_DIR/mercury.config.json').obsidian.vaultName||'Mercury_KB')}catch(e){console.log('Mercury_KB')}" 2>/dev/null)
+# Read vault config via jq (primary) or node (fallback)
+if command -v jq &>/dev/null && [ -f "$CLAUDE_PROJECT_DIR/mercury.config.json" ]; then
+  VAULT_NAME=$(jq -r '.obsidian.vaultName // "Mercury_KB"' "$CLAUDE_PROJECT_DIR/mercury.config.json" 2>/dev/null)
+  KB_VAULT_PATH=$(jq -r '.obsidian.vaultPath // empty' "$CLAUDE_PROJECT_DIR/mercury.config.json" 2>/dev/null)
+else
+  VAULT_NAME=$(node -e "try{const c=require('$CLAUDE_PROJECT_DIR/mercury.config.json');console.log(c.obsidian.vaultName||'Mercury_KB')}catch(e){console.log('Mercury_KB')}" 2>/dev/null)
+  KB_VAULT_PATH=$(node -e "try{console.log(require('$CLAUDE_PROJECT_DIR/mercury.config.json').obsidian.vaultPath)}catch(e){}" 2>/dev/null)
+fi
 # Detect active tasks via Obsidian CLI (preferred) or config-resolved path (fallback)
+# Task ID formats: TASK-NAME-NNN (manual) or TASK-hexhexhex (shortId)
 ACTIVE_TASKS=""
 if command -v obsidian &>/dev/null; then
   ACTIVE_TASKS=$(obsidian vault="$VAULT_NAME" search query="in_progress" 2>/dev/null \
-    | grep -oE 'TASK-[A-Z][A-Z0-9-]+-[0-9]+' | head -5 | sort -u)
+    | grep -oE 'TASK-[A-Za-z0-9-]+' | head -5 | sort -u)
 else
-  # Fallback: resolve vault path from mercury.config.json using node (handles JSON escaping)
-  KB_VAULT_PATH=""
-  if [ -f "$CLAUDE_PROJECT_DIR/mercury.config.json" ]; then
-    KB_VAULT_PATH=$(node -e "try{console.log(require('$CLAUDE_PROJECT_DIR/mercury.config.json').obsidian.vaultPath)}catch(e){}" 2>/dev/null)
-  fi
   if [ -n "$KB_VAULT_PATH" ] && [ -d "$KB_VAULT_PATH/10-tasks" ]; then
     ACTIVE_TASKS=$(find "$KB_VAULT_PATH/10-tasks" -name "*.json" -not -name "*.receipt.json" \
       -exec grep -lE '"status":[[:space:]]*"(in_progress|dispatched|implementation_done)"' {} \; 2>/dev/null \

--- a/.claude/hooks/session-init.sh
+++ b/.claude/hooks/session-init.sh
@@ -36,12 +36,12 @@ ACTIVE_TASKS=""
 if command -v obsidian &>/dev/null; then
   ACTIVE_TASKS=$(obsidian vault="$VAULT_NAME" search query="in_progress" 2>/dev/null \
     | grep -oE 'TASK-[A-Za-z0-9-]+' | head -5 | sort -u)
-else
-  if [ -n "$KB_VAULT_PATH" ] && [ -d "$KB_VAULT_PATH/10-tasks" ]; then
-    ACTIVE_TASKS=$(find "$KB_VAULT_PATH/10-tasks" -name "*.json" -not -name "*.receipt.json" \
-      -exec grep -lE '"status":[[:space:]]*"(in_progress|dispatched|implementation_done)"' {} \; 2>/dev/null \
-      | head -5 | while read -r f; do basename "$f" .json; done)
-  fi
+fi
+# Fallback: filesystem scan when CLI unavailable or returned no results
+if [ -z "$ACTIVE_TASKS" ] && [ -n "$KB_VAULT_PATH" ] && [ -d "$KB_VAULT_PATH/10-tasks" ]; then
+  ACTIVE_TASKS=$(find "$KB_VAULT_PATH/10-tasks" -name "*.json" -not -name "*.receipt.json" \
+    -exec grep -lE '"status":[[:space:]]*"(in_progress|dispatched|implementation_done)"' {} \; 2>/dev/null \
+    | head -5 | while read -r f; do basename "$f" .json; done)
 fi
 
 # Write current-session.md (ensure directory exists)

--- a/.claude/hooks/session-init.sh
+++ b/.claude/hooks/session-init.sh
@@ -43,9 +43,15 @@ if [ -z "$ACTIVE_TASKS" ] && [ -n "$KB_VAULT_PATH" ] && [ -d "$KB_VAULT_PATH/10-
     -exec grep -lE '"status":[[:space:]]*"(in_progress|dispatched|implementation_done)"' {} \; 2>/dev/null \
     | head -5 | while read -r f; do basename "$f" .json; done)
 fi
-# Fallback 2: sibling vault convention ({ProjectDir}_KB alongside project)
+# Fallback 2: sibling vault convention ({ProjectName}_KB alongside project)
 if [ -z "$ACTIVE_TASKS" ]; then
-  SIBLING_KB="$(dirname "$CLAUDE_PROJECT_DIR")/${VAULT_NAME}"
+  # Prefer configured vault name; derive from {ProjectName}_KB when using default
+  if [ "$VAULT_NAME" = "Mercury_KB" ]; then
+    PROJECT_NAME=$(basename "$CLAUDE_PROJECT_DIR")
+    SIBLING_KB="$(dirname "$CLAUDE_PROJECT_DIR")/${PROJECT_NAME}_KB"
+  else
+    SIBLING_KB="$(dirname "$CLAUDE_PROJECT_DIR")/${VAULT_NAME}"
+  fi
   if [ -d "$SIBLING_KB/10-tasks" ]; then
     ACTIVE_TASKS=$(find "$SIBLING_KB/10-tasks" -name "*.json" -not -name "*.receipt.json" \
       -exec grep -lE '"status":[[:space:]]*"(in_progress|dispatched|implementation_done)"' {} \; 2>/dev/null \

--- a/.claude/hooks/session-init.sh
+++ b/.claude/hooks/session-init.sh
@@ -37,11 +37,20 @@ if command -v obsidian &>/dev/null; then
   ACTIVE_TASKS=$(obsidian vault="$VAULT_NAME" search query="in_progress" 2>/dev/null \
     | grep -oE 'TASK-[A-Za-z0-9-]+' | head -5 | sort -u)
 fi
-# Fallback: filesystem scan when CLI unavailable or returned no results
+# Fallback 1: filesystem scan using config-resolved vaultPath
 if [ -z "$ACTIVE_TASKS" ] && [ -n "$KB_VAULT_PATH" ] && [ -d "$KB_VAULT_PATH/10-tasks" ]; then
   ACTIVE_TASKS=$(find "$KB_VAULT_PATH/10-tasks" -name "*.json" -not -name "*.receipt.json" \
     -exec grep -lE '"status":[[:space:]]*"(in_progress|dispatched|implementation_done)"' {} \; 2>/dev/null \
     | head -5 | while read -r f; do basename "$f" .json; done)
+fi
+# Fallback 2: sibling vault convention ({ProjectDir}_KB alongside project)
+if [ -z "$ACTIVE_TASKS" ]; then
+  SIBLING_KB="$(dirname "$CLAUDE_PROJECT_DIR")/${VAULT_NAME}"
+  if [ -d "$SIBLING_KB/10-tasks" ]; then
+    ACTIVE_TASKS=$(find "$SIBLING_KB/10-tasks" -name "*.json" -not -name "*.receipt.json" \
+      -exec grep -lE '"status":[[:space:]]*"(in_progress|dispatched|implementation_done)"' {} \; 2>/dev/null \
+      | head -5 | while read -r f; do basename "$f" .json; done)
+  fi
 fi
 
 # Write current-session.md (ensure directory exists)

--- a/.claude/skills/dispatch-task/SKILL.md
+++ b/.claude/skills/dispatch-task/SKILL.md
@@ -61,7 +61,7 @@ Build the JSON payload for `create_task`. The orchestrator generates `taskId`, `
 
 Optional fields (include when needed): `phaseId`, `branch`, `docsMustUpdate`, `reviewConfig`, `handoffToAcceptance`, `maxReworks`.
 
-The full template with all fields is at `Mercury_KB/99-templates/task-bundle.template.json` — read it for the complete schema including resilience and contextInjection.
+The full template with all fields is at `99-templates/task-bundle.template.json` in the KB vault — read it via Obsidian MCP (`mcp__obsidian__obsidian_get_file_contents` with filepath `99-templates/task-bundle.template.json`).
 
 ## Step 3: Persist via RPC
 

--- a/.claude/skills/dispatch-task/SKILL.md
+++ b/.claude/skills/dispatch-task/SKILL.md
@@ -53,7 +53,7 @@ Build the JSON payload for `create_task`. The orchestrator generates `taskId`, `
   "allowedWriteScope": {
     "codePaths": ["<paths the worker may modify>"]
   },
-  "docsMustNotTouch": ["CLAUDE.md", "AGENTS.md", "Mercury_KB/99-templates/"],
+  "docsMustNotTouch": ["CLAUDE.md", "AGENTS.md", "99-templates/"],
   "definitionOfDone": ["<objectively verifiable criterion 1>", "<criterion 2>"],
   "requiredEvidence": ["<test output, runtime proof, screenshots>"]
 }
@@ -117,4 +117,4 @@ After dispatch succeeds:
 - **Empty definitionOfDone**: Without verifiable criteria, acceptance review cannot function. Each criterion should be objectively testable.
 - **Overly broad allowedWriteScope**: Scope the worker tightly. `["packages/"]` is too broad — prefer `["packages/orchestrator/src/"]`.
 - **Missing readScope docs**: If the worker needs context docs to understand the task, list them. The orchestrator injects these into the dispatch prompt.
-- **Forgetting docsMustNotTouch defaults**: Always include `CLAUDE.md`, `AGENTS.md`, and `Mercury_KB/99-templates/` unless the task specifically requires modifying them.
+- **Forgetting docsMustNotTouch defaults**: Always include `CLAUDE.md`, `AGENTS.md`, and `99-templates/` unless the task specifically requires modifying them.

--- a/.claude/skills/pr-flow/SKILL.md
+++ b/.claude/skills/pr-flow/SKILL.md
@@ -35,7 +35,8 @@ if ! [[ "$TASK_ID" =~ ^TASK- ]]; then
   TASK_ID=$(echo "$BRANCH" | grep -oE 'TASK-[A-Z][A-Z0-9-]+-[0-9]+' | head -1)
 fi
 # Resolve KB vault path from mercury.config.json (KB is outside project CWD)
-KB_VAULT_PATH=$(jq -r '.obsidian.vaultPath // empty' mercury.config.json 2>/dev/null)
+KB_VAULT_PATH=$(jq -r '.obsidian.vaultPath // empty' mercury.config.json 2>/dev/null \
+  || node -e "try{console.log(require('./mercury.config.json').obsidian.vaultPath)}catch(e){}" 2>/dev/null)
 TASK_FILE=""
 if [ -n "$TASK_ID" ] && [ -n "$KB_VAULT_PATH" ] && [ -f "$KB_VAULT_PATH/10-tasks/$TASK_ID.json" ]; then
   TASK_FILE="$KB_VAULT_PATH/10-tasks/$TASK_ID.json"

--- a/.claude/skills/pr-flow/SKILL.md
+++ b/.claude/skills/pr-flow/SKILL.md
@@ -34,9 +34,11 @@ TASK_ID=${BRANCH##*/}
 if ! [[ "$TASK_ID" =~ ^TASK- ]]; then
   TASK_ID=$(echo "$BRANCH" | grep -oE 'TASK-[A-Z][A-Z0-9-]+-[0-9]+' | head -1)
 fi
+# Resolve KB vault path from mercury.config.json (KB is outside project CWD)
+KB_VAULT_PATH=$(jq -r '.obsidian.vaultPath // empty' mercury.config.json 2>/dev/null)
 TASK_FILE=""
-if [ -n "$TASK_ID" ] && [ -f "Mercury_KB/10-tasks/$TASK_ID.json" ]; then
-  TASK_FILE="Mercury_KB/10-tasks/$TASK_ID.json"
+if [ -n "$TASK_ID" ] && [ -n "$KB_VAULT_PATH" ] && [ -f "$KB_VAULT_PATH/10-tasks/$TASK_ID.json" ]; then
+  TASK_FILE="$KB_VAULT_PATH/10-tasks/$TASK_ID.json"
 fi
 # When TASK_FILE is absent (non-task branches), ALLOWED_SCOPE stays empty → scope checks pass all files.
 declare -a ALLOWED_SCOPE=()
@@ -49,8 +51,8 @@ gh api rate_limit --jq '.resources.core.remaining'
 ### Step 1: Create or Reuse the PR
 
 ```bash
-SUMMARY=$(jq -r '.summary // "PR update"' Mercury_KB/10-tasks/"$TASK_ID".receipt.json 2>/dev/null || echo "PR update")
-DOD_COUNT=$(jq -r '(.definitionOfDone // []) | length' Mercury_KB/10-tasks/"$TASK_ID".json 2>/dev/null || echo "unknown")
+SUMMARY=$(jq -r '.summary // "PR update"' "$KB_VAULT_PATH/10-tasks/$TASK_ID.receipt.json" 2>/dev/null || echo "PR update")
+DOD_COUNT=$(jq -r '(.definitionOfDone // []) | length' "$TASK_FILE" 2>/dev/null || echo "unknown")
 PR_BODY=$(cat <<EOF
 ## Summary
 $SUMMARY

--- a/.mercury/templates/dispatch-prompt.template.md
+++ b/.mercury/templates/dispatch-prompt.template.md
@@ -8,7 +8,7 @@
 
 ## KB Access
 
-KB 文件位于 Obsidian vault `Mercury_KB`，**不在项目目录内**。
+KB 文件位于 Obsidian vault `{{vaultName}}`，**不在项目目录内**。
 - 使用 `mcp__obsidian__obsidian_get_file_contents` 读取，filepath 为 vault-relative 路径（如 `{{taskFilePath}}`）
 - 使用 `mcp__obsidian__obsidian_simple_search` 搜索
 - **禁止**从项目 CWD 拼接 `Mercury_KB/xxx` 路径

--- a/.mercury/templates/dispatch-prompt.template.md
+++ b/.mercury/templates/dispatch-prompt.template.md
@@ -2,9 +2,16 @@
 
 {{context}}
 
-**TaskBundle**: `{{taskFilePath}}`
+**TaskBundle**: `{{taskFilePath}}` (vault-relative — 使用 Obsidian MCP 读取)
 **允许写入**: {{allowedWriteScope}}
 **禁止修改**: {{docsMustNotTouch}}
+
+## KB Access
+
+KB 文件位于 Obsidian vault `Mercury_KB`，**不在项目目录内**。
+- 使用 `mcp__obsidian__obsidian_get_file_contents` 读取，filepath 为 vault-relative 路径（如 `{{taskFilePath}}`）
+- 使用 `mcp__obsidian__obsidian_simple_search` 搜索
+- **禁止**从项目 CWD 拼接 `Mercury_KB/xxx` 路径
 
 ## Task Bundle (machine-readable)
 

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -820,6 +820,29 @@ export class TaskManager {
 // ─── Prompt Builders ───
 
 /** Format allowedWriteScope for human-readable display (codePaths + kbPaths). */
+/**
+ * Resolve the Obsidian vault name from mercury.config.json.
+ * Priority: obsidian.vaultName > basename(obsidian.vaultPath) > null.
+ * Returns null when config is missing or has no obsidian section.
+ */
+function resolveVaultName(basePath: string): string | null {
+  try {
+    const configPath = resolve(basePath, "mercury.config.json");
+    const config = JSON.parse(readFileSync(configPath, "utf-8"));
+    const obs = config.obsidian;
+    if (!obs) return null;
+    if (obs.vaultName) return obs.vaultName;
+    if (obs.vaultPath) {
+      // Derive vault name from the last segment of the configured path
+      const segments = obs.vaultPath.replace(/[\\/]+$/, "").split(/[\\/]/);
+      return segments[segments.length - 1] || null;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
 function formatWriteScope(scope: TaskBundle["allowedWriteScope"]): string {
   const parts: string[] = [];
   if (scope.codePaths.length) parts.push(`code: ${scope.codePaths.join(", ")}`);
@@ -887,20 +910,15 @@ export function buildDevPrompt(
 
   const scopeDisplay = formatWriteScope(task.allowedWriteScope);
 
-  // Read vault name from config for template injection
-  let vaultName = "Mercury_KB";
-  try {
-    const configPath = resolve(basePath, "mercury.config.json");
-    const config = JSON.parse(readFileSync(configPath, "utf-8"));
-    vaultName = config.obsidian?.vaultName ?? vaultName;
-  } catch { /* use default */ }
+  // Resolve vault name: prefer vaultName, derive from vaultPath basename, or null
+  const vaultName = resolveVaultName(basePath);
 
   // Single-pass template substitution to prevent cross-replacement
   const placeholders: Record<string, string> = {
     "{{taskId}}": `${task.title} [${task.taskId}]`,
     "{{context}}": task.context,
     "{{taskFilePath}}": `10-tasks/${task.taskId}.json`,
-    "{{vaultName}}": vaultName,
+    "{{vaultName}}": vaultName ?? "Mercury_KB",
     "{{allowedWriteScope}}": scopeDisplay,
     "{{docsMustNotTouch}}": task.docsMustNotTouch.join(", ") || "无",
     "{{bundleJson}}": JSON.stringify(bundleMeta, null, 2),

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -888,7 +888,7 @@ export function buildDevPrompt(
   const placeholders: Record<string, string> = {
     "{{taskId}}": `${task.title} [${task.taskId}]`,
     "{{context}}": task.context,
-    "{{taskFilePath}}": `{Project}_KB/10-tasks/${task.taskId}.json`,
+    "{{taskFilePath}}": `10-tasks/${task.taskId}.json`,
     "{{allowedWriteScope}}": scopeDisplay,
     "{{docsMustNotTouch}}": task.docsMustNotTouch.join(", ") || "无",
     "{{bundleJson}}": JSON.stringify(bundleMeta, null, 2),
@@ -944,10 +944,12 @@ export function buildReferencePrompt(
 
   lines.push(`实现任务 ${task.taskId}: ${task.title}`);
   lines.push("");
-  lines.push(`任务详情: 读取 ${taskFilePath}`);
+  lines.push(`任务详情: 使用 Obsidian MCP 读取 ${taskFilePath} (vault-relative 路径)`);
   if (handoffFilePath) {
-    lines.push(`项目上下文: 读取 ${handoffFilePath}`);
+    lines.push(`项目上下文: 使用 Obsidian MCP 读取 ${handoffFilePath}`);
   }
+  lines.push("");
+  lines.push("KB 访问: 使用 mcp__obsidian__obsidian_get_file_contents，禁止从项目 CWD 拼接 Mercury_KB/ 路径");
   lines.push("");
   lines.push("完成后:");
   lines.push(`1. 将 implementation receipt 写入 ${taskFilePath} 的 implementationReceipt 字段`);

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -884,11 +884,20 @@ export function buildDevPrompt(
 
   const scopeDisplay = formatWriteScope(task.allowedWriteScope);
 
+  // Read vault name from config for template injection
+  let vaultName = "Mercury_KB";
+  try {
+    const configPath = resolve(basePath, "mercury.config.json");
+    const config = JSON.parse(readFileSync(configPath, "utf-8"));
+    vaultName = config.obsidian?.vaultName ?? vaultName;
+  } catch { /* use default */ }
+
   // Single-pass template substitution to prevent cross-replacement
   const placeholders: Record<string, string> = {
     "{{taskId}}": `${task.title} [${task.taskId}]`,
     "{{context}}": task.context,
     "{{taskFilePath}}": `10-tasks/${task.taskId}.json`,
+    "{{vaultName}}": vaultName,
     "{{allowedWriteScope}}": scopeDisplay,
     "{{docsMustNotTouch}}": task.docsMustNotTouch.join(", ") || "无",
     "{{bundleJson}}": JSON.stringify(bundleMeta, null, 2),
@@ -940,6 +949,10 @@ export function buildReferencePrompt(
   taskFilePath: string,
   handoffFilePath?: string,
 ): string {
+  // Defensive: warn if path looks like absolute or has Mercury_KB prefix
+  if (taskFilePath.includes("Mercury_KB") || /^[A-Z]:[/\\]|^\//.test(taskFilePath)) {
+    console.warn(`[buildReferencePrompt] taskFilePath should be vault-relative, got: ${taskFilePath}`);
+  }
   const lines: string[] = [];
 
   lines.push(`实现任务 ${task.taskId}: ${task.title}`);

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -950,8 +950,12 @@ export function buildReferencePrompt(
   handoffFilePath?: string,
 ): string {
   // Defensive: warn if path looks like absolute or has Mercury_KB prefix
-  if (taskFilePath.includes("Mercury_KB") || /^[A-Z]:[/\\]|^\//.test(taskFilePath)) {
+  const isNotVaultRelative = (p: string) => p.includes("Mercury_KB") || /^[A-Z]:[/\\]|^\//.test(p);
+  if (isNotVaultRelative(taskFilePath)) {
     console.warn(`[buildReferencePrompt] taskFilePath should be vault-relative, got: ${taskFilePath}`);
+  }
+  if (handoffFilePath && isNotVaultRelative(handoffFilePath)) {
+    console.warn(`[buildReferencePrompt] handoffFilePath should be vault-relative, got: ${handoffFilePath}`);
   }
   const lines: string[] = [];
 

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -528,9 +528,12 @@ export class TaskManager {
       }
     }
 
-    // Check docsUpdated against docsMustNotTouch
+    // Check docsUpdated against docsMustNotTouch (supports prefix matching for directories)
     for (const doc of receipt.docsUpdated) {
-      if (task.docsMustNotTouch.includes(doc)) {
+      const blocked = task.docsMustNotTouch.some(
+        (entry) => doc === entry || (entry.endsWith("/") && doc.startsWith(entry))
+      );
+      if (blocked) {
         violations.push({ file: doc, reason: "Listed in docsMustNotTouch" });
       }
     }
@@ -921,6 +924,11 @@ function fallbackDevTemplate(): string {
     "# Dispatch: {{taskId}}",
     "",
     "{{context}}",
+    "",
+    "## KB Access",
+    "KB vault: `{{vaultName}}` — use Obsidian MCP (`mcp__obsidian__*`) or CLI (`obsidian vault=\"{{vaultName}}\"`).",
+    "Task bundle: `{{taskFilePath}}` (vault-relative path).",
+    "Never construct `Mercury_KB/...` paths from the project CWD.",
     "",
     "## Task Bundle (machine-readable)",
     "```json",


### PR DESCRIPTION
## Summary
- Fix KB path resolution: agents no longer try CWD-relative `Mercury_KB/` paths
- Dispatch template now includes KB Access section guiding agents to use Obsidian MCP
- `{{taskFilePath}}` renders as vault-relative path (`10-tasks/TASK-xxx.json`)
- session-init hook uses Obsidian CLI (preferred) or config-resolved vaultPath
- pr-flow skills resolve KB path from `mercury.config.json` instead of hardcoding

Closes #51

## Changes
| File | Change |
|------|--------|
| `task-manager.ts` | `{{taskFilePath}}` → vault-relative; `buildReferencePrompt` adds MCP hint |
| `dispatch-prompt.template.md` | New KB Access section with Obsidian MCP instructions |
| `session-init.sh` | Obsidian CLI priority → config vaultPath fallback |
| `pr-flow/SKILL.md` (both) | `jq` reads config vaultPath instead of `Mercury_KB/` |
| `dispatch-task/SKILL.md` | Template path → vault-relative + MCP reference |

## Test plan
- [x] `tsc --noEmit` passes for orchestrator package
- [x] session-init hook runs without error (Obsidian CLI path detected)
- [x] Obsidian CLI verified works with vault-relative paths
- [x] Obsidian MCP verified works with vault-relative paths
- [x] No remaining problematic Mercury_KB CWD-relative references

🤖 Generated with [Claude Code](https://claude.com/claude-code)