### PR TITLE
fix(gui): use visible light-green link color on dark theme

### DIFF
--- a/packages/gui/src/components/AgentPanel.vue
+++ b/packages/gui/src/components/AgentPanel.vue
@@ -1428,12 +1428,12 @@ watch(
   color: var(--link-color);
   text-decoration: none;
 }
+.markdown-body :deep(a:visited) {
+  color: var(--link-visited);
+}
 .markdown-body :deep(a:hover) {
   color: var(--link-hover);
   text-decoration: underline;
-}
-.markdown-body :deep(a:visited) {
-  color: var(--link-visited);
 }
 
 /* Workspace bar above input */

--- a/packages/gui/src/components/AgentPanel.vue
+++ b/packages/gui/src/components/AgentPanel.vue
@@ -1424,6 +1424,14 @@ watch(
   padding-left: 10px;
   color: var(--text-secondary);
 }
+.markdown-body :deep(a) {
+  color: #4ade80;
+  text-decoration: none;
+}
+.markdown-body :deep(a:hover) {
+  color: #86efac;
+  text-decoration: underline;
+}
 
 /* Workspace bar above input */
 .workspace-bar {

--- a/packages/gui/src/components/AgentPanel.vue
+++ b/packages/gui/src/components/AgentPanel.vue
@@ -1431,7 +1431,8 @@ watch(
 .markdown-body :deep(a:visited) {
   color: var(--link-visited);
 }
-.markdown-body :deep(a:hover) {
+.markdown-body :deep(a:hover),
+.markdown-body :deep(a:focus) {
   color: var(--link-hover);
   text-decoration: underline;
 }

--- a/packages/gui/src/components/AgentPanel.vue
+++ b/packages/gui/src/components/AgentPanel.vue
@@ -1425,12 +1425,15 @@ watch(
   color: var(--text-secondary);
 }
 .markdown-body :deep(a) {
-  color: #4ade80;
+  color: var(--link-color);
   text-decoration: none;
 }
 .markdown-body :deep(a:hover) {
-  color: #86efac;
+  color: var(--link-hover);
   text-decoration: underline;
+}
+.markdown-body :deep(a:visited) {
+  color: var(--link-visited);
 }
 
 /* Workspace bar above input */

--- a/packages/gui/src/styles/main.css
+++ b/packages/gui/src/styles/main.css
@@ -53,3 +53,16 @@ html, body, #app {
 ::-webkit-scrollbar-thumb:hover {
   background: var(--text-muted);
 }
+
+/* Link styles for dark theme */
+a {
+  color: #4ade80;
+  text-decoration: none;
+}
+a:hover {
+  color: #86efac;
+  text-decoration: underline;
+}
+a:visited {
+  color: #6ee7b7;
+}

--- a/packages/gui/src/styles/main.css
+++ b/packages/gui/src/styles/main.css
@@ -17,6 +17,9 @@
   --font-sans: "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
   --radius: 6px;
   --panel-gap: 4px;
+  --link-color: #4ade80;
+  --link-hover: #86efac;
+  --link-visited: #6ee7b7;
 }
 
 * {
@@ -54,21 +57,15 @@ html, body, #app {
   background: var(--text-muted);
 }
 
-/* Link color variables for dark theme */
-:root {
-  --link-color: #4ade80;
-  --link-hover: #86efac;
-  --link-visited: #6ee7b7;
-}
-
+/* Link styles — LVHA order: link, visited, hover, active */
 a {
   color: var(--link-color);
   text-decoration: none;
 }
+a:visited {
+  color: var(--link-visited);
+}
 a:hover {
   color: var(--link-hover);
   text-decoration: underline;
-}
-a:visited {
-  color: var(--link-visited);
 }

--- a/packages/gui/src/styles/main.css
+++ b/packages/gui/src/styles/main.css
@@ -65,7 +65,8 @@ a {
 a:visited {
   color: var(--link-visited);
 }
-a:hover {
+a:hover,
+a:focus {
   color: var(--link-hover);
   text-decoration: underline;
 }

--- a/packages/gui/src/styles/main.css
+++ b/packages/gui/src/styles/main.css
@@ -54,15 +54,21 @@ html, body, #app {
   background: var(--text-muted);
 }
 
-/* Link styles for dark theme */
+/* Link color variables for dark theme */
+:root {
+  --link-color: #4ade80;
+  --link-hover: #86efac;
+  --link-visited: #6ee7b7;
+}
+
 a {
-  color: #4ade80;
+  color: var(--link-color);
   text-decoration: none;
 }
 a:hover {
-  color: #86efac;
+  color: var(--link-hover);
   text-decoration: underline;
 }
 a:visited {
-  color: #6ee7b7;
+  color: var(--link-visited);
 }


### PR DESCRIPTION
## Summary
- Dark blue default link color (#0000EE) is invisible on the dark theme background (--bg-primary: #1a1a2e)
- Added light-green link styling (#4ade80) globally in `main.css` and scoped in `AgentPanel.vue` markdown body

## Changes
- `main.css`: Global `a` / `a:hover` / `a:visited` styles
- `AgentPanel.vue`: `.markdown-body :deep(a)` scoped styles

## Test plan
- [ ] Verify links in agent panel markdown are visible (light green)
- [ ] Verify hover state changes color
- [ ] Verify visited links use distinct shade