### PR TITLE
fix(sdk-adapters): prevent ProcessTransport crash on concurrent approval writes (#87)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,5 @@
 export { EventBus } from "./event-bus.js";
-export { ROLE_CARDS, makeRoleSlotKey, parseRoleSlotKey, isStreamingEvent, normalizePriority } from "./types.js";
+export { ROLE_CARDS, makeRoleSlotKey, parseRoleSlotKey, isStreamingEvent, isTransportCrashError, normalizePriority } from "./types.js";
 export type {
   AcceptanceBundle,
   AcceptanceVerdict,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -579,6 +579,14 @@ export function isStreamingEvent(value: AdapterYield): value is AgentStreamingEv
   return "type" in value && (value as AgentStreamingEvent).type === "streaming";
 }
 
+/** Check if an error indicates a ProcessTransport "not ready for writing" crash. */
+export function isTransportCrashError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return msg.includes("[transport:crash]")
+    || msg.includes("not ready for writing")
+    || msg.includes("ProcessTransport");
+}
+
 export interface AgentOneShotOptions {
   model?: string;
   sandbox?: string;

--- a/packages/gui/src/lib/tauri-bridge.ts
+++ b/packages/gui/src/lib/tauri-bridge.ts
@@ -814,6 +814,8 @@ export interface AgentErrorEvent {
   agentId: string;
   sessionId: string;
   error: string;
+  /** True when the error was caused by SDK ProcessTransport disconnecting. */
+  isTransportCrash?: boolean;
 }
 
 export interface SidecarReadyEvent {

--- a/packages/gui/src/stores/approvals.ts
+++ b/packages/gui/src/stores/approvals.ts
@@ -87,11 +87,12 @@ async function deny(requestId: string, reason?: string): Promise<void> {
 function cancelPendingApprovalsForSession(sessionId: string, reason: string): void {
   const now = Date.now();
   let changed = false;
+  const next = new Map(approvalRequests.value);
   for (const [, request] of approvalRequests.value) {
     if (request.sessionId === sessionId && request.status === "pending") {
-      upsertRequest({
+      next.set(request.id, {
         ...request,
-        status: "cancelled" as ApprovalRequest["status"],
+        status: "cancelled",
         resolvedAt: now,
         decisionBy: "system",
         decisionReason: reason,
@@ -100,6 +101,7 @@ function cancelPendingApprovalsForSession(sessionId: string, reason: string): vo
     }
   }
   if (changed) {
+    approvalRequests.value = next;
     // Refresh from backend to ensure consistency
     void refreshApprovals();
   }

--- a/packages/gui/src/stores/approvals.ts
+++ b/packages/gui/src/stores/approvals.ts
@@ -6,6 +6,7 @@ import {
   getApprovalMode as bridgeGetApprovalMode,
   listApprovalRequests as bridgeListApprovalRequests,
   onMercuryEvent,
+  onAgentError,
   setApprovalMode as bridgeSetApprovalMode,
 } from "../lib/tauri-bridge";
 
@@ -79,6 +80,31 @@ async function deny(requestId: string, reason?: string): Promise<void> {
   }
 }
 
+/**
+ * Immediately cancel all pending approvals for a given session.
+ * Called when a transport crash makes approval buttons unresponsive.
+ */
+function cancelPendingApprovalsForSession(sessionId: string, reason: string): void {
+  const now = Date.now();
+  let changed = false;
+  for (const [, request] of approvalRequests.value) {
+    if (request.sessionId === sessionId && request.status === "pending") {
+      upsertRequest({
+        ...request,
+        status: "cancelled" as ApprovalRequest["status"],
+        resolvedAt: now,
+        decisionBy: "system",
+        decisionReason: reason,
+      });
+      changed = true;
+    }
+  }
+  if (changed) {
+    // Refresh from backend to ensure consistency
+    void refreshApprovals();
+  }
+}
+
 let approvalsInitialized = false;
 
 async function initApprovalStore(): Promise<void> {
@@ -102,6 +128,17 @@ async function initApprovalStore(): Promise<void> {
     const payload = event.payload as unknown as ApprovalRequest;
     if (payload?.id) {
       upsertRequest(payload);
+    }
+  });
+
+  // When a transport crash occurs, immediately cancel pending approvals for
+  // that session so the GUI doesn't show stale, unresponsive approval buttons.
+  await onAgentError((data) => {
+    if (data.isTransportCrash) {
+      cancelPendingApprovalsForSession(
+        data.sessionId,
+        "Transport disconnected — approval cancelled",
+      );
     }
   });
 }

--- a/packages/gui/src/stores/messages.ts
+++ b/packages/gui/src/stores/messages.ts
@@ -348,10 +348,14 @@ async function initMessageListeners() {
   await onAgentError((data) => {
     const panelKey = resolvePanelKey(data.agentId, data.sessionId);
     if (!panelKey) return;
+    const userMessage = data.isTransportCrash
+      ? "Agent connection lost (transport disconnected). Pending approvals have been cancelled. You may start a new session."
+      : `Error: ${data.error}`;
     appendMessage(panelKey, {
       role: "system",
-      content: `Error: ${data.error}`,
+      content: userMessage,
       timestamp: Date.now(),
+      metadata: data.isTransportCrash ? { isTransportCrash: true } : undefined,
     });
     setStatus(panelKey, "error");
   });

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -1574,8 +1574,19 @@ export class Orchestrator {
       return { completed: true, lastAssistantMessage };
     } catch (err) {
       const errorMsg = err instanceof Error ? err.message : String(err);
-      this.cancelPendingApprovalsForSession(sessionId, "Session failed while approval was pending");
-      this.bus.emit("agent.error", agentId, sessionId, { error: errorMsg });
+      const isTransportCrash = errorMsg.includes("[transport:crash]")
+        || errorMsg.includes("not ready for writing")
+        || errorMsg.includes("ProcessTransport");
+      this.cancelPendingApprovalsForSession(
+        sessionId,
+        isTransportCrash
+          ? "Transport disconnected — approvals cancelled"
+          : "Session failed while approval was pending",
+      );
+      this.bus.emit("agent.error", agentId, sessionId, {
+        error: errorMsg,
+        isTransportCrash,
+      });
       // Ensure frontend streaming state is always closed, even on errors
       this.transport.sendNotification("agent_stream_end", {
         agentId,
@@ -1585,6 +1596,7 @@ export class Orchestrator {
         agentId,
         sessionId,
         error: errorMsg,
+        isTransportCrash,
       });
 
       // Keep failed sessions in history, but detach them from active role routing.

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -7,7 +7,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { mkdirSync } from "node:fs";
 import { copyFile, mkdir, readdir, writeFile, rename, unlink } from "node:fs/promises";
 import { dirname, join, relative, resolve } from "node:path";
-import { EventBus, isStreamingEvent, makeRoleSlotKey } from "@mercury/core";
+import { EventBus, isStreamingEvent, isTransportCrashError, makeRoleSlotKey } from "@mercury/core";
 import type {
   AgentConfig,
   AgentSendHooks,
@@ -1574,9 +1574,7 @@ export class Orchestrator {
       return { completed: true, lastAssistantMessage };
     } catch (err) {
       const errorMsg = err instanceof Error ? err.message : String(err);
-      const isTransportCrash = errorMsg.includes("[transport:crash]")
-        || errorMsg.includes("not ready for writing")
-        || errorMsg.includes("ProcessTransport");
+      const isTransportCrash = isTransportCrashError(err);
       this.cancelPendingApprovalsForSession(
         sessionId,
         isTransportCrash

--- a/packages/sdk-adapters/src/claude-adapter.ts
+++ b/packages/sdk-adapters/src/claude-adapter.ts
@@ -11,17 +11,18 @@
  */
 
 import { randomUUID } from "node:crypto";
-import type {
-  AdapterYield,
-  AgentAdapter,
-  AgentApprovalRequest,
-  AgentConfig,
-  AgentMessage,
-  AgentSendHooks,
-  AgentStreamingEvent,
-  ImageAttachment,
-  SessionInfo,
-  SlashCommand,
+import {
+  isTransportCrashError,
+  type AdapterYield,
+  type AgentAdapter,
+  type AgentApprovalRequest,
+  type AgentConfig,
+  type AgentMessage,
+  type AgentSendHooks,
+  type AgentStreamingEvent,
+  type ImageAttachment,
+  type SessionInfo,
+  type SlashCommand,
 } from "@mercury/core";
 
 /** Extract text content from SDK message content blocks. */
@@ -57,15 +58,6 @@ class AsyncMutex {
       this.locked = false;
     }
   }
-}
-
-/** Check if an error is a ProcessTransport "not ready" crash. */
-function isTransportNotReady(err: unknown): boolean {
-  if (err instanceof Error) {
-    return err.message.includes("not ready for writing")
-      || err.message.includes("ProcessTransport");
-  }
-  return String(err).includes("not ready for writing");
 }
 
 export class ClaudeAdapter implements AgentAdapter {
@@ -612,7 +604,7 @@ export class ClaudeAdapter implements AgentAdapter {
       // race condition when concurrent approval responses hit the transport.
       // Convert to a structured error that the orchestrator can handle gracefully
       // instead of letting it crash the entire session unrecoverably.
-      if (isTransportNotReady(err)) {
+      if (isTransportCrashError(err)) {
         const transportError = new Error(
           `[transport:crash] SDK ProcessTransport disconnected during session ${sessionId}. ` +
           `The session may be resumable via its SDK session ID.`,

--- a/packages/sdk-adapters/src/claude-adapter.ts
+++ b/packages/sdk-adapters/src/claude-adapter.ts
@@ -34,6 +34,40 @@ function extractTextFromBlocks(content: unknown): string {
     .join("\n");
 }
 
+/** Simple mutex for serializing async operations. */
+class AsyncMutex {
+  private queue: (() => void)[] = [];
+  private locked = false;
+
+  async acquire(): Promise<() => void> {
+    if (!this.locked) {
+      this.locked = true;
+      return () => this.release();
+    }
+    return new Promise<() => void>((resolve) => {
+      this.queue.push(() => resolve(() => this.release()));
+    });
+  }
+
+  private release(): void {
+    const next = this.queue.shift();
+    if (next) {
+      next();
+    } else {
+      this.locked = false;
+    }
+  }
+}
+
+/** Check if an error is a ProcessTransport "not ready" crash. */
+function isTransportNotReady(err: unknown): boolean {
+  if (err instanceof Error) {
+    return err.message.includes("not ready for writing")
+      || err.message.includes("ProcessTransport");
+  }
+  return String(err).includes("not ready for writing");
+}
+
 export class ClaudeAdapter implements AgentAdapter {
   readonly agentId: string;
   readonly config: AgentConfig;
@@ -44,6 +78,8 @@ export class ClaudeAdapter implements AgentAdapter {
   private sharedSystemPrompt?: string;
   private activeQueries = new Map<string, AsyncGenerator<unknown, void> & { supportedModels?(): Promise<unknown[]>; setModel?(model?: string): Promise<void> }>();
   private modelsCache: { id: string; name: string }[] | null = null;
+  /** Per-session mutex to serialize approval responses and prevent concurrent transport writes. */
+  private approvalMutex = new Map<string, AsyncMutex>();
 
   constructor(config?: Partial<AgentConfig>) {
     this.config = {
@@ -312,6 +348,15 @@ export class ClaudeAdapter implements AgentAdapter {
     }
 
     const onApprovalRequest = hooks?.onApprovalRequest;
+    // Ensure per-session mutex exists for serializing approval write-backs.
+    // Multiple concurrent canUseTool calls from the SDK can race to write
+    // control_response to the transport, causing "not ready for writing".
+    // Ref: https://platform.claude.com/docs/en/agent-sdk/permissions
+    if (!this.approvalMutex.has(sessionId)) {
+      this.approvalMutex.set(sessionId, new AsyncMutex());
+    }
+    const mutex = this.approvalMutex.get(sessionId)!;
+
     if (onApprovalRequest) {
       options.canUseTool = async (
         toolName: string,
@@ -343,19 +388,27 @@ export class ClaudeAdapter implements AgentAdapter {
         };
 
         const decision = await onApprovalRequest(approvalRequest);
-        if (decision.action === "approve") {
+
+        // Serialize the response through a mutex to prevent concurrent
+        // transport writes that cause "not ready for writing" crashes.
+        const release = await mutex.acquire();
+        try {
+          if (decision.action === "approve") {
+            return {
+              behavior: "allow",
+              updatedInput: decision.updatedInput,
+              toolUseID: requestOptions.toolUseID,
+            };
+          }
           return {
-            behavior: "allow",
-            updatedInput: decision.updatedInput,
+            behavior: "deny",
+            message: decision.reason ?? `Mercury denied ${toolName}`,
+            interrupt: true,
             toolUseID: requestOptions.toolUseID,
           };
+        } finally {
+          release();
         }
-        return {
-          behavior: "deny",
-          message: decision.reason ?? `Mercury denied ${toolName}`,
-          interrupt: true,
-          toolUseID: requestOptions.toolUseID,
-        };
       };
     }
 
@@ -423,138 +476,159 @@ export class ClaudeAdapter implements AgentAdapter {
     // sdk.query() accepts string | AsyncIterable<SDKUserMessage> — both paths converge here
     const queryIter = sdk.query(queryArgs as { prompt: string; options: Record<string, unknown> });
     this.activeQueries.set(sessionId, queryIter as Parameters<typeof this.activeQueries.set>[1]);
-    for await (const message of queryIter) {
-      session.lastActiveAt = Date.now();
+    try {
+      for await (const message of queryIter) {
+        session.lastActiveAt = Date.now();
 
-      if (typeof message !== "object" || message === null || !("type" in message)) {
-        continue;
-      }
+        if (typeof message !== "object" || message === null || !("type" in message)) {
+          continue;
+        }
 
-      const msg = message as Record<string, unknown>;
+        const msg = message as Record<string, unknown>;
 
-      // Capture SDK session ID from init message
-      if (msg.type === "system" && msg.subtype === "init" && msg.session_id) {
-        sdkSessionId = msg.session_id as string;
-      }
+        // Capture SDK session ID from init message
+        if (msg.type === "system" && msg.subtype === "init" && msg.session_id) {
+          sdkSessionId = msg.session_id as string;
+        }
 
-      // Streaming events — incremental content from includePartialMessages: true
-      // Type: SDKPartialAssistantMessage { type: "stream_event", event: RawMessageStreamEvent }
-      // Ref: https://platform.claude.com/docs/en/agent-sdk/streaming-output
-      if (msg.type === "stream_event") {
-        const event = msg.event as Record<string, unknown> | undefined;
-        if (!event) continue;
+        // Streaming events — incremental content from includePartialMessages: true
+        // Type: SDKPartialAssistantMessage { type: "stream_event", event: RawMessageStreamEvent }
+        // Ref: https://platform.claude.com/docs/en/agent-sdk/streaming-output
+        if (msg.type === "stream_event") {
+          const event = msg.event as Record<string, unknown> | undefined;
+          if (!event) continue;
 
-        const eventType = event.type as string;
-        const now = Date.now();
+          const eventType = event.type as string;
+          const now = Date.now();
 
-        // Extract token usage from message_start (input tokens) and message_delta (output tokens).
-        // Per Claude API docs: message_start.message.usage has initial {input_tokens, output_tokens},
-        // message_delta.usage.output_tokens is CUMULATIVE for this message.
-        // Ref: https://platform.claude.com/docs/en/build-with-claude/streaming
-        if (eventType === "message_start") {
-          const message = event.message as Record<string, unknown> | undefined;
-          const usage = message?.usage as Record<string, unknown> | undefined;
-          if (usage?.input_tokens) {
-            inputTokens = usage.input_tokens as number;
-            cumulativeTokenCount = inputTokens + ((usage.output_tokens as number) ?? 0);
-            session.tokenUsage = cumulativeTokenCount;
+          // Extract token usage from message_start (input tokens) and message_delta (output tokens).
+          // Per Claude API docs: message_start.message.usage has initial {input_tokens, output_tokens},
+          // message_delta.usage.output_tokens is CUMULATIVE for this message.
+          // Ref: https://platform.claude.com/docs/en/build-with-claude/streaming
+          if (eventType === "message_start") {
+            const message = event.message as Record<string, unknown> | undefined;
+            const usage = message?.usage as Record<string, unknown> | undefined;
+            if (usage?.input_tokens) {
+              inputTokens = usage.input_tokens as number;
+              cumulativeTokenCount = inputTokens + ((usage.output_tokens as number) ?? 0);
+              session.tokenUsage = cumulativeTokenCount;
+            }
+          } else if (eventType === "message_delta") {
+            const usage = event.usage as Record<string, unknown> | undefined;
+            if (usage?.output_tokens) {
+              cumulativeTokenCount = inputTokens + (usage.output_tokens as number);
+              session.tokenUsage = cumulativeTokenCount;
+            }
           }
-        } else if (eventType === "message_delta") {
-          const usage = event.usage as Record<string, unknown> | undefined;
-          if (usage?.output_tokens) {
-            cumulativeTokenCount = inputTokens + (usage.output_tokens as number);
-            session.tokenUsage = cumulativeTokenCount;
+
+          if (eventType === "content_block_start") {
+            const contentBlock = event.content_block as Record<string, unknown> | undefined;
+            inToolBlock = contentBlock?.type === "tool_use";
+            if (inToolBlock) {
+              yield {
+                type: "streaming",
+                eventKind: "tool_start",
+                toolName: contentBlock!.name as string,
+                tokenCount: cumulativeTokenCount || undefined,
+                timestamp: now,
+              } satisfies AgentStreamingEvent;
+            }
+          } else if (eventType === "content_block_delta") {
+            const delta = event.delta as Record<string, unknown> | undefined;
+            if (delta?.type === "text_delta") {
+              yield {
+                type: "streaming",
+                eventKind: "text_delta",
+                content: delta.text as string,
+                tokenCount: cumulativeTokenCount || undefined,
+                timestamp: now,
+              } satisfies AgentStreamingEvent;
+            } else if (delta?.type === "input_json_delta") {
+              yield {
+                type: "streaming",
+                eventKind: "tool_delta",
+                toolInput: delta.partial_json as string,
+                tokenCount: cumulativeTokenCount || undefined,
+                timestamp: now,
+              } satisfies AgentStreamingEvent;
+            }
+          } else if (eventType === "content_block_stop") {
+            // Only emit tool_end if the ending block was a tool_use.
+            // content_block_stop fires for all block types (text + tool_use).
+            if (inToolBlock) {
+              yield {
+                type: "streaming",
+                eventKind: "tool_end",
+                tokenCount: cumulativeTokenCount || undefined,
+                timestamp: now,
+              } satisfies AgentStreamingEvent;
+              inToolBlock = false;
+            }
+          }
+          continue;
+        }
+
+        // Assistant messages — content is an array of blocks [{text: "..."}, {name: "ToolName"}]
+        if (msg.type === "assistant") {
+          const content = msg.message
+            ? extractTextFromBlocks((msg.message as Record<string, unknown>).content)
+            : extractTextFromBlocks(msg.content);
+
+          if (content) {
+            hasYieldedAssistant = true;
+            yield {
+              role: "assistant",
+              content,
+              timestamp: Date.now(),
+              metadata: { sdkSessionId },
+            };
           }
         }
 
-        if (eventType === "content_block_start") {
-          const contentBlock = event.content_block as Record<string, unknown> | undefined;
-          inToolBlock = contentBlock?.type === "tool_use";
-          if (inToolBlock) {
+        // Result messages — only yield if no assistant messages were emitted.
+        // SDK streams content via assistant messages (possibly chunked), then emits
+        // a result with the full concatenated text. Showing both causes duplication.
+        if (msg.type === "result" && !hasYieldedAssistant) {
+          const resultText =
+            typeof msg.result === "string"
+              ? msg.result
+              : extractTextFromBlocks(msg.result);
+          if (resultText) {
             yield {
-              type: "streaming",
-              eventKind: "tool_start",
-              toolName: contentBlock!.name as string,
-              tokenCount: cumulativeTokenCount || undefined,
-              timestamp: now,
-            } satisfies AgentStreamingEvent;
-          }
-        } else if (eventType === "content_block_delta") {
-          const delta = event.delta as Record<string, unknown> | undefined;
-          if (delta?.type === "text_delta") {
-            yield {
-              type: "streaming",
-              eventKind: "text_delta",
-              content: delta.text as string,
-              tokenCount: cumulativeTokenCount || undefined,
-              timestamp: now,
-            } satisfies AgentStreamingEvent;
-          } else if (delta?.type === "input_json_delta") {
-            yield {
-              type: "streaming",
-              eventKind: "tool_delta",
-              toolInput: delta.partial_json as string,
-              tokenCount: cumulativeTokenCount || undefined,
-              timestamp: now,
-            } satisfies AgentStreamingEvent;
-          }
-        } else if (eventType === "content_block_stop") {
-          // Only emit tool_end if the ending block was a tool_use.
-          // content_block_stop fires for all block types (text + tool_use).
-          if (inToolBlock) {
-            yield {
-              type: "streaming",
-              eventKind: "tool_end",
-              tokenCount: cumulativeTokenCount || undefined,
-              timestamp: now,
-            } satisfies AgentStreamingEvent;
-            inToolBlock = false;
+              role: "assistant",
+              content: resultText,
+              timestamp: Date.now(),
+              metadata: {
+                sdkSessionId,
+                isResult: true,
+                subtype: msg.subtype as string | undefined,
+              },
+            };
           }
         }
-        continue;
       }
-
-      // Assistant messages — content is an array of blocks [{text: "..."}, {name: "ToolName"}]
-      if (msg.type === "assistant") {
-        const content = msg.message
-          ? extractTextFromBlocks((msg.message as Record<string, unknown>).content)
-          : extractTextFromBlocks(msg.content);
-
-        if (content) {
-          hasYieldedAssistant = true;
-          yield {
-            role: "assistant",
-            content,
-            timestamp: Date.now(),
-            metadata: { sdkSessionId },
-          };
+    } catch (err) {
+      // Detect ProcessTransport "not ready for writing" — this is a known SDK
+      // race condition when concurrent approval responses hit the transport.
+      // Convert to a structured error that the orchestrator can handle gracefully
+      // instead of letting it crash the entire session unrecoverably.
+      if (isTransportNotReady(err)) {
+        const transportError = new Error(
+          `[transport:crash] SDK ProcessTransport disconnected during session ${sessionId}. ` +
+          `The session may be resumable via its SDK session ID.`,
+        );
+        transportError.cause = err;
+        // Preserve resume token so the orchestrator can attempt recovery
+        if (sdkSessionId) {
+          session.resumeToken = sdkSessionId;
         }
+        throw transportError;
       }
-
-      // Result messages — only yield if no assistant messages were emitted.
-      // SDK streams content via assistant messages (possibly chunked), then emits
-      // a result with the full concatenated text. Showing both causes duplication.
-      if (msg.type === "result" && !hasYieldedAssistant) {
-        const resultText =
-          typeof msg.result === "string"
-            ? msg.result
-            : extractTextFromBlocks(msg.result);
-        if (resultText) {
-          yield {
-            role: "assistant",
-            content: resultText,
-            timestamp: Date.now(),
-            metadata: {
-              sdkSessionId,
-              isResult: true,
-              subtype: msg.subtype as string | undefined,
-            },
-          };
-        }
-      }
+      throw err;
+    } finally {
+      this.activeQueries.delete(sessionId);
+      this.approvalMutex.delete(sessionId);
     }
-
-    this.activeQueries.delete(sessionId);
 
     // Store SDK session ID for future resume after restart.
     if (sdkSessionId) {
@@ -591,6 +665,7 @@ export class ClaudeAdapter implements AgentAdapter {
     if (session) {
       session.status = "completed";
     }
+    this.approvalMutex.delete(sessionId);
   }
 
   /**


### PR DESCRIPTION
## Summary
- **Root cause**: SDK `canUseTool` callbacks called concurrently for multiple approval requests race to write `control_response` to `ProcessTransport`, causing "not ready for writing" crash
- **Layer 2a (adapter)**: Per-session `AsyncMutex` serializes approval response write-backs, preventing concurrent transport writes
- **Layer 2b (orchestrator)**: `streamMessages` catch block detects transport crashes, emits `isTransportCrash` flag for targeted GUI handling
- **Layer 3 (GUI)**: Pending approvals cancelled immediately on transport crash; user sees friendly disconnect message instead of raw SDK error

## Test plan
- [ ] Trigger 3+ concurrent approval requests (e.g. WebSearch permissions) and verify no crash
- [ ] Switch GUI windows during pending approvals and verify session survives
- [ ] Verify transport crash shows user-friendly error message in session panel
- [ ] Verify pending approval buttons are cleared on transport disconnect
- [ ] Regression: normal approval flow (single request, approve/deny) still works
- [ ] Regression: auto_accept mode still bypasses approval without issues

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)