### PR TITLE
feat(orchestrator): auto session handoff and loop detection (#101)

### DIFF
--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -162,7 +162,21 @@ export class Orchestrator {
       // Fire-and-forget: deliver callback to Main Agent
       void this.deliverTaskCallback(payload);
     });
+
+    // Auto-handoff: when a session crosses the 70% token threshold, trigger handoff
+    this.bus.on("orchestrator.context.compact", (event) => {
+      void this.triggerSessionHandoff(
+        event.agentId,
+        event.sessionId,
+        event.payload as { tokenUsage: number; tokenLimit: number; ratio: number },
+      );
+    });
   }
+
+  /** Track recent tool calls per session for loop detection. */
+  private recentToolCalls = new Map<string, string[]>();
+  private static readonly LOOP_DETECTION_WINDOW = 6;
+  private static readonly LOOP_DETECTION_THRESHOLD = 3;
 
   /** Inject optional knowledge service + wire up task persistence (with optional SQLite dual-write). */
   setKnowledgeService(kb: KnowledgeService) {
@@ -1543,6 +1557,10 @@ export class Orchestrator {
               timestamp: yielded.timestamp,
             },
           });
+          // Loop detection: track tool calls and warn if repeating
+          if (yielded.toolName && yielded.eventKind === "tool_start") {
+            this.detectToolLoop(sessionId, yielded.toolName);
+          }
           continue;
         }
 
@@ -1688,6 +1706,90 @@ export class Orchestrator {
       // Persist session state so checkpoint survives a crash
       this.persistSessionState(session);
     }
+  }
+
+  /**
+   * Trigger automatic session handoff when context window is near exhaustion.
+   * Creates a new session inheriting context from the old one.
+   */
+  private async triggerSessionHandoff(
+    agentId: string,
+    sessionId: string,
+    info: { tokenUsage: number; tokenLimit: number; ratio: number },
+  ): Promise<void> {
+    const adapter = this.registry.getAdapter(agentId);
+    const session = this.sessions.get(sessionId);
+    if (!session || session.status !== "active") return;
+
+    const summary = [
+      `Session ${sessionId} reached ${Math.round(info.ratio * 100)}% token usage.`,
+      `Role: ${session.role ?? "unknown"}, Task: ${session.sessionName ?? "none"}.`,
+      "Automatically handing off to a new session to continue work.",
+    ].join(" ");
+
+    this.transport.sendNotification("log", {
+      message: `[harness] Auto-handoff triggered for ${agentId}:${sessionId} at ${Math.round(info.ratio * 100)}% token usage`,
+    });
+
+    try {
+      const newSession = await adapter.handoffSession(sessionId, summary);
+      newSession.role = session.role;
+      newSession.frozenRole = session.frozenRole;
+      newSession.sessionName = session.sessionName;
+      this.sessions.set(newSession.sessionId, newSession);
+
+      if (session.role) {
+        const slotKey = makeRoleSlotKey(session.role, agentId);
+        this.roleSessions.set(slotKey, newSession.sessionId);
+      }
+
+      const taskId = this.taskManager.getTaskForSession(sessionId);
+      if (taskId) {
+        this.taskManager.bindSession(taskId, newSession.sessionId);
+      }
+
+      this.bus.emit("orchestrator.session.handoff", agentId, newSession.sessionId, {
+        fromSession: sessionId,
+        toSession: newSession.sessionId,
+        reason: "token_threshold",
+        tokenUsage: info.tokenUsage,
+        tokenLimit: info.tokenLimit,
+      });
+
+      this.persistState(true);
+    } catch (err) {
+      this.transport.sendNotification("log", {
+        message: `[harness] Auto-handoff failed for ${agentId}:${sessionId}: ${err instanceof Error ? err.message : err}`,
+      });
+    }
+  }
+
+  /**
+   * Detect tool-call loops in agent sessions.
+   * Returns true if the same tool has been called N+ times consecutively.
+   */
+  detectToolLoop(sessionId: string, toolName: string): boolean {
+    let recent = this.recentToolCalls.get(sessionId);
+    if (!recent) {
+      recent = [];
+      this.recentToolCalls.set(sessionId, recent);
+    }
+
+    recent.push(toolName);
+    if (recent.length > Orchestrator.LOOP_DETECTION_WINDOW) {
+      recent.shift();
+    }
+
+    if (recent.length >= Orchestrator.LOOP_DETECTION_THRESHOLD) {
+      const lastN = recent.slice(-Orchestrator.LOOP_DETECTION_THRESHOLD);
+      if (lastN.every((t) => t === lastN[0])) {
+        this.transport.sendNotification("log", {
+          message: `[harness] Loop detected in session ${sessionId}: tool "${toolName}" called ${Orchestrator.LOOP_DETECTION_THRESHOLD}+ times consecutively`,
+        });
+        return true;
+      }
+    }
+    return false;
   }
 
   /** Persist session info to session-persistence (fire-and-forget). */

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -1733,9 +1733,14 @@ export class Orchestrator {
 
     try {
       const newSession = await adapter.handoffSession(sessionId, summary);
+      // Mark old session as overflow so it's not treated as active
+      session.status = "overflow";
+      session.lastActiveAt = Date.now();
+
       newSession.role = session.role;
       newSession.frozenRole = session.frozenRole;
       newSession.sessionName = session.sessionName;
+      newSession.parentSessionId = sessionId;
       this.sessions.set(newSession.sessionId, newSession);
 
       if (session.role) {
@@ -1768,7 +1773,7 @@ export class Orchestrator {
    * Detect tool-call loops in agent sessions.
    * Returns true if the same tool has been called N+ times consecutively.
    */
-  detectToolLoop(sessionId: string, toolName: string): boolean {
+  private detectToolLoop(sessionId: string, toolName: string): boolean {
     let recent = this.recentToolCalls.get(sessionId);
     if (!recent) {
       recent = [];
@@ -2442,6 +2447,7 @@ export class Orchestrator {
     }
 
     this.bus.emit("agent.session.end", agentId, sessionId, {});
+    this.recentToolCalls.delete(sessionId);
     this.persistState(true);
   }
 
@@ -2465,6 +2471,7 @@ export class Orchestrator {
       }
     }
     this.bus.emit("agent.session.delete", agentId, sessionId, {});
+    this.recentToolCalls.delete(sessionId);
     this.persistState(true);
   }
 


### PR DESCRIPTION
## Summary
- **Auto session handoff**: When `checkTokenThreshold()` emits `orchestrator.context.compact` at 70% token usage, the orchestrator now calls `adapter.handoffSession()` to create a new session with role/task rebinding
- **Loop detection**: Tracks consecutive tool calls per session; logs warning when same tool is called 3+ times in a row (wired into `streamMessages` at `tool_start` events)

## Problem (Issue #101, Phase 1 items 1-2)
1. Token checkpoint at 70% existed but nothing acted on the event — sessions would hit context limits
2. No mechanism to detect looping agents wasting tokens on repeated identical tool calls

## Test plan
- [ ] Type-check passes
- [ ] Dispatch long task → 70% checkpoint → auto-handoff in logs
- [ ] Agent loops on same tool → loop detection warning in logs

Partial fix for #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)