### PR TITLE
fix(orchestrator): address acceptance review findings (17 items)

### DIFF
--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -254,8 +254,17 @@ export class Orchestrator {
     await this.buildAndInjectContext();
   }
 
-  /** Graceful shutdown — close SQLite connection and release resources. */
+  /** Graceful shutdown — clean up callback queue and close SQLite. */
   async shutdown(): Promise<void> {
+    try {
+      const cleaned = this.callbackQueue?.cleanup();
+      if (cleaned) {
+        this.transport.sendNotification("log", {
+          message: `[orchestrator] Cleaned up ${cleaned} delivered callback(s) on shutdown`,
+        });
+      }
+    } catch { /* best-effort */ }
+    this.callbackQueue = null;
     this.sqliteDb?.close();
     this.sqliteDb = null;
   }
@@ -1577,9 +1586,20 @@ export class Orchestrator {
               timestamp: yielded.timestamp,
             },
           });
-          // Loop detection: track tool calls and warn if repeating
+          // Loop detection: track tool calls and intervene if looping
           if (yielded.toolName && yielded.eventKind === "tool_start") {
-            this.detectToolLoop(sessionId, yielded.toolName);
+            if (this.detectToolLoop(sessionId, yielded.toolName)) {
+              // Inject warning into the session to break the loop
+              void this.sendPrompt(
+                agentId,
+                `[LOOP DETECTED] You have called "${yielded.toolName}" ${Orchestrator.LOOP_DETECTION_THRESHOLD}+ times consecutively. This suggests a loop. Stop repeating the same action and try a different approach.`,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+              ).catch(() => { /* best-effort warning injection */ });
+            }
           }
           continue;
         }
@@ -1811,6 +1831,8 @@ export class Orchestrator {
         this.transport.sendNotification("log", {
           message: `[harness] Loop detected in session ${sessionId}: tool "${toolName}" called ${Orchestrator.LOOP_DETECTION_THRESHOLD}+ times consecutively`,
         });
+        // Reset window to avoid repeated warnings on every subsequent call
+        recent.length = 0;
         return true;
       }
     }
@@ -1954,19 +1976,38 @@ export class Orchestrator {
       message: `[task] Research task ${task.taskId} completed by ${agentId}, fast-tracking to closed`,
     });
 
+    // Verify KB write: check if the expected KB file was actually created
+    const kbPaths = task.allowedWriteScope?.kbPaths ?? [];
+    const expectedKbFile = kbPaths[0];
+    let kbWriteVerified = false;
+    if (expectedKbFile && this.kb?.isEnabled()) {
+      try {
+        const content = await this.kb.read(expectedKbFile);
+        kbWriteVerified = !!content && content.length > 100;
+      } catch {
+        // KB file not found or not readable
+      }
+      if (!kbWriteVerified) {
+        this.transport.sendNotification("log", {
+          message: `[task] WARNING: Research task ${task.taskId} did not write expected KB file "${expectedKbFile}". Findings may be lost.`,
+        });
+      }
+    }
+
     // Store a lightweight receipt
     const parsed = this.tryParseJsonRecord(finalMessage);
     const evidenceArr = this.readStringArray(parsed?.evidence);
     const findingsArr = this.readStringArray(parsed?.findings);
     const recommendationsArr = this.readStringArray(parsed?.recommendations);
+    const docsUpdated = kbWriteVerified && expectedKbFile ? [expectedKbFile] : [];
     const receipt: ImplementationReceipt = {
       implementer: agentId,
       branch: "",
       summary: this.readString(parsed?.summary) ?? finalMessage.slice(0, 500),
       changedFiles: [],
       evidence: evidenceArr.length > 0 ? evidenceArr : findingsArr,
-      docsUpdated: [],
-      residualRisks: [],
+      docsUpdated,
+      residualRisks: kbWriteVerified ? [] : ["KB write not verified — research output may only exist in task result"],
       completedAt: Date.now(),
     };
 
@@ -2963,13 +3004,19 @@ export class Orchestrator {
     });
 
     for (const entry of pending) {
-      const entryPayload = JSON.parse(entry.payload_json) as TaskCallbackPayload;
+      let entryPayload: TaskCallbackPayload;
+      try {
+        entryPayload = JSON.parse(entry.payload_json) as TaskCallbackPayload;
+      } catch {
+        this.transport.sendNotification("log", {
+          message: `[orchestrator] Corrupt callback payload (id=${entry.id}), marking failed and skipping`,
+        });
+        this.callbackQueue.markAttemptFailed(entry.id, "corrupt payload JSON", 1);
+        continue; // Skip this entry, continue with next
+      }
       const prompt = this.formatCallbackPrompt(entryPayload);
 
       try {
-        // sendPrompt initiates streaming; marking delivered after the call
-        // succeeds means the transport accepted the prompt. This is
-        // at-least-once delivery — acceptable since callbacks are idempotent.
         await this.sendPrompt(mainAgentId, prompt, undefined, "main");
         this.callbackQueue.markDelivered(entry.id);
       } catch (err) {

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -254,8 +254,12 @@ export class Orchestrator {
     await this.buildAndInjectContext();
   }
 
-  /** Graceful shutdown — clean up callback queue and close SQLite. */
+  private shuttingDown = false;
+
+  /** Graceful shutdown — quiesce drain, clean up queue, close SQLite. */
   async shutdown(): Promise<void> {
+    // Prevent new enqueues and drain attempts during shutdown
+    this.shuttingDown = true;
     try {
       const cleaned = this.callbackQueue?.cleanup();
       if (cleaned) {
@@ -1589,15 +1593,13 @@ export class Orchestrator {
           // Loop detection: track tool calls and intervene if looping
           if (yielded.toolName && yielded.eventKind === "tool_start") {
             if (this.detectToolLoop(sessionId, yielded.toolName)) {
-              // Inject warning into the session to break the loop
+              // Inject warning into the current session's role slot
+              const loopSession = this.sessions.get(sessionId);
               void this.sendPrompt(
                 agentId,
                 `[LOOP DETECTED] You have called "${yielded.toolName}" ${Orchestrator.LOOP_DETECTION_THRESHOLD}+ times consecutively. This suggests a loop. Stop repeating the same action and try a different approach.`,
                 undefined,
-                undefined,
-                undefined,
-                undefined,
-                undefined,
+                loopSession?.role,
               ).catch(() => { /* best-effort warning injection */ });
             }
           }
@@ -1976,9 +1978,14 @@ export class Orchestrator {
       message: `[task] Research task ${task.taskId} completed by ${agentId}, fast-tracking to closed`,
     });
 
-    // Verify KB write: check if the expected KB file was actually created
-    const kbPaths = task.allowedWriteScope?.kbPaths ?? [];
-    const expectedKbFile = kbPaths[0];
+    // Verify KB write: derive the same target path as deriveKbWriteInstructions
+    const kbPaths = (task.allowedWriteScope?.kbPaths ?? []).filter((p) => p.trim().length > 0);
+    let expectedKbFile: string | undefined;
+    if (kbPaths.length > 0) {
+      expectedKbFile = kbPaths[0].endsWith(".md")
+        ? kbPaths[0]
+        : `${kbPaths[0].replace(/\/+$/, "")}/${task.taskId}.md`;
+    }
     let kbWriteVerified = false;
     if (expectedKbFile && this.kb?.isEnabled()) {
       try {
@@ -2911,6 +2918,7 @@ export class Orchestrator {
     }
 
     // Step 1: Persist to callback queue (crash-safe)
+    if (this.shuttingDown) return;
     if (this.callbackQueue) {
       const enqueued = this.callbackQueue.enqueue(payload);
       if (!enqueued) {
@@ -2966,6 +2974,7 @@ export class Orchestrator {
   private callbackDrainLock: Promise<void> = Promise.resolve();
 
   private async attemptCallbackDelivery(): Promise<void> {
+    if (this.shuttingDown) return;
     // Serialize: chain onto the existing drain lock to prevent concurrent reads
     const prev = this.callbackDrainLock;
     let resolve!: () => void;

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -274,6 +274,11 @@ export class TaskManager {
     if (normCodePaths.length === 0 && normKbPaths.length === 0) {
       errors.push("allowedWriteScope must have at least 1 codePath or kbPath");
     }
+    // Research/design tasks must have kbPath for report output (fail-fast)
+    const taskRole = params.role ?? "dev";
+    if ((taskRole === "research" || taskRole === "design") && normKbPaths.length === 0) {
+      errors.push(`${taskRole} tasks require at least one non-empty allowedWriteScope.kbPaths entry for report output`);
+    }
     if (errors.length > 0) {
       throw new Error(`createTask validation failed:\n  - ${errors.join("\n  - ")}`);
     }

--- a/packages/orchestrator/src/task-persistence-sqlite.ts
+++ b/packages/orchestrator/src/task-persistence-sqlite.ts
@@ -103,6 +103,7 @@ const MIGRATIONS = [
       );
       CREATE INDEX IF NOT EXISTS idx_cbq_status ON callback_queue(status);
       CREATE INDEX IF NOT EXISTS idx_cbq_task ON callback_queue(task_id);
+      CREATE INDEX IF NOT EXISTS idx_cbq_created ON callback_queue(created_at);
     `,
   },
 ];


### PR DESCRIPTION
## Summary

Addresses findings from deep acceptance review across PR #104, #105, #102/#103.

### Priority fixes (HIGH)
1. **#1 JSON.parse try-catch in drain loop** — corrupt payload now skipped safely with `continue`, preventing full queue stall
2. **#10 Loop detection now actionable** — injects `[LOOP DETECTED]` warning prompt into agent session, not just a log line
3. **#13/#14 KB write runtime verification** — `handleResearchStreamComplete` checks if expected KB file exists; warns in receipt.residualRisks if missing

### Medium fixes
4. **#15 createTask kbPath fail-fast** — research/design tasks rejected at creation if no kbPath (not just at dispatch)
5. **#3/#5 cleanup() + created_at index** — cleanup wired into `shutdown()`, `created_at` index added to migration v3
6. **#11 Loop counter reset** — window cleared after detection to prevent warning spam

### Deferred (acknowledged, tracked)
- #2 Idempotency key granularity (acceptanceId) — future enhancement
- #6 markAttemptFailed race — low probability in single-process architecture
- #7 Adapter summary usage — adapter-specific, tracked separately
- #8 Streaming mid-handoff — requires SDK-level support
- #9 Overflow session TTL — existing 30-day TTL applies
- #12 Tool name + params matching — risk of false negatives, deferred
- #16 KB service availability check — deferred to dispatch-time gate
- #17 Multiple kbPaths — single-path is intentional for simplicity

## Test plan
- [ ] Type-check passes
- [ ] Corrupt callback_queue entry → skipped, next entries still delivered
- [ ] Loop detection → warning prompt injected into session
- [ ] Research task completes → receipt shows kbWriteVerified status

🤖 Generated with [Claude Code](https://claude.com/claude-code)