### PR TITLE
feat(orchestrator): MCP Streamable HTTP transport + NotificationBroadcaster (#84)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -46,5 +46,6 @@ export type {
   TaskComplexity,
   TaskPriority,
   TaskStatus,
+  TransportsConfig,
   ModelRecommendation,
 } from "./types.js";

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -107,6 +107,7 @@ export interface TransportsConfig {
   mcp?: {
     enabled?: boolean;
     path?: string;
+    maxSessions?: number;
   };
   /** Native SSE event stream on /events. Disabled by default. */
   sse?: {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -96,10 +96,31 @@ export interface RTKConfig {
   commands: string[]; // command basenames to wrap, e.g. ["codex", "gemini"]
 }
 
+export interface TransportsConfig {
+  stdio?: boolean;
+  http?: {
+    enabled?: boolean;
+    host?: string;
+    port?: number;
+  };
+  mcp?: {
+    enabled?: boolean;
+    path?: string;
+  };
+  sse?: {
+    enabled?: boolean;
+    path?: string;
+    maxConnections?: number;
+    heartbeatIntervalMs?: number;
+  };
+}
+
 export interface MercuryConfig {
   agents: AgentConfig[];
   workDir?: string;
+  /** @deprecated Use transports.http.port instead. Both work; this is kept for backward compat. */
   rpcPort?: number;
+  transports?: TransportsConfig;
   obsidian?: ObsidianConfig;
   rtk?: RTKConfig;
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -97,16 +97,18 @@ export interface RTKConfig {
 }
 
 export interface TransportsConfig {
-  stdio?: boolean;
+  /** HTTP JSON-RPC server. Enabled by default on 127.0.0.1:7654. */
   http?: {
     enabled?: boolean;
     host?: string;
     port?: number;
   };
+  /** MCP Streamable HTTP on /mcp. Requires http to be enabled. */
   mcp?: {
     enabled?: boolean;
     path?: string;
   };
+  /** Native SSE event stream on /events. Disabled by default. */
   sse?: {
     enabled?: boolean;
     path?: string;

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -13,12 +13,13 @@ process.stderr.setDefaultEncoding("utf-8");
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, isAbsolute, resolve } from "node:path";
-import type { MercuryConfig, AgentConfig, ObsidianConfig } from "@mercury/core";
+import type { MercuryConfig, AgentConfig, ObsidianConfig, TransportsConfig } from "@mercury/core";
 import { RpcTransport } from "./rpc-transport.js";
 import { AgentRegistry } from "./agent-registry.js";
 import { Orchestrator } from "./orchestrator.js";
 import { KnowledgeService } from "./knowledge-service.js";
-import { createMcpServer } from "./mcp-server.js";
+import { createMcpServer, McpHttpSessionManager } from "./mcp-server.js";
+import { NotificationBroadcaster } from "./notification-broadcaster.js";
 
 const DEFAULT_RPC_PORT = 7654;
 
@@ -238,7 +239,7 @@ function parseRpcPort(raw: string | undefined): number | null {
   return port;
 }
 
-/** Determine RPC port from env, config, or default. */
+/** Determine RPC port from env, config (transports.http.port or legacy rpcPort), or default. */
 function resolveRpcPort(config: MercuryConfig): number {
   const envPort = parseRpcPort(process.env.MERCURY_RPC_PORT);
   if (envPort !== null) {
@@ -251,6 +252,13 @@ function resolveRpcPort(config: MercuryConfig): number {
     );
   }
 
+  // New config path: transports.http.port
+  const httpPort = config.transports?.http?.port;
+  if (typeof httpPort === "number" && Number.isInteger(httpPort)) {
+    return httpPort;
+  }
+
+  // Legacy config path: rpcPort
   if (typeof config.rpcPort === "number" && Number.isInteger(config.rpcPort)) {
     return config.rpcPort;
   }
@@ -258,11 +266,22 @@ function resolveRpcPort(config: MercuryConfig): number {
   return DEFAULT_RPC_PORT;
 }
 
-/** Set permissive CORS headers on an HTTP response. */
+/** Resolve transports config with defaults. */
+function resolveTransports(config: MercuryConfig): Required<Pick<TransportsConfig, "stdio">> & TransportsConfig {
+  return {
+    stdio: true,
+    ...config.transports,
+    http: { enabled: true, host: "127.0.0.1", ...config.transports?.http },
+    mcp: { enabled: true, path: "/mcp", ...config.transports?.mcp },
+    sse: { enabled: false, path: "/events", maxConnections: 10, heartbeatIntervalMs: 30000, ...config.transports?.sse },
+  };
+}
+
+/** Set CORS headers on an HTTP response. */
 function setCorsHeaders(res: ServerResponse): void {
   res.setHeader("Access-Control-Allow-Origin", "*");
-  res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
-  res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+  res.setHeader("Access-Control-Allow-Methods", "POST, GET, DELETE, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type, MCP-Session-Id");
 }
 
 /** Send a JSON-RPC response with CORS headers. */
@@ -323,77 +342,177 @@ function mapRpcError(err: unknown): { code: number; message: string } {
   return { code: -32603, message };
 }
 
-/** Create an HTTP server that handles JSON-RPC 2.0 requests via the orchestrator. */
-function createHttpRpcServer(orchestrator: Orchestrator, port: number): Server {
-  return createServer(async (req, res) => {
-    setCorsHeaders(res);
+/** Handle a JSON-RPC 2.0 POST request (used by /rpc and legacy root routes). */
+async function handleJsonRpcPost(
+  orchestrator: Orchestrator,
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void> {
+  if (req.method !== "POST") {
+    res.statusCode = 405;
+    res.end("Method Not Allowed");
+    return;
+  }
 
+  let body = "";
+  try {
+    body = await readRequestBody(req);
+  } catch (err) {
+    sendHttpJson(res, 500, { jsonrpc: "2.0", error: mapRpcError(err), id: null });
+    return;
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(body);
+  } catch {
+    sendHttpJson(res, 400, { jsonrpc: "2.0", error: { code: -32700, message: "Parse error" }, id: null });
+    return;
+  }
+
+  if (!isJsonRpcRequest(payload)) {
+    sendHttpJson(res, 400, { jsonrpc: "2.0", error: { code: -32603, message: "Invalid JSON-RPC request" }, id: null });
+    return;
+  }
+
+  try {
+    const result = await orchestrator.handleRpc(payload.method, payload.params ?? {});
+    sendHttpJson(res, 200, { jsonrpc: "2.0", result, id: payload.id });
+  } catch (err) {
+    sendHttpJson(res, 500, { jsonrpc: "2.0", error: mapRpcError(err), id: payload.id });
+  }
+}
+
+/** Native SSE event stream for non-MCP clients. */
+function handleSseConnection(
+  req: IncomingMessage,
+  res: ServerResponse,
+  broadcaster: NotificationBroadcaster,
+  sseConfig: NonNullable<TransportsConfig["sse"]>,
+): void {
+  if (req.method !== "GET") {
+    res.statusCode = 405;
+    res.end("Method Not Allowed");
+    return;
+  }
+
+  const maxConns = sseConfig.maxConnections ?? 10;
+  // Count existing SSE channels
+  if (broadcaster.channelCount > maxConns + 5) {
+    res.statusCode = 503;
+    res.end("Too many SSE connections");
+    return;
+  }
+
+  res.writeHead(200, {
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache",
+    "Connection": "keep-alive",
+    "Access-Control-Allow-Origin": "http://localhost:1420",
+  });
+  res.write(":ok\n\n");
+
+  const channelName = `sse:${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const heartbeatMs = sseConfig.heartbeatIntervalMs ?? 30000;
+  const heartbeat = setInterval(() => {
+    res.write(":heartbeat\n\n");
+  }, heartbeatMs);
+
+  broadcaster.addChannel({
+    name: channelName,
+    send: (method: string, params: Record<string, unknown>) => {
+      res.write(`event: ${method}\ndata: ${JSON.stringify(params)}\n\n`);
+    },
+    close: () => {
+      clearInterval(heartbeat);
+      if (!res.writableEnded) res.end();
+    },
+  });
+
+  req.on("close", () => {
+    clearInterval(heartbeat);
+    broadcaster.removeChannel(channelName);
+  });
+}
+
+interface HttpServerContext {
+  orchestrator: Orchestrator;
+  mcpSessions: McpHttpSessionManager | null;
+  broadcaster: NotificationBroadcaster;
+  transportsConfig: ReturnType<typeof resolveTransports>;
+}
+
+/**
+ * Create an HTTP server with path-based routing:
+ *   POST /rpc        — JSON-RPC 2.0 (existing, backward compat)
+ *   POST|GET|DELETE /mcp  — MCP Streamable HTTP
+ *   GET  /events     — Native SSE stream
+ *   GET  /health     — Health check
+ *   POST /           — Legacy JSON-RPC (backward compat with TASK-ARCH-005 clients)
+ */
+function createHttpServer(ctx: HttpServerContext, port: number): Server {
+  const { orchestrator, mcpSessions, broadcaster, transportsConfig } = ctx;
+  const mcpPath = transportsConfig.mcp?.path ?? "/mcp";
+  const ssePath = transportsConfig.sse?.path ?? "/events";
+
+  return createServer(async (req, res) => {
+    const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
+    const pathname = url.pathname;
+
+    // CORS preflight
     if (req.method === "OPTIONS") {
+      setCorsHeaders(res);
       res.statusCode = 204;
       res.end();
       return;
     }
 
-    if (req.method !== "POST") {
-      res.statusCode = 405;
-      res.end("Method Not Allowed");
+    // Health check
+    if (pathname === "/health") {
+      res.statusCode = 200;
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({
+        status: "ok",
+        mcpSessions: mcpSessions?.sessionCount ?? 0,
+        broadcasterChannels: broadcaster.channelCount,
+        timestamp: Date.now(),
+      }));
       return;
     }
 
-    let body = "";
-    try {
-      body = await readRequestBody(req);
-    } catch (err) {
-      sendHttpJson(res, 500, {
-        jsonrpc: "2.0",
-        error: mapRpcError(err),
-        id: null,
-      });
+    // MCP Streamable HTTP
+    if (pathname === mcpPath && mcpSessions && transportsConfig.mcp?.enabled !== false) {
+      // MCP transport handles its own CORS/headers
+      await mcpSessions.handleRequest(req, res);
       return;
     }
 
-    let payload: unknown;
-    try {
-      payload = JSON.parse(body);
-    } catch {
-      sendHttpJson(res, 400, {
-        jsonrpc: "2.0",
-        error: { code: -32700, message: "Parse error" },
-        id: null,
-      });
+    // Native SSE
+    if (pathname === ssePath && transportsConfig.sse?.enabled) {
+      handleSseConnection(req, res, broadcaster, transportsConfig.sse);
       return;
     }
 
-    if (!isJsonRpcRequest(payload)) {
-      sendHttpJson(res, 400, {
-        jsonrpc: "2.0",
-        error: { code: -32603, message: "Invalid JSON-RPC request" },
-        id: null,
-      });
+    // JSON-RPC: /rpc or root /
+    if (pathname === "/rpc" || pathname === "/") {
+      setCorsHeaders(res);
+      await handleJsonRpcPost(orchestrator, req, res);
       return;
     }
 
-    try {
-      const result = await orchestrator.handleRpc(payload.method, payload.params ?? {});
-      sendHttpJson(res, 200, {
-        jsonrpc: "2.0",
-        result,
-        id: payload.id,
-      });
-    } catch (err) {
-      sendHttpJson(res, 500, {
-        jsonrpc: "2.0",
-        error: mapRpcError(err),
-        id: payload.id,
-      });
-    }
+    res.statusCode = 404;
+    res.end("Not Found");
   }).listen(port, "127.0.0.1", () => {
-    transport.log(`HTTP JSON-RPC listening on http://127.0.0.1:${port}`);
+    const routes = ["POST /rpc (JSON-RPC)"];
+    if (transportsConfig.mcp?.enabled !== false) routes.push(`POST|GET|DELETE ${mcpPath} (MCP)`);
+    if (transportsConfig.sse?.enabled) routes.push(`GET ${ssePath} (SSE)`);
+    routes.push("GET /health");
+    transport.log(`HTTP server listening on http://127.0.0.1:${port} — routes: ${routes.join(", ")}`);
   });
 }
 
-/** Wire process shutdown signals to gracefully close the HTTP server. */
-function wireShutdown(server: Server): void {
+/** Wire process shutdown signals to gracefully close the HTTP server and MCP sessions. */
+function wireShutdown(server: Server, mcpSessions: McpHttpSessionManager | null, broadcaster: NotificationBroadcaster): void {
   const originalExit = process.exit.bind(process);
   let shuttingDown = false;
 
@@ -405,11 +524,13 @@ function wireShutdown(server: Server): void {
       return;
     }
     shuttingDown = true;
-    transport.log(`Shutting down HTTP JSON-RPC server (${reason})`);
+    transport.log(`Shutting down HTTP server (${reason})`);
+    broadcaster.closeAll();
+    mcpSessions?.closeAll().catch(() => {});
     server.close((err) => {
       process.exit = originalExit;
       if (err) {
-        transport.log(`HTTP JSON-RPC shutdown error: ${err instanceof Error ? err.message : err}`);
+        transport.log(`HTTP server shutdown error: ${err instanceof Error ? err.message : err}`);
       }
       if (exitCode !== undefined) {
         originalExit(err ? 1 : exitCode);
@@ -433,13 +554,34 @@ function wireShutdown(server: Server): void {
   });
 }
 
-/** Start stdin/stdout RPC transport and HTTP JSON-RPC server, then signal ready. */
+/** Start stdin/stdout RPC transport, HTTP server with MCP + SSE, then signal ready. */
 function startTransports(orchestrator: Orchestrator, registry: AgentRegistry, config: MercuryConfig): void {
+  const transportsConfig = resolveTransports(config);
+  const port = resolveRpcPort(config);
+
+  // Wire NotificationBroadcaster: replaces single-channel sendNotification
+  const broadcaster = NotificationBroadcaster.wrapTransport(transport);
+
+  // Start stdio transport (primary, always enabled in sidecar mode)
   transport.start((method, params) => orchestrator.handleRpc(method, params));
-  const httpServer = createHttpRpcServer(orchestrator, resolveRpcPort(config));
-  wireShutdown(httpServer);
+
+  // Create MCP HTTP session manager (enabled by default)
+  const mcpSessions = transportsConfig.mcp?.enabled !== false
+    ? new McpHttpSessionManager(orchestrator, broadcaster, (msg) => transport.log(msg))
+    : null;
+
+  // Create shared HTTP server with path-based routing
+  const httpServer = createHttpServer({ orchestrator, mcpSessions, broadcaster, transportsConfig }, port);
+  wireShutdown(httpServer, mcpSessions, broadcaster);
+
   transport.sendNotification("ready", {
     agents: registry.listAgents().map((a) => a.id),
+    transports: {
+      stdio: true,
+      http: true,
+      mcp: mcpSessions !== null,
+      sse: transportsConfig.sse?.enabled ?? false,
+    },
     timestamp: Date.now(),
   });
 }

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -525,9 +525,8 @@ function createHttpServer(ctx: HttpServerContext, host: string, port: number): S
       return;
     }
 
-    // JSON-RPC: /rpc or root /
+    // JSON-RPC: /rpc or root / (CORS set by sendHttpJson inside handler)
     if (pathname === "/rpc" || pathname === "/") {
-      setCorsHeaders(res, req);
       await handleJsonRpcPost(orchestrator, req, res);
       return;
     }
@@ -558,15 +557,17 @@ function wireShutdown(server: Server, mcpSessions: McpHttpSessionManager | null,
     shuttingDown = true;
     transport.log(`Shutting down HTTP server (${reason})`);
     broadcaster.closeAll();
-    mcpSessions?.closeAll().catch(() => {});
-    server.close((err) => {
-      process.exit = originalExit;
-      if (err) {
-        transport.log(`HTTP server shutdown error: ${err instanceof Error ? err.message : err}`);
-      }
-      if (exitCode !== undefined) {
-        originalExit(err ? 1 : exitCode);
-      }
+    const mcpCleanup = mcpSessions?.closeAll().catch(() => {}) ?? Promise.resolve();
+    mcpCleanup.then(() => {
+      server.close((err) => {
+        process.exit = originalExit;
+        if (err) {
+          transport.log(`HTTP server shutdown error: ${err instanceof Error ? err.message : err}`);
+        }
+        if (exitCode !== undefined) {
+          originalExit(err ? 1 : exitCode);
+        }
+      });
     });
   };
 
@@ -602,13 +603,23 @@ function startTransports(orchestrator: Orchestrator, registry: AgentRegistry, co
   let mcpSessions: McpHttpSessionManager | null = null;
 
   if (httpEnabled) {
+    const mcpMaxSessions = transportsConfig.mcp?.maxSessions ?? 10;
     mcpSessions = mcpEnabled
-      ? new McpHttpSessionManager(orchestrator, broadcaster, (msg) => transport.log(msg))
+      ? new McpHttpSessionManager(orchestrator, broadcaster, (msg) => transport.log(msg), mcpMaxSessions)
       : null;
 
     const httpHost = transportsConfig.http?.host ?? "127.0.0.1";
     const httpServer = createHttpServer({ orchestrator, mcpSessions, broadcaster, transportsConfig }, httpHost, port);
     wireShutdown(httpServer, mcpSessions, broadcaster);
+  } else {
+    // Basic signal handling when HTTP server is not started (per Node.js process docs)
+    const gracefulExit = (reason: string) => {
+      transport.log(`Shutting down (${reason})`);
+      broadcaster.closeAll();
+      process.exit(0);
+    };
+    process.once("SIGINT", () => gracefulExit("SIGINT"));
+    process.once("SIGTERM", () => gracefulExit("SIGTERM"));
   }
 
   transport.sendNotification("ready", {

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -254,22 +254,36 @@ function resolveRpcPort(config: MercuryConfig): number {
 
   // New config path: transports.http.port
   const httpPort = config.transports?.http?.port;
-  if (typeof httpPort === "number" && Number.isInteger(httpPort)) {
+  if (typeof httpPort === "number" && Number.isInteger(httpPort) && httpPort >= 1 && httpPort <= 65535) {
     return httpPort;
+  }
+  if (httpPort !== undefined) {
+    transport.log(`Invalid transports.http.port=${httpPort}, falling back to config/default`);
   }
 
   // Legacy config path: rpcPort
-  if (typeof config.rpcPort === "number" && Number.isInteger(config.rpcPort)) {
+  if (typeof config.rpcPort === "number" && Number.isInteger(config.rpcPort) && config.rpcPort >= 1 && config.rpcPort <= 65535) {
     return config.rpcPort;
+  }
+  if (config.rpcPort !== undefined) {
+    transport.log(`Invalid rpcPort=${config.rpcPort}, falling back to default`);
   }
 
   return DEFAULT_RPC_PORT;
 }
 
+// Phase 1: only accept loopback hosts (127.0.0.1, ::1, localhost) for security.
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "::1", "localhost"]);
+
 /** Resolve transports config with defaults. stdio is not user-configurable (always on in sidecar). */
 function resolveTransports(config: MercuryConfig): TransportsConfig {
+  const userHost = config.transports?.http?.host;
+  const host = userHost && LOOPBACK_HOSTS.has(userHost) ? userHost : "127.0.0.1";
+  if (userHost && !LOOPBACK_HOSTS.has(userHost)) {
+    transport.log(`Ignoring non-loopback transports.http.host="${userHost}", using 127.0.0.1 (localhost-only binding)`);
+  }
   return {
-    http: { enabled: true, host: "127.0.0.1", ...config.transports?.http },
+    http: { enabled: true, ...config.transports?.http, host },
     mcp: { enabled: true, path: "/mcp", ...config.transports?.mcp },
     sse: { enabled: false, path: "/events", maxConnections: 10, heartbeatIntervalMs: 30000, ...config.transports?.sse },
   };
@@ -382,7 +396,7 @@ async function handleJsonRpcPost(
   }
 
   if (!isJsonRpcRequest(payload)) {
-    sendHttpJson(res, 400, { jsonrpc: "2.0", error: { code: -32603, message: "Invalid JSON-RPC request" }, id: null }, req);
+    sendHttpJson(res, 400, { jsonrpc: "2.0", error: { code: -32600, message: "Invalid Request" }, id: null }, req);
     return;
   }
 
@@ -431,21 +445,26 @@ function handleSseConnection(
     res.write(":heartbeat\n\n");
   }, heartbeatMs);
 
+  let cleanedUp = false;
+  const cleanup = () => {
+    if (cleanedUp) return;
+    cleanedUp = true;
+    clearInterval(heartbeat);
+    broadcaster.removeChannel(channelName);
+    if (!res.writableEnded) res.end();
+  };
+
   broadcaster.addChannel({
     name: channelName,
     send: (method: string, params: Record<string, unknown>) => {
       res.write(`event: ${method}\ndata: ${JSON.stringify(params)}\n\n`);
     },
-    close: () => {
-      clearInterval(heartbeat);
-      if (!res.writableEnded) res.end();
-    },
+    close: cleanup,
   });
 
-  req.on("close", () => {
-    clearInterval(heartbeat);
-    broadcaster.removeChannel(channelName);
-  });
+  req.once("close", cleanup);
+  res.once("close", cleanup);
+  res.once("error", cleanup);
 }
 
 interface HttpServerContext {
@@ -463,7 +482,7 @@ interface HttpServerContext {
  *   GET  /health     — Health check
  *   POST /           — Legacy JSON-RPC (backward compat with TASK-ARCH-005 clients)
  */
-function createHttpServer(ctx: HttpServerContext, port: number): Server {
+function createHttpServer(ctx: HttpServerContext, host: string, port: number): Server {
   const { orchestrator, mcpSessions, broadcaster, transportsConfig } = ctx;
   const mcpPath = transportsConfig.mcp?.path ?? "/mcp";
   const ssePath = transportsConfig.sse?.path ?? "/events";
@@ -515,12 +534,12 @@ function createHttpServer(ctx: HttpServerContext, port: number): Server {
 
     res.statusCode = 404;
     res.end("Not Found");
-  }).listen(port, "127.0.0.1", () => {
+  }).listen(port, host, () => {
     const routes = ["POST /rpc (JSON-RPC)"];
     if (transportsConfig.mcp?.enabled !== false) routes.push(`POST|GET|DELETE ${mcpPath} (MCP)`);
     if (transportsConfig.sse?.enabled) routes.push(`GET ${ssePath} (SSE)`);
     routes.push("GET /health");
-    transport.log(`HTTP server listening on http://127.0.0.1:${port} — routes: ${routes.join(", ")}`);
+    transport.log(`HTTP server listening on http://${host}:${port} — routes: ${routes.join(", ")}`);
   });
 }
 
@@ -587,7 +606,8 @@ function startTransports(orchestrator: Orchestrator, registry: AgentRegistry, co
       ? new McpHttpSessionManager(orchestrator, broadcaster, (msg) => transport.log(msg))
       : null;
 
-    const httpServer = createHttpServer({ orchestrator, mcpSessions, broadcaster, transportsConfig }, port);
+    const httpHost = transportsConfig.http?.host ?? "127.0.0.1";
+    const httpServer = createHttpServer({ orchestrator, mcpSessions, broadcaster, transportsConfig }, httpHost, port);
     wireShutdown(httpServer, mcpSessions, broadcaster);
   }
 

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -266,20 +266,30 @@ function resolveRpcPort(config: MercuryConfig): number {
   return DEFAULT_RPC_PORT;
 }
 
-/** Resolve transports config with defaults. */
-function resolveTransports(config: MercuryConfig): Required<Pick<TransportsConfig, "stdio">> & TransportsConfig {
+/** Resolve transports config with defaults. stdio is not user-configurable (always on in sidecar). */
+function resolveTransports(config: MercuryConfig): TransportsConfig {
   return {
-    stdio: true,
-    ...config.transports,
     http: { enabled: true, host: "127.0.0.1", ...config.transports?.http },
     mcp: { enabled: true, path: "/mcp", ...config.transports?.mcp },
     sse: { enabled: false, path: "/events", maxConnections: 10, heartbeatIntervalMs: 30000, ...config.transports?.sse },
   };
 }
 
-/** Set CORS headers on an HTTP response. */
-function setCorsHeaders(res: ServerResponse): void {
-  res.setHeader("Access-Control-Allow-Origin", "*");
+const ALLOWED_ORIGINS = new Set([
+  "http://localhost:1420",   // Tauri dev server
+  "http://127.0.0.1:1420",
+  "http://localhost:7654",
+  "http://127.0.0.1:7654",
+  "tauri://localhost",       // Tauri production webview
+]);
+
+/** Set CORS headers on an HTTP response, restricted to known localhost origins. */
+function setCorsHeaders(res: ServerResponse, req?: IncomingMessage): void {
+  const origin = req?.headers.origin;
+  if (origin && ALLOWED_ORIGINS.has(origin)) {
+    res.setHeader("Access-Control-Allow-Origin", origin);
+  }
+  // No Access-Control-Allow-Origin header if origin not in allowlist
   res.setHeader("Access-Control-Allow-Methods", "POST, GET, DELETE, OPTIONS");
   res.setHeader("Access-Control-Allow-Headers", "Content-Type, MCP-Session-Id");
 }
@@ -289,8 +299,9 @@ function sendHttpJson(
   res: ServerResponse,
   statusCode: number,
   payload: JsonRpcHttpResponse,
+  req?: IncomingMessage,
 ): void {
-  setCorsHeaders(res);
+  setCorsHeaders(res, req);
   res.statusCode = statusCode;
   res.setHeader("Content-Type", "application/json; charset=utf-8");
   res.end(JSON.stringify(payload));
@@ -358,7 +369,7 @@ async function handleJsonRpcPost(
   try {
     body = await readRequestBody(req);
   } catch (err) {
-    sendHttpJson(res, 500, { jsonrpc: "2.0", error: mapRpcError(err), id: null });
+    sendHttpJson(res, 500, { jsonrpc: "2.0", error: mapRpcError(err), id: null }, req);
     return;
   }
 
@@ -366,20 +377,20 @@ async function handleJsonRpcPost(
   try {
     payload = JSON.parse(body);
   } catch {
-    sendHttpJson(res, 400, { jsonrpc: "2.0", error: { code: -32700, message: "Parse error" }, id: null });
+    sendHttpJson(res, 400, { jsonrpc: "2.0", error: { code: -32700, message: "Parse error" }, id: null }, req);
     return;
   }
 
   if (!isJsonRpcRequest(payload)) {
-    sendHttpJson(res, 400, { jsonrpc: "2.0", error: { code: -32603, message: "Invalid JSON-RPC request" }, id: null });
+    sendHttpJson(res, 400, { jsonrpc: "2.0", error: { code: -32603, message: "Invalid JSON-RPC request" }, id: null }, req);
     return;
   }
 
   try {
     const result = await orchestrator.handleRpc(payload.method, payload.params ?? {});
-    sendHttpJson(res, 200, { jsonrpc: "2.0", result, id: payload.id });
+    sendHttpJson(res, 200, { jsonrpc: "2.0", result, id: payload.id }, req);
   } catch (err) {
-    sendHttpJson(res, 500, { jsonrpc: "2.0", error: mapRpcError(err), id: payload.id });
+    sendHttpJson(res, 500, { jsonrpc: "2.0", error: mapRpcError(err), id: payload.id }, req);
   }
 }
 
@@ -397,19 +408,21 @@ function handleSseConnection(
   }
 
   const maxConns = sseConfig.maxConnections ?? 10;
-  // Count existing SSE channels
-  if (broadcaster.channelCount > maxConns + 5) {
+  if (broadcaster.countByPrefix("sse:") >= maxConns) {
     res.statusCode = 503;
     res.end("Too many SSE connections");
     return;
   }
 
-  res.writeHead(200, {
+  const origin = req.headers.origin;
+  const corsOrigin = origin && ALLOWED_ORIGINS.has(origin) ? origin : undefined;
+  const headers: Record<string, string> = {
     "Content-Type": "text/event-stream",
     "Cache-Control": "no-cache",
     "Connection": "keep-alive",
-    "Access-Control-Allow-Origin": "http://localhost:1420",
-  });
+  };
+  if (corsOrigin) headers["Access-Control-Allow-Origin"] = corsOrigin;
+  res.writeHead(200, headers);
   res.write(":ok\n\n");
 
   const channelName = `sse:${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -461,7 +474,7 @@ function createHttpServer(ctx: HttpServerContext, port: number): Server {
 
     // CORS preflight
     if (req.method === "OPTIONS") {
-      setCorsHeaders(res);
+      setCorsHeaders(res, req);
       res.statusCode = 204;
       res.end();
       return;
@@ -495,7 +508,7 @@ function createHttpServer(ctx: HttpServerContext, port: number): Server {
 
     // JSON-RPC: /rpc or root /
     if (pathname === "/rpc" || pathname === "/") {
-      setCorsHeaders(res);
+      setCorsHeaders(res, req);
       await handleJsonRpcPost(orchestrator, req, res);
       return;
     }
@@ -565,22 +578,26 @@ function startTransports(orchestrator: Orchestrator, registry: AgentRegistry, co
   // Start stdio transport (primary, always enabled in sidecar mode)
   transport.start((method, params) => orchestrator.handleRpc(method, params));
 
-  // Create MCP HTTP session manager (enabled by default)
-  const mcpSessions = transportsConfig.mcp?.enabled !== false
-    ? new McpHttpSessionManager(orchestrator, broadcaster, (msg) => transport.log(msg))
-    : null;
+  const httpEnabled = transportsConfig.http?.enabled !== false;
+  const mcpEnabled = httpEnabled && transportsConfig.mcp?.enabled !== false;
+  let mcpSessions: McpHttpSessionManager | null = null;
 
-  // Create shared HTTP server with path-based routing
-  const httpServer = createHttpServer({ orchestrator, mcpSessions, broadcaster, transportsConfig }, port);
-  wireShutdown(httpServer, mcpSessions, broadcaster);
+  if (httpEnabled) {
+    mcpSessions = mcpEnabled
+      ? new McpHttpSessionManager(orchestrator, broadcaster, (msg) => transport.log(msg))
+      : null;
+
+    const httpServer = createHttpServer({ orchestrator, mcpSessions, broadcaster, transportsConfig }, port);
+    wireShutdown(httpServer, mcpSessions, broadcaster);
+  }
 
   transport.sendNotification("ready", {
     agents: registry.listAgents().map((a) => a.id),
     transports: {
       stdio: true,
-      http: true,
+      http: httpEnabled,
       mcp: mcpSessions !== null,
-      sse: transportsConfig.sse?.enabled ?? false,
+      sse: httpEnabled && (transportsConfig.sse?.enabled ?? false),
     },
     timestamp: Date.now(),
   });

--- a/packages/orchestrator/src/mcp-server.ts
+++ b/packages/orchestrator/src/mcp-server.ts
@@ -427,13 +427,16 @@ export interface McpHttpSession {
 export class McpHttpSessionManager {
   private sessions = new Map<string, McpHttpSession>();
   private log: (msg: string) => void;
+  private maxSessions: number;
 
   constructor(
     private orchestrator: Orchestrator,
     private broadcaster: NotificationBroadcaster | null,
     logger: (msg: string) => void,
+    maxSessions = 10,
   ) {
     this.log = logger;
+    this.maxSessions = maxSessions;
   }
 
   get sessionCount(): number {
@@ -457,6 +460,11 @@ export class McpHttpSessionManager {
 
     // New session: only via POST without session header (MCP initialize)
     if (req.method === "POST" && !sessionId) {
+      if (this.sessions.size >= this.maxSessions) {
+        res.statusCode = 503;
+        res.end(JSON.stringify({ error: "Too many MCP sessions" }));
+        return;
+      }
       await this.createSession(req, res);
       return;
     }

--- a/packages/orchestrator/src/mcp-server.ts
+++ b/packages/orchestrator/src/mcp-server.ts
@@ -428,6 +428,7 @@ export class McpHttpSessionManager {
   private sessions = new Map<string, McpHttpSession>();
   private log: (msg: string) => void;
   private maxSessions: number;
+  private closing = false;
 
   constructor(
     private orchestrator: Orchestrator,
@@ -437,6 +438,15 @@ export class McpHttpSessionManager {
   ) {
     this.log = logger;
     this.maxSessions = maxSessions;
+  }
+
+  private cleanupSession(sid: string): void {
+    if (this.closing) return;
+    this.sessions.delete(sid);
+    if (this.broadcaster) {
+      this.broadcaster.removeChannel(`mcp-http:${sid}`);
+    }
+    this.log(`MCP HTTP session closed: ${sid}`);
   }
 
   get sessionCount(): number {
@@ -515,15 +525,11 @@ export class McpHttpSessionManager {
       },
     });
 
-    // Wire session lifecycle cleanup
+    // Wire session lifecycle cleanup (guarded against closeAll race)
     transport.onclose = () => {
       const sid = transport.sessionId;
       if (sid) {
-        this.sessions.delete(sid);
-        if (this.broadcaster) {
-          this.broadcaster.removeChannel(`mcp-http:${sid}`);
-        }
-        this.log(`MCP HTTP session closed: ${sid}`);
+        this.cleanupSession(sid);
       }
     };
 
@@ -534,6 +540,7 @@ export class McpHttpSessionManager {
   }
 
   async closeAll(): Promise<void> {
+    this.closing = true;
     for (const [sid, session] of this.sessions) {
       try {
         await session.transport.close();
@@ -545,5 +552,6 @@ export class McpHttpSessionManager {
       }
     }
     this.sessions.clear();
+    this.closing = false;
   }
 }

--- a/packages/orchestrator/src/mcp-server.ts
+++ b/packages/orchestrator/src/mcp-server.ts
@@ -22,9 +22,13 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { z } from "zod";
+import { randomUUID } from "node:crypto";
+import type { IncomingMessage, ServerResponse } from "node:http";
 import type { Orchestrator } from "./orchestrator.js";
 import type { RpcTransport } from "./rpc-transport.js";
+import type { NotificationBroadcaster } from "./notification-broadcaster.js";
 
 // ─── Shared Schema Fragments ───
 
@@ -59,14 +63,10 @@ function rpcTool(
   }
 }
 
-// ─── Factory ───
+// ─── Shared Tool Registration ───
 
-export function createMcpServer(orchestrator: Orchestrator, transport: RpcTransport) {
-  const server = new McpServer(
-    { name: "mercury-orchestrator", version: "0.1.0" },
-    { capabilities: { tools: {} } },
-  );
-
+/** Register all Mercury RPC methods as MCP tools on the given McpServer instance. */
+function registerMcpTools(server: McpServer, orchestrator: Orchestrator): void {
   // ─── Agent Management ───
 
   rpcTool(server, orchestrator, "get_agents",
@@ -369,8 +369,17 @@ export function createMcpServer(orchestrator: Orchestrator, transport: RpcTransp
 
   rpcTool(server, orchestrator, "ping",
     "Health check — returns pong with timestamp");
+}
 
-  // ─── Start Function ───
+// ─── Factory: stdio MCP Server (--mcp flag) ───
+
+export function createMcpServer(orchestrator: Orchestrator, transport: RpcTransport) {
+  const server = new McpServer(
+    { name: "mercury-orchestrator", version: "0.1.0" },
+    { capabilities: { tools: {} } },
+  );
+
+  registerMcpTools(server, orchestrator);
 
   async function start(): Promise<void> {
     const stdioTransport = new StdioServerTransport();
@@ -401,4 +410,131 @@ export function createMcpServer(orchestrator: Orchestrator, transport: RpcTransp
   }
 
   return { start, server };
+}
+
+// ─── Factory: HTTP MCP Sessions (shared HTTP server) ───
+// Uses StreamableHTTPServerTransport from @modelcontextprotocol/sdk (^1.27.1, verified npm 2026-03-28)
+
+export interface McpHttpSession {
+  server: McpServer;
+  transport: StreamableHTTPServerTransport;
+}
+
+/**
+ * Manages per-session MCP servers over Streamable HTTP.
+ * Each MCP client gets its own McpServer + StreamableHTTPServerTransport pair.
+ */
+export class McpHttpSessionManager {
+  private sessions = new Map<string, McpHttpSession>();
+  private log: (msg: string) => void;
+
+  constructor(
+    private orchestrator: Orchestrator,
+    private broadcaster: NotificationBroadcaster | null,
+    logger: (msg: string) => void,
+  ) {
+    this.log = logger;
+  }
+
+  get sessionCount(): number {
+    return this.sessions.size;
+  }
+
+  /**
+   * Handle an incoming HTTP request on the /mcp route.
+   * POST without session: creates new session (MCP initialize).
+   * POST/GET/DELETE with session: routes to existing session transport.
+   */
+  async handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const sessionId = req.headers["mcp-session-id"] as string | undefined;
+
+    // Existing session: route to its transport
+    if (sessionId && this.sessions.has(sessionId)) {
+      const session = this.sessions.get(sessionId)!;
+      await session.transport.handleRequest(req, res);
+      return;
+    }
+
+    // New session: only via POST (MCP initialize)
+    if (req.method === "POST") {
+      await this.createSession(req, res);
+      return;
+    }
+
+    // GET/DELETE without valid session
+    if (sessionId) {
+      res.statusCode = 404;
+      res.end(JSON.stringify({ error: "Session not found" }));
+    } else {
+      res.statusCode = 400;
+      res.end(JSON.stringify({ error: "Missing MCP-Session-Id header" }));
+    }
+  }
+
+  private async createSession(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: () => randomUUID(),
+      onsessioninitialized: (sid) => {
+        this.log(`MCP HTTP session initialized: ${sid}`);
+      },
+    });
+
+    const server = new McpServer(
+      { name: "mercury-orchestrator", version: "0.1.0" },
+      { capabilities: { tools: {} } },
+    );
+
+    registerMcpTools(server, this.orchestrator);
+
+    // Wire session lifecycle
+    transport.onclose = () => {
+      const sid = transport.sessionId;
+      if (sid) {
+        this.sessions.delete(sid);
+        if (this.broadcaster) {
+          this.broadcaster.removeChannel(`mcp-http:${sid}`);
+        }
+        this.log(`MCP HTTP session closed: ${sid}`);
+      }
+    };
+
+    await server.connect(transport);
+
+    // Register as broadcaster channel for event fan-out
+    const sid = transport.sessionId;
+    if (sid) {
+      this.sessions.set(sid, { server, transport });
+
+      if (this.broadcaster) {
+        this.broadcaster.addChannel({
+          name: `mcp-http:${sid}`,
+          send: (method: string, params: Record<string, unknown>) => {
+            server.server.sendLoggingMessage({
+              level: method === "log" ? "info" : "debug",
+              logger: "mercury",
+              data: { method, ...params },
+            }).catch(() => {});
+          },
+          close: () => {},
+        });
+      }
+    }
+
+    // Handle the initial request that created this session
+    await transport.handleRequest(req, res);
+  }
+
+  async closeAll(): Promise<void> {
+    for (const [sid, session] of this.sessions) {
+      try {
+        await session.transport.close();
+      } catch {
+        // best-effort
+      }
+      if (this.broadcaster) {
+        this.broadcaster.removeChannel(`mcp-http:${sid}`);
+      }
+    }
+    this.sessions.clear();
+  }
 }

--- a/packages/orchestrator/src/mcp-server.ts
+++ b/packages/orchestrator/src/mcp-server.ts
@@ -505,6 +505,12 @@ export class McpHttpSessionManager {
     const transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: () => randomUUID(),
       onsessioninitialized: (sid) => {
+        // Double-check limit (guard against TOCTOU race)
+        if (this.sessions.size >= this.maxSessions) {
+          this.log(`MCP HTTP session rejected (over limit): ${sid}`);
+          transport.close();
+          return;
+        }
         this.log(`MCP HTTP session initialized: ${sid}`);
         this.sessions.set(sid, { server, transport });
 

--- a/packages/orchestrator/src/mcp-server.ts
+++ b/packages/orchestrator/src/mcp-server.ts
@@ -455,30 +455,25 @@ export class McpHttpSessionManager {
       return;
     }
 
-    // New session: only via POST (MCP initialize)
-    if (req.method === "POST") {
+    // New session: only via POST without session header (MCP initialize)
+    if (req.method === "POST" && !sessionId) {
       await this.createSession(req, res);
       return;
     }
 
-    // GET/DELETE without valid session
+    // POST with invalid/expired session ID → 404
     if (sessionId) {
       res.statusCode = 404;
       res.end(JSON.stringify({ error: "Session not found" }));
-    } else {
-      res.statusCode = 400;
-      res.end(JSON.stringify({ error: "Missing MCP-Session-Id header" }));
+      return;
     }
+
+    // GET/DELETE without session header
+    res.statusCode = 400;
+    res.end(JSON.stringify({ error: "Missing MCP-Session-Id header" }));
   }
 
   private async createSession(req: IncomingMessage, res: ServerResponse): Promise<void> {
-    const transport = new StreamableHTTPServerTransport({
-      sessionIdGenerator: () => randomUUID(),
-      onsessioninitialized: (sid) => {
-        this.log(`MCP HTTP session initialized: ${sid}`);
-      },
-    });
-
     const server = new McpServer(
       { name: "mercury-orchestrator", version: "0.1.0" },
       { capabilities: { tools: {} } },
@@ -486,7 +481,33 @@ export class McpHttpSessionManager {
 
     registerMcpTools(server, this.orchestrator);
 
-    // Wire session lifecycle
+    // sessionId is generated inside handleRequest() during MCP initialize,
+    // so we register the session in onsessioninitialized — the SDK hook
+    // designed for multi-session tracking (verified: MCP TS SDK docs).
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: () => randomUUID(),
+      onsessioninitialized: (sid) => {
+        this.log(`MCP HTTP session initialized: ${sid}`);
+        this.sessions.set(sid, { server, transport });
+
+        // Register as broadcaster channel for event fan-out
+        if (this.broadcaster) {
+          this.broadcaster.addChannel({
+            name: `mcp-http:${sid}`,
+            send: (method: string, params: Record<string, unknown>) => {
+              server.server.sendLoggingMessage({
+                level: method === "log" ? "info" : "debug",
+                logger: "mercury",
+                data: { method, ...params },
+              }).catch(() => {});
+            },
+            close: () => {},
+          });
+        }
+      },
+    });
+
+    // Wire session lifecycle cleanup
     transport.onclose = () => {
       const sid = transport.sessionId;
       if (sid) {
@@ -500,27 +521,7 @@ export class McpHttpSessionManager {
 
     await server.connect(transport);
 
-    // Register as broadcaster channel for event fan-out
-    const sid = transport.sessionId;
-    if (sid) {
-      this.sessions.set(sid, { server, transport });
-
-      if (this.broadcaster) {
-        this.broadcaster.addChannel({
-          name: `mcp-http:${sid}`,
-          send: (method: string, params: Record<string, unknown>) => {
-            server.server.sendLoggingMessage({
-              level: method === "log" ? "info" : "debug",
-              logger: "mercury",
-              data: { method, ...params },
-            }).catch(() => {});
-          },
-          close: () => {},
-        });
-      }
-    }
-
-    // Handle the initial request that created this session
+    // Handle the initial request — this triggers sessionId generation
     await transport.handleRequest(req, res);
   }
 

--- a/packages/orchestrator/src/notification-broadcaster.ts
+++ b/packages/orchestrator/src/notification-broadcaster.ts
@@ -1,0 +1,85 @@
+/**
+ * NotificationBroadcaster — Multi-channel event fan-out.
+ *
+ * Replaces single-channel sendNotification (stdout only) with a broadcaster
+ * that delivers events to all registered channels simultaneously:
+ * - stdio (primary, always present in sidecar mode)
+ * - MCP HTTP sessions (SSE via StreamableHTTPServerTransport)
+ * - Native SSE connections (optional GET /events endpoint)
+ */
+
+export interface NotificationChannel {
+  readonly name: string;
+  send(method: string, params: Record<string, unknown>): void;
+  close(): void;
+}
+
+export class NotificationBroadcaster {
+  private channels = new Map<string, NotificationChannel>();
+
+  addChannel(channel: NotificationChannel): void {
+    this.channels.set(channel.name, channel);
+  }
+
+  removeChannel(name: string): void {
+    const ch = this.channels.get(name);
+    if (ch) {
+      ch.close();
+      this.channels.delete(name);
+    }
+  }
+
+  hasChannel(name: string): boolean {
+    return this.channels.has(name);
+  }
+
+  get channelCount(): number {
+    return this.channels.size;
+  }
+
+  broadcast(method: string, params: Record<string, unknown>): void {
+    for (const ch of this.channels.values()) {
+      try {
+        ch.send(method, params);
+      } catch {
+        // Non-fatal: individual channel failure must not block others
+      }
+    }
+  }
+
+  closeAll(): void {
+    for (const ch of this.channels.values()) {
+      try {
+        ch.close();
+      } catch {
+        // best-effort cleanup
+      }
+    }
+    this.channels.clear();
+  }
+
+  /**
+   * Wrap an RpcTransport so its sendNotification goes through the broadcaster.
+   * The transport's original sendNotification becomes the "stdio" channel.
+   */
+  static wrapTransport(
+    transport: { sendNotification: (method: string, params: Record<string, unknown>) => void },
+  ): NotificationBroadcaster {
+    const broadcaster = new NotificationBroadcaster();
+
+    // Capture original sendNotification as stdio channel
+    const originalSend = transport.sendNotification.bind(transport);
+    broadcaster.addChannel({
+      name: "stdio",
+      send: originalSend,
+      close: () => {},
+    });
+
+    // Replace transport.sendNotification with broadcaster
+    transport.sendNotification = (method: string, params: Record<string, unknown>) => {
+      broadcaster.broadcast(method, params);
+    };
+
+    return broadcaster;
+  }
+}

--- a/packages/orchestrator/src/notification-broadcaster.ts
+++ b/packages/orchestrator/src/notification-broadcaster.ts
@@ -37,6 +37,15 @@ export class NotificationBroadcaster {
     return this.channels.size;
   }
 
+  /** Count channels whose name starts with the given prefix. */
+  countByPrefix(prefix: string): number {
+    let count = 0;
+    for (const name of this.channels.keys()) {
+      if (name.startsWith(prefix)) count++;
+    }
+    return count;
+  }
+
   broadcast(method: string, params: Record<string, unknown>): void {
     for (const ch of this.channels.values()) {
       try {


### PR DESCRIPTION
## Summary

- **New**: `NotificationBroadcaster` — multi-channel event fan-out replacing single-channel stdout-only `sendNotification`
- **New**: `McpHttpSessionManager` — per-session MCP server over Streamable HTTP (`POST|GET|DELETE /mcp`) using installed `@modelcontextprotocol/sdk` ^1.27.1
- **New**: Path-based HTTP routing on shared port 7654: `POST /rpc` (JSON-RPC), `/mcp` (MCP), `GET /events` (SSE, opt-in), `GET /health`
- **New**: `TransportsConfig` type in `@mercury/core` for configuration-driven transport enable/disable
- Zero new dependencies, zero breaking changes to stdio sidecar

Closes #84

## Design

Based on RESEARCH-084 and DESIGN-084 transport adapter architecture.

Key architectural decisions:
- `handleRpc()` is already transport-agnostic — no new abstraction layer needed
- Shared HTTP server (single port) with route-based dispatch
- Per-session `McpServer` + `StreamableHTTPServerTransport` factory pattern
- `NotificationBroadcaster.wrapTransport()` preserves stdio as primary channel

## Test plan

- [ ] Verify `npx tsc --noEmit` passes for both `@mercury/core` and `packages/orchestrator`
- [ ] Start orchestrator in sidecar mode → confirm GUI still works via stdio
- [ ] `curl -X POST http://127.0.0.1:7654/rpc` → verify JSON-RPC still works
- [ ] `curl http://127.0.0.1:7654/health` → returns status JSON
- [ ] Connect MCP client to `http://127.0.0.1:7654/mcp` → verify tool listing and invocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)