### PR TITLE
feat(orchestrator): persistent callback queue with cold-start drain (#99)

### DIFF
--- a/packages/orchestrator/src/callback-queue.ts
+++ b/packages/orchestrator/src/callback-queue.ts
@@ -1,0 +1,143 @@
+/**
+ * Callback Queue — SQLite-backed persistent queue for task completion callbacks.
+ *
+ * Callbacks are enqueued when a task completes and delivered to the Main Agent
+ * session when available. If no session is active, callbacks remain pending and
+ * are drained on the next Main Agent session creation (cold-start drain).
+ *
+ * Uses the same better-sqlite3 Database instance as TaskPersistenceSqlite.
+ * The callback_queue table is created by migration v3.
+ */
+
+import type Database from "better-sqlite3";
+
+/** Payload emitted by orchestrator.task.callback events. */
+export interface TaskCallbackPayload {
+  taskId: string;
+  originatorSessionId?: string;
+  verdict: string;
+  findings?: string[];
+  recommendations?: string[];
+}
+
+export interface CallbackQueueEntry {
+  id: number;
+  idempotency_key: string;
+  task_id: string;
+  verdict: string;
+  payload_json: string;
+  status: "pending" | "delivered" | "failed";
+  created_at: number;
+  delivered_at: number | null;
+  delivery_attempts: number;
+  last_error: string | null;
+}
+
+type Log = (msg: string) => void;
+
+const DEFAULT_MAX_ATTEMPTS = 5;
+const DEFAULT_RETENTION_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+export class CallbackQueue {
+  private stmts: {
+    enqueue: Database.Statement;
+    getPending: Database.Statement;
+    markDelivered: Database.Statement;
+    incrementAttempt: Database.Statement;
+    markFailed: Database.Statement;
+    getById: Database.Statement;
+    cleanup: Database.Statement;
+  };
+  private log: Log;
+
+  constructor(db: Database.Database, log: Log = () => {}) {
+    this.log = log;
+    this.stmts = {
+      enqueue: db.prepare(`
+        INSERT OR IGNORE INTO callback_queue
+          (idempotency_key, task_id, verdict, payload_json, status, created_at)
+        VALUES (@idempotency_key, @task_id, @verdict, @payload_json, 'pending', @created_at)
+      `),
+      getPending: db.prepare(
+        `SELECT * FROM callback_queue WHERE status = 'pending' ORDER BY created_at ASC`,
+      ),
+      markDelivered: db.prepare(
+        `UPDATE callback_queue SET status = 'delivered', delivered_at = @now WHERE id = @id`,
+      ),
+      incrementAttempt: db.prepare(
+        `UPDATE callback_queue SET delivery_attempts = delivery_attempts + 1, last_error = @error WHERE id = @id`,
+      ),
+      markFailed: db.prepare(
+        `UPDATE callback_queue SET status = 'failed' WHERE id = @id`,
+      ),
+      getById: db.prepare(
+        `SELECT * FROM callback_queue WHERE id = @id`,
+      ),
+      cleanup: db.prepare(
+        `DELETE FROM callback_queue WHERE status = 'delivered' AND delivered_at < @cutoff`,
+      ),
+    };
+  }
+
+  /**
+   * Generate idempotency key from payload.
+   * Uses a 10-second time bucket to deduplicate rapid retries of the same verdict.
+   */
+  static makeIdempotencyKey(payload: TaskCallbackPayload): string {
+    const bucket = Math.floor(Date.now() / 10_000);
+    return `${payload.taskId}:${payload.verdict}:${bucket}`;
+  }
+
+  /**
+   * Insert a callback into the queue.
+   * Returns true if inserted, false if idempotency key already exists.
+   */
+  enqueue(payload: TaskCallbackPayload): boolean {
+    const key = CallbackQueue.makeIdempotencyKey(payload);
+    const result = this.stmts.enqueue.run({
+      idempotency_key: key,
+      task_id: payload.taskId,
+      verdict: payload.verdict,
+      payload_json: JSON.stringify(payload),
+      created_at: Date.now(),
+    });
+    const inserted = result.changes > 0;
+    if (inserted) {
+      this.log(`[callback-queue] Enqueued callback for ${payload.taskId} (verdict: ${payload.verdict})`);
+    }
+    return inserted;
+  }
+
+  /** Return all pending entries ordered by created_at ASC. */
+  getPending(): CallbackQueueEntry[] {
+    return this.stmts.getPending.all() as CallbackQueueEntry[];
+  }
+
+  /** Mark a queued entry as successfully delivered. */
+  markDelivered(id: number): void {
+    this.stmts.markDelivered.run({ id, now: Date.now() });
+  }
+
+  /**
+   * Increment attempt count and record error.
+   * After maxAttempts, mark as "failed" to stop further retries.
+   */
+  markAttemptFailed(id: number, error: string, maxAttempts = DEFAULT_MAX_ATTEMPTS): void {
+    this.stmts.incrementAttempt.run({ id, error });
+    const entry = this.stmts.getById.get({ id }) as CallbackQueueEntry | undefined;
+    if (entry && entry.delivery_attempts >= maxAttempts) {
+      this.stmts.markFailed.run({ id });
+      this.log(`[callback-queue] Callback ${id} failed after ${maxAttempts} attempts`);
+    }
+  }
+
+  /**
+   * Delete delivered entries older than retentionMs (default 7 days).
+   * Returns count of deleted entries.
+   */
+  cleanup(retentionMs = DEFAULT_RETENTION_MS): number {
+    const cutoff = Date.now() - retentionMs;
+    const result = this.stmts.cleanup.run({ cutoff });
+    return result.changes;
+  }
+}

--- a/packages/orchestrator/src/callback-queue.ts
+++ b/packages/orchestrator/src/callback-queue.ts
@@ -18,6 +18,8 @@ export interface TaskCallbackPayload {
   verdict: string;
   findings?: string[];
   recommendations?: string[];
+  /** Stable rework count used for idempotency key generation. */
+  reworkCount?: number;
 }
 
 export interface CallbackQueueEntry {
@@ -80,12 +82,13 @@ export class CallbackQueue {
   }
 
   /**
-   * Generate idempotency key from payload.
-   * Uses a 10-second time bucket to deduplicate rapid retries of the same verdict.
+   * Generate a stable idempotency key from payload.
+   * Uses taskId + verdict + reworkCount so the same logical callback always maps
+   * to the same key regardless of timing (restarts, retries, slow paths).
    */
   static makeIdempotencyKey(payload: TaskCallbackPayload): string {
-    const bucket = Math.floor(Date.now() / 10_000);
-    return `${payload.taskId}:${payload.verdict}:${bucket}`;
+    const rework = payload.reworkCount ?? 0;
+    return `${payload.taskId}:${payload.verdict}:rework${rework}`;
   }
 
   /**

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -57,6 +57,8 @@ import type { PersistedSessionState } from "./session-persistence.js";
 import { TranscriptPersistence } from "./transcript-persistence.js";
 import type { TranscriptMessage } from "./transcript-persistence.js";
 import { installRTKCommandWrapper, isRTKAvailable } from "./rtk-wrapper.js";
+import { CallbackQueue } from "./callback-queue.js";
+import type { TaskCallbackPayload } from "./callback-queue.js";
 
 type NativeSessionBridge = {
   listNativeSessions?: (cwd?: string) => Promise<SessionInfo[]>;
@@ -82,14 +84,7 @@ type ParsedMainReviewDecision = {
   structured: StructuredReviewResult;
 };
 
-/** Shared type for orchestrator.task.callback event payload. */
-type TaskCallbackPayload = {
-  taskId: string;
-  originatorSessionId?: string;
-  verdict: AcceptanceVerdict;
-  findings?: string[];
-  recommendations?: string[];
-};
+// TaskCallbackPayload imported from ./callback-queue.js
 
 const ROLE_CONTEXT_ROLES = ["main", "dev", "acceptance", "critic", "research", "design"] as const;
 type RoleContextKey = (typeof ROLE_CONTEXT_ROLES)[number];
@@ -122,6 +117,7 @@ export class Orchestrator {
   >();
   private kb: KnowledgeService | null = null;
   private sqliteDb: TaskPersistenceSqlite | null = null;
+  private callbackQueue: CallbackQueue | null = null;
   private projectConfig: MercuryConfig | null = null;
   private configFilePath: string | null = null;
   private taskManager: TaskManager;
@@ -185,9 +181,10 @@ export class Orchestrator {
       }
       const dbPath = join(mercuryDir, "mercury.db");
       this.sqliteDb = new TaskPersistenceSqlite(dbPath, logFn);
+      this.callbackQueue = new CallbackQueue(this.sqliteDb.getDatabase(), logFn);
       const dualPersistence = new TaskPersistenceDual(this.sqliteDb, kbPersistence, logFn);
       this.taskManager.setPersistence(dualPersistence);
-      logFn("[orchestrator] Persistence: SQLite (primary) + KB (sync)");
+      logFn("[orchestrator] Persistence: SQLite (primary) + KB (sync), callback queue enabled");
     } catch (err) {
       // Fallback to KB-only if SQLite fails to initialize
       logFn(`[orchestrator] SQLite init failed, falling back to KB-only: ${err instanceof Error ? err.message : err}`);
@@ -1408,6 +1405,15 @@ export class Orchestrator {
       currentPromptHash: promptState.currentPromptHash,
       legacyRoleConfig: promptState.legacyRoleConfig,
     });
+
+    // Cold-start drain: deliver pending callbacks when a Main Agent session starts
+    if (effectiveRole === "main") {
+      void this.attemptCallbackDelivery().catch((err) => {
+        this.transport.sendNotification("log", {
+          message: `[orchestrator] Cold-start callback drain failed: ${err instanceof Error ? err.message : err}`,
+        });
+      });
+    }
 
     this.persistState(true);
     return session;
@@ -2731,7 +2737,6 @@ export class Orchestrator {
    */
   private async deliverTaskCallback(payload: TaskCallbackPayload): Promise<void> {
     // If originator is an external MCP client, broadcaster already delivered the event.
-    // Do NOT activate internal Main Agent session — the MCP client receives via mercury_event.
     if (payload.originatorSessionId?.startsWith("mcp-http:")) {
       this.transport.sendNotification("log", {
         message: `[orchestrator] Task callback for ${payload.taskId} — MCP originator (${payload.originatorSessionId}), relying on broadcaster`,
@@ -2739,29 +2744,68 @@ export class Orchestrator {
       return;
     }
 
+    // Step 1: Persist to callback queue (crash-safe)
+    if (this.callbackQueue) {
+      const enqueued = this.callbackQueue.enqueue(payload);
+      if (!enqueued) {
+        this.transport.sendNotification("log", {
+          message: `[orchestrator] Callback already queued (idempotent skip) for ${payload.taskId}:${payload.verdict}`,
+        });
+        return;
+      }
+    }
+
+    // Step 2: Attempt immediate delivery of all pending callbacks
+    await this.attemptCallbackDelivery();
+  }
+
+  /**
+   * Attempt to deliver all pending callbacks to the active Main Agent session.
+   * Called from deliverTaskCallback (immediate) and startRoleSession (cold-start drain).
+   */
+  private async attemptCallbackDelivery(): Promise<void> {
+    if (!this.callbackQueue) return;
+
     const mainAgentId = this.findMainAgentId();
     if (!mainAgentId) return;
 
-    // Only deliver if there's an active Main Agent session (avoid spawning new session)
     const mainSlot = makeRoleSlotKey("main", mainAgentId);
     const activeSessionId = this.roleSessions.get(mainSlot);
-    if (!activeSessionId) {
-      this.transport.sendNotification("log", {
-        message: `[orchestrator] No active Main Agent session for callback delivery (task: ${payload.taskId})`,
-      });
-      return;
-    }
+    if (!activeSessionId) return;
 
-    // Stale session guard: validate session exists and is not completed/overflow
     const session = this.sessions.get(activeSessionId);
     if (!session || session.status === "completed" || session.status === "overflow") {
-      this.transport.sendNotification("log", {
-        message: `[orchestrator] Main Agent session ${activeSessionId} is stale (${session?.status ?? "missing"}), skipping callback for ${payload.taskId}`,
-      });
       this.roleSessions.delete(mainSlot);
       return;
     }
 
+    const pending = this.callbackQueue.getPending();
+    if (pending.length === 0) return;
+
+    this.transport.sendNotification("log", {
+      message: `[orchestrator] Delivering ${pending.length} pending callback(s) to Main Agent session ${activeSessionId}`,
+    });
+
+    for (const entry of pending) {
+      const entryPayload = JSON.parse(entry.payload_json) as TaskCallbackPayload;
+      const prompt = this.formatCallbackPrompt(entryPayload);
+
+      try {
+        await this.sendPrompt(mainAgentId, prompt, undefined, "main");
+        this.callbackQueue.markDelivered(entry.id);
+      } catch (err) {
+        const errorMsg = err instanceof Error ? err.message : String(err);
+        this.callbackQueue.markAttemptFailed(entry.id, errorMsg);
+        this.transport.sendNotification("log", {
+          message: `[orchestrator] Callback delivery failed for ${entry.task_id}: ${errorMsg}`,
+        });
+        break; // Stop — session may be dead
+      }
+    }
+  }
+
+  /** Format a callback payload into a prompt string for the Main Agent. */
+  private formatCallbackPrompt(payload: TaskCallbackPayload): string {
     const task = this.taskManager.getTask(payload.taskId);
     const taskTitle = task?.title ?? payload.taskId;
     const findings = payload.findings?.length
@@ -2771,7 +2815,7 @@ export class Orchestrator {
       ? `\nRecommendations:\n${payload.recommendations.map((r) => `- ${r}`).join("\n")}`
       : "";
 
-    const callbackPrompt = [
+    return [
       `[Task Callback] ${taskTitle}`,
       `Task ID: ${payload.taskId}`,
       `Acceptance Verdict: ${payload.verdict.toUpperCase()}`,
@@ -2783,15 +2827,6 @@ export class Orchestrator {
           ? "Task is blocked. Manual intervention required."
           : "Rework has been triggered. Dev agent will receive updated instructions.",
     ].filter(Boolean).join("\n");
-
-    try {
-      await this.sendPrompt(mainAgentId, callbackPrompt, undefined, "main");
-    } catch (err) {
-      // Non-fatal: callback delivery is best-effort
-      this.transport.sendNotification("log", {
-        message: `[orchestrator] Failed to deliver task callback to Main Agent: ${err instanceof Error ? err.message : err}`,
-      });
-    }
   }
 
   /**

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -568,6 +568,20 @@ export class Orchestrator {
     if (approvalsChanged) {
       this.persistState(true);
     }
+
+    // Cold-start drain for restored Main sessions: deliver any pending callbacks
+    // that accumulated while Mercury was offline. startRoleSession only handles
+    // newly created sessions; restored sessions need this explicit drain.
+    for (const [key] of this.roleSessions) {
+      if (key.startsWith("main:")) {
+        void this.attemptCallbackDelivery().catch((err) => {
+          this.transport.sendNotification("log", {
+            message: `[orchestrator] Restored-session callback drain failed: ${err instanceof Error ? err.message : err}`,
+          });
+        });
+        break; // Only need one drain for all pending callbacks
+      }
+    }
   }
 
   /**
@@ -1880,6 +1894,7 @@ export class Orchestrator {
       verdict: "pass",
       findings: findingsArr,
       recommendations: recommendationsArr,
+      reworkCount: task.reworkCount,
     });
   }
 
@@ -1943,6 +1958,7 @@ export class Orchestrator {
       verdict: "pass",
       findings: designFindings,
       recommendations: designRecommendations,
+      reworkCount: task.reworkCount,
     });
   }
 
@@ -2753,17 +2769,68 @@ export class Orchestrator {
         });
         return;
       }
+      // Step 2: Attempt immediate delivery of all pending callbacks
+      await this.attemptCallbackDelivery();
+    } else {
+      // Fallback: no SQLite queue available — attempt best-effort direct delivery
+      this.transport.sendNotification("log", {
+        message: `[orchestrator] No callback queue (SQLite unavailable), attempting direct delivery for ${payload.taskId}`,
+      });
+      await this.attemptDirectCallbackDelivery(payload);
     }
+  }
 
-    // Step 2: Attempt immediate delivery of all pending callbacks
-    await this.attemptCallbackDelivery();
+  /**
+   * Best-effort direct delivery when no SQLite callback queue is available.
+   * Does not persist — if delivery fails, the callback is lost.
+   */
+  private async attemptDirectCallbackDelivery(payload: TaskCallbackPayload): Promise<void> {
+    const mainAgentId = this.findMainAgentId();
+    if (!mainAgentId) return;
+
+    const mainSlot = makeRoleSlotKey("main", mainAgentId);
+    const activeSessionId = this.roleSessions.get(mainSlot);
+    if (!activeSessionId) return;
+
+    const session = this.sessions.get(activeSessionId);
+    if (!session || session.status === "completed" || session.status === "overflow") return;
+
+    const prompt = this.formatCallbackPrompt(payload);
+    try {
+      await this.sendPrompt(mainAgentId, prompt, undefined, "main");
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : String(err);
+      this.transport.sendNotification("log", {
+        message: `[orchestrator] Direct callback delivery failed for ${payload.taskId}: ${errorMsg}`,
+      });
+    }
   }
 
   /**
    * Attempt to deliver all pending callbacks to the active Main Agent session.
    * Called from deliverTaskCallback (immediate) and startRoleSession (cold-start drain).
+   *
+   * Serialized via callbackDrainLock to prevent concurrent drains from
+   * reading the same pending rows and double-delivering.
    */
+  private callbackDrainLock: Promise<void> = Promise.resolve();
+
   private async attemptCallbackDelivery(): Promise<void> {
+    // Serialize: chain onto the existing drain lock to prevent concurrent reads
+    const prev = this.callbackDrainLock;
+    let resolve!: () => void;
+    this.callbackDrainLock = new Promise<void>((r) => { resolve = r; });
+    await prev;
+
+    try {
+      await this.drainCallbackQueue();
+    } finally {
+      resolve();
+    }
+  }
+
+  /** Internal drain logic — must only be called under callbackDrainLock. */
+  private async drainCallbackQueue(): Promise<void> {
     if (!this.callbackQueue) return;
 
     const mainAgentId = this.findMainAgentId();
@@ -2791,6 +2858,9 @@ export class Orchestrator {
       const prompt = this.formatCallbackPrompt(entryPayload);
 
       try {
+        // sendPrompt initiates streaming; marking delivered after the call
+        // succeeds means the transport accepted the prompt. This is
+        // at-least-once delivery — acceptable since callbacks are idempotent.
         await this.sendPrompt(mainAgentId, prompt, undefined, "main");
         this.callbackQueue.markDelivered(entry.id);
       } catch (err) {
@@ -2804,29 +2874,57 @@ export class Orchestrator {
     }
   }
 
-  /** Format a callback payload into a prompt string for the Main Agent. */
+  /**
+   * Format a callback payload into a prompt string for the Main Agent.
+   * Includes full task context so the Main session can act on the callback
+   * even if it was created after the task, or context has been compacted.
+   */
   private formatCallbackPrompt(payload: TaskCallbackPayload): string {
     const task = this.taskManager.getTask(payload.taskId);
     const taskTitle = task?.title ?? payload.taskId;
-    const findings = payload.findings?.length
-      ? `\nFindings:\n${payload.findings.map((f) => `- ${f}`).join("\n")}`
-      : "";
-    const recommendations = payload.recommendations?.length
-      ? `\nRecommendations:\n${payload.recommendations.map((r) => `- ${r}`).join("\n")}`
-      : "";
 
-    return [
+    // Build rich context lines from task state
+    const lines: string[] = [
       `[Task Callback] ${taskTitle}`,
       `Task ID: ${payload.taskId}`,
       `Acceptance Verdict: ${payload.verdict.toUpperCase()}`,
-      findings,
-      recommendations,
+    ];
+
+    if (task) {
+      lines.push(`Status: ${task.status}`);
+      lines.push(`Assigned To: ${task.assignedTo}`);
+      if (task.context) {
+        lines.push(`Description: ${task.context}`);
+      }
+      if (task.branch) {
+        lines.push(`Branch: ${task.branch}`);
+      }
+      lines.push(`Rework: ${task.reworkCount}/${task.maxReworks}`);
+      if (task.implementationReceipt) {
+        const receipt = task.implementationReceipt;
+        const summary = receipt.summary ?? receipt.changedFiles?.join(", ");
+        if (summary) {
+          lines.push(`Implementation Summary: ${summary}`);
+        }
+      }
+    }
+
+    if (payload.findings?.length) {
+      lines.push(`\nFindings:\n${payload.findings.map((f) => `- ${f}`).join("\n")}`);
+    }
+    if (payload.recommendations?.length) {
+      lines.push(`\nRecommendations:\n${payload.recommendations.map((r) => `- ${r}`).join("\n")}`);
+    }
+
+    lines.push(
       payload.verdict === "pass"
         ? "Task has been verified and closed."
         : payload.verdict === "blocked"
           ? "Task is blocked. Manual intervention required."
           : "Rework has been triggered. Dev agent will receive updated instructions.",
-    ].filter(Boolean).join("\n");
+    );
+
+    return lines.filter(Boolean).join("\n");
   }
 
   /**
@@ -2931,6 +3029,7 @@ export class Orchestrator {
           taskId: task.taskId,
           originatorSessionId: task.originatorSessionId,
           verdict: "pass",
+          reworkCount: task.reworkCount,
         },
       );
 
@@ -2971,6 +3070,7 @@ export class Orchestrator {
           verdict: results.verdict,
           findings: results.findings,
           recommendations: results.recommendations,
+          reworkCount: task.reworkCount,
         },
       );
 
@@ -2992,6 +3092,7 @@ export class Orchestrator {
           verdict: "blocked",
           findings: results.findings,
           recommendations: results.recommendations,
+          reworkCount: task.reworkCount,
         },
       );
 

--- a/packages/orchestrator/src/task-persistence-sqlite.ts
+++ b/packages/orchestrator/src/task-persistence-sqlite.ts
@@ -85,6 +85,26 @@ const MIGRATIONS = [
     description: "add_task_role_column",
     sql: `ALTER TABLE tasks ADD COLUMN role TEXT DEFAULT 'dev';`,
   },
+  {
+    version: 3,
+    description: "add_callback_queue_table",
+    sql: `
+      CREATE TABLE IF NOT EXISTS callback_queue (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        idempotency_key TEXT NOT NULL UNIQUE,
+        task_id TEXT NOT NULL,
+        verdict TEXT NOT NULL CHECK(verdict IN ('pass','partial','fail','blocked')),
+        payload_json TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'pending' CHECK(status IN ('pending','delivered','failed')),
+        created_at INTEGER NOT NULL,
+        delivered_at INTEGER,
+        delivery_attempts INTEGER NOT NULL DEFAULT 0,
+        last_error TEXT
+      );
+      CREATE INDEX IF NOT EXISTS idx_cbq_status ON callback_queue(status);
+      CREATE INDEX IF NOT EXISTS idx_cbq_task ON callback_queue(task_id);
+    `,
+  },
 ];
 
 function applyMigrations(db: Database.Database, log: Log): void {
@@ -355,6 +375,11 @@ export class TaskPersistenceSqlite implements TaskPersistence {
       "SELECT (SELECT COUNT(*) FROM tasks) + (SELECT COUNT(*) FROM issues) + (SELECT COUNT(*) FROM acceptances) as total"
     ).get() as { total: number };
     return row.total === 0;
+  }
+
+  /** Expose underlying database for shared-table modules (e.g. CallbackQueue). */
+  getDatabase(): Database.Database {
+    return this.db;
   }
 
   /** Close the database connection. */


### PR DESCRIPTION
## Summary
- Add SQLite-backed `callback_queue` table (migration v3) with idempotency key
- New `CallbackQueue` class with enqueue/deliver/cleanup operations
- Refactor `deliverTaskCallback`: enqueue to SQLite first, then attempt delivery
- Cold-start drain: pending callbacks delivered when Main Agent session starts
- Idempotency via UNIQUE constraint on `taskId:verdict:timeBucket` key

## Problem (Issue #99)
When a sub-agent completes a task, `deliverTaskCallback()` was fire-and-forget:
1. No Main session → callback silently dropped
2. Orchestrator crash → callback lost
3. External CLI sessions → forced to poll

## Solution
Callbacks are now persisted to SQLite before delivery. If delivery fails or no session exists, they remain pending and are drained on next Main Agent session creation.

## Test plan
- [ ] Type-check passes
- [ ] Start orchestrator, complete task with no Main session → callback queued
- [ ] Start Main session → pending callbacks drained
- [ ] Duplicate emit → idempotency key prevents double entry
- [ ] Restart orchestrator → pending callbacks survive

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)