### PR TITLE
fix(orchestrator): terminal flash on Windows — windowsHide (#94)

### DIFF
--- a/packages/orchestrator/src/knowledge-service.ts
+++ b/packages/orchestrator/src/knowledge-service.ts
@@ -251,6 +251,7 @@ export class KnowledgeService {
     try {
       const { stdout } = await execFileAsync(this.obsidianBin, fullArgs, {
         timeout: 15_000,
+        windowsHide: true,
       });
       return stdout;
     } catch (err) {
@@ -387,10 +388,12 @@ export class KnowledgeService {
       await execFileAsync("git", ["add", "-A"], {
         cwd: vaultPath,
         timeout: 10_000,
+        windowsHide: true,
       });
       await execFileAsync("git", ["commit", "-m", message, "--allow-empty"], {
         cwd: vaultPath,
         timeout: 10_000,
+        windowsHide: true,
       });
     } catch {
       // Fire-and-forget: log but never throw


### PR DESCRIPTION
## Summary
- Add `windowsHide: true` to all 3 `execFileAsync` calls in `knowledge-service.ts`
- Prevents terminal window flash when KnowledgeService spawns Obsidian CLI or git processes on Windows

## Test plan
- [ ] Open Mercury GUI on Windows, switch between agent tabs — no terminal flash
- [ ] Knowledge service operations (read/write/search/gitSync) still function correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)