### PR TITLE
fix(gui): new-file diff, tasks F5 refresh, ghost session dedup (#52, #74, #79)

### DIFF
--- a/packages/gui/src-tauri/src/commands.rs
+++ b/packages/gui/src-tauri/src/commands.rs
@@ -207,9 +207,35 @@ pub async fn get_git_diff(repo_path: String, file_path: String) -> Result<String
         return Ok(staged_diff);
     }
 
-    // Both diffs empty — check if this is an untracked (new) file.
-    // Use `git diff --no-index <null> <file>` to let Git handle encoding,
-    // binary detection, and symlink semantics natively instead of manual assembly.
+    // Both diffs empty — verify the file is actually untracked before falling
+    // back to --no-index. A clean tracked file also produces empty diffs, and
+    // without this guard it would be incorrectly rendered as a "new file".
+    let repo_for_status = repo_path.clone();
+    let file_for_status = file_path.clone();
+    let status_output = run_git_command(move || {
+        Command::new("git")
+            .args(["status", "--porcelain=v1", "--", &file_for_status])
+            .current_dir(&repo_for_status)
+            .output()
+    })
+    .await
+    .map_err(|e| format!("git status failed to spawn: {}", e))?;
+
+    if !status_output.status.success() {
+        let stderr = String::from_utf8_lossy(&status_output.stderr);
+        return Err(format!("git status failed: {}", stderr.trim()));
+    }
+
+    let is_untracked = String::from_utf8_lossy(&status_output.stdout)
+        .lines()
+        .any(|line| line.starts_with("?? "));
+    if !is_untracked {
+        // File is tracked and clean — no changes to show.
+        return Ok(String::new());
+    }
+
+    // File is untracked (new) — use `git diff --no-index <null> <file>` to let
+    // Git handle encoding, binary detection, and symlink semantics natively.
     #[cfg(windows)]
     let null_path = "NUL";
     #[cfg(not(windows))]

--- a/packages/gui/src-tauri/src/commands.rs
+++ b/packages/gui/src-tauri/src/commands.rs
@@ -186,11 +186,12 @@ pub async fn get_git_diff(repo_path: String, file_path: String) -> Result<String
     }
 
     // No unstaged changes — try staged diff
-    // git diff --cached: https://git-scm.com/docs/git-diff
+    let repo_for_staged = repo_path.clone();
+    let file_for_staged = file_path.clone();
     let staged = run_git_command(move || {
         Command::new("git")
-            .args(["diff", "--cached", "--ignore-cr-at-eol", "--", &file_path])
-            .current_dir(&repo_path)
+            .args(["diff", "--cached", "--ignore-cr-at-eol", "--", &file_for_staged])
+            .current_dir(&repo_for_staged)
             .output()
     })
     .await
@@ -201,7 +202,53 @@ pub async fn get_git_diff(repo_path: String, file_path: String) -> Result<String
         return Err(format!("git diff --cached failed: {}", stderr.trim()));
     }
 
-    Ok(String::from_utf8_lossy(&staged.stdout).to_string())
+    let staged_diff = String::from_utf8_lossy(&staged.stdout).to_string();
+    if !staged_diff.is_empty() {
+        return Ok(staged_diff);
+    }
+
+    // Both diffs empty — check if this is an untracked (new) file.
+    // For untracked files, synthesise a diff showing all lines as additions.
+    let repo_for_ls = repo_path.clone();
+    let file_for_ls = file_path.clone();
+    let ls_output = run_git_command(move || {
+        Command::new("git")
+            .args(["ls-files", "--others", "--exclude-standard", "--", &file_for_ls])
+            .current_dir(&repo_for_ls)
+            .output()
+    })
+    .await
+    .map_err(|e| format!("git ls-files failed to spawn: {}", e))?;
+
+    if ls_output.status.success() {
+        let ls_stdout = String::from_utf8_lossy(&ls_output.stdout).to_string();
+        if !ls_stdout.trim().is_empty() {
+            // File is untracked — read its contents and build a synthetic unified diff
+            let full_path = std::path::Path::new(&repo_path).join(&file_path);
+            let content = tokio::task::spawn_blocking(move || {
+                std::fs::read_to_string(&full_path)
+                    .map_err(|e| format!("Failed to read new file: {}", e))
+            })
+            .await
+            .map_err(|e| format!("Task join error: {}", e))??;
+
+            let lines: Vec<&str> = content.lines().collect();
+            let line_count = lines.len();
+            let mut diff = format!(
+                "--- /dev/null\n+++ b/{}\n@@ -0,0 +1,{} @@\n",
+                file_path, line_count
+            );
+            for line in &lines {
+                diff.push('+');
+                diff.push_str(line);
+                diff.push('\n');
+            }
+            return Ok(diff);
+        }
+    }
+
+    // Truly no changes
+    Ok(String::new())
 }
 
 /// List all local and remote git branches for a given directory.

--- a/packages/gui/src-tauri/src/commands.rs
+++ b/packages/gui/src-tauri/src/commands.rs
@@ -208,43 +208,29 @@ pub async fn get_git_diff(repo_path: String, file_path: String) -> Result<String
     }
 
     // Both diffs empty — check if this is an untracked (new) file.
-    // For untracked files, synthesise a diff showing all lines as additions.
-    let repo_for_ls = repo_path.clone();
-    let file_for_ls = file_path.clone();
-    let ls_output = run_git_command(move || {
+    // Use `git diff --no-index /dev/null <file>` to let Git handle encoding,
+    // binary detection, and symlink semantics natively instead of manual assembly.
+    let repo_for_noindex = repo_path.clone();
+    let file_for_noindex = file_path.clone();
+    let noindex_output = run_git_command(move || {
         Command::new("git")
-            .args(["ls-files", "--others", "--exclude-standard", "--", &file_for_ls])
-            .current_dir(&repo_for_ls)
+            .args(["diff", "--no-index", "--ignore-cr-at-eol", "--", "/dev/null", &file_for_noindex])
+            .current_dir(&repo_for_noindex)
             .output()
     })
     .await
-    .map_err(|e| format!("git ls-files failed to spawn: {}", e))?;
+    .map_err(|e| format!("git diff --no-index failed to spawn: {}", e))?;
 
-    if ls_output.status.success() {
-        let ls_stdout = String::from_utf8_lossy(&ls_output.stdout).to_string();
-        if !ls_stdout.trim().is_empty() {
-            // File is untracked — read its contents and build a synthetic unified diff
-            let full_path = std::path::Path::new(&repo_path).join(&file_path);
-            let content = tokio::task::spawn_blocking(move || {
-                std::fs::read_to_string(&full_path)
-                    .map_err(|e| format!("Failed to read new file: {}", e))
-            })
-            .await
-            .map_err(|e| format!("Task join error: {}", e))??;
+    // git diff --no-index exits 1 when there ARE differences (which is expected
+    // for a new file vs /dev/null), so we only treat exit code >= 128 as an error.
+    if noindex_output.status.code().unwrap_or(128) >= 128 {
+        let stderr = String::from_utf8_lossy(&noindex_output.stderr);
+        return Err(format!("git diff --no-index failed: {}", stderr.trim()));
+    }
 
-            let lines: Vec<&str> = content.lines().collect();
-            let line_count = lines.len();
-            let mut diff = format!(
-                "--- /dev/null\n+++ b/{}\n@@ -0,0 +1,{} @@\n",
-                file_path, line_count
-            );
-            for line in &lines {
-                diff.push('+');
-                diff.push_str(line);
-                diff.push('\n');
-            }
-            return Ok(diff);
-        }
+    let noindex_diff = String::from_utf8_lossy(&noindex_output.stdout).to_string();
+    if !noindex_diff.is_empty() {
+        return Ok(noindex_diff);
     }
 
     // Truly no changes

--- a/packages/gui/src-tauri/src/commands.rs
+++ b/packages/gui/src-tauri/src/commands.rs
@@ -221,14 +221,20 @@ pub async fn get_git_diff(repo_path: String, file_path: String) -> Result<String
     .await
     .map_err(|e| format!("git diff --no-index failed to spawn: {}", e))?;
 
-    // git diff --no-index exits 1 when there ARE differences (which is expected
-    // for a new file vs /dev/null), so we only treat exit code >= 128 as an error.
-    if noindex_output.status.code().unwrap_or(128) >= 128 {
-        let stderr = String::from_utf8_lossy(&noindex_output.stderr);
+    // git diff --no-index exit codes:
+    //   0 = no differences (shouldn't happen for new file vs /dev/null)
+    //   1 = differences found (expected for a new file)
+    //  ≥128 = fatal error (bad args, etc.)
+    // Exit code 1 with empty stdout but non-empty stderr indicates a file access
+    // error (e.g. permission denied, symlink loop) rather than a real diff.
+    let exit_code = noindex_output.status.code().unwrap_or(128);
+    let stderr = String::from_utf8_lossy(&noindex_output.stderr);
+    let noindex_diff = String::from_utf8_lossy(&noindex_output.stdout).to_string();
+
+    if exit_code >= 128 || (exit_code != 0 && noindex_diff.is_empty() && !stderr.is_empty()) {
         return Err(format!("git diff --no-index failed: {}", stderr.trim()));
     }
 
-    let noindex_diff = String::from_utf8_lossy(&noindex_output.stdout).to_string();
     if !noindex_diff.is_empty() {
         return Ok(noindex_diff);
     }

--- a/packages/gui/src-tauri/src/commands.rs
+++ b/packages/gui/src-tauri/src/commands.rs
@@ -208,13 +208,18 @@ pub async fn get_git_diff(repo_path: String, file_path: String) -> Result<String
     }
 
     // Both diffs empty — check if this is an untracked (new) file.
-    // Use `git diff --no-index /dev/null <file>` to let Git handle encoding,
+    // Use `git diff --no-index <null> <file>` to let Git handle encoding,
     // binary detection, and symlink semantics natively instead of manual assembly.
+    #[cfg(windows)]
+    let null_path = "NUL";
+    #[cfg(not(windows))]
+    let null_path = "/dev/null";
+
     let repo_for_noindex = repo_path.clone();
     let file_for_noindex = file_path.clone();
     let noindex_output = run_git_command(move || {
         Command::new("git")
-            .args(["diff", "--no-index", "--ignore-cr-at-eol", "--", "/dev/null", &file_for_noindex])
+            .args(["diff", "--no-index", "--ignore-cr-at-eol", "--", null_path, &file_for_noindex])
             .current_dir(&repo_for_noindex)
             .output()
     })

--- a/packages/gui/src/App.vue
+++ b/packages/gui/src/App.vue
@@ -127,14 +127,23 @@ function handleCreateSession() {
   showAgentRoleSelector.value = true;
 }
 
+const INIT_MODULES = ["initAgents", "initMessageListeners", "initApprovalStore", "initEventListeners", "initTaskListeners"] as const;
+
 onMounted(async () => {
-  await Promise.allSettled([
+  const results = await Promise.allSettled([
     initAgents(),
     initMessageListeners(),
     initApprovalStore(),
     initEventListeners(),
     initTaskListeners(),
   ]);
+  if (import.meta.env.DEV) {
+    results.forEach((r, i) => {
+      if (r.status === "rejected") {
+        console.warn(`[Mercury] ${INIT_MODULES[i]} failed:`, r.reason);
+      }
+    });
+  }
 });
 
 onBeforeUnmount(() => {

--- a/packages/gui/src/App.vue
+++ b/packages/gui/src/App.vue
@@ -31,7 +31,7 @@ const {
 const { initMessageListeners } = useMessageStore();
 const { initApprovalStore } = useApprovalStore();
 const { initEventListeners } = useEventStore();
-const { loadTasks, initTaskListeners } = useTaskStore();
+const { initTaskListeners, disposeTaskListeners } = useTaskStore();
 
 const showSettings = ref(false);
 const showRemoteControl = ref(false);
@@ -135,12 +135,11 @@ onMounted(async () => {
     initEventListeners(),
     initTaskListeners(),
   ]);
-  // loadTasks depends on agents being loaded first
-  await loadTasks();
 });
 
 onBeforeUnmount(() => {
   stopExplorerResize();
+  disposeTaskListeners();
 });
 </script>
 

--- a/packages/gui/src/App.vue
+++ b/packages/gui/src/App.vue
@@ -137,13 +137,15 @@ onMounted(async () => {
     initEventListeners(),
     initTaskListeners(),
   ]);
-  if (import.meta.env.DEV) {
-    results.forEach((r, i) => {
-      if (r.status === "rejected") {
-        console.warn(`[Mercury] ${INIT_MODULES[i]} failed:`, r.reason);
+  results.forEach((r, i) => {
+    if (r.status === "rejected") {
+      // Always log module name at error level for production observability
+      console.error(`[Mercury] ${INIT_MODULES[i]} failed`);
+      if (import.meta.env.DEV) {
+        console.error(`  Detail:`, r.reason);
       }
-    });
-  }
+    }
+  });
 });
 
 onBeforeUnmount(() => {

--- a/packages/gui/src/components/TaskDashboard.vue
+++ b/packages/gui/src/components/TaskDashboard.vue
@@ -13,7 +13,21 @@ const {
   selectTask,
   setFilter,
   refreshTask,
+  loadTasks,
 } = useTaskStore();
+
+import { ref } from "vue";
+const isRefreshing = ref(false);
+
+async function handleRefresh() {
+  if (isRefreshing.value) return;
+  isRefreshing.value = true;
+  try {
+    await loadTasks();
+  } finally {
+    isRefreshing.value = false;
+  }
+}
 
 const { agents } = useAgentStore();
 
@@ -121,6 +135,16 @@ async function handleCreateAcceptance(taskId: string) {
         <span class="badge-count">{{
           s.status === null ? totalCount : (statusCounts[s.status] ?? 0)
         }}</span>
+      </button>
+
+      <button
+        class="refresh-btn"
+        :class="{ spinning: isRefreshing }"
+        :disabled="isRefreshing"
+        title="Reload tasks"
+        @click="handleRefresh"
+      >
+        ↻
       </button>
     </div>
 
@@ -248,7 +272,7 @@ async function handleCreateAcceptance(taskId: string) {
 .task-dashboard {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 0;
   min-height: 0;
   height: 100%;
 }
@@ -259,8 +283,45 @@ async function handleCreateAcceptance(taskId: string) {
   padding: 6px 8px;
   background: var(--bg-secondary);
   border: 1px solid var(--border);
-  border-radius: var(--radius);
+  border-radius: var(--radius) var(--radius) 0 0;
   flex-wrap: wrap;
+  align-items: center;
+}
+
+.refresh-btn {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 16px;
+  cursor: pointer;
+  transition: transform 0.2s, color 0.2s;
+  flex-shrink: 0;
+}
+
+.refresh-btn:hover {
+  color: var(--text-primary);
+  background: var(--bg-panel);
+}
+
+.refresh-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.refresh-btn.spinning {
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
 }
 
 .status-badge {
@@ -300,7 +361,7 @@ async function handleCreateAcceptance(taskId: string) {
 .dashboard-body {
   display: grid;
   grid-template-columns: 3fr 2fr;
-  gap: 8px;
+  gap: 0;
   min-height: 0;
   flex: 1;
 }
@@ -308,7 +369,8 @@ async function handleCreateAcceptance(taskId: string) {
 .task-list {
   background: var(--bg-secondary);
   border: 1px solid var(--border);
-  border-radius: var(--radius);
+  border-top: none;
+  border-radius: 0 0 0 var(--radius);
   overflow-y: auto;
   padding: 4px;
 }
@@ -382,7 +444,9 @@ async function handleCreateAcceptance(taskId: string) {
 .task-detail {
   background: var(--bg-secondary);
   border: 1px solid var(--border);
-  border-radius: var(--radius);
+  border-top: none;
+  border-left: none;
+  border-radius: 0 0 var(--radius) 0;
   overflow-y: auto;
   padding: 12px;
 }

--- a/packages/gui/src/components/TaskDashboard.vue
+++ b/packages/gui/src/components/TaskDashboard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, ref } from "vue";
 import { useTaskStore } from "../stores/tasks";
 import type { TaskStatus } from "../lib/tauri-bridge";
 import { dispatchBundleTask, createAcceptance } from "../lib/tauri-bridge";
@@ -16,14 +16,19 @@ const {
   loadTasks,
 } = useTaskStore();
 
-import { ref } from "vue";
 const isRefreshing = ref(false);
+const refreshError = ref(false);
 
 async function handleRefresh() {
   if (isRefreshing.value) return;
   isRefreshing.value = true;
+  refreshError.value = false;
   try {
     await loadTasks();
+  } catch (e) {
+    console.error("Task refresh failed:", e);
+    refreshError.value = true;
+    setTimeout(() => (refreshError.value = false), 3000);
   } finally {
     isRefreshing.value = false;
   }
@@ -139,12 +144,12 @@ async function handleCreateAcceptance(taskId: string) {
 
       <button
         class="refresh-btn"
-        :class="{ spinning: isRefreshing }"
+        :class="{ spinning: isRefreshing, 'refresh-error': refreshError }"
         :disabled="isRefreshing"
-        title="Reload tasks"
+        :title="refreshError ? 'Refresh failed — click to retry' : 'Reload tasks'"
         @click="handleRefresh"
       >
-        ↻
+        {{ refreshError ? '✕' : '↻' }}
       </button>
     </div>
 
@@ -317,6 +322,11 @@ async function handleCreateAcceptance(taskId: string) {
 
 .refresh-btn.spinning {
   animation: spin 0.8s linear infinite;
+}
+
+.refresh-btn.refresh-error {
+  color: #ef4444;
+  border-color: #ef4444;
 }
 
 @keyframes spin {

--- a/packages/gui/src/lib/tauri-bridge.ts
+++ b/packages/gui/src/lib/tauri-bridge.ts
@@ -504,6 +504,8 @@ export interface SessionListItem {
   active: boolean;
   parentSessionId?: string;
   promptHash?: string;
+  currentPromptHash?: string;
+  legacyRoleConfig?: boolean;
 }
 
 /** List sessions, optionally filtered by agent, role, or terminal status. */

--- a/packages/gui/src/stores/agents.ts
+++ b/packages/gui/src/stores/agents.ts
@@ -342,12 +342,15 @@ async function hydrateSessionMeta(): Promise<void> {
       }
 
       let pruned = false;
+      // Track which sessionIds have been assigned a canonical panelKey.
+      // Prefer session-unique keys (3 segments) over legacy keys (2 segments).
+      const seenSessionIds = new Map<string, string>();
+
       for (const [panelKey, sessionId] of groupEntries) {
         const match = knownSessions.find((s) => s.sessionId === sessionId);
         if (!match) {
           // Stale session in localStorage that backend no longer knows — prune it.
           // Skip per-item persist; we batch-save after the loop.
-          // Mirror the full cleanup from agent.session.end/delete.
           cleanupPanelState(panelKey, sessionId, true);
           statuses.value.delete(panelKey);
           workDirs.value.delete(panelKey);
@@ -356,6 +359,27 @@ async function hydrateSessionMeta(): Promise<void> {
           pruned = true;
           continue;
         }
+
+        // Deduplicate: if another panelKey already claimed this sessionId,
+        // keep the one with more segments (new format {role}:{agentId}:{sid}).
+        const existingKey = seenSessionIds.get(sessionId);
+        if (existingKey) {
+          const existingSegments = existingKey.split(":").length;
+          const currentSegments = panelKey.split(":").length;
+          const keyToRemove = currentSegments > existingSegments ? existingKey : panelKey;
+          const keyToKeep = currentSegments > existingSegments ? panelKey : existingKey;
+          clearSession(keyToRemove, true);
+          statuses.value.delete(keyToRemove);
+          workDirs.value.delete(keyToRemove);
+          gitBranches.value.delete(keyToRemove);
+          removeBookmark(keyToRemove);
+          seenSessionIds.set(sessionId, keyToKeep);
+          pruned = true;
+          if (keyToRemove === panelKey) continue;
+        } else {
+          seenSessionIds.set(sessionId, panelKey);
+        }
+
         setSessionInfo(panelKey, {
           sessionId: match.sessionId,
           sessionName: match.sessionName,

--- a/packages/gui/src/stores/agents.ts
+++ b/packages/gui/src/stores/agents.ts
@@ -346,6 +346,10 @@ async function hydrateSessionMeta(): Promise<void> {
       const seenSessionIds = new Map<string, string>();
 
       for (const [panelKey, sessionId] of groupEntries) {
+        // Guard: verify snapshot is still current — a concurrent session.start
+        // during the await may have re-bound this panelKey to a different session.
+        if (sessions.value.get(panelKey) !== sessionId) continue;
+
         const match = knownById.get(sessionId);
         if (!match) {
           // Stale session in localStorage that backend no longer knows — prune it.
@@ -367,11 +371,14 @@ async function hydrateSessionMeta(): Promise<void> {
           const currentSegments = panelKey.split(":").length;
           const keyToRemove = currentSegments > existingSegments ? existingKey : panelKey;
           const keyToKeep = currentSegments > existingSegments ? panelKey : existingKey;
-          clearSession(keyToRemove, true);
-          statuses.value.delete(keyToRemove);
-          workDirs.value.delete(keyToRemove);
-          gitBranches.value.delete(keyToRemove);
-          removeBookmark(keyToRemove);
+          // Re-check that the key-to-remove hasn't been re-bound during await
+          if (sessions.value.get(keyToRemove) === sessionId) {
+            clearSession(keyToRemove, true);
+            statuses.value.delete(keyToRemove);
+            workDirs.value.delete(keyToRemove);
+            gitBranches.value.delete(keyToRemove);
+            removeBookmark(keyToRemove);
+          }
           seenSessionIds.set(sessionId, keyToKeep);
           pruned = true;
           if (keyToRemove === panelKey) continue;
@@ -472,23 +479,27 @@ async function initAgents() {
         ? `${payload.role}:${event.agentId}`
         : `${payload.role}:${event.agentId}:${event.sessionId}`;
 
-      // Deduplicate: if any existing panelKey already maps to this sessionId
-      // (e.g. a legacy key restored from localStorage), unbind the old panel
-      // without clearing sessionPromptState — the same sessionId will be
-      // re-registered under the new panelKey by setSessionInfo below.
+      // Deduplicate: collect ALL existing panelKeys that map to this sessionId
+      // (e.g. legacy keys restored from localStorage). Snapshot first to avoid
+      // mutating sessions.value while iterating.
       if (payload.role !== "main") {
+        const duplicateKeys: string[] = [];
         for (const [existingKey, existingSid] of sessions.value) {
           if (existingSid === event.sessionId && existingKey !== panelKey) {
-            clearSession(existingKey);
-            statuses.value.delete(existingKey);
-            triggerRef(statuses);
-            workDirs.value.delete(existingKey);
-            triggerRef(workDirs);
-            gitBranches.value.delete(existingKey);
-            triggerRef(gitBranches);
-            removeBookmark(existingKey);
-            break;
+            duplicateKeys.push(existingKey);
           }
+        }
+        for (const dupKey of duplicateKeys) {
+          clearSession(dupKey);
+          statuses.value.delete(dupKey);
+          workDirs.value.delete(dupKey);
+          gitBranches.value.delete(dupKey);
+          removeBookmark(dupKey);
+        }
+        if (duplicateKeys.length) {
+          triggerRef(statuses);
+          triggerRef(workDirs);
+          triggerRef(gitBranches);
         }
       }
 

--- a/packages/gui/src/stores/agents.ts
+++ b/packages/gui/src/stores/agents.ts
@@ -193,12 +193,12 @@ function getSessionInfo(panelKey: string): SessionMeta | undefined {
   return sessionMeta.value.get(panelKey);
 }
 
-function clearSession(panelKey: string) {
+function clearSession(panelKey: string, skipPersist = false) {
   sessions.value.delete(panelKey);
   triggerRef(sessions);
   sessionMeta.value.delete(panelKey);
   triggerRef(sessionMeta);
-  saveSessions();
+  if (!skipPersist) saveSessions();
 }
 
 function setWorkDir(panelKey: string, cwd: string) {
@@ -341,13 +341,16 @@ async function hydrateSessionMeta(): Promise<void> {
         groupEntries.push([panelKey, sessionId]);
       }
 
+      let pruned = false;
       for (const [panelKey, sessionId] of groupEntries) {
         const match = knownSessions.find((s) => s.sessionId === sessionId);
         if (!match) {
-          // Stale session in localStorage that backend no longer knows — prune it
-          cleanupPanelState(panelKey, sessionId);
+          // Stale session in localStorage that backend no longer knows — prune it.
+          // Skip per-item persist; we batch-save after the loop.
+          cleanupPanelState(panelKey, sessionId, true);
           statuses.value.delete(panelKey);
           removeBookmark(panelKey);
+          pruned = true;
           continue;
         }
         setSessionInfo(panelKey, {
@@ -360,6 +363,7 @@ async function hydrateSessionMeta(): Promise<void> {
           legacyRoleConfig: (match as typeof match & { legacyRoleConfig?: boolean }).legacyRoleConfig,
         });
       }
+      if (pruned) saveSessions();
     } catch {
       // Best-effort hydration only
     }
@@ -390,10 +394,10 @@ async function loadAgents() {
 }
 
 /** Shared cleanup for session end/delete: removes prompt state and session mapping. */
-function cleanupPanelState(panelKey: string, sessionId: string): void {
+function cleanupPanelState(panelKey: string, sessionId: string, skipPersist = false): void {
   sessionPromptState.value.delete(sessionId);
   triggerRef(sessionPromptState);
-  clearSession(panelKey);
+  clearSession(panelKey, skipPersist);
 }
 
 let agentListenersInitialized = false;

--- a/packages/gui/src/stores/agents.ts
+++ b/packages/gui/src/stores/agents.ts
@@ -333,11 +333,23 @@ async function hydrateSessionMeta(): Promise<void> {
     const { role, agentId } = parsePanelKey(groupKey);
     try {
       const knownSessions = await fetchSessions(agentId, role, false);
+      // Collect panelKeys for this group to iterate safely while mutating
+      const groupEntries: [string, string][] = [];
       for (const [panelKey, sessionId] of sessions.value) {
         const pk = parsePanelKey(panelKey);
         if (pk.role !== role || pk.agentId !== agentId) continue;
+        groupEntries.push([panelKey, sessionId]);
+      }
+
+      for (const [panelKey, sessionId] of groupEntries) {
         const match = knownSessions.find((s) => s.sessionId === sessionId);
-        if (!match) continue;
+        if (!match) {
+          // Stale session in localStorage that backend no longer knows — prune it
+          cleanupPanelState(panelKey, sessionId);
+          statuses.value.delete(panelKey);
+          removeBookmark(panelKey);
+          continue;
+        }
         setSessionInfo(panelKey, {
           sessionId: match.sessionId,
           sessionName: match.sessionName,
@@ -424,6 +436,20 @@ async function initAgents() {
       const panelKey = payload.role === "main"
         ? `${payload.role}:${event.agentId}`
         : `${payload.role}:${event.agentId}:${event.sessionId}`;
+
+      // Deduplicate: if any existing panelKey already maps to this sessionId
+      // (e.g. a legacy key restored from localStorage), clean it up first to
+      // prevent ghost duplicates in the bookmark rail.
+      if (payload.role !== "main") {
+        for (const [existingKey, existingSid] of sessions.value) {
+          if (existingSid === event.sessionId && existingKey !== panelKey) {
+            cleanupPanelState(existingKey, existingSid);
+            statuses.value.delete(existingKey);
+            removeBookmark(existingKey);
+            break;
+          }
+        }
+      }
 
       // setSessionInfo internally calls setSession, which registers the
       // panelKey→sessionId mapping needed by resolvePanelKey in messages.ts.

--- a/packages/gui/src/stores/agents.ts
+++ b/packages/gui/src/stores/agents.ts
@@ -165,9 +165,13 @@ function updateSessionPromptState(sessionId: string, info: Partial<SessionMeta>)
     return;
   }
   const existing = sessionPromptState.value.get(sessionId);
+  // Only patch explicitly-returned fields — omit undefined to preserve cache
+  const defined = Object.fromEntries(
+    Object.entries(nextState).filter(([, v]) => v !== undefined),
+  );
   sessionPromptState.value.set(sessionId, {
     ...existing,
-    ...nextState,
+    ...defined,
   });
   triggerRef(sessionPromptState);
 }
@@ -482,6 +486,9 @@ async function initAgents() {
       // Deduplicate: collect ALL existing panelKeys that map to this sessionId
       // (e.g. legacy keys restored from localStorage). Snapshot first to avoid
       // mutating sessions.value while iterating.
+      // Preserve sessionName from old panel before clearing, in case the event
+      // doesn't carry one — prevents sessions losing their human-readable name.
+      let preservedSessionName: string | undefined;
       if (payload.role !== "main") {
         const duplicateKeys: string[] = [];
         for (const [existingKey, existingSid] of sessions.value) {
@@ -489,7 +496,11 @@ async function initAgents() {
             duplicateKeys.push(existingKey);
           }
         }
+        // Read sessionName BEFORE clearing metadata
         for (const dupKey of duplicateKeys) {
+          if (!preservedSessionName) {
+            preservedSessionName = sessionMeta.value.get(dupKey)?.sessionName;
+          }
           clearSession(dupKey);
           statuses.value.delete(dupKey);
           workDirs.value.delete(dupKey);
@@ -507,7 +518,7 @@ async function initAgents() {
       // panelKey→sessionId mapping needed by resolvePanelKey in messages.ts.
       setSessionInfo(panelKey, {
         sessionId: event.sessionId,
-        sessionName: payload.sessionName,
+        sessionName: payload.sessionName ?? preservedSessionName,
         status: "active",
         lastActiveAt: event.timestamp,
         promptHash: payload.promptHash,

--- a/packages/gui/src/stores/agents.ts
+++ b/packages/gui/src/stores/agents.ts
@@ -363,7 +363,10 @@ async function hydrateSessionMeta(): Promise<void> {
           legacyRoleConfig: match.legacyRoleConfig,
         });
       }
-      if (pruned) saveSessions();
+      if (pruned) {
+        triggerRef(statuses);
+        saveSessions();
+      }
     } catch {
       // Best-effort hydration only
     }
@@ -449,6 +452,7 @@ async function initAgents() {
           if (existingSid === event.sessionId && existingKey !== panelKey) {
             cleanupPanelState(existingKey, existingSid);
             statuses.value.delete(existingKey);
+            triggerRef(statuses);
             removeBookmark(existingKey);
             break;
           }

--- a/packages/gui/src/stores/agents.ts
+++ b/packages/gui/src/stores/agents.ts
@@ -319,27 +319,26 @@ function setModelCache(agentId: string, models: { id: string; name: string }[]) 
 }
 
 async function hydrateSessionMeta(): Promise<void> {
-  // Group by {role}:{agentId} (ignoring optional session suffix)
-  const byAgent = new Map<string, string[]>();
+  // Group by {role}:{agentId} — snapshot panelKey→sessionId BEFORE any await
+  // to prevent TOCTOU: sessions arriving during fetchSessions won't be
+  // mistakenly pruned as stale.
+  const byAgent = new Map<string, [string, string][]>();
   for (const [panelKey, sessionId] of sessions.value) {
     const { role, agentId } = parsePanelKey(panelKey);
     const groupKey = `${role}:${agentId}`;
     const list = byAgent.get(groupKey) ?? [];
-    list.push(sessionId);
+    list.push([panelKey, sessionId]);
     byAgent.set(groupKey, list);
   }
 
-  for (const groupKey of byAgent.keys()) {
+  for (const [groupKey, groupEntries] of byAgent) {
     const { role, agentId } = parsePanelKey(groupKey);
     try {
       const knownSessions = await fetchSessions(agentId, role, false);
-      // Collect panelKeys for this group to iterate safely while mutating
-      const groupEntries: [string, string][] = [];
-      for (const [panelKey, sessionId] of sessions.value) {
-        const pk = parsePanelKey(panelKey);
-        if (pk.role !== role || pk.agentId !== agentId) continue;
-        groupEntries.push([panelKey, sessionId]);
-      }
+      // O(1) lookup instead of O(n) find per entry
+      const knownById = new Map(
+        knownSessions.map((s) => [s.sessionId, s] as const),
+      );
 
       let pruned = false;
       // Track which sessionIds have been assigned a canonical panelKey.
@@ -347,7 +346,7 @@ async function hydrateSessionMeta(): Promise<void> {
       const seenSessionIds = new Map<string, string>();
 
       for (const [panelKey, sessionId] of groupEntries) {
-        const match = knownSessions.find((s) => s.sessionId === sessionId);
+        const match = knownById.get(sessionId);
         if (!match) {
           // Stale session in localStorage that backend no longer knows — prune it.
           // Skip per-item persist; we batch-save after the loop.

--- a/packages/gui/src/stores/agents.ts
+++ b/packages/gui/src/stores/agents.ts
@@ -359,8 +359,8 @@ async function hydrateSessionMeta(): Promise<void> {
           status: match.status,
           lastActiveAt: match.lastActiveAt,
           promptHash: match.promptHash,
-          currentPromptHash: (match as typeof match & { currentPromptHash?: string }).currentPromptHash,
-          legacyRoleConfig: (match as typeof match & { legacyRoleConfig?: boolean }).legacyRoleConfig,
+          currentPromptHash: match.currentPromptHash,
+          legacyRoleConfig: match.legacyRoleConfig,
         });
       }
       if (pruned) saveSessions();

--- a/packages/gui/src/stores/agents.ts
+++ b/packages/gui/src/stores/agents.ts
@@ -347,8 +347,11 @@ async function hydrateSessionMeta(): Promise<void> {
         if (!match) {
           // Stale session in localStorage that backend no longer knows — prune it.
           // Skip per-item persist; we batch-save after the loop.
+          // Mirror the full cleanup from agent.session.end/delete.
           cleanupPanelState(panelKey, sessionId, true);
           statuses.value.delete(panelKey);
+          workDirs.value.delete(panelKey);
+          gitBranches.value.delete(panelKey);
           removeBookmark(panelKey);
           pruned = true;
           continue;
@@ -365,6 +368,8 @@ async function hydrateSessionMeta(): Promise<void> {
       }
       if (pruned) {
         triggerRef(statuses);
+        triggerRef(workDirs);
+        triggerRef(gitBranches);
         saveSessions();
       }
     } catch {
@@ -445,14 +450,19 @@ async function initAgents() {
         : `${payload.role}:${event.agentId}:${event.sessionId}`;
 
       // Deduplicate: if any existing panelKey already maps to this sessionId
-      // (e.g. a legacy key restored from localStorage), clean it up first to
-      // prevent ghost duplicates in the bookmark rail.
+      // (e.g. a legacy key restored from localStorage), unbind the old panel
+      // without clearing sessionPromptState — the same sessionId will be
+      // re-registered under the new panelKey by setSessionInfo below.
       if (payload.role !== "main") {
         for (const [existingKey, existingSid] of sessions.value) {
           if (existingSid === event.sessionId && existingKey !== panelKey) {
-            cleanupPanelState(existingKey, existingSid);
+            clearSession(existingKey);
             statuses.value.delete(existingKey);
             triggerRef(statuses);
+            workDirs.value.delete(existingKey);
+            triggerRef(workDirs);
+            gitBranches.value.delete(existingKey);
+            triggerRef(gitBranches);
             removeBookmark(existingKey);
             break;
           }

--- a/packages/gui/src/stores/tasks.ts
+++ b/packages/gui/src/stores/tasks.ts
@@ -80,6 +80,10 @@ async function initTaskListeners() {
     // sidecar may not be available yet when onMounted fires).
     pending.push(await onSidecarReady(() => loadTasks()));
 
+    // Attempt immediate load in case sidecar is already ready — the ready
+    // event may have been emitted before we registered the listener above.
+    void loadTasks();
+
     pending.push(await onMercuryEvent((event: MercuryEvent) => {
       if (event.type.startsWith("orchestrator.task.") || event.type.startsWith("orchestrator.acceptance.")) {
         const taskId =
@@ -106,6 +110,14 @@ async function initTaskListeners() {
   return taskListenersInitPromise;
 }
 
+/** Teardown all task event listeners — useful for tests and HMR cleanup. */
+function disposeTaskListeners() {
+  for (const unlisten of taskUnlisteners) unlisten();
+  taskUnlisteners.length = 0;
+  taskListenersInitialized = false;
+  taskListenersInitPromise = null;
+}
+
 export function useTaskStore() {
   return {
     tasks,
@@ -119,5 +131,6 @@ export function useTaskStore() {
     loadTasks,
     refreshTask,
     initTaskListeners,
+    disposeTaskListeners,
   };
 }

--- a/packages/gui/src/stores/tasks.ts
+++ b/packages/gui/src/stores/tasks.ts
@@ -8,6 +8,7 @@ import type {
   TaskStatus,
   MercuryEvent,
 } from "../lib/tauri-bridge";
+import type { UnlistenFn } from "@tauri-apps/api/event";
 import { listTasks, getTask, onMercuryEvent, onSidecarReady } from "../lib/tauri-bridge";
 
 const tasks = ref<TaskBundle[]>([]);
@@ -65,26 +66,37 @@ async function refreshTask(taskId: string) {
 }
 
 let taskListenersInitialized = false;
+const taskUnlisteners: UnlistenFn[] = [];
 
 async function initTaskListeners() {
   if (taskListenersInitialized) return;
-  taskListenersInitialized = true;
 
-  // Reload tasks whenever sidecar becomes ready (handles F5 page refresh where
-  // sidecar may not be available yet when onMounted fires).
-  await onSidecarReady(() => loadTasks());
+  const pending: UnlistenFn[] = [];
+  try {
+    // Reload tasks whenever sidecar becomes ready (handles F5 page refresh where
+    // sidecar may not be available yet when onMounted fires).
+    pending.push(await onSidecarReady(() => loadTasks()));
 
-  await onMercuryEvent((event: MercuryEvent) => {
-    if (event.type.startsWith("orchestrator.task.") || event.type.startsWith("orchestrator.acceptance.")) {
-      const taskId =
-        (event.payload as Record<string, unknown>).taskId as string | undefined;
-      if (taskId) {
-        refreshTask(taskId);
-      } else {
-        loadTasks();
+    pending.push(await onMercuryEvent((event: MercuryEvent) => {
+      if (event.type.startsWith("orchestrator.task.") || event.type.startsWith("orchestrator.acceptance.")) {
+        const taskId =
+          (event.payload as Record<string, unknown>).taskId as string | undefined;
+        if (taskId) {
+          refreshTask(taskId);
+        } else {
+          loadTasks();
+        }
       }
-    }
-  });
+    }));
+
+    // All listeners registered — commit
+    taskListenersInitialized = true;
+    taskUnlisteners.push(...pending);
+  } catch (e) {
+    // Rollback: unregister any listeners that were successfully created
+    for (const unlisten of pending) unlisten();
+    console.error("Failed to init task listeners:", e);
+  }
 }
 
 export function useTaskStore() {

--- a/packages/gui/src/stores/tasks.ts
+++ b/packages/gui/src/stores/tasks.ts
@@ -40,12 +40,21 @@ function setFilter(status: TaskStatus | null) {
   statusFilter.value = status;
 }
 
+let loadTasksInflight: Promise<void> | null = null;
+
 async function loadTasks() {
-  try {
-    tasks.value = await listTasks();
-  } catch (e) {
-    console.error("Failed to load tasks:", e);
-  }
+  if (loadTasksInflight) return loadTasksInflight;
+  loadTasksInflight = (async () => {
+    try {
+      tasks.value = await listTasks();
+    } catch (e) {
+      console.error("Failed to load tasks:", e);
+      throw e; // re-throw so callers (e.g. handleRefresh) can catch
+    } finally {
+      loadTasksInflight = null;
+    }
+  })();
+  return loadTasksInflight;
 }
 
 /** Refresh a single task by ID (e.g. after event notification). */

--- a/packages/gui/src/stores/tasks.ts
+++ b/packages/gui/src/stores/tasks.ts
@@ -8,7 +8,7 @@ import type {
   TaskStatus,
   MercuryEvent,
 } from "../lib/tauri-bridge";
-import { listTasks, getTask, onMercuryEvent } from "../lib/tauri-bridge";
+import { listTasks, getTask, onMercuryEvent, onSidecarReady } from "../lib/tauri-bridge";
 
 const tasks = ref<TaskBundle[]>([]);
 const selectedTaskId = ref<string | null>(null);
@@ -69,6 +69,10 @@ let taskListenersInitialized = false;
 async function initTaskListeners() {
   if (taskListenersInitialized) return;
   taskListenersInitialized = true;
+
+  // Reload tasks whenever sidecar becomes ready (handles F5 page refresh where
+  // sidecar may not be available yet when onMounted fires).
+  await onSidecarReady(() => loadTasks());
 
   await onMercuryEvent((event: MercuryEvent) => {
     if (event.type.startsWith("orchestrator.task.") || event.type.startsWith("orchestrator.acceptance.")) {

--- a/packages/gui/src/stores/tasks.ts
+++ b/packages/gui/src/stores/tasks.ts
@@ -67,10 +67,13 @@ async function refreshTask(taskId: string) {
 
 let taskListenersInitialized = false;
 const taskUnlisteners: UnlistenFn[] = [];
+let taskListenersInitPromise: Promise<void> | null = null;
 
 async function initTaskListeners() {
   if (taskListenersInitialized) return;
+  if (taskListenersInitPromise) return taskListenersInitPromise;
 
+  taskListenersInitPromise = (async () => {
   const pending: UnlistenFn[] = [];
   try {
     // Reload tasks whenever sidecar becomes ready (handles F5 page refresh where
@@ -95,8 +98,12 @@ async function initTaskListeners() {
   } catch (e) {
     // Rollback: unregister any listeners that were successfully created
     for (const unlisten of pending) unlisten();
+    taskListenersInitPromise = null;
     console.error("Failed to init task listeners:", e);
   }
+  })();
+
+  return taskListenersInitPromise;
 }
 
 export function useTaskStore() {


### PR DESCRIPTION
## Summary

- **B1 (#79)**: Untracked files now show full content as green additions in diff view instead of "no changes". When both `git diff` and `git diff --cached` return empty, `get_git_diff` falls back to `git ls-files --others --exclude-standard` to detect untracked files and synthesises a proper unified diff.
- **B2 (#74)**: Sub-agent sessions no longer produce ghost duplicates in the bookmark rail. Deduplication on `session.start` cleans up legacy panelKeys mapping to the same sessionId, and `hydrateSessionMeta` prunes stale sessions that the backend no longer recognizes.
- **B3 (#52)**: Tasks page now correctly loads after F5 refresh by registering an `onSidecarReady` callback that re-fetches tasks once the sidecar becomes available.

## Test plan

- [ ] Create an untracked file, open diff view → should show all lines as green additions
- [ ] Open sub-agent session, verify no duplicate entries in SessionsPanel
- [ ] F5 refresh on Tasks page → tasks should reload after sidecar reconnects
- [ ] `cargo check` + `cargo clippy` pass
- [ ] `pnpm --filter @mercury/gui build` passes

Closes #52, closes #74, closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)