### PR TITLE
fix(gui+hooks): process-tree kill on Windows + push-guard hardening (#78, #81)

### DIFF
--- a/.claude/hooks/pre-commit-guard.sh
+++ b/.claude/hooks/pre-commit-guard.sh
@@ -7,7 +7,13 @@ INPUT=$(cat)
 
 # Debug: log raw input for diagnosing guard bypass
 STATE_DIR="$(dirname "$0")/state"
-echo "[$(date -Iseconds)] INPUT=$INPUT" >> "$STATE_DIR/pre-commit-guard-debug.log"
+mkdir -p "$STATE_DIR"
+# Truncate debug log if > 100KB to prevent unbounded growth
+LOG_FILE="$STATE_DIR/pre-commit-guard-debug.log"
+if [ -f "$LOG_FILE" ] && [ "$(wc -c < "$LOG_FILE")" -gt 102400 ]; then
+  tail -100 "$LOG_FILE" > "$LOG_FILE.tmp" && mv "$LOG_FILE.tmp" "$LOG_FILE"
+fi
+echo "[$(date -Iseconds)] INPUT=$INPUT" >> "$LOG_FILE"
 
 # Extract command (jq preferred, sed fallback — no grep -oP for portability)
 if command -v jq >/dev/null 2>&1; then
@@ -17,7 +23,7 @@ else
 fi
 
 # Debug: log extracted command
-echo "[$(date -Iseconds)] COMMAND=$COMMAND" >> "$STATE_DIR/pre-commit-guard-debug.log"
+echo "[$(date -Iseconds)] COMMAND=$COMMAND" >> "$LOG_FILE"
 
 # Only intercept git commit commands.
 # Use printf '%s' to handle multi-line/heredoc commands that contain embedded

--- a/.claude/hooks/pre-commit-guard.sh
+++ b/.claude/hooks/pre-commit-guard.sh
@@ -5,6 +5,10 @@
 # Read stdin (hook JSON input)
 INPUT=$(cat)
 
+# Debug: log raw input for diagnosing guard bypass
+STATE_DIR="$(dirname "$0")/state"
+echo "[$(date -Iseconds)] INPUT=$INPUT" >> "$STATE_DIR/pre-commit-guard-debug.log"
+
 # Extract command (jq preferred, sed fallback — no grep -oP for portability)
 if command -v jq >/dev/null 2>&1; then
   COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
@@ -12,13 +16,17 @@ else
   COMMAND=$(echo "$INPUT" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
 fi
 
-# Only intercept git commit commands
-echo "$COMMAND" | grep -qE 'git\s+commit' || exit 0
+# Debug: log extracted command
+echo "[$(date -Iseconds)] COMMAND=$COMMAND" >> "$STATE_DIR/pre-commit-guard-debug.log"
+
+# Only intercept git commit commands.
+# Use printf '%s' to handle multi-line/heredoc commands that contain embedded
+# newlines. `echo` can truncate on some shells; printf '%s' preserves the string.
+printf '%s' "$COMMAND" | grep -qE 'git\s+commit' || exit 0
 
 # Allow --amend (fixing previous commit, review already done)
-echo "$COMMAND" | grep -qE '\-\-amend' && exit 0
+printf '%s' "$COMMAND" | grep -qE '\-\-amend' && exit 0
 
-STATE_DIR="$(dirname "$0")/state"
 FLAG="$STATE_DIR/review-passed"
 
 if [ -f "$FLAG" ]; then

--- a/.claude/hooks/pre-commit-guard.sh
+++ b/.claude/hooks/pre-commit-guard.sh
@@ -7,7 +7,9 @@ INPUT=$(cat)
 
 # Debug: log raw input for diagnosing guard bypass
 STATE_DIR="$(dirname "$0")/state"
-mkdir -p "$STATE_DIR"
+if ! mkdir -p "$STATE_DIR"; then
+  echo "WARNING: cannot create state dir: $STATE_DIR" >&2
+fi
 # Truncate debug log if > 100KB to prevent unbounded growth
 LOG_FILE="$STATE_DIR/pre-commit-guard-debug.log"
 if [ -f "$LOG_FILE" ] && [ "$(wc -c < "$LOG_FILE")" -gt 102400 ]; then

--- a/.claude/hooks/pre-commit-guard.sh
+++ b/.claude/hooks/pre-commit-guard.sh
@@ -5,17 +5,19 @@
 # Read stdin (hook JSON input)
 INPUT=$(cat)
 
-# Debug: log raw input for diagnosing guard bypass
+# Debug logging: opt-in via GUARD_DEBUG=1 to avoid persisting sensitive payloads.
 STATE_DIR="$(dirname "$0")/state"
 if ! mkdir -p "$STATE_DIR"; then
   echo "WARNING: cannot create state dir: $STATE_DIR" >&2
 fi
-# Truncate debug log if > 100KB to prevent unbounded growth
 LOG_FILE="$STATE_DIR/pre-commit-guard-debug.log"
-if [ -f "$LOG_FILE" ] && [ "$(wc -c < "$LOG_FILE")" -gt 102400 ]; then
-  tail -100 "$LOG_FILE" > "$LOG_FILE.tmp" && mv "$LOG_FILE.tmp" "$LOG_FILE"
+if [ "${GUARD_DEBUG:-0}" = "1" ]; then
+  # Truncate debug log if > 100KB to prevent unbounded growth
+  if [ -f "$LOG_FILE" ] && [ "$(wc -c < "$LOG_FILE")" -gt 102400 ]; then
+    tail -100 "$LOG_FILE" > "$LOG_FILE.tmp" && mv "$LOG_FILE.tmp" "$LOG_FILE"
+  fi
+  echo "[$(date -Iseconds)] INPUT=$INPUT" >> "$LOG_FILE"
 fi
-echo "[$(date -Iseconds)] INPUT=$INPUT" >> "$LOG_FILE"
 
 # Extract command (jq preferred, sed fallback — no grep -oP for portability)
 if command -v jq >/dev/null 2>&1; then
@@ -24,16 +26,22 @@ else
   COMMAND=$(echo "$INPUT" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
 fi
 
-# Debug: log extracted command
-echo "[$(date -Iseconds)] COMMAND=$COMMAND" >> "$LOG_FILE"
+if [ "${GUARD_DEBUG:-0}" = "1" ]; then
+  echo "[$(date -Iseconds)] COMMAND=$COMMAND" >> "$LOG_FILE"
+fi
 
 # Only intercept git commit commands.
 # Use printf '%s' to handle multi-line/heredoc commands that contain embedded
 # newlines. `echo` can truncate on some shells; printf '%s' preserves the string.
 printf '%s' "$COMMAND" | grep -qE 'git\s+commit' || exit 0
 
-# Allow --amend (fixing previous commit, review already done)
-printf '%s' "$COMMAND" | grep -qE '\-\-amend' && exit 0
+# Allow --amend (fixing previous commit, review already done).
+# Match --amend as a standalone argument token (preceded by whitespace),
+# not inside a quoted message string like -m "...--amend..."
+# We check for whitespace-delimited --amend to avoid false positives in heredocs.
+if printf '%s' "$COMMAND" | grep -qE '(^|\s)--amend(\s|$)'; then
+  exit 0
+fi
 
 FLAG="$STATE_DIR/review-passed"
 

--- a/.claude/hooks/push-guard.sh
+++ b/.claude/hooks/push-guard.sh
@@ -4,17 +4,22 @@
 
 INPUT=$(cat)
 
-# Debug: log raw input for diagnosing guard bypass (consistent with pre-commit-guard.sh)
+# Debug logging: opt-in via GUARD_DEBUG=1 to avoid persisting sensitive payloads.
 STATE_DIR="$(dirname "$0")/state"
 if ! mkdir -p "$STATE_DIR"; then
   echo "WARNING: cannot create state dir: $STATE_DIR" >&2
-  # Continue execution — only debug logging is affected
 fi
 LOG_FILE="$STATE_DIR/push-guard-debug.log"
-if [ -f "$LOG_FILE" ] && [ "$(wc -c < "$LOG_FILE")" -gt 102400 ]; then
+
+debug_log() {
+  [ "${GUARD_DEBUG:-0}" = "1" ] && echo "[$(date -Iseconds)] $1" >> "$LOG_FILE"
+}
+
+if [ "${GUARD_DEBUG:-0}" = "1" ] && [ -f "$LOG_FILE" ] && [ "$(wc -c < "$LOG_FILE")" -gt 102400 ]; then
   tail -100 "$LOG_FILE" > "$LOG_FILE.tmp" && mv "$LOG_FILE.tmp" "$LOG_FILE"
 fi
-echo "[$(date -Iseconds)] INPUT=$INPUT" >> "$LOG_FILE"
+
+debug_log "INPUT=$INPUT"
 
 # Extract command
 if command -v jq >/dev/null 2>&1; then
@@ -23,20 +28,35 @@ else
   COMMAND=$(echo "$INPUT" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
 fi
 
-# Debug: log extracted command
-echo "[$(date -Iseconds)] COMMAND=$COMMAND" >> "$LOG_FILE"
+debug_log "COMMAND=$COMMAND"
 
 # Only intercept git push commands
 printf '%s' "$COMMAND" | grep -qE '\bgit\s+push\b' || exit 0
 
-# Block push to protected branches (develop, master, main)
-# Extract all arguments after "git push", excluding flags (starting with -)
-# and the remote name (first non-flag arg, typically "origin").
-# Then normalize each target: strip leading "+", strip "refs/heads/" prefix,
-# extract refspec RHS (part after ":"), and check against protected names.
+# Helper: emit the standard BLOCKED message and exit
+block_push() {
+  local reason="$1"
+  debug_log "BLOCKED: $reason"
+  cat >&2 <<'MSG'
+BLOCKED: Direct push to develop/master is forbidden (CLAUDE.md rule).
+All merges into develop must go through a Pull Request.
+Use: git push -u origin <feature-branch> && gh pr create --base develop
+MSG
+  exit 2
+}
+
+# ── Phase 1: Detect dangerous flags before token parsing ──
+# --all pushes ALL local branches (including protected ones).
+# --mirror mirrors ALL refs and force-updates + prunes the remote.
+if printf '%s' "$COMMAND" | grep -qE '(^|\s)--(all|mirror)(\s|$)'; then
+  block_push "--all or --mirror flag detected"
+fi
+
+# ── Phase 2: Parse explicit refspec targets ──
 PUSH_ARGS=$(printf '%s' "$COMMAND" | sed 's/.*git[[:space:]]\+push[[:space:]]*//')
 PROTECTED="^(develop|master|main)$"
 SKIPPED_REMOTE=false
+HAS_EXPLICIT_TARGET=false
 
 for TOKEN in $PUSH_ARGS; do
   # Skip flags like --force, -u, --set-upstream
@@ -48,22 +68,17 @@ for TOKEN in $PUSH_ARGS; do
     continue
   fi
 
+  HAS_EXPLICIT_TARGET=true
+
   # Normalize: strip leading "+" (force-push prefix)
   NORMALIZED="${TOKEN##+}"
 
   # Check refspec RHS if present (e.g. HEAD:develop → develop)
   if printf '%s' "$NORMALIZED" | grep -q ':'; then
     REFSPEC_TARGET="${NORMALIZED##*:}"
-    # Strip refs/heads/ prefix from refspec target
     REFSPEC_TARGET="${REFSPEC_TARGET#refs/heads/}"
     if printf '%s' "$REFSPEC_TARGET" | grep -qE "$PROTECTED"; then
-      echo "[$(date -Iseconds)] BLOCKED: refspec target '$REFSPEC_TARGET' from '$TOKEN'" >> "$LOG_FILE"
-      cat >&2 <<'MSG'
-BLOCKED: Direct push to develop/master is forbidden (CLAUDE.md rule).
-All merges into develop must go through a Pull Request.
-Use: git push -u origin <feature-branch> && gh pr create --base develop
-MSG
-      exit 2
+      block_push "refspec target '$REFSPEC_TARGET' from '$TOKEN'"
     fi
     continue
   fi
@@ -73,14 +88,19 @@ MSG
 
   # Check if the normalized token is a protected branch
   if printf '%s' "$NORMALIZED" | grep -qE "$PROTECTED"; then
-    echo "[$(date -Iseconds)] BLOCKED: direct target '$NORMALIZED' from '$TOKEN'" >> "$LOG_FILE"
-    cat >&2 <<'MSG'
-BLOCKED: Direct push to develop/master is forbidden (CLAUDE.md rule).
-All merges into develop must go through a Pull Request.
-Use: git push -u origin <feature-branch> && gh pr create --base develop
-MSG
-    exit 2
+    block_push "direct target '$NORMALIZED' from '$TOKEN'"
   fi
 done
+
+# ── Phase 3: Handle implicit push (no explicit refspec) ──
+# `git push` or `git push origin` with no refspec uses push.default (typically
+# "simple"), which pushes the current branch to its upstream. If the current
+# branch IS a protected branch, this is an implicit push to develop/master.
+if [ "$HAS_EXPLICIT_TARGET" = false ]; then
+  CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+  if printf '%s' "$CURRENT_BRANCH" | grep -qE "$PROTECTED"; then
+    block_push "implicit push from current branch '$CURRENT_BRANCH'"
+  fi
+fi
 
 exit 0

--- a/.claude/hooks/push-guard.sh
+++ b/.claude/hooks/push-guard.sh
@@ -12,16 +12,17 @@ else
 fi
 
 # Only intercept git push commands
-printf '%s' "$COMMAND" | grep -qE 'git\s+push' || exit 0
+printf '%s' "$COMMAND" | grep -qE '\bgit\s+push\b' || exit 0
 
 # Block push to protected branches (develop, master, main)
 # Check if the push target includes a protected branch name
 if printf '%s' "$COMMAND" | grep -qE 'git\s+push.*\b(origin\s+)?(develop|master|main)\b'; then
   # Allow if pushing a feature branch that happens to contain the word
   # e.g. "git push -u origin fix/develop-typo" should NOT be blocked
-  # Only block when the protected branch IS the push target (last argument)
+  # Only block when the protected branch IS the push target (last argument),
+  # including refspec syntax like HEAD:develop or feature:main.
   LAST_ARG=$(printf '%s' "$COMMAND" | grep -oE '\S+$')
-  if [ "$LAST_ARG" = "develop" ] || [ "$LAST_ARG" = "master" ] || [ "$LAST_ARG" = "main" ]; then
+  if printf '%s' "$LAST_ARG" | grep -qE '^(develop|master|main)$|:(develop|master|main)$'; then
     cat >&2 <<'MSG'
 BLOCKED: Direct push to develop/master is forbidden (CLAUDE.md rule).
 All merges into develop must go through a Pull Request.

--- a/.claude/hooks/push-guard.sh
+++ b/.claude/hooks/push-guard.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# GATE: block direct push to develop/master — all merges must go through PRs.
+# Token cost: ZERO. No external deps.
+
+INPUT=$(cat)
+
+# Extract command
+if command -v jq >/dev/null 2>&1; then
+  COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+else
+  COMMAND=$(echo "$INPUT" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+fi
+
+# Only intercept git push commands
+printf '%s' "$COMMAND" | grep -qE 'git\s+push' || exit 0
+
+# Block push to protected branches (develop, master, main)
+# Check if the push target includes a protected branch name
+if printf '%s' "$COMMAND" | grep -qE 'git\s+push.*\b(origin\s+)?(develop|master|main)\b'; then
+  # Allow if pushing a feature branch that happens to contain the word
+  # e.g. "git push -u origin fix/develop-typo" should NOT be blocked
+  # Only block when the protected branch IS the push target (last argument)
+  LAST_ARG=$(printf '%s' "$COMMAND" | grep -oE '\S+$')
+  if [ "$LAST_ARG" = "develop" ] || [ "$LAST_ARG" = "master" ] || [ "$LAST_ARG" = "main" ]; then
+    cat >&2 <<'MSG'
+BLOCKED: Direct push to develop/master is forbidden (CLAUDE.md rule).
+All merges into develop must go through a Pull Request.
+Use: git push -u origin <feature-branch> && gh pr create --base develop
+MSG
+    exit 2
+  fi
+fi
+
+exit 0

--- a/.claude/hooks/push-guard.sh
+++ b/.claude/hooks/push-guard.sh
@@ -4,6 +4,15 @@
 
 INPUT=$(cat)
 
+# Debug: log raw input for diagnosing guard bypass (consistent with pre-commit-guard.sh)
+STATE_DIR="$(dirname "$0")/state"
+mkdir -p "$STATE_DIR"
+LOG_FILE="$STATE_DIR/push-guard-debug.log"
+if [ -f "$LOG_FILE" ] && [ "$(wc -c < "$LOG_FILE")" -gt 102400 ]; then
+  tail -100 "$LOG_FILE" > "$LOG_FILE.tmp" && mv "$LOG_FILE.tmp" "$LOG_FILE"
+fi
+echo "[$(date -Iseconds)] INPUT=$INPUT" >> "$LOG_FILE"
+
 # Extract command
 if command -v jq >/dev/null 2>&1; then
   COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
@@ -11,18 +20,57 @@ else
   COMMAND=$(echo "$INPUT" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
 fi
 
+# Debug: log extracted command
+echo "[$(date -Iseconds)] COMMAND=$COMMAND" >> "$LOG_FILE"
+
 # Only intercept git push commands
 printf '%s' "$COMMAND" | grep -qE '\bgit\s+push\b' || exit 0
 
 # Block push to protected branches (develop, master, main)
-# Check if the push target includes a protected branch name
-if printf '%s' "$COMMAND" | grep -qE 'git\s+push.*\b(origin\s+)?(develop|master|main)\b'; then
-  # Allow if pushing a feature branch that happens to contain the word
-  # e.g. "git push -u origin fix/develop-typo" should NOT be blocked
-  # Only block when the protected branch IS the push target (last argument),
-  # including refspec syntax like HEAD:develop or feature:main.
-  LAST_ARG=$(printf '%s' "$COMMAND" | grep -oE '\S+$')
-  if printf '%s' "$LAST_ARG" | grep -qE '^(develop|master|main)$|:(develop|master|main)$'; then
+# Extract all arguments after "git push", excluding flags (starting with -)
+# and the remote name (first non-flag arg, typically "origin").
+# Then normalize each target: strip leading "+", strip "refs/heads/" prefix,
+# extract refspec RHS (part after ":"), and check against protected names.
+PUSH_ARGS=$(printf '%s' "$COMMAND" | sed 's/.*git[[:space:]]\+push[[:space:]]*//')
+PROTECTED="^(develop|master|main)$"
+SKIPPED_REMOTE=false
+
+for TOKEN in $PUSH_ARGS; do
+  # Skip flags like --force, -u, --set-upstream
+  case "$TOKEN" in --*|-*) continue ;; esac
+
+  # Skip the first non-flag arg (remote name, e.g. "origin")
+  if [ "$SKIPPED_REMOTE" = false ]; then
+    SKIPPED_REMOTE=true
+    continue
+  fi
+
+  # Normalize: strip leading "+" (force-push prefix)
+  NORMALIZED="${TOKEN##+}"
+
+  # Check refspec RHS if present (e.g. HEAD:develop → develop)
+  if printf '%s' "$NORMALIZED" | grep -q ':'; then
+    REFSPEC_TARGET="${NORMALIZED##*:}"
+    # Strip refs/heads/ prefix from refspec target
+    REFSPEC_TARGET="${REFSPEC_TARGET#refs/heads/}"
+    if printf '%s' "$REFSPEC_TARGET" | grep -qE "$PROTECTED"; then
+      echo "[$(date -Iseconds)] BLOCKED: refspec target '$REFSPEC_TARGET' from '$TOKEN'" >> "$LOG_FILE"
+      cat >&2 <<'MSG'
+BLOCKED: Direct push to develop/master is forbidden (CLAUDE.md rule).
+All merges into develop must go through a Pull Request.
+Use: git push -u origin <feature-branch> && gh pr create --base develop
+MSG
+      exit 2
+    fi
+    continue
+  fi
+
+  # Strip refs/heads/ prefix (e.g. refs/heads/develop → develop)
+  NORMALIZED="${NORMALIZED#refs/heads/}"
+
+  # Check if the normalized token is a protected branch
+  if printf '%s' "$NORMALIZED" | grep -qE "$PROTECTED"; then
+    echo "[$(date -Iseconds)] BLOCKED: direct target '$NORMALIZED' from '$TOKEN'" >> "$LOG_FILE"
     cat >&2 <<'MSG'
 BLOCKED: Direct push to develop/master is forbidden (CLAUDE.md rule).
 All merges into develop must go through a Pull Request.
@@ -30,6 +78,6 @@ Use: git push -u origin <feature-branch> && gh pr create --base develop
 MSG
     exit 2
   fi
-fi
+done
 
 exit 0

--- a/.claude/hooks/push-guard.sh
+++ b/.claude/hooks/push-guard.sh
@@ -6,7 +6,10 @@ INPUT=$(cat)
 
 # Debug: log raw input for diagnosing guard bypass (consistent with pre-commit-guard.sh)
 STATE_DIR="$(dirname "$0")/state"
-mkdir -p "$STATE_DIR"
+if ! mkdir -p "$STATE_DIR"; then
+  echo "WARNING: cannot create state dir: $STATE_DIR" >&2
+  # Continue execution — only debug logging is affected
+fi
 LOG_FILE="$STATE_DIR/push-guard-debug.log"
 if [ -f "$LOG_FILE" ] && [ "$(wc -c < "$LOG_FILE")" -gt 102400 ]; then
   tail -100 "$LOG_FILE" > "$LOG_FILE.tmp" && mv "$LOG_FILE.tmp" "$LOG_FILE"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -31,6 +31,11 @@
           },
           {
             "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/push-guard.sh\"",
+            "timeout": 5
+          },
+          {
+            "type": "command",
             "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/pr-create-guard.sh\"",
             "timeout": 5
           },

--- a/packages/gui/src-tauri/src/remote_control.rs
+++ b/packages/gui/src-tauri/src/remote_control.rs
@@ -5,8 +5,6 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::{Child, Command};
 use tokio::sync::Mutex;
 
-#[cfg(target_os = "windows")]
-use std::os::windows::process::CommandExt;
 
 /// Manages a `claude remote-control` child process.
 /// Parses stdout for session URL, emits Tauri events for GUI updates.
@@ -358,12 +356,27 @@ impl RemoteControlManager {
                 // taskkill /T /F /PID kills the entire process tree rooted at the child PID.
                 // This ensures cmd.exe, claude.exe, and any grandchild processes are all terminated.
                 if let Some(pid) = c.id() {
-                    let _ = std::process::Command::new("taskkill")
+                    let mut kill_cmd = Command::new("taskkill");
+                    kill_cmd
                         .args(["/T", "/F", "/PID", &pid.to_string()])
-                        .creation_flags(0x08000000) // CREATE_NO_WINDOW
-                        .output();
+                        .creation_flags(0x08000000); // CREATE_NO_WINDOW
+                    match kill_cmd.output().await {
+                        Ok(output) if !output.status.success() => {
+                            #[cfg(debug_assertions)]
+                            eprintln!(
+                                "[remote-control] taskkill failed: {}",
+                                String::from_utf8_lossy(&output.stderr)
+                            );
+                        }
+                        Err(e) => {
+                            #[cfg(debug_assertions)]
+                            eprintln!("[remote-control] taskkill spawn error: {}", e);
+                        }
+                        _ => {}
+                    }
                 } else {
-                    // Fallback: process may have already exited, try normal kill.
+                    // id() returns None when the child has already been reaped by the OS
+                    // or was never successfully spawned. Attempt normal kill as best-effort.
                     let _ = c.kill().await;
                 }
             }

--- a/packages/gui/src-tauri/src/remote_control.rs
+++ b/packages/gui/src-tauri/src/remote_control.rs
@@ -5,6 +5,9 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::{Child, Command};
 use tokio::sync::Mutex;
 
+#[cfg(target_os = "windows")]
+use std::os::windows::process::CommandExt;
+
 /// Manages a `claude remote-control` child process.
 /// Parses stdout for session URL, emits Tauri events for GUI updates.
 ///
@@ -343,10 +346,31 @@ impl RemoteControlManager {
     }
 
     /// Stop the remote-control session, killing the child process and resetting all state.
+    ///
+    /// On Windows, `child.kill()` only terminates the direct child (cmd.exe), leaving the
+    /// actual `claude` process alive as an orphan. We use `taskkill /T /F /PID` to kill
+    /// the entire process tree instead.
     pub async fn stop(&self) -> Result<(), String> {
         let mut child = self.child.lock().await;
         if let Some(ref mut c) = *child {
-            let _ = c.kill().await;
+            #[cfg(target_os = "windows")]
+            {
+                // taskkill /T /F /PID kills the entire process tree rooted at the child PID.
+                // This ensures cmd.exe, claude.exe, and any grandchild processes are all terminated.
+                if let Some(pid) = c.id() {
+                    let _ = std::process::Command::new("taskkill")
+                        .args(["/T", "/F", "/PID", &pid.to_string()])
+                        .creation_flags(0x08000000) // CREATE_NO_WINDOW
+                        .output();
+                } else {
+                    // Fallback: process may have already exited, try normal kill.
+                    let _ = c.kill().await;
+                }
+            }
+            #[cfg(not(target_os = "windows"))]
+            {
+                let _ = c.kill().await;
+            }
             // Wait for the child process to fully exit (timeout 5s) to avoid zombies.
             let _ = tokio::time::timeout(
                 std::time::Duration::from_secs(5),

--- a/packages/gui/src-tauri/src/remote_control.rs
+++ b/packages/gui/src-tauri/src/remote_control.rs
@@ -360,19 +360,23 @@ impl RemoteControlManager {
                     kill_cmd
                         .args(["/T", "/F", "/PID", &pid.to_string()])
                         .creation_flags(0x08000000); // CREATE_NO_WINDOW
-                    match kill_cmd.output().await {
-                        Ok(output) if !output.status.success() => {
-                            #[cfg(debug_assertions)]
+                    let taskkill_ok = match kill_cmd.output().await {
+                        Ok(output) if output.status.success() => true,
+                        Ok(output) => {
                             eprintln!(
                                 "[remote-control] taskkill failed: {}",
                                 String::from_utf8_lossy(&output.stderr)
                             );
+                            false
                         }
                         Err(e) => {
-                            #[cfg(debug_assertions)]
                             eprintln!("[remote-control] taskkill spawn error: {}", e);
+                            false
                         }
-                        _ => {}
+                    };
+                    if !taskkill_ok {
+                        // Best-effort fallback: try normal kill if taskkill failed.
+                        let _ = c.kill().await;
                     }
                 } else {
                     // id() returns None when the child has already been reaped by the OS
@@ -385,11 +389,22 @@ impl RemoteControlManager {
                 let _ = c.kill().await;
             }
             // Wait for the child process to fully exit (timeout 5s) to avoid zombies.
-            let _ = tokio::time::timeout(
+            // If the child does not exit within the timeout, treat stop as failed.
+            match tokio::time::timeout(
                 std::time::Duration::from_secs(5),
                 c.wait(),
-            ).await;
-            *child = None;
+            ).await {
+                Ok(_) => {
+                    *child = None;
+                }
+                Err(_) => {
+                    // Child still alive after timeout — do NOT clear state.
+                    // Return error so the GUI knows the process may still be running.
+                    return Err(
+                        "Stop timed out: child process may still be running".to_string()
+                    );
+                }
+            }
         }
         {
             let mut status = self.status.lock().await;


### PR DESCRIPTION
## Summary

### 1. Windows process-tree kill (TASK-DEV-078)
- **Root cause**: `child.kill()` on Windows only terminates the direct child (`cmd.exe`), leaving `claude.exe` alive as an orphan. The stdout pipe stays open, causing infinite log output.
- **Fix**: Use `taskkill /T /F /PID` on Windows to kill the entire process tree. Non-Windows keeps existing `c.kill().await`.
- Added `CREATE_NO_WINDOW` flag to avoid flashing a console window.

### 2. Hook hardening (#81)
- **Root cause**: During this task, a commit was pushed directly to `develop` bypassing the PR-only rule. The pre-commit guard was bypassed by a residual `review-passed` flag, and no push guard existed.
- **Fix**:
  - New `push-guard.sh`: blocks `git push origin develop/master/main` directly
  - `pre-commit-guard.sh`: replaced `echo` with `printf '%s'` for multi-line robustness, added debug logging
  - `settings.json`: registered push-guard in PreToolUse Bash hooks
- The direct commit on develop has been reverted (`c089e1c`).

## Changed files
- `packages/gui/src-tauri/src/remote_control.rs` — `stop()` method + Windows import
- `.claude/hooks/push-guard.sh` (new)
- `.claude/hooks/pre-commit-guard.sh` (updated)
- `.claude/settings.json` (updated)

## Test plan
- [ ] Start remote-control session on Windows
- [ ] Click Stop → verify all child processes terminated
- [ ] Verify no orphan processes remain (`tasklist | findstr claude`)
- [ ] Start again after stop → verify clean restart
- [ ] `cargo check` passes
- [ ] Push guard blocks `git push origin develop` (tested locally)
- [ ] Commit guard blocks unreviewed commits (tested locally)

Closes TASK-DEV-078
Fixes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)