### PR TITLE
fix(orchestrator): KB double-path, EPIPE crash, MaxListeners, partial verdict

### DIFF
--- a/packages/gui/src-tauri/Cargo.lock
+++ b/packages/gui/src-tauri/Cargo.lock
@@ -2059,6 +2059,7 @@ dependencies = [
  "tauri-plugin-window-state",
  "tokio",
  "url",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/packages/gui/src-tauri/Cargo.toml
+++ b/packages/gui/src-tauri/Cargo.toml
@@ -24,3 +24,4 @@ serde_json = "1"
 tokio = { version = "1", features = ["process", "io-util", "rt-multi-thread", "sync", "macros", "time"] }
 url = "2"
 dirs = "6"
+windows-sys = { version = "0.61.2", features = ["Win32_Foundation", "Win32_System_JobObjects"] }

--- a/packages/gui/src-tauri/src/lib.rs
+++ b/packages/gui/src-tauri/src/lib.rs
@@ -3,6 +3,8 @@ mod pr_monitor;
 mod remote_control;
 mod sidecar;
 mod types;
+#[cfg(target_os = "windows")]
+mod windows_job;
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -31,7 +33,12 @@ fn find_project_root(start: PathBuf) -> Option<PathBuf> {
     loop {
         if dir.join("pnpm-workspace.yaml").exists()
             && dir.join("package.json").exists()
-            && dir.join("packages").join("orchestrator").join("src").join("index.ts").exists()
+            && dir
+                .join("packages")
+                .join("orchestrator")
+                .join("src")
+                .join("index.ts")
+                .exists()
         {
             return Some(dir);
         }
@@ -53,9 +60,15 @@ pub fn run() {
             // Restore and focus the existing window regardless of its current state
             // (minimized, hidden, or normal). Order matters: show → unminimize → focus.
             if let Some(w) = app.get_webview_window("main") {
-                if let Err(e) = w.show() { eprintln!("[single-instance] show failed: {e}"); }
-                if let Err(e) = w.unminimize() { eprintln!("[single-instance] unminimize failed: {e}"); }
-                if let Err(e) = w.set_focus() { eprintln!("[single-instance] set_focus failed: {e}"); }
+                if let Err(e) = w.show() {
+                    eprintln!("[single-instance] show failed: {e}");
+                }
+                if let Err(e) = w.unminimize() {
+                    eprintln!("[single-instance] unminimize failed: {e}");
+                }
+                if let Err(e) = w.set_focus() {
+                    eprintln!("[single-instance] set_focus failed: {e}");
+                }
             } else {
                 eprintln!("[single-instance] main window not found");
             }
@@ -237,11 +250,7 @@ pub fn run() {
                     };
 
                     // Global timeout covers RC (5s) + sidecar (3s) + margin
-                    match tokio::time::timeout(
-                        tokio::time::Duration::from_secs(10),
-                        shutdown,
-                    )
-                    .await
+                    match tokio::time::timeout(tokio::time::Duration::from_secs(10), shutdown).await
                     {
                         Ok(_) => {}
                         Err(_) => eprintln!(

--- a/packages/gui/src-tauri/src/remote_control.rs
+++ b/packages/gui/src-tauri/src/remote_control.rs
@@ -5,6 +5,8 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::{Child, Command};
 use tokio::sync::Mutex;
 
+#[cfg(target_os = "windows")]
+use crate::windows_job::ProcessJob;
 
 /// Manages a `claude remote-control` child process.
 /// Parses stdout for session URL, emits Tauri events for GUI updates.
@@ -21,6 +23,8 @@ use tokio::sync::Mutex;
 #[derive(Clone)]
 pub struct RemoteControlManager {
     child: Arc<Mutex<Option<Child>>>,
+    #[cfg(target_os = "windows")]
+    job: Arc<Mutex<Option<ProcessJob>>>,
     session_url: Arc<Mutex<Option<String>>>,
     status: Arc<Mutex<RemoteControlStatus>>,
     session_name: Arc<Mutex<Option<String>>>,
@@ -58,6 +62,8 @@ impl RemoteControlManager {
     pub fn new() -> Self {
         Self {
             child: Arc::new(Mutex::new(None)),
+            #[cfg(target_os = "windows")]
+            job: Arc::new(Mutex::new(None)),
             session_url: Arc::new(Mutex::new(None)),
             status: Arc::new(Mutex::new(RemoteControlStatus::Stopped)),
             session_name: Arc::new(Mutex::new(None)),
@@ -99,12 +105,15 @@ impl RemoteControlManager {
             let mut status = self.status.lock().await;
             *status = RemoteControlStatus::Starting;
         }
-        let _ = app_handle.emit("remote-control-status", RemoteControlState {
-            status: RemoteControlStatus::Starting,
-            session_url: None,
-            session_name: session_name.clone(),
-        error_message: None,
-        });
+        let _ = app_handle.emit(
+            "remote-control-status",
+            RemoteControlState {
+                status: RemoteControlStatus::Starting,
+                session_url: None,
+                session_name: session_name.clone(),
+                error_message: None,
+            },
+        );
 
         // Build command: `claude remote-control --verbose`
         // On Windows, claude is a .cmd script so we must run via cmd.exe.
@@ -117,8 +126,8 @@ impl RemoteControlManager {
             }
             c.arg("--verbose");
             c.creation_flags(0x08000000); // CREATE_NO_WINDOW
-            // Force UTF-8 encoding to prevent codepage 936/GBK garbling on CJK Windows.
-            // Mirrors sidecar.rs environment setup for consistency.
+                                          // Force UTF-8 encoding to prevent codepage 936/GBK garbling on CJK Windows.
+                                          // Mirrors sidecar.rs environment setup for consistency.
             c.env("LANG", "en_US.UTF-8");
             c.env("LC_ALL", "en_US.UTF-8");
             c.env("PYTHONIOENCODING", "utf-8");
@@ -154,15 +163,39 @@ impl RemoteControlManager {
                     *name = None;
                 }
                 let err_msg = format!("Failed to spawn claude remote-control: {}", e);
-                let _ = app_handle.emit("remote-control-status", RemoteControlState {
-                    status: RemoteControlStatus::Error,
-                    session_url: None,
-                    session_name: None,
-                    error_message: Some(err_msg.clone()),
-                });
+                let _ = app_handle.emit(
+                    "remote-control-status",
+                    RemoteControlState {
+                        status: RemoteControlStatus::Error,
+                        session_url: None,
+                        session_name: None,
+                        error_message: Some(err_msg.clone()),
+                    },
+                );
                 return Err(err_msg);
             }
         };
+        #[cfg(target_os = "windows")]
+        {
+            match ProcessJob::new_kill_on_close() {
+                Ok(job) => {
+                    if let Err(e) = job.assign(&child) {
+                        eprintln!(
+                            "[remote-control] WARNING: failed to assign process to job object: {}",
+                            e
+                        );
+                    }
+                    let mut job_guard = self.job.lock().await;
+                    *job_guard = Some(job);
+                }
+                Err(e) => {
+                    eprintln!(
+                        "[remote-control] WARNING: failed to create job object: {}",
+                        e
+                    );
+                }
+            }
+        }
 
         let stdout = child.stdout.take().ok_or("Failed to get stdout")?;
         let stderr = child.stderr.take().ok_or("Failed to get stderr")?;
@@ -178,6 +211,8 @@ impl RemoteControlManager {
         let child_clone = self.child.clone();
         let cleanup_flag_stdout = self.cleanup_done.clone();
         let generation_stdout = self.generation.clone();
+        #[cfg(target_os = "windows")]
+        let job_stdout = self.job.clone();
         let app_stdout = app_handle.clone();
         let name_for_stdout = session_name.clone();
         tokio::spawn(async move {
@@ -191,10 +226,13 @@ impl RemoteControlManager {
                 }
 
                 // Forward the raw line (preserving whitespace for QR/ASCII art) to the GUI.
-                let _ = app_stdout.emit("remote-control-log", serde_json::json!({
-                    "level": "stdout",
-                    "message": &line,
-                }));
+                let _ = app_stdout.emit(
+                    "remote-control-log",
+                    serde_json::json!({
+                        "level": "stdout",
+                        "message": &line,
+                    }),
+                );
 
                 let trimmed = line.trim().to_string();
                 if trimmed.is_empty() {
@@ -216,15 +254,21 @@ impl RemoteControlManager {
                             let mut status_guard = status_clone.lock().await;
                             *status_guard = RemoteControlStatus::WaitingForConnection;
                         }
-                        let _ = app_stdout.emit("remote-control-status", RemoteControlState {
-                            status: RemoteControlStatus::WaitingForConnection,
-                            session_url: Some(url.clone()),
-                            session_name: name_for_stdout.clone(),
-                        error_message: None,
-                        });
-                        let _ = app_stdout.emit("remote-control-url", serde_json::json!({
-                            "url": url,
-                        }));
+                        let _ = app_stdout.emit(
+                            "remote-control-status",
+                            RemoteControlState {
+                                status: RemoteControlStatus::WaitingForConnection,
+                                session_url: Some(url.clone()),
+                                session_name: name_for_stdout.clone(),
+                                error_message: None,
+                            },
+                        );
+                        let _ = app_stdout.emit(
+                            "remote-control-url",
+                            serde_json::json!({
+                                "url": url,
+                            }),
+                        );
                     }
                 }
 
@@ -240,12 +284,15 @@ impl RemoteControlManager {
                         *status_guard = RemoteControlStatus::Connected;
                     }
                     let url_val = url_clone.lock().await.clone();
-                    let _ = app_stdout.emit("remote-control-status", RemoteControlState {
-                        status: RemoteControlStatus::Connected,
-                        session_url: url_val,
-                        session_name: name_for_stdout.clone(),
-                    error_message: None,
-                    });
+                    let _ = app_stdout.emit(
+                        "remote-control-status",
+                        RemoteControlState {
+                            status: RemoteControlStatus::Connected,
+                            session_url: url_val,
+                            session_name: name_for_stdout.clone(),
+                            error_message: None,
+                        },
+                    );
                 }
             }
 
@@ -266,12 +313,20 @@ impl RemoteControlManager {
                     let mut child_guard = child_clone.lock().await;
                     *child_guard = None;
                 }
-                let _ = app_stdout.emit("remote-control-status", RemoteControlState {
-                    status: RemoteControlStatus::Stopped,
-                    session_url: None,
-                    session_name: name_for_stdout.clone(),
-                error_message: None,
-                });
+                #[cfg(target_os = "windows")]
+                {
+                    let mut job_guard = job_stdout.lock().await;
+                    *job_guard = None;
+                }
+                let _ = app_stdout.emit(
+                    "remote-control-status",
+                    RemoteControlState {
+                        status: RemoteControlStatus::Stopped,
+                        session_url: None,
+                        session_name: name_for_stdout.clone(),
+                        error_message: None,
+                    },
+                );
             }
         });
 
@@ -281,6 +336,8 @@ impl RemoteControlManager {
         let child_stderr = self.child.clone();
         let cleanup_flag_stderr = self.cleanup_done.clone();
         let generation_stderr = self.generation.clone();
+        #[cfg(target_os = "windows")]
+        let job_stderr = self.job.clone();
         let app_stderr = app_handle.clone();
         let name_for_stderr = session_name;
         tokio::spawn(async move {
@@ -309,10 +366,13 @@ impl RemoteControlManager {
                 } else {
                     "info"
                 };
-                let _ = app_stderr.emit("remote-control-log", serde_json::json!({
-                    "level": level,
-                    "message": trimmed,
-                }));
+                let _ = app_stderr.emit(
+                    "remote-control-log",
+                    serde_json::json!({
+                        "level": level,
+                        "message": trimmed,
+                    }),
+                );
             }
 
             // stderr closed — only the first task to reach here runs cleanup
@@ -331,12 +391,20 @@ impl RemoteControlManager {
                     let mut child_guard = child_stderr.lock().await;
                     *child_guard = None;
                 }
-                let _ = app_stderr.emit("remote-control-status", RemoteControlState {
-                    status: RemoteControlStatus::Stopped,
-                    session_url: None,
-                    session_name: name_for_stderr,
-                error_message: None,
-                });
+                #[cfg(target_os = "windows")]
+                {
+                    let mut job_guard = job_stderr.lock().await;
+                    *job_guard = None;
+                }
+                let _ = app_stderr.emit(
+                    "remote-control-status",
+                    RemoteControlState {
+                        status: RemoteControlStatus::Stopped,
+                        session_url: None,
+                        session_name: name_for_stderr,
+                        error_message: None,
+                    },
+                );
             }
         });
 
@@ -390,21 +458,21 @@ impl RemoteControlManager {
             }
             // Wait for the child process to fully exit (timeout 5s) to avoid zombies.
             // If the child does not exit within the timeout, treat stop as failed.
-            match tokio::time::timeout(
-                std::time::Duration::from_secs(5),
-                c.wait(),
-            ).await {
+            match tokio::time::timeout(std::time::Duration::from_secs(5), c.wait()).await {
                 Ok(_) => {
                     *child = None;
                 }
                 Err(_) => {
                     // Child still alive after timeout — do NOT clear state.
                     // Return error so the GUI knows the process may still be running.
-                    return Err(
-                        "Stop timed out: child process may still be running".to_string()
-                    );
+                    return Err("Stop timed out: child process may still be running".to_string());
                 }
             }
+        }
+        #[cfg(target_os = "windows")]
+        {
+            let mut job = self.job.lock().await;
+            *job = None;
         }
         {
             let mut status = self.status.lock().await;
@@ -430,7 +498,7 @@ impl RemoteControlManager {
             status,
             session_url,
             session_name,
-        error_message: None,
+            error_message: None,
         }
     }
 
@@ -472,9 +540,7 @@ fn extract_url(line: &str) -> Option<String> {
 fn redact_url(line: &str) -> String {
     if let Some(start) = line.find("https://") {
         let rest = &line[start..];
-        let end = rest
-            .find(|c: char| c.is_whitespace())
-            .unwrap_or(rest.len());
+        let end = rest.find(|c: char| c.is_whitespace()).unwrap_or(rest.len());
         format!("{}[REDACTED_URL]{}", &line[..start], &line[start + end..])
     } else {
         line.to_string()

--- a/packages/gui/src-tauri/src/remote_control.rs
+++ b/packages/gui/src-tauri/src/remote_control.rs
@@ -215,6 +215,7 @@ impl RemoteControlManager {
         let job_stdout = self.job.clone();
         let app_stdout = app_handle.clone();
         let name_for_stdout = session_name.clone();
+        let session_name_stdout = self.session_name.clone();
         tokio::spawn(async move {
             let reader = BufReader::new(stdout);
             let mut lines = reader.lines();
@@ -313,6 +314,10 @@ impl RemoteControlManager {
                     let mut child_guard = child_clone.lock().await;
                     *child_guard = None;
                 }
+                {
+                    let mut name_guard = session_name_stdout.lock().await;
+                    *name_guard = None;
+                }
                 #[cfg(target_os = "windows")]
                 {
                     let mut job_guard = job_stdout.lock().await;
@@ -323,7 +328,7 @@ impl RemoteControlManager {
                     RemoteControlState {
                         status: RemoteControlStatus::Stopped,
                         session_url: None,
-                        session_name: name_for_stdout.clone(),
+                        session_name: None,
                         error_message: None,
                     },
                 );
@@ -339,7 +344,8 @@ impl RemoteControlManager {
         #[cfg(target_os = "windows")]
         let job_stderr = self.job.clone();
         let app_stderr = app_handle.clone();
-        let name_for_stderr = session_name;
+        let session_name_stderr = self.session_name.clone();
+        drop(session_name);
         tokio::spawn(async move {
             let reader = BufReader::new(stderr);
             let mut lines = reader.lines();
@@ -391,6 +397,10 @@ impl RemoteControlManager {
                     let mut child_guard = child_stderr.lock().await;
                     *child_guard = None;
                 }
+                {
+                    let mut name_guard = session_name_stderr.lock().await;
+                    *name_guard = None;
+                }
                 #[cfg(target_os = "windows")]
                 {
                     let mut job_guard = job_stderr.lock().await;
@@ -401,7 +411,7 @@ impl RemoteControlManager {
                     RemoteControlState {
                         status: RemoteControlStatus::Stopped,
                         session_url: None,
-                        session_name: name_for_stderr,
+                        session_name: None,
                         error_message: None,
                     },
                 );

--- a/packages/gui/src-tauri/src/remote_control.rs
+++ b/packages/gui/src-tauri/src/remote_control.rs
@@ -469,8 +469,11 @@ impl RemoteControlManager {
             // Wait for the child process to fully exit (timeout 5s) to avoid zombies.
             // If the child does not exit within the timeout, treat stop as failed.
             match tokio::time::timeout(std::time::Duration::from_secs(5), c.wait()).await {
-                Ok(_) => {
+                Ok(Ok(_)) => {
                     *child = None;
+                }
+                Ok(Err(e)) => {
+                    return Err(format!("Stop failed: wait error: {}", e));
                 }
                 Err(_) => {
                     // Child still alive after timeout — do NOT clear state.

--- a/packages/gui/src-tauri/src/sidecar.rs
+++ b/packages/gui/src-tauri/src/sidecar.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tauri::Emitter;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
@@ -19,6 +20,10 @@ pub struct SidecarManager {
     _job: Option<Arc<ProcessJob>>,
     pending: Arc<Mutex<HashMap<u64, oneshot::Sender<serde_json::Value>>>>,
     next_id: Arc<Mutex<u64>>,
+    /// Set to `true` when the sidecar's stdout EOF is detected. Once set,
+    /// `is_alive()` returns `false` and new RPCs are rejected immediately
+    /// rather than queuing and waiting for a 30-second timeout.
+    transport_dead: Arc<AtomicBool>,
 }
 
 impl SidecarManager {
@@ -85,10 +90,12 @@ impl SidecarManager {
 
         let pending: Arc<Mutex<HashMap<u64, oneshot::Sender<serde_json::Value>>>> =
             Arc::new(Mutex::new(HashMap::new()));
+        let transport_dead: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
 
         // Read stdout (JSON-RPC messages from orchestrator)
         let pending_clone = pending.clone();
         let app_clone = app_handle.clone();
+        let transport_dead_clone = transport_dead.clone();
         tokio::spawn(async move {
             let reader = BufReader::new(stdout);
             let mut lines = reader.lines();
@@ -128,6 +135,7 @@ impl SidecarManager {
             }
 
             eprintln!("[tauri] Orchestrator sidecar stdout closed");
+            transport_dead_clone.store(true, Ordering::Release);
             {
                 let mut pending = pending_clone.lock().await;
                 pending.clear();
@@ -158,6 +166,7 @@ impl SidecarManager {
             _job: job,
             pending,
             next_id: Arc::new(Mutex::new(1)),
+            transport_dead,
         })
     }
 
@@ -272,6 +281,9 @@ impl SidecarManager {
     }
 
     pub async fn is_alive(&self) -> bool {
+        if self.transport_dead.load(Ordering::Acquire) {
+            return false;
+        }
         let mut child = self.child.lock().await;
         matches!(child.try_wait(), Ok(None))
     }
@@ -313,7 +325,7 @@ impl SidecarManager {
             let _ = child.kill().await;
         }
 
-        match timeout(Duration::from_secs(5), child.wait()).await {
+        match timeout(Duration::from_secs(3), child.wait()).await {
             Ok(Ok(_status)) => {}
             Ok(Err(e)) => eprintln!("[tauri] sidecar wait failed during shutdown: {}", e),
             Err(_) => eprintln!("[tauri] sidecar wait timed out during shutdown"),

--- a/packages/gui/src-tauri/src/sidecar.rs
+++ b/packages/gui/src-tauri/src/sidecar.rs
@@ -29,9 +29,9 @@ impl SidecarManager {
             let mut c = Command::new("cmd");
             c.args(["/c", "pnpm", "exec", "tsx"]);
             c.arg(&orchestrator_entry);
-            c.creation_flags(0x08000000); // CREATE_NO_WINDOW
             // Force UTF-8 encoding to prevent codepage 936/GBK garbling on CJK Windows.
             // PYTHONIOENCODING: protects any Python subprocess spawned downstream.
+            c.creation_flags(0x08000000); // CREATE_NO_WINDOW
             c.env("LANG", "en_US.UTF-8");
             c.env("LC_ALL", "en_US.UTF-8");
             c.env("PYTHONIOENCODING", "utf-8");
@@ -221,7 +221,46 @@ impl SidecarManager {
 
     pub async fn shutdown(&self) {
         let mut child = self.child.lock().await;
-        let _ = child.kill().await;
+        #[cfg(target_os = "windows")]
+        {
+            // The sidecar is launched via `cmd /c pnpm exec tsx ...`, so killing the
+            // direct child is not enough. Use taskkill to terminate the whole tree,
+            // otherwise the Node.js orchestrator can survive and keep 127.0.0.1:7654 bound.
+            if let Some(pid) = child.id() {
+                let mut kill_cmd = Command::new("taskkill");
+                kill_cmd
+                    .args(["/T", "/F", "/PID", &pid.to_string()])
+                    .creation_flags(0x08000000); // CREATE_NO_WINDOW
+
+                match kill_cmd.output().await {
+                    Ok(output) if output.status.success() => {}
+                    Ok(output) => {
+                        eprintln!(
+                            "[tauri] sidecar taskkill failed: {}",
+                            String::from_utf8_lossy(&output.stderr)
+                        );
+                        let _ = child.kill().await;
+                    }
+                    Err(e) => {
+                        eprintln!("[tauri] sidecar taskkill spawn error: {}", e);
+                        let _ = child.kill().await;
+                    }
+                }
+            } else {
+                let _ = child.kill().await;
+            }
+        }
+
+        #[cfg(not(target_os = "windows"))]
+        {
+            let _ = child.kill().await;
+        }
+
+        match timeout(Duration::from_secs(5), child.wait()).await {
+            Ok(Ok(_status)) => {}
+            Ok(Err(e)) => eprintln!("[tauri] sidecar wait failed during shutdown: {}", e),
+            Err(_) => eprintln!("[tauri] sidecar wait timed out during shutdown"),
+        }
     }
 }
 

--- a/packages/gui/src-tauri/src/sidecar.rs
+++ b/packages/gui/src-tauri/src/sidecar.rs
@@ -184,20 +184,31 @@ impl SidecarManager {
             id: Some(serde_json::Value::Number(id.into())),
         };
 
+        // Serialize before inserting into pending so a serialization error
+        // never leaves a stale entry in the map.
+        let msg = serde_json::to_string(&request).map_err(|e| e.to_string())?;
+
         let (tx, rx) = oneshot::channel();
         {
             let mut pending = self.pending.lock().await;
             pending.insert(id, tx);
         }
 
-        let msg = serde_json::to_string(&request).map_err(|e| e.to_string())?;
-        {
+        // Write to sidecar; on failure remove the pending entry to avoid leaks.
+        let write_result: Result<(), String> = async {
             let mut stdin = self.stdin.lock().await;
             stdin
                 .write_all(format!("{}\n", msg).as_bytes())
                 .await
                 .map_err(|e| format!("Failed to write to sidecar: {}", e))?;
             stdin.flush().await.map_err(|e| e.to_string())?;
+            Ok(())
+        }
+        .await;
+        if let Err(e) = write_result {
+            let mut pending = self.pending.lock().await;
+            pending.remove(&id);
+            return Err(e);
         }
 
         let response = match timeout(Duration::from_secs(30), rx).await {

--- a/packages/gui/src-tauri/src/sidecar.rs
+++ b/packages/gui/src-tauri/src/sidecar.rs
@@ -8,11 +8,15 @@ use tokio::sync::{oneshot, Mutex};
 use tokio::time::{timeout, Duration};
 
 use crate::types::RpcRequest;
+#[cfg(target_os = "windows")]
+use crate::windows_job::ProcessJob;
 
 #[derive(Clone)]
 pub struct SidecarManager {
     stdin: Arc<Mutex<tokio::process::ChildStdin>>,
     child: Arc<Mutex<Child>>,
+    #[cfg(target_os = "windows")]
+    _job: Option<Arc<ProcessJob>>,
     pending: Arc<Mutex<HashMap<u64, oneshot::Sender<serde_json::Value>>>>,
     next_id: Arc<Mutex<u64>>,
 }
@@ -20,6 +24,17 @@ pub struct SidecarManager {
 impl SidecarManager {
     pub async fn spawn(app_handle: tauri::AppHandle, project_dir: String) -> Result<Self, String> {
         let orchestrator_entry = resolve_orchestrator_entry(&project_dir)?;
+        #[cfg(target_os = "windows")]
+        let job = match ProcessJob::new_kill_on_close() {
+            Ok(job) => Some(Arc::new(job)),
+            Err(e) => {
+                eprintln!(
+                    "[tauri] WARNING: failed to create sidecar job object: {}",
+                    e
+                );
+                None
+            }
+        };
 
         // In dev mode, use pnpm exec tsx to run the orchestrator.
         // Using pnpm instead of npx avoids npm warn noise from inherited env vars.
@@ -54,6 +69,15 @@ impl SidecarManager {
         let mut child = cmd
             .spawn()
             .map_err(|e| format!("Failed to spawn orchestrator: {}", e))?;
+        #[cfg(target_os = "windows")]
+        if let Some(job) = job.as_ref() {
+            if let Err(e) = job.assign(&child) {
+                eprintln!(
+                    "[tauri] WARNING: failed to assign sidecar to job object: {}",
+                    e
+                );
+            }
+        }
 
         let stdin = child.stdin.take().ok_or("Failed to get stdin")?;
         let stdout = child.stdout.take().ok_or("Failed to get stdout")?;
@@ -102,6 +126,18 @@ impl SidecarManager {
                 }
                 tokio::task::yield_now().await;
             }
+
+            eprintln!("[tauri] Orchestrator sidecar stdout closed");
+            {
+                let mut pending = pending_clone.lock().await;
+                pending.clear();
+            }
+            let _ = app_clone.emit(
+                "sidecar-error",
+                serde_json::json!({
+                    "error": "Orchestrator sidecar disconnected before replying. Check sidecar stderr for the root cause."
+                }),
+            );
         });
 
         // Read stderr (log messages)
@@ -118,6 +154,8 @@ impl SidecarManager {
         Ok(Self {
             stdin: Arc::new(Mutex::new(stdin)),
             child: Arc::new(Mutex::new(child)),
+            #[cfg(target_os = "windows")]
+            _job: job,
             pending,
             next_id: Arc::new(Mutex::new(1)),
         })
@@ -128,6 +166,10 @@ impl SidecarManager {
         method: &str,
         params: serde_json::Value,
     ) -> Result<serde_json::Value, String> {
+        if !self.is_alive().await {
+            return Err("Orchestrator sidecar is not running".to_string());
+        }
+
         let id = {
             let mut next = self.next_id.lock().await;
             let id = *next;
@@ -197,6 +239,10 @@ impl SidecarManager {
         method: &str,
         params: serde_json::Value,
     ) -> Result<(), String> {
+        if !self.is_alive().await {
+            return Err("Orchestrator sidecar is not running".to_string());
+        }
+
         let request = RpcRequest {
             jsonrpc: "2.0".to_string(),
             method: method.to_string(),

--- a/packages/gui/src-tauri/src/windows_job.rs
+++ b/packages/gui/src-tauri/src/windows_job.rs
@@ -20,6 +20,15 @@ use windows_sys::Win32::System::JobObjects::{
 /// Windows Job Object wrapper that terminates the assigned process tree when the
 /// job handle is closed. This protects against orphaned sidecar/CLI children when
 /// the GUI or dev terminal is closed abruptly.
+///
+/// # Known race window
+/// The current spawn flow calls [`ProcessJob::assign`] *after* `Command::spawn()`,
+/// leaving a brief window where the child process is not yet tracked by the job.
+/// An abrupt GUI termination or panic in that window may produce an orphan.
+/// The `taskkill /T /F` fallback in `SidecarManager::shutdown` provides
+/// best-effort cleanup but does not make the assignment atomic. A proper fix
+/// (`CREATE_SUSPENDED` + `ResumeThread`) is tracked in Issue #107; this
+/// behaviour is intentionally left as-is for now.
 #[cfg(target_os = "windows")]
 pub struct ProcessJob {
     handle: OwnedHandle,

--- a/packages/gui/src-tauri/src/windows_job.rs
+++ b/packages/gui/src-tauri/src/windows_job.rs
@@ -1,0 +1,72 @@
+#[cfg(target_os = "windows")]
+use std::ffi::c_void;
+#[cfg(target_os = "windows")]
+use std::io;
+#[cfg(target_os = "windows")]
+use std::mem::{size_of, zeroed};
+#[cfg(target_os = "windows")]
+use std::os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle, RawHandle};
+#[cfg(target_os = "windows")]
+use tokio::process::Child;
+#[cfg(target_os = "windows")]
+use windows_sys::Win32::Foundation::HANDLE;
+#[cfg(target_os = "windows")]
+use windows_sys::Win32::System::JobObjects::{
+    AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation,
+    SetInformationJobObject, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+    JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+};
+
+/// Windows Job Object wrapper that terminates the assigned process tree when the
+/// job handle is closed. This protects against orphaned sidecar/CLI children when
+/// the GUI or dev terminal is closed abruptly.
+#[cfg(target_os = "windows")]
+pub struct ProcessJob {
+    handle: OwnedHandle,
+}
+
+#[cfg(target_os = "windows")]
+impl ProcessJob {
+    pub fn new_kill_on_close() -> io::Result<Self> {
+        unsafe {
+            let raw = CreateJobObjectW(std::ptr::null(), std::ptr::null());
+            if raw.is_null() {
+                return Err(io::Error::last_os_error());
+            }
+
+            let handle = OwnedHandle::from_raw_handle(raw as RawHandle);
+            let mut info: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = zeroed();
+            info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+
+            if SetInformationJobObject(
+                handle.as_raw_handle() as HANDLE,
+                JobObjectExtendedLimitInformation,
+                &info as *const _ as *const c_void,
+                size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+            ) == 0
+            {
+                return Err(io::Error::last_os_error());
+            }
+
+            Ok(Self { handle })
+        }
+    }
+
+    pub fn assign(&self, child: &Child) -> io::Result<()> {
+        let process_handle = child.raw_handle().ok_or_else(|| {
+            io::Error::new(io::ErrorKind::Other, "Child process handle is unavailable")
+        })?;
+
+        unsafe {
+            if AssignProcessToJobObject(
+                self.handle.as_raw_handle() as HANDLE,
+                process_handle as HANDLE,
+            ) == 0
+            {
+                return Err(io::Error::last_os_error());
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/packages/gui/src/stores/agents.ts
+++ b/packages/gui/src/stores/agents.ts
@@ -5,7 +5,7 @@
  * panelKey (roleSlotKey = "{role}:{agentId}"), NOT by raw agentId.
  */
 
-import { ref, computed, shallowRef, triggerRef } from "vue";
+import { ref, computed, shallowRef, triggerRef, watch } from "vue";
 import type { AgentConfig, MercuryEvent } from "../lib/tauri-bridge";
 import {
   getAgents as fetchAgents,
@@ -462,6 +462,7 @@ async function initAgents() {
   await onSidecarReady(() => loadAgents());
 
   await onSidecarError((data) => {
+    sidecarReady.value = false;
     sidecarError.value = data.error;
   });
 
@@ -596,6 +597,29 @@ async function initAgents() {
   setTimeout(pollFn, pollDelay);
 }
 
+function waitForSidecarReady(): Promise<void> {
+  if (sidecarReady.value) return Promise.resolve();
+  if (sidecarError.value) return Promise.reject(new Error(sidecarError.value));
+
+  return new Promise((resolve, reject) => {
+    const stop = watch(
+      [sidecarReady, sidecarError],
+      ([ready, error]) => {
+        if (ready) {
+          stop();
+          resolve();
+          return;
+        }
+        if (error) {
+          stop();
+          reject(new Error(error));
+        }
+      },
+      { immediate: true },
+    );
+  });
+}
+
 export function useAgentStore() {
   return {
     agents,
@@ -622,6 +646,7 @@ export function useAgentStore() {
     getGitBranch,
     defaultWorkDir,
     initAgents,
+    waitForSidecarReady,
     // Bookmark Rail
     bookmarks,
     bookmarkList,

--- a/packages/gui/src/stores/approvals.ts
+++ b/packages/gui/src/stores/approvals.ts
@@ -9,6 +9,7 @@ import {
   onAgentError,
   setApprovalMode as bridgeSetApprovalMode,
 } from "../lib/tauri-bridge";
+import { useAgentStore } from "./agents";
 
 const approvalMode = ref<ApprovalMode>("main_agent_review");
 const approvalRequests = ref<Map<string, ApprovalRequest>>(new Map());
@@ -112,37 +113,44 @@ let approvalsInitialized = false;
 async function initApprovalStore(): Promise<void> {
   if (approvalsInitialized) return;
   approvalsInitialized = true;
+  try {
+    const { waitForSidecarReady } = useAgentStore();
+    await waitForSidecarReady();
 
-  const [modeResult, requests] = await Promise.all([
-    bridgeGetApprovalMode(),
-    bridgeListApprovalRequests(),
-  ]);
-  approvalMode.value = modeResult.mode;
-  const next = new Map<string, ApprovalRequest>();
-  for (const request of requests) next.set(request.id, request);
-  approvalRequests.value = next;
+    const [modeResult, requests] = await Promise.all([
+      bridgeGetApprovalMode(),
+      bridgeListApprovalRequests(),
+    ]);
+    approvalMode.value = modeResult.mode;
+    const next = new Map<string, ApprovalRequest>();
+    for (const request of requests) next.set(request.id, request);
+    approvalRequests.value = next;
 
-  await onMercuryEvent((event: MercuryEvent) => {
-    if (event.type !== "agent.approval.requested" && event.type !== "agent.approval.resolved") {
-      return;
-    }
+    await onMercuryEvent((event: MercuryEvent) => {
+      if (event.type !== "agent.approval.requested" && event.type !== "agent.approval.resolved") {
+        return;
+      }
 
-    const payload = event.payload as unknown as ApprovalRequest;
-    if (payload?.id) {
-      upsertRequest(payload);
-    }
-  });
+      const payload = event.payload as unknown as ApprovalRequest;
+      if (payload?.id) {
+        upsertRequest(payload);
+      }
+    });
 
-  // When a transport crash occurs, immediately cancel pending approvals for
-  // that session so the GUI doesn't show stale, unresponsive approval buttons.
-  await onAgentError((data) => {
-    if (data.isTransportCrash) {
-      cancelPendingApprovalsForSession(
-        data.sessionId,
-        "Transport disconnected — approval cancelled",
-      );
-    }
-  });
+    // When a transport crash occurs, immediately cancel pending approvals for
+    // that session so the GUI doesn't show stale, unresponsive approval buttons.
+    await onAgentError((data) => {
+      if (data.isTransportCrash) {
+        cancelPendingApprovalsForSession(
+          data.sessionId,
+          "Transport disconnected — approval cancelled",
+        );
+      }
+    });
+  } catch (e) {
+    approvalsInitialized = false;
+    throw e;
+  }
 }
 
 export function useApprovalStore() {

--- a/packages/gui/src/stores/tasks.ts
+++ b/packages/gui/src/stores/tasks.ts
@@ -86,6 +86,12 @@ async function initTaskListeners() {
   taskListenersInitPromise = (async () => {
     const { waitForSidecarReady } = useAgentStore();
     const pending: UnlistenFn[] = [];
+    // Accumulators for events that arrive while the initial snapshot is in-flight.
+    // Without these, refreshTask() writes could be clobbered by the subsequent
+    // tasks.value = await listTasks() assignment.
+    const pendingRefreshIds = new Set<string>();
+    let pendingFullReload = false;
+    let snapshotInflight = false;
     try {
       // Register all listeners before taking the initial snapshot so events
       // arriving during snapshotting are not lost.
@@ -98,10 +104,11 @@ async function initTaskListeners() {
         if (event.type.startsWith("orchestrator.task.") || event.type.startsWith("orchestrator.acceptance.")) {
           const taskId =
             (event.payload as Record<string, unknown>).taskId as string | undefined;
-          if (taskId) {
-            refreshTask(taskId);
+          if (snapshotInflight) {
+            // Queue for replay after the snapshot completes to avoid clobbering.
+            if (taskId) { pendingRefreshIds.add(taskId); } else { pendingFullReload = true; }
           } else {
-            loadTasks();
+            if (taskId) { refreshTask(taskId); } else { loadTasks(); }
           }
         }
       }));
@@ -109,8 +116,19 @@ async function initTaskListeners() {
       // Listeners are active — now take the initial snapshot.
       // If the ready event was emitted before we registered the listener above,
       // wait on the shared sidecar-ready state that agents.ts keeps in sync.
+      snapshotInflight = true;
       await waitForSidecarReady();
       await loadTasks();
+      snapshotInflight = false;
+
+      // Replay any events that arrived during the snapshot to avoid lost updates.
+      if (pendingFullReload) {
+        await loadTasks();
+      } else {
+        for (const id of pendingRefreshIds) refreshTask(id);
+      }
+      pendingRefreshIds.clear();
+      pendingFullReload = false;
 
       // All listeners registered and snapshot complete — commit
       taskListenersInitialized = true;

--- a/packages/gui/src/stores/tasks.ts
+++ b/packages/gui/src/stores/tasks.ts
@@ -87,14 +87,12 @@ async function initTaskListeners() {
     const { waitForSidecarReady } = useAgentStore();
     const pending: UnlistenFn[] = [];
     try {
+      // Register all listeners before taking the initial snapshot so events
+      // arriving during snapshotting are not lost.
+
       // Reload tasks whenever sidecar becomes ready (handles F5 page refresh where
       // sidecar may not be available yet when onMounted fires).
       pending.push(await onSidecarReady(() => loadTasks()));
-
-      // If the ready event was emitted before we registered the listener above,
-      // wait on the shared sidecar-ready state that agents.ts keeps in sync.
-      await waitForSidecarReady();
-      await loadTasks();
 
       pending.push(await onMercuryEvent((event: MercuryEvent) => {
         if (event.type.startsWith("orchestrator.task.") || event.type.startsWith("orchestrator.acceptance.")) {
@@ -108,7 +106,13 @@ async function initTaskListeners() {
         }
       }));
 
-      // All listeners registered — commit
+      // Listeners are active — now take the initial snapshot.
+      // If the ready event was emitted before we registered the listener above,
+      // wait on the shared sidecar-ready state that agents.ts keeps in sync.
+      await waitForSidecarReady();
+      await loadTasks();
+
+      // All listeners registered and snapshot complete — commit
       taskListenersInitialized = true;
       taskUnlisteners.push(...pending);
     } catch (e) {
@@ -116,6 +120,7 @@ async function initTaskListeners() {
       for (const unlisten of pending) unlisten();
       taskListenersInitPromise = null;
       console.error("Failed to init task listeners:", e);
+      throw e;
     }
   })();
 

--- a/packages/gui/src/stores/tasks.ts
+++ b/packages/gui/src/stores/tasks.ts
@@ -117,7 +117,13 @@ async function initTaskListeners() {
       // If the ready event was emitted before we registered the listener above,
       // wait on the shared sidecar-ready state that agents.ts keeps in sync.
       snapshotInflight = true;
-      await waitForSidecarReady();
+      const SIDECAR_READY_TIMEOUT_MS = 30_000;
+      await Promise.race([
+        waitForSidecarReady(),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error("waitForSidecarReady timed out after 30s")), SIDECAR_READY_TIMEOUT_MS)
+        ),
+      ]);
       await loadTasks();
       snapshotInflight = false;
 
@@ -125,7 +131,7 @@ async function initTaskListeners() {
       if (pendingFullReload) {
         await loadTasks();
       } else {
-        for (const id of pendingRefreshIds) refreshTask(id);
+        await Promise.all(Array.from(pendingRefreshIds).map((id) => refreshTask(id)));
       }
       pendingRefreshIds.clear();
       pendingFullReload = false;

--- a/packages/gui/src/stores/tasks.ts
+++ b/packages/gui/src/stores/tasks.ts
@@ -10,6 +10,7 @@ import type {
 } from "../lib/tauri-bridge";
 import type { UnlistenFn } from "@tauri-apps/api/event";
 import { listTasks, getTask, onMercuryEvent, onSidecarReady } from "../lib/tauri-bridge";
+import { useAgentStore } from "./agents";
 
 const tasks = ref<TaskBundle[]>([]);
 const selectedTaskId = ref<string | null>(null);
@@ -83,37 +84,39 @@ async function initTaskListeners() {
   if (taskListenersInitPromise) return taskListenersInitPromise;
 
   taskListenersInitPromise = (async () => {
-  const pending: UnlistenFn[] = [];
-  try {
-    // Reload tasks whenever sidecar becomes ready (handles F5 page refresh where
-    // sidecar may not be available yet when onMounted fires).
-    pending.push(await onSidecarReady(() => loadTasks()));
+    const { waitForSidecarReady } = useAgentStore();
+    const pending: UnlistenFn[] = [];
+    try {
+      // Reload tasks whenever sidecar becomes ready (handles F5 page refresh where
+      // sidecar may not be available yet when onMounted fires).
+      pending.push(await onSidecarReady(() => loadTasks()));
 
-    // Attempt immediate load in case sidecar is already ready — the ready
-    // event may have been emitted before we registered the listener above.
-    void loadTasks();
+      // If the ready event was emitted before we registered the listener above,
+      // wait on the shared sidecar-ready state that agents.ts keeps in sync.
+      await waitForSidecarReady();
+      await loadTasks();
 
-    pending.push(await onMercuryEvent((event: MercuryEvent) => {
-      if (event.type.startsWith("orchestrator.task.") || event.type.startsWith("orchestrator.acceptance.")) {
-        const taskId =
-          (event.payload as Record<string, unknown>).taskId as string | undefined;
-        if (taskId) {
-          refreshTask(taskId);
-        } else {
-          loadTasks();
+      pending.push(await onMercuryEvent((event: MercuryEvent) => {
+        if (event.type.startsWith("orchestrator.task.") || event.type.startsWith("orchestrator.acceptance.")) {
+          const taskId =
+            (event.payload as Record<string, unknown>).taskId as string | undefined;
+          if (taskId) {
+            refreshTask(taskId);
+          } else {
+            loadTasks();
+          }
         }
-      }
-    }));
+      }));
 
-    // All listeners registered — commit
-    taskListenersInitialized = true;
-    taskUnlisteners.push(...pending);
-  } catch (e) {
-    // Rollback: unregister any listeners that were successfully created
-    for (const unlisten of pending) unlisten();
-    taskListenersInitPromise = null;
-    console.error("Failed to init task listeners:", e);
-  }
+      // All listeners registered — commit
+      taskListenersInitialized = true;
+      taskUnlisteners.push(...pending);
+    } catch (e) {
+      // Rollback: unregister any listeners that were successfully created
+      for (const unlisten of pending) unlisten();
+      taskListenersInitPromise = null;
+      console.error("Failed to init task listeners:", e);
+    }
   })();
 
   return taskListenersInitPromise;

--- a/packages/gui/src/stores/tasks.ts
+++ b/packages/gui/src/stores/tasks.ts
@@ -77,6 +77,7 @@ async function refreshTask(taskId: string) {
 
 let taskListenersInitialized = false;
 const taskUnlisteners: UnlistenFn[] = [];
+const taskPendingListenerBatches = new Set<UnlistenFn[]>();
 let taskListenersInitPromise: Promise<void> | null = null;
 
 async function initTaskListeners() {
@@ -86,6 +87,7 @@ async function initTaskListeners() {
   taskListenersInitPromise = (async () => {
     const { waitForSidecarReady } = useAgentStore();
     const pending: UnlistenFn[] = [];
+    taskPendingListenerBatches.add(pending);
     // Accumulators for events that arrive while the initial snapshot is in-flight.
     // Without these, refreshTask() writes could be clobbered by the subsequent
     // tasks.value = await listTasks() assignment.
@@ -118,12 +120,20 @@ async function initTaskListeners() {
       // wait on the shared sidecar-ready state that agents.ts keeps in sync.
       snapshotInflight = true;
       const SIDECAR_READY_TIMEOUT_MS = 30_000;
-      await Promise.race([
-        waitForSidecarReady(),
-        new Promise<never>((_, reject) =>
-          setTimeout(() => reject(new Error("waitForSidecarReady timed out after 30s")), SIDECAR_READY_TIMEOUT_MS)
-        ),
-      ]);
+      let readyTimeoutHandle: ReturnType<typeof setTimeout> | null = null;
+      try {
+        await Promise.race([
+          waitForSidecarReady(),
+          new Promise<never>((_, reject) => {
+            readyTimeoutHandle = setTimeout(
+              () => reject(new Error("waitForSidecarReady timed out after 30s")),
+              SIDECAR_READY_TIMEOUT_MS
+            );
+          }),
+        ]);
+      } finally {
+        if (readyTimeoutHandle !== null) clearTimeout(readyTimeoutHandle);
+      }
       await loadTasks();
       snapshotInflight = false;
 
@@ -145,6 +155,8 @@ async function initTaskListeners() {
       taskListenersInitPromise = null;
       console.error("Failed to init task listeners:", e);
       throw e;
+    } finally {
+      taskPendingListenerBatches.delete(pending);
     }
   })();
 
@@ -155,6 +167,10 @@ async function initTaskListeners() {
 function disposeTaskListeners() {
   for (const unlisten of taskUnlisteners) unlisten();
   taskUnlisteners.length = 0;
+  for (const batch of taskPendingListenerBatches) {
+    for (const unlisten of batch) unlisten();
+  }
+  taskPendingListenerBatches.clear();
   taskListenersInitialized = false;
   taskListenersInitPromise = null;
 }

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -10,6 +10,17 @@ process.stdin.setEncoding("utf-8");
 process.stdout.setDefaultEncoding("utf-8");
 process.stderr.setDefaultEncoding("utf-8");
 
+// ─── Resilience: suppress EPIPE when parent pipe closes ───
+process.stdout.on("error", (err: NodeJS.ErrnoException) => {
+  if (err.code !== "EPIPE") throw err;
+});
+process.stderr.on("error", (err: NodeJS.ErrnoException) => {
+  if (err.code !== "EPIPE") throw err;
+});
+
+// ─── Increase max listeners to accommodate per-session signal handlers ───
+process.setMaxListeners(50);
+
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, isAbsolute, resolve } from "node:path";

--- a/packages/orchestrator/src/knowledge-service.ts
+++ b/packages/orchestrator/src/knowledge-service.ts
@@ -78,7 +78,17 @@ export class KnowledgeService {
       return null;
     }
 
-    const pathSegments = relativePath.split(/[\\/]+/).filter(Boolean);
+    // Strip leading vault-name prefix (e.g. "Mercury_KB/04-research/foo.md" → "04-research/foo.md")
+    // to prevent double-path like D:\Mercury\Mercury_KB\Mercury_KB\...
+    const vaultBaseName = path.basename(vaultPath);
+    const prefixSlash = `${vaultBaseName}/`;
+    const prefixBackslash = `${vaultBaseName}\\`;
+    let normalizedRelative = relativePath;
+    if (normalizedRelative.startsWith(prefixSlash) || normalizedRelative.startsWith(prefixBackslash)) {
+      normalizedRelative = normalizedRelative.slice(prefixSlash.length);
+    }
+
+    const pathSegments = normalizedRelative.split(/[\\/]+/).filter(Boolean);
     const resolved = path.join(vaultPath, ...pathSegments);
     const normalizedVault = path.resolve(vaultPath);
     const normalizedResolved = path.resolve(resolved);

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -2018,6 +2018,9 @@ export class Orchestrator {
       completedAt: Date.now(),
     };
 
+    // Verdict: partial if expected KB file was not written, pass otherwise
+    const verdict = (expectedKbFile && !kbWriteVerified) ? "partial" : "pass";
+
     // Fast-track through full state machine: in_progress → implementation_done → main_review → acceptance → verified → closed
     try {
       this.taskManager.transitionTask(task.taskId, "implementation_done", agentId);
@@ -2025,11 +2028,19 @@ export class Orchestrator {
       this.taskManager.transitionTask(task.taskId, "main_review", agentId);
       this.taskManager.transitionTask(task.taskId, "acceptance", agentId);
 
+      if (verdict === "partial") {
+        this.transport.sendNotification("log", {
+          message: `[task] Research task ${task.taskId} verdict downgraded to partial — KB file not written: "${expectedKbFile}"`,
+        });
+      }
+
       // Persist synthetic acceptance so getTaskResult() returns verdict
       this.taskManager.persistSyntheticAcceptance(task.taskId, agentId, {
-        verdict: "pass",
+        verdict,
         findings: findingsArr,
-        recommendations: recommendationsArr,
+        recommendations: verdict === "partial"
+          ? [`KB file not written: ${expectedKbFile}`, ...recommendationsArr]
+          : recommendationsArr,
       });
 
       this.taskManager.transitionTask(task.taskId, "verified", agentId);
@@ -2046,7 +2057,7 @@ export class Orchestrator {
     this.bus.emit("orchestrator.task.callback", agentId, "orchestrator", {
       taskId: task.taskId,
       originatorSessionId: task.originatorSessionId,
-      verdict: "pass",
+      verdict,
       findings: findingsArr,
       recommendations: recommendationsArr,
       reworkCount: task.reworkCount,
@@ -2633,7 +2644,7 @@ export class Orchestrator {
     const role: AgentRole = task.role ?? "dev";
 
     let kbContext: string | undefined;
-    if (this.kb?.isEnabled() && task.readScope.requiredDocs.length > 0) {
+    if (this.kb?.isEnabled() && (task.readScope.requiredDocs?.length ?? 0) > 0) {
       try {
         kbContext = await this.kb.buildContext(task.readScope.requiredDocs);
       } catch {

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -324,7 +324,10 @@ export class TaskManager {
       role: requiredRole,
       branch: params.branch,
       codeScope: params.codeScope,
-      readScope: params.readScope,
+      readScope: {
+        requiredDocs: (params.readScope as Record<string, unknown>)?.requiredDocs as string[] ?? [],
+        optionalDocs: (params.readScope as Record<string, unknown>)?.optionalDocs as string[] ?? [],
+      },
       allowedWriteScope: { codePaths: normCodePaths, kbPaths: normKbPaths },
       docsMustUpdate: params.docsMustUpdate ?? [],
       docsMustNotTouch: params.docsMustNotTouch ?? [],


### PR DESCRIPTION
## Summary

Four bugs found via end-to-end research dispatch verification (TASK-7c0bed2d):

- **KB double-path**: `resolveVaultFilePath` joined `vaultPath` with kbPaths already containing the vault folder name, producing paths like `D:\Mercury\Mercury_KB\Mercury_KB\04-research\...`. Now strips the vaultName prefix before joining.
- **readScope crash**: `prepareBundleTaskExecution` accessed `readScope.requiredDocs.length` without null-check. Crashes when task created via RPC with `globs`-only readScope. Added optional-chaining guard.
- **readScope normalization**: `createTask` stored raw RPC readScope without guaranteeing `requiredDocs`/`optionalDocs` fields. Now normalizes on creation.
- **EPIPE crash + MaxListeners**: `stdout`/`stderr` EPIPE when parent Tauri pipe closes caused unhandled `error` event crash. Added error handlers suppressing EPIPE only. Raised `process.setMaxListeners(50)` for per-session signal handlers from Claude SDK.
- **KB write verdict**: Research fast-track always gave `verdict="pass"` even when KB file was not written (contradicting PR #103 title "make KB write mandatory"). Now downgrades to `verdict="partial"` when `kbWriteVerified=false`.

## Root cause of previous KB write failures

The real reason prior research sessions never wrote to KB: the kbPath `Mercury_KB/04-research/RESEARCH-HARNESS-003-phase23.md` resolved to `D:\Mercury\Mercury_KB\Mercury_KB\04-research\...` (non-existent double path). Both the write attempt and the verification read failed silently, but the task still received `verdict="pass"`.

## Test plan

- [ ] Dispatch a research task with `kbPaths: ["Mercury_KB/04-research/test.md"]` — verify file is created at `D:\Mercury\Mercury_KB\04-research\test.md` (no double path)
- [ ] Dispatch a research task where agent does NOT call `kb_write` — verify verdict is `partial`, not `pass`
- [ ] Kill parent process while orchestrator is running — verify no EPIPE crash in logs
- [ ] Create 11+ agent sessions — verify no MaxListenersExceededWarning

Closes #109 (partial — token budget enforcement is a separate feat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)