### PR TITLE
feat(orchestrator): role-based dispatch + callback routing (#94)

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -341,6 +341,7 @@ export interface TaskBundle {
   closedAt: string | null; // ISO 8601, set by TaskManager when status → closed/verified
   failedAt: string | null; // ISO 8601, set by TaskManager when status → failed
   assignedTo: string;
+  role?: AgentRole; // Task dispatch role: dev, research, design (default: dev)
   assignee?: TaskAssignee; // Agents First: structured agent+model+session metadata
   branch?: string;
 

--- a/packages/orchestrator/src/mcp-server.ts
+++ b/packages/orchestrator/src/mcp-server.ts
@@ -49,7 +49,11 @@ function rpcTool(
   description: string,
   inputSchema?: Record<string, z.ZodTypeAny>,
 ) {
-  const cb = async (args: Record<string, unknown>) => {
+  const cb = async (args: Record<string, unknown>, extra?: { sessionId?: string }) => {
+    // Inject MCP session ID for task creation so callback routing knows the originator
+    if (name === "create_task" && extra?.sessionId) {
+      args = { ...args, _mcpOriginatorSessionId: `mcp-http:${extra.sessionId}` };
+    }
     const result = await orchestrator.handleRpc(name, args);
     return {
       content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
@@ -163,6 +167,7 @@ function registerMcpTools(server: McpServer, orchestrator: Orchestrator): void {
       title: z.string().describe("Short task title"),
       priority: z.enum(["P0", "P1", "P2", "P3"]).optional().describe("Task priority level"),
       assignedTo: agentId.optional().describe("Agent to assign (auto-selected if omitted)"),
+      role: z.enum(["dev", "research", "design"]).optional().describe("Task dispatch role (default: dev)"),
       description: z.string().optional().describe("Detailed task description"),
       context: z.string().describe("Task context for dev agent"),
       codeScope: z.record(z.string(), z.unknown()).optional().describe("Code scope boundaries"),

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -1844,20 +1844,28 @@ export class Orchestrator {
     };
 
     // Fast-track through full state machine: in_progress → implementation_done → main_review → acceptance → verified → closed
-    this.taskManager.transitionTask(task.taskId, "implementation_done", agentId);
-    this.taskManager.updateTaskField(task.taskId, "implementationReceipt", receipt);
-    this.taskManager.transitionTask(task.taskId, "main_review", agentId);
-    this.taskManager.transitionTask(task.taskId, "acceptance", agentId);
+    try {
+      this.taskManager.transitionTask(task.taskId, "implementation_done", agentId);
+      this.taskManager.updateTaskField(task.taskId, "implementationReceipt", receipt);
+      this.taskManager.transitionTask(task.taskId, "main_review", agentId);
+      this.taskManager.transitionTask(task.taskId, "acceptance", agentId);
 
-    // Persist synthetic acceptance so getTaskResult() returns verdict
-    this.taskManager.persistSyntheticAcceptance(task.taskId, agentId, {
-      verdict: "pass",
-      findings: findingsArr,
-      recommendations: recommendationsArr,
-    });
+      // Persist synthetic acceptance so getTaskResult() returns verdict
+      this.taskManager.persistSyntheticAcceptance(task.taskId, agentId, {
+        verdict: "pass",
+        findings: findingsArr,
+        recommendations: recommendationsArr,
+      });
 
-    this.taskManager.transitionTask(task.taskId, "verified", agentId);
-    this.taskManager.transitionTask(task.taskId, "closed", agentId);
+      this.taskManager.transitionTask(task.taskId, "verified", agentId);
+      this.taskManager.transitionTask(task.taskId, "closed", agentId);
+    } catch (err) {
+      this.transport.sendNotification("log", {
+        message: `[task] Research fast-track failed for ${task.taskId} at status ${this.taskManager.getTask(task.taskId)?.status ?? "unknown"}: ${err instanceof Error ? err.message : err}`,
+      });
+      try { this.taskManager.transitionTask(task.taskId, "failed", agentId); } catch { /* already terminal */ }
+      return;
+    }
 
     // Emit callback so originator is notified
     this.bus.emit("orchestrator.task.callback", agentId, "orchestrator", {
@@ -1899,20 +1907,28 @@ export class Orchestrator {
     };
 
     // Fast-track through full state machine: in_progress → ... → closed
-    this.taskManager.transitionTask(task.taskId, "implementation_done", agentId);
-    this.taskManager.updateTaskField(task.taskId, "implementationReceipt", receipt);
-    this.taskManager.transitionTask(task.taskId, "main_review", agentId);
-    this.taskManager.transitionTask(task.taskId, "acceptance", agentId);
+    try {
+      this.taskManager.transitionTask(task.taskId, "implementation_done", agentId);
+      this.taskManager.updateTaskField(task.taskId, "implementationReceipt", receipt);
+      this.taskManager.transitionTask(task.taskId, "main_review", agentId);
+      this.taskManager.transitionTask(task.taskId, "acceptance", agentId);
 
-    // Persist synthetic acceptance so getTaskResult() returns verdict
-    this.taskManager.persistSyntheticAcceptance(task.taskId, agentId, {
-      verdict: "pass",
-      findings: designFindings,
-      recommendations: designRecommendations,
-    });
+      // Persist synthetic acceptance so getTaskResult() returns verdict
+      this.taskManager.persistSyntheticAcceptance(task.taskId, agentId, {
+        verdict: "pass",
+        findings: designFindings,
+        recommendations: designRecommendations,
+      });
 
-    this.taskManager.transitionTask(task.taskId, "verified", agentId);
-    this.taskManager.transitionTask(task.taskId, "closed", agentId);
+      this.taskManager.transitionTask(task.taskId, "verified", agentId);
+      this.taskManager.transitionTask(task.taskId, "closed", agentId);
+    } catch (err) {
+      this.transport.sendNotification("log", {
+        message: `[task] Design fast-track failed for ${task.taskId} at status ${this.taskManager.getTask(task.taskId)?.status ?? "unknown"}: ${err instanceof Error ? err.message : err}`,
+      });
+      try { this.taskManager.transitionTask(task.taskId, "failed", agentId); } catch { /* already terminal */ }
+      return;
+    }
 
     // Emit callback so originator is notified
     this.bus.emit("orchestrator.task.callback", agentId, "orchestrator", {

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -35,6 +35,8 @@ import type { RpcTransport } from "./rpc-transport.js";
 import {
   TaskManager,
   buildDevPrompt,
+  buildResearchPrompt,
+  buildDesignPrompt,
   buildReferencePrompt,
   buildAcceptancePrompt,
   buildReworkPrompt,
@@ -755,8 +757,20 @@ export class Orchestrator {
           params.taskId as string,
           (params.oneShot as boolean | null) ?? undefined,
         );
-      case "create_task":
-        return this.taskManager.createTask(params as unknown as CreateTaskParams);
+      case "create_task": {
+        const createParams = params as unknown as CreateTaskParams & { _mcpOriginatorSessionId?: string };
+        const mcpOriginatorId = createParams._mcpOriginatorSessionId;
+        delete (createParams as unknown as Record<string, unknown>)._mcpOriginatorSessionId;
+        const created = this.taskManager.createTask(createParams);
+        // If dispatched from MCP HTTP client, store originator for callback routing
+        if (mcpOriginatorId && typeof created === "object" && created !== null) {
+          const taskId = (created as { taskId: string }).taskId;
+          if (taskId) {
+            this.taskManager.updateTaskField(taskId, "originatorSessionId", mcpOriginatorId);
+          }
+        }
+        return created;
+      }
       case "get_task":
         return (await this.taskManager.getTaskAsync(params.taskId as string)) ?? null;
       case "get_task_result":
@@ -1721,6 +1735,15 @@ export class Orchestrator {
     }
     if (role === "acceptance") {
       await this.handleAcceptanceStreamComplete(task, finalMessage);
+      return;
+    }
+    if (role === "research") {
+      await this.handleResearchStreamComplete(task, agentId, finalMessage);
+      return;
+    }
+    if (role === "design") {
+      await this.handleDesignStreamComplete(task, agentId, finalMessage);
+      return;
     }
   }
 
@@ -1788,6 +1811,95 @@ export class Orchestrator {
       return;
     }
     await this.recordAcceptanceFlow(acceptanceId, results);
+  }
+
+  /**
+   * Handle research task completion — fast-track to closed (no review/acceptance cycle).
+   */
+  private async handleResearchStreamComplete(
+    task: TaskBundle,
+    agentId: string,
+    finalMessage: string,
+  ): Promise<void> {
+    if (task.status !== "in_progress") return;
+
+    this.transport.sendNotification("log", {
+      message: `[task] Research task ${task.taskId} completed by ${agentId}, fast-tracking to closed`,
+    });
+
+    // Store a lightweight receipt
+    const parsed = this.tryParseJsonRecord(finalMessage);
+    const receipt: ImplementationReceipt = {
+      implementer: agentId,
+      branch: "",
+      summary: this.readString(parsed?.summary) ?? finalMessage.slice(0, 500),
+      changedFiles: [],
+      evidence: this.readStringArray(parsed?.findings) ?? this.readStringArray(parsed?.evidence) ?? [],
+      docsUpdated: [],
+      residualRisks: [],
+      completedAt: Date.now(),
+    };
+
+    // Fast-track through full state machine: in_progress → implementation_done → main_review → acceptance → verified → closed
+    this.taskManager.transitionTask(task.taskId, "implementation_done", agentId);
+    this.taskManager.updateTaskField(task.taskId, "implementationReceipt", receipt);
+    this.taskManager.transitionTask(task.taskId, "main_review", agentId);
+    this.taskManager.transitionTask(task.taskId, "acceptance", agentId);
+    this.taskManager.transitionTask(task.taskId, "verified", agentId);
+    this.taskManager.transitionTask(task.taskId, "closed", agentId);
+
+    // Emit callback so originator is notified
+    this.bus.emit("orchestrator.task.callback", agentId, "orchestrator", {
+      taskId: task.taskId,
+      originatorSessionId: task.originatorSessionId,
+      verdict: "pass",
+      findings: this.readStringArray(parsed?.findings) ?? [],
+      recommendations: this.readStringArray(parsed?.recommendations) ?? [],
+    });
+  }
+
+  /**
+   * Handle design task completion — fast-track to closed (no review/acceptance cycle).
+   */
+  private async handleDesignStreamComplete(
+    task: TaskBundle,
+    agentId: string,
+    finalMessage: string,
+  ): Promise<void> {
+    if (task.status !== "in_progress") return;
+
+    this.transport.sendNotification("log", {
+      message: `[task] Design task ${task.taskId} completed by ${agentId}, fast-tracking to closed`,
+    });
+
+    const parsed = this.tryParseJsonRecord(finalMessage);
+    const receipt: ImplementationReceipt = {
+      implementer: agentId,
+      branch: "",
+      summary: this.readString(parsed?.summary) ?? finalMessage.slice(0, 500),
+      changedFiles: [],
+      evidence: this.readStringArray(parsed?.artifacts) ?? [],
+      docsUpdated: [],
+      residualRisks: [],
+      completedAt: Date.now(),
+    };
+
+    // Fast-track through full state machine: in_progress → ... → closed
+    this.taskManager.transitionTask(task.taskId, "implementation_done", agentId);
+    this.taskManager.updateTaskField(task.taskId, "implementationReceipt", receipt);
+    this.taskManager.transitionTask(task.taskId, "main_review", agentId);
+    this.taskManager.transitionTask(task.taskId, "acceptance", agentId);
+    this.taskManager.transitionTask(task.taskId, "verified", agentId);
+    this.taskManager.transitionTask(task.taskId, "closed", agentId);
+
+    // Emit callback so originator is notified
+    this.bus.emit("orchestrator.task.callback", agentId, "orchestrator", {
+      taskId: task.taskId,
+      originatorSessionId: task.originatorSessionId,
+      verdict: "pass",
+      findings: [],
+      recommendations: [],
+    });
   }
 
   private parseImplementationReceipt(
@@ -2277,7 +2389,7 @@ export class Orchestrator {
   private async prepareBundleTaskExecution(taskId: string): Promise<{
     task: TaskBundle;
     prompt: string;
-    devRolePrompt: string;
+    rolePrompt: string;
     baseRolePrompt: string;
   }> {
     const task = await this.taskManager.getTaskAsync(taskId);
@@ -2288,15 +2400,20 @@ export class Orchestrator {
       task.assignedTo = (task.assignedTo as unknown as { agentId: string }).agentId;
     }
 
-    const mainAgentId = this.findMainAgentId();
-    if (mainAgentId) {
-      const mainSlot = makeRoleSlotKey("main", mainAgentId);
-      this.taskManager.updateTaskField(
-        taskId,
-        "originatorSessionId",
-        this.roleSessions.get(mainSlot),
-      );
+    // Only set originatorSessionId if not already set (preserves MCP originator)
+    if (!task.originatorSessionId) {
+      const mainAgentId = this.findMainAgentId();
+      if (mainAgentId) {
+        const mainSlot = makeRoleSlotKey("main", mainAgentId);
+        this.taskManager.updateTaskField(
+          taskId,
+          "originatorSessionId",
+          this.roleSessions.get(mainSlot),
+        );
+      }
     }
+
+    const role: AgentRole = task.role ?? "dev";
 
     let kbContext: string | undefined;
     if (this.kb?.isEnabled() && task.readScope.requiredDocs.length > 0) {
@@ -2307,11 +2424,21 @@ export class Orchestrator {
       }
     }
 
+    // Build role-appropriate prompt
+    let prompt: string;
+    if (role === "research") {
+      prompt = buildResearchPrompt(task, kbContext);
+    } else if (role === "design") {
+      prompt = buildDesignPrompt(task, kbContext);
+    } else {
+      prompt = buildDevPrompt(task, kbContext, this.getProjectRoot());
+    }
+
     return {
       task,
-      prompt: buildDevPrompt(task, kbContext, this.getProjectRoot()),
-      devRolePrompt: this.buildSystemRolePrompt("dev", task),
-      baseRolePrompt: this.buildSystemRolePrompt("dev"),
+      prompt,
+      rolePrompt: this.buildSystemRolePrompt(role, task),
+      baseRolePrompt: this.buildSystemRolePrompt(role),
     };
   }
 
@@ -2335,9 +2462,10 @@ export class Orchestrator {
       };
     }
 
-    const { task, prompt, devRolePrompt, baseRolePrompt } =
+    const { task, prompt, rolePrompt, baseRolePrompt } =
       await this.prepareBundleTaskExecution(taskId);
     const agentId = task.assignedTo;
+    const role: AgentRole = task.role ?? "dev";
     const adapter = this.registry.getAdapter(agentId);
     if (!adapter.executeOneShot) {
       throw new Error(`Agent ${agentId} does not support executeOneShot()`);
@@ -2352,9 +2480,9 @@ export class Orchestrator {
 
     const cwd = this.agentCwds.get(agentId) ?? process.cwd();
     const startedAt = Date.now();
-    const sessionName = this.buildRoleSessionName(agentId, "dev", task.title);
+    const sessionName = this.buildRoleSessionName(agentId, role, task.title);
     const result = await adapter.executeOneShot(
-      this.wrapPromptWithRoleContext(prompt, devRolePrompt),
+      this.wrapPromptWithRoleContext(prompt, rolePrompt),
       cwd,
     );
 
@@ -2370,8 +2498,8 @@ export class Orchestrator {
     const session: SessionInfo = {
       sessionId,
       agentId,
-      role: "dev",
-      frozenRole: "dev",
+      role,
+      frozenRole: role,
       sessionName,
       cwd: nativeInfo?.cwd ?? cwd,
       startedAt: nativeInfo?.startedAt ?? startedAt,
@@ -2380,16 +2508,16 @@ export class Orchestrator {
       tokenLimit: nativeInfo?.tokenLimit,
       status: "completed",
       resumeToken: result.threadId,
-      frozenSystemPrompt: devRolePrompt,
+      frozenSystemPrompt: rolePrompt,
       baseRolePromptHash: this.hashPrompt(baseRolePrompt),
-      promptHash: this.hashPrompt(devRolePrompt),
+      promptHash: this.hashPrompt(rolePrompt),
     };
 
     this.sessions.set(sessionId, session);
     this.taskManager.bindSession(taskId, sessionId);
 
     this.bus.emit("agent.session.start", agentId, sessionId, {
-      role: "dev",
+      role,
       sessionName,
       promptHash: session.promptHash,
       currentPromptHash: undefined,
@@ -2501,7 +2629,8 @@ export class Orchestrator {
         // This try/catch only catches synchronous failures (session creation,
         // state transitions). Streaming failures trigger G2 crash recovery
         // in streamMessages() catch handler — automatic re-dispatch.
-        const { task: freshTask, prompt, devRolePrompt } = await this.prepareBundleTaskExecution(taskId);
+        const { task: freshTask, prompt, rolePrompt } = await this.prepareBundleTaskExecution(taskId);
+        const role: AgentRole = freshTask.role ?? "dev";
 
         // Transition: drafted → dispatched → in_progress
         if (freshTask.status === "drafted") {
@@ -2509,7 +2638,7 @@ export class Orchestrator {
         }
 
         // Start role-scoped session for assigned agent
-        const session = await this.startRoleSession(freshTask.assignedTo, "dev", freshTask.title, devRolePrompt);
+        const session = await this.startRoleSession(freshTask.assignedTo, role, freshTask.title, rolePrompt);
         this.taskManager.bindSession(taskId, session.sessionId);
 
         // Transition to in_progress (only if not already there)
@@ -2522,9 +2651,9 @@ export class Orchestrator {
           freshTask.assignedTo,
           prompt,
           undefined,
-          "dev",
+          role,
           freshTask.title,
-          devRolePrompt,
+          rolePrompt,
           freshTask.taskId,
         );
 
@@ -2563,6 +2692,15 @@ export class Orchestrator {
    * Called when acceptance result (pass/fail/partial/blocked) is recorded.
    */
   private async deliverTaskCallback(payload: TaskCallbackPayload): Promise<void> {
+    // If originator is an external MCP client, broadcaster already delivered the event.
+    // Do NOT activate internal Main Agent session — the MCP client receives via mercury_event.
+    if (payload.originatorSessionId?.startsWith("mcp-http:")) {
+      this.transport.sendNotification("log", {
+        message: `[orchestrator] Task callback for ${payload.taskId} — MCP originator (${payload.originatorSessionId}), relying on broadcaster`,
+      });
+      return;
+    }
+
     const mainAgentId = this.findMainAgentId();
     if (!mainAgentId) return;
 
@@ -2573,6 +2711,16 @@ export class Orchestrator {
       this.transport.sendNotification("log", {
         message: `[orchestrator] No active Main Agent session for callback delivery (task: ${payload.taskId})`,
       });
+      return;
+    }
+
+    // Stale session guard: validate session exists and is not completed/overflow
+    const session = this.sessions.get(activeSessionId);
+    if (!session || session.status === "completed" || session.status === "overflow") {
+      this.transport.sendNotification("log", {
+        message: `[orchestrator] Main Agent session ${activeSessionId} is stale (${session?.status ?? "missing"}), skipping callback for ${payload.taskId}`,
+      });
+      this.roleSessions.delete(mainSlot);
       return;
     }
 
@@ -2866,15 +3014,16 @@ export class Orchestrator {
         effectiveReason ?? "Main Agent review: sent back for rework",
       );
 
-      // Send rework directive to dev agent
+      // Send rework directive to the agent in its original role
+      const reworkRole: AgentRole = task.role ?? "dev";
       const reworkPrompt = `# Rework Required [${task.taskId}]\n\nMain Agent review returned this task for rework.\n\n**Reason:** ${effectiveReason ?? "Unspecified"}\n\nPlease address and resubmit.`;
       if (newSession) {
-        const devRolePrompt = this.buildSystemRolePrompt("dev", task);
+        const reworkRolePrompt = this.buildSystemRolePrompt(reworkRole, task);
         const session = await this.startRoleSession(
           task.assignedTo,
-          "dev",
+          reworkRole,
           task.title,
-          devRolePrompt,
+          reworkRolePrompt,
         );
         this.taskManager.bindSession(taskId, session.sessionId);
       }
@@ -2882,9 +3031,9 @@ export class Orchestrator {
         task.assignedTo,
         reworkPrompt,
         undefined,
-        "dev",
+        reworkRole,
         task.title,
-        this.buildSystemRolePrompt("dev", task),
+        this.buildSystemRolePrompt(reworkRole, task),
         task.taskId,
       );
 

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -1829,12 +1829,15 @@ export class Orchestrator {
 
     // Store a lightweight receipt
     const parsed = this.tryParseJsonRecord(finalMessage);
+    const evidenceArr = this.readStringArray(parsed?.evidence);
+    const findingsArr = this.readStringArray(parsed?.findings);
+    const recommendationsArr = this.readStringArray(parsed?.recommendations);
     const receipt: ImplementationReceipt = {
       implementer: agentId,
       branch: "",
       summary: this.readString(parsed?.summary) ?? finalMessage.slice(0, 500),
       changedFiles: [],
-      evidence: this.readStringArray(parsed?.findings) ?? this.readStringArray(parsed?.evidence) ?? [],
+      evidence: evidenceArr.length > 0 ? evidenceArr : findingsArr,
       docsUpdated: [],
       residualRisks: [],
       completedAt: Date.now(),
@@ -1845,6 +1848,14 @@ export class Orchestrator {
     this.taskManager.updateTaskField(task.taskId, "implementationReceipt", receipt);
     this.taskManager.transitionTask(task.taskId, "main_review", agentId);
     this.taskManager.transitionTask(task.taskId, "acceptance", agentId);
+
+    // Persist synthetic acceptance so getTaskResult() returns verdict
+    this.taskManager.persistSyntheticAcceptance(task.taskId, agentId, {
+      verdict: "pass",
+      findings: findingsArr,
+      recommendations: recommendationsArr,
+    });
+
     this.taskManager.transitionTask(task.taskId, "verified", agentId);
     this.taskManager.transitionTask(task.taskId, "closed", agentId);
 
@@ -1853,8 +1864,8 @@ export class Orchestrator {
       taskId: task.taskId,
       originatorSessionId: task.originatorSessionId,
       verdict: "pass",
-      findings: this.readStringArray(parsed?.findings) ?? [],
-      recommendations: this.readStringArray(parsed?.recommendations) ?? [],
+      findings: findingsArr,
+      recommendations: recommendationsArr,
     });
   }
 
@@ -1873,12 +1884,15 @@ export class Orchestrator {
     });
 
     const parsed = this.tryParseJsonRecord(finalMessage);
+    const artifactsArr = this.readStringArray(parsed?.artifacts);
+    const designFindings = this.readStringArray(parsed?.findings);
+    const designRecommendations = this.readStringArray(parsed?.recommendations);
     const receipt: ImplementationReceipt = {
       implementer: agentId,
       branch: "",
       summary: this.readString(parsed?.summary) ?? finalMessage.slice(0, 500),
       changedFiles: [],
-      evidence: this.readStringArray(parsed?.artifacts) ?? [],
+      evidence: artifactsArr,
       docsUpdated: [],
       residualRisks: [],
       completedAt: Date.now(),
@@ -1889,6 +1903,14 @@ export class Orchestrator {
     this.taskManager.updateTaskField(task.taskId, "implementationReceipt", receipt);
     this.taskManager.transitionTask(task.taskId, "main_review", agentId);
     this.taskManager.transitionTask(task.taskId, "acceptance", agentId);
+
+    // Persist synthetic acceptance so getTaskResult() returns verdict
+    this.taskManager.persistSyntheticAcceptance(task.taskId, agentId, {
+      verdict: "pass",
+      findings: designFindings,
+      recommendations: designRecommendations,
+    });
+
     this.taskManager.transitionTask(task.taskId, "verified", agentId);
     this.taskManager.transitionTask(task.taskId, "closed", agentId);
 
@@ -1897,8 +1919,8 @@ export class Orchestrator {
       taskId: task.taskId,
       originatorSessionId: task.originatorSessionId,
       verdict: "pass",
-      findings: [],
-      recommendations: [],
+      findings: designFindings,
+      recommendations: designRecommendations,
     });
   }
 
@@ -2527,13 +2549,13 @@ export class Orchestrator {
     this.bus.emit("agent.message.send", agentId, sessionId, {
       prompt: prompt.slice(0, 200),
       hasImages: 0,
-      role: "dev",
+      role,
       oneShot: true,
     });
     this.transport.sendNotification("agent_working", {
       agentId,
       sessionId,
-      role: "dev",
+      role,
       startedAt,
       oneShot: true,
     });

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -52,6 +52,7 @@ export interface CreateTaskParams {
   phaseId?: string;
   priority: TaskBundle["priority"];
   assignedTo?: string; // Optional: auto-assigned via G9 modelRecommendation if omitted
+  role?: string; // Task dispatch role: dev, research, design (default: dev)
   branch?: string;
   codeScope: TaskBundle["codeScope"];
   readScope: TaskBundle["readScope"];
@@ -127,11 +128,12 @@ export class TaskManager {
       throw new Error("agentListLookup not injected — Orchestrator wiring incomplete");
     }
     const agents = this.agentListLookup();
-    // Only consider agents with "dev" role
-    const devAgents = agents.filter((a) => a.roles.includes("dev"));
-    if (devAgents.length === 0) {
+    // Filter agents by the requested role (default: dev)
+    const targetRole = params.role ?? "dev";
+    const roleAgents = agents.filter((a) => a.roles.includes(targetRole as AgentRole));
+    if (roleAgents.length === 0) {
       throw new Error(
-        `No agents with 'dev' role in registry (${agents.length} total agents) — cannot auto-assign task`,
+        `No agents with '${targetRole}' role in registry (${agents.length} total agents) — cannot auto-assign task`,
       );
     }
 
@@ -151,8 +153,8 @@ export class TaskManager {
       return agentId;
     };
 
-    if (devAgents.length === 1) {
-      return selectAndEmit(devAgents[0].id, "single-dev-agent");
+    if (roleAgents.length === 1) {
+      return selectAndEmit(roleAgents[0].id, `single-${targetRole}-agent`);
     }
 
     const rawRec = params.modelRecommendation;
@@ -161,12 +163,12 @@ export class TaskManager {
     const hasCaps = !!rawRec?.requiredCapabilities?.some((c) => c.trim().length > 0);
     const hasComplexity = !!rawRec?.complexity;
     if (!rawRec || (!hasModel && !hasCaps && !hasComplexity)) {
-      return selectAndEmit(devAgents[0].id, "no-recommendation-fallback");
+      return selectAndEmit(roleAgents[0].id, "no-recommendation-fallback");
     }
     const rec = rawRec;
 
-    // Score each dev agent
-    const scored = devAgents.map((agent) => {
+    // Score each candidate agent
+    const scored = roleAgents.map((agent) => {
       let score = 0;
 
       // Preferred model match: trim + lowercase to handle whitespace in MCP/JSON inputs
@@ -287,14 +289,15 @@ export class TaskManager {
     const explicitAssignedTo = params.assignedTo?.trim();
     const assignedTo = explicitAssignedTo || this.autoSelectAgent(params, taskId);
 
-    // Validate assignedTo references a registered agent with 'dev' role
+    // Validate assignedTo references a registered agent with the required role
+    const requiredRole = (params.role ?? "dev") as AgentRole;
     if (this.agentConfigLookup) {
       const agentConfig = this.agentConfigLookup(assignedTo);
       if (!agentConfig) {
         throw new Error(`createTask validation failed: agent "${assignedTo}" is not registered`);
       }
-      if (!agentConfig.roles.includes("dev")) {
-        throw new Error(`createTask validation failed: agent "${assignedTo}" does not have 'dev' role`);
+      if (!agentConfig.roles.includes(requiredRole)) {
+        throw new Error(`createTask validation failed: agent "${assignedTo}" does not have '${requiredRole}' role`);
       }
     }
 
@@ -308,6 +311,7 @@ export class TaskManager {
       closedAt: null,
       failedAt: null,
       assignedTo,
+      role: requiredRole,
       branch: params.branch,
       codeScope: params.codeScope,
       readScope: params.readScope,
@@ -959,6 +963,106 @@ function fallbackDevTemplate(): string {
     "{{receiptTemplate}}",
     "```",
   ].join("\n");
+}
+
+/**
+ * Build a research-role dispatch prompt.
+ * Research tasks produce findings/reports, not code commits.
+ */
+export function buildResearchPrompt(
+  task: TaskBundle,
+  kbContext?: string,
+): string {
+  const lines = [
+    `# Research Task: ${task.title} [${task.taskId}]`,
+    "",
+    task.context,
+    "",
+    "## Task Bundle",
+    "```json",
+    JSON.stringify({
+      taskId: task.taskId,
+      priority: task.priority,
+      definitionOfDone: task.definitionOfDone,
+      readScope: task.readScope,
+      allowedWriteScope: task.allowedWriteScope,
+    }, null, 2),
+    "```",
+    "",
+    "## Research Instructions",
+    "- Conduct deep research on the topic described above.",
+    "- Use web search, codebase analysis, and KB resources as needed.",
+    "- Produce structured findings with evidence and recommendations.",
+    "- No code commits expected — output your research report as your final message.",
+    "",
+    "## Output Format",
+    "Return a JSON research report as your final message:",
+    "```json",
+    JSON.stringify({
+      researcher: "",
+      summary: "",
+      findings: [""],
+      recommendations: [""],
+      evidence: [""],
+      completedAt: "",
+    }, null, 2),
+    "```",
+  ];
+
+  if (kbContext) {
+    lines.push("", "## Project Knowledge Base Context", kbContext);
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Build a design-role dispatch prompt.
+ * Design tasks produce design artifacts, not code commits.
+ */
+export function buildDesignPrompt(
+  task: TaskBundle,
+  kbContext?: string,
+): string {
+  const lines = [
+    `# Design Task: ${task.title} [${task.taskId}]`,
+    "",
+    task.context,
+    "",
+    "## Task Bundle",
+    "```json",
+    JSON.stringify({
+      taskId: task.taskId,
+      priority: task.priority,
+      definitionOfDone: task.definitionOfDone,
+      readScope: task.readScope,
+      allowedWriteScope: task.allowedWriteScope,
+    }, null, 2),
+    "```",
+    "",
+    "## Design Instructions",
+    "- Produce design artifacts (specs, diagrams, architecture docs) for the topic above.",
+    "- Reference existing code patterns and KB docs as needed.",
+    "- No code implementation expected — output your design document as your final message.",
+    "",
+    "## Output Format",
+    "Return a JSON design report as your final message:",
+    "```json",
+    JSON.stringify({
+      designer: "",
+      summary: "",
+      designDoc: "",
+      artifacts: [""],
+      completedAt: "",
+    }, null, 2),
+    "```",
+  ];
+
+  if (kbContext) {
+    lines.push("", "## Project Knowledge Base Context", kbContext);
+  }
+
+  return lines.join("\n");
 }
 
 /**

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -289,8 +289,13 @@ export class TaskManager {
     const explicitAssignedTo = params.assignedTo?.trim();
     const assignedTo = explicitAssignedTo || this.autoSelectAgent(params, taskId);
 
-    // Validate assignedTo references a registered agent with the required role
-    const requiredRole = (params.role ?? "dev") as AgentRole;
+    // Validate role is a known dispatch role
+    const VALID_DISPATCH_ROLES: readonly string[] = ["dev", "research", "design"];
+    const rawRole = params.role ?? "dev";
+    if (!VALID_DISPATCH_ROLES.includes(rawRole)) {
+      throw new Error(`createTask validation failed: invalid role "${rawRole}" (must be one of: ${VALID_DISPATCH_ROLES.join(", ")})`);
+    }
+    const requiredRole = rawRole as AgentRole;
     if (this.agentConfigLookup) {
       const agentConfig = this.agentConfigLookup(assignedTo);
       if (!agentConfig) {
@@ -657,6 +662,42 @@ export class TaskManager {
 
   getAcceptance(acceptanceId: string): AcceptanceBundle | undefined {
     return this.acceptances.get(acceptanceId);
+  }
+
+  /** Persist a synthetic acceptance for fast-tracked tasks (research/design) so getTaskResult() returns a verdict. */
+  persistSyntheticAcceptance(
+    taskId: string,
+    acceptorId: string,
+    results: { verdict: AcceptanceVerdict; findings: string[]; recommendations: string[] },
+  ): void {
+    const acceptanceId = `ACC-${shortId()}`;
+    const acceptance: AcceptanceBundle = {
+      acceptanceId,
+      linkedTaskId: taskId,
+      status: "completed",
+      acceptor: acceptorId,
+      scope: { filesToReview: [], docsToCheck: [], runtimeChecks: [] },
+      blindInputPolicy: { allowed: [], forbidden: [] },
+      results,
+      completedAt: Date.now(),
+    };
+    this.acceptances.set(acceptanceId, acceptance);
+    this.persistAcceptance(acceptance);
+
+    // Link to task
+    const task = this.tasks.get(taskId);
+    if (task) {
+      if (!task.handoffToAcceptance) {
+        task.handoffToAcceptance = {
+          acceptanceBundleId: acceptanceId,
+          blindInputPolicy: acceptance.blindInputPolicy,
+          acceptanceFocus: task.definitionOfDone,
+        };
+      } else {
+        task.handoffToAcceptance.acceptanceBundleId = acceptanceId;
+      }
+      this.persistTask(task);
+    }
   }
 
   /** Find the latest acceptance for a given task ID. */

--- a/packages/orchestrator/src/task-persistence-sqlite.ts
+++ b/packages/orchestrator/src/task-persistence-sqlite.ts
@@ -80,6 +80,11 @@ const MIGRATIONS = [
       );
     `,
   },
+  {
+    version: 2,
+    description: "add_task_role_column",
+    sql: `ALTER TABLE tasks ADD COLUMN role TEXT DEFAULT 'dev';`,
+  },
 ];
 
 function applyMigrations(db: Database.Database, log: Log): void {
@@ -138,13 +143,13 @@ export class TaskPersistenceSqlite implements TaskPersistence {
           created_at, closed_at, failed_at, assigned_to, branch,
           context, dispatch_attempts, max_dispatch_attempts,
           last_dispatch_error, rework_count, max_reworks,
-          originator_session_id, raw_json
+          originator_session_id, role, raw_json
         ) VALUES (
           @task_id, @title, @status, @priority, @phase_id,
           @created_at, @closed_at, @failed_at, @assigned_to, @branch,
           @context, @dispatch_attempts, @max_dispatch_attempts,
           @last_dispatch_error, @rework_count, @max_reworks,
-          @originator_session_id, @raw_json
+          @originator_session_id, @role, @raw_json
         )
       `),
 
@@ -229,6 +234,7 @@ export class TaskPersistenceSqlite implements TaskPersistence {
       rework_count: task.reworkCount ?? 0,
       max_reworks: task.maxReworks ?? 2,
       originator_session_id: task.originatorSessionId ?? null,
+      role: task.role ?? "dev",
       raw_json: JSON.stringify({ ...task, priority }),
     });
   }

--- a/packages/orchestrator/src/task-persistence-sqlite.ts
+++ b/packages/orchestrator/src/task-persistence-sqlite.ts
@@ -169,14 +169,14 @@ export class TaskPersistenceSqlite implements TaskPersistence {
         )
       `),
 
-      selectAllTasks: this.db.prepare("SELECT raw_json FROM tasks"),
+      selectAllTasks: this.db.prepare("SELECT raw_json, role FROM tasks"),
       selectAllIssues: this.db.prepare("SELECT raw_json FROM issues"),
       selectAllAcceptances: this.db.prepare("SELECT raw_json FROM acceptances"),
-      selectTask: this.db.prepare("SELECT raw_json FROM tasks WHERE task_id = ?"),
-      selectTasksByStatus: this.db.prepare("SELECT raw_json FROM tasks WHERE status = ?"),
-      selectTasksByAssigned: this.db.prepare("SELECT raw_json FROM tasks WHERE assigned_to = ?"),
-      selectTasksByBoth: this.db.prepare("SELECT raw_json FROM tasks WHERE status = ? AND assigned_to = ?"),
-      selectAllTasksList: this.db.prepare("SELECT raw_json FROM tasks"),
+      selectTask: this.db.prepare("SELECT raw_json, role FROM tasks WHERE task_id = ?"),
+      selectTasksByStatus: this.db.prepare("SELECT raw_json, role FROM tasks WHERE status = ?"),
+      selectTasksByAssigned: this.db.prepare("SELECT raw_json, role FROM tasks WHERE assigned_to = ?"),
+      selectTasksByBoth: this.db.prepare("SELECT raw_json, role FROM tasks WHERE status = ? AND assigned_to = ?"),
+      selectAllTasksList: this.db.prepare("SELECT raw_json, role FROM tasks"),
     };
   }
 
@@ -235,7 +235,7 @@ export class TaskPersistenceSqlite implements TaskPersistence {
       max_reworks: task.maxReworks ?? 2,
       originator_session_id: task.originatorSessionId ?? null,
       role: task.role ?? "dev",
-      raw_json: JSON.stringify({ ...task, priority }),
+      raw_json: JSON.stringify({ ...task, priority, role: task.role ?? "dev" }),
     });
   }
 
@@ -262,6 +262,16 @@ export class TaskPersistenceSqlite implements TaskPersistence {
     });
   }
 
+  /** Parse a task row, backfilling role from the column if missing in raw_json. */
+  private parseTaskRow(row: unknown): TaskBundle | null {
+    const { raw_json, role } = row as { raw_json: string; role?: string };
+    const task = this.parseJson<TaskBundle>(raw_json);
+    if (task && !task.role) {
+      task.role = (role as TaskBundle["role"]) ?? "dev";
+    }
+    return task;
+  }
+
   /** Load all tasks, acceptances, and issues from SQLite. */
   async loadAll(): Promise<{
     tasks: TaskBundle[];
@@ -269,7 +279,7 @@ export class TaskPersistenceSqlite implements TaskPersistence {
     issues: IssueBundle[];
   }> {
     const tasks = this.stmts.selectAllTasks.all()
-      .map((r: unknown) => this.parseJson<TaskBundle>((r as { raw_json: string }).raw_json))
+      .map((r: unknown) => this.parseTaskRow(r))
       .filter((t): t is TaskBundle => t !== null);
 
     const acceptances = this.stmts.selectAllAcceptances.all()
@@ -286,9 +296,9 @@ export class TaskPersistenceSqlite implements TaskPersistence {
 
   /** Load a single task by ID from SQLite. */
   async loadTask(taskId: string): Promise<TaskBundle | null> {
-    const row = this.stmts.selectTask.get(taskId) as { raw_json: string } | undefined;
+    const row = this.stmts.selectTask.get(taskId) as { raw_json: string; role?: string } | undefined;
     if (!row) return null;
-    return this.parseJson<TaskBundle>(row.raw_json);
+    return this.parseTaskRow(row);
   }
 
   /** Load tasks with optional status/assignedTo filter — uses indexed queries. */
@@ -304,7 +314,7 @@ export class TaskPersistenceSqlite implements TaskPersistence {
       rows = this.stmts.selectAllTasksList.all();
     }
     return rows
-      .map((r: unknown) => this.parseJson<TaskBundle>((r as { raw_json: string }).raw_json))
+      .map((r: unknown) => this.parseTaskRow(r))
       .filter((t): t is TaskBundle => t !== null);
   }
 


### PR DESCRIPTION
## Summary
- Add `role?: AgentRole` field to TaskBundle, enabling dispatch of dev/research/design tasks to role-appropriate agents
- Implement research and design prompt builders with role-specific instructions and output formats
- Add fast-track stream completion handlers for research/design roles (skip review/acceptance cycle)
- Fix callback routing: MCP originator guard prevents internal Main Agent activation for external callers
- Add stale session guard in `deliverTaskCallback()` to prevent callbacks to completed/missing sessions
- SQLite migration v2 adds `role` column with backward-compatible default `'dev'`
- MCP `create_task` schema accepts optional `role` parameter

## Test plan
- [ ] `pnpm build` passes all packages
- [ ] `create_task` with `role: "research"` via MCP → DB persists `role = "research"`
- [ ] Research task dispatch → logs show `startRoleSession` with "research" role
- [ ] Research task completes → fast-tracks to closed (no review cycle)
- [ ] External MCP dispatch → no internal Main Agent activation, MCP client gets callback via broadcaster
- [ ] Restart orchestrator → stale sessions don't receive callbacks
- [ ] Existing tasks without role → dispatch as "dev" correctly (backward compat)

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)