### PR TITLE
feat(orchestrator): configurable research loop cap (#109)

### DIFF
--- a/.agents/skills/deep-research/SKILL.md
+++ b/.agents/skills/deep-research/SKILL.md
@@ -132,6 +132,12 @@ Verifier checklist:
 
 Return `PASS`, `PARTIAL`, or `FAIL` plus dimension scores and gaps.
 
+## Iteration Limit
+
+If the task prompt contains a `MAX_ITERATIONS: N` directive, treat it as a hard upper bound that overrides the default gate config. Stop the loop when that round count is reached, mark outstanding gaps, then proceed to KB write and submission.
+
+`MAX_ITERATIONS: 0` means no limit (default behaviour).
+
 ## Termination Conditions
 
 | Condition | Action |
@@ -139,7 +145,7 @@ Return `PASS`, `PARTIAL`, or `FAIL` plus dimension scores and gaps.
 | Quality gate passed + verification PASS | Submit for human review |
 | Quality gate passed + verification PARTIAL | Address gaps, re-verify |
 | Quality gate passed + verification FAIL | Continue research rounds |
-| Max iterations reached | Mark incomplete items and submit |
+| Max iterations reached (config or injected limit) | Mark incomplete items and submit |
 | Human interruption | Save state and submit current progress |
 
 ## State Externalization

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -118,6 +118,15 @@ export interface TransportsConfig {
   };
 }
 
+export interface ResearchConfig {
+  /**
+   * Maximum number of research rounds per task.
+   * 0 means unlimited (same as not setting this field).
+   * When the agent reaches this limit it must stop looping and submit its findings.
+   */
+  maxIterations?: number;
+}
+
 export interface MercuryConfig {
   agents: AgentConfig[];
   workDir?: string;
@@ -126,6 +135,7 @@ export interface MercuryConfig {
   transports?: TransportsConfig;
   obsidian?: ObsidianConfig;
   rtk?: RTKConfig;
+  research?: ResearchConfig;
 }
 
 // ─── Approval Control Plane ───

--- a/packages/gui/src/components/SettingsPanel.vue
+++ b/packages/gui/src/components/SettingsPanel.vue
@@ -3,13 +3,13 @@ import { ref, onMounted, watch } from "vue";
 import { open } from "@tauri-apps/plugin-dialog";
 import { useConfigStore } from "../stores/config";
 import { refreshContext, getContextStatus, kbList, getRoleInstructions } from "../lib/tauri-bridge";
-import type { AgentConfig, ContextStatus, ObsidianConfig } from "../lib/tauri-bridge";
+import type { AgentConfig, ContextStatus, ObsidianConfig, ResearchConfig } from "../lib/tauri-bridge";
 
 const emit = defineEmits<{ close: [] }>();
 
 const { config, loading, error, loadConfig, saveConfig } = useConfigStore();
 
-const activeTab = ref<"agents" | "project" | "display">("agents");
+const activeTab = ref<"agents" | "project" | "research" | "display">("agents");
 const saving = ref(false);
 const saveMsg = ref("");
 const roleContextExpanded = ref(true);
@@ -145,6 +145,7 @@ function normalizeObsidianConfig(source?: ObsidianConfig | null): ObsidianConfig
 const editAgents = ref<AgentConfig[]>([]);
 const editObsidian = ref<ObsidianConfig>(createEmptyObsidianConfig());
 const editWorkDir = ref(".");
+const editResearch = ref<ResearchConfig>({});
 
 onMounted(async () => {
   await loadConfig();
@@ -160,6 +161,7 @@ function syncFromConfig() {
   editAgents.value = JSON.parse(JSON.stringify(config.value.agents));
   editObsidian.value = normalizeObsidianConfig(config.value.obsidian);
   editWorkDir.value = config.value.workDir ?? ".";
+  editResearch.value = { ...config.value.research };
 }
 
 watch(config, syncFromConfig);
@@ -444,10 +446,16 @@ async function handleSave() {
   saveMsg.value = "";
 
   try {
+    const researchToSave: ResearchConfig = {};
+    const maxIter = editResearch.value.maxIterations;
+    if (maxIter !== undefined && maxIter !== null) {
+      researchToSave.maxIterations = Number(maxIter);
+    }
     await saveConfig({
       agents: editAgents.value,
       workDir: editWorkDir.value,
       obsidian: normalizeObsidianConfig(editObsidian.value),
+      research: researchToSave,
     });
     saveMsg.value = "Saved";
     setTimeout(() => {
@@ -481,6 +489,7 @@ function handleKeydown(event: KeyboardEvent) {
       <div class="settings-tabs">
         <button :class="{ active: activeTab === 'agents' }" @click="activeTab = 'agents'">Agents</button>
         <button :class="{ active: activeTab === 'project' }" @click="activeTab = 'project'">Project</button>
+        <button :class="{ active: activeTab === 'research' }" @click="activeTab = 'research'">Research</button>
         <button :class="{ active: activeTab === 'display' }" @click="activeTab = 'display'">Display</button>
       </div>
 
@@ -768,6 +777,33 @@ function handleKeydown(event: KeyboardEvent) {
                 </div>
               </div>
             </div>
+          </div>
+        </div>
+
+        <div v-if="activeTab === 'research'" class="tab-content">
+          <div class="section">
+            <h3>Research Loop</h3>
+            <p class="hint compact">
+              Limit how many rounds a research agent may iterate before it must submit findings.
+              Set to <strong>0</strong> for no limit (default behaviour).
+            </p>
+            <label>
+              <span>Max iterations per task</span>
+              <input
+                id="research-max-iterations"
+                name="research-max-iterations"
+                type="number"
+                min="0"
+                step="1"
+                v-model.number="editResearch.maxIterations"
+                class="field-input"
+                placeholder="0 (unlimited)"
+              />
+            </label>
+            <p class="hint compact">
+              When the limit is reached the agent stops looping and submits whatever findings it has.
+              This value is injected into the research agent's prompt as a hard cap.
+            </p>
           </div>
         </div>
 

--- a/packages/gui/src/lib/tauri-bridge.ts
+++ b/packages/gui/src/lib/tauri-bridge.ts
@@ -232,10 +232,19 @@ export interface ObsidianConfig {
   };
 }
 
+export interface ResearchConfig {
+  /**
+   * Maximum research rounds per task. 0 = unlimited (same as omitting).
+   * The research agent must stop looping and submit findings when this limit is reached.
+   */
+  maxIterations?: number;
+}
+
 export interface MercuryProjectConfig {
   agents: AgentConfig[];
   workDir?: string;
   obsidian?: ObsidianConfig;
+  research?: ResearchConfig;
 }
 
 /** Retrieve the current Mercury project configuration. */

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -2655,7 +2655,8 @@ export class Orchestrator {
     // Build role-appropriate prompt
     let prompt: string;
     if (role === "research") {
-      prompt = buildResearchPrompt(task, kbContext);
+      const maxIterations = this.projectConfig?.research?.maxIterations;
+      prompt = buildResearchPrompt(task, kbContext, maxIterations);
     } else if (role === "design") {
       prompt = buildDesignPrompt(task, kbContext);
     } else {

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -1053,6 +1053,7 @@ function deriveKbWriteInstructions(task: TaskBundle): string[] {
 export function buildResearchPrompt(
   task: TaskBundle,
   kbContext?: string,
+  maxIterations?: number,
 ): string {
   const lines = [
     `# Research Task: ${task.title} [${task.taskId}]`,
@@ -1075,6 +1076,11 @@ export function buildResearchPrompt(
     "- Use web search, codebase analysis, and KB resources as needed.",
     "- Produce structured findings with evidence and recommendations.",
     "- No code commits expected.",
+    ...(maxIterations && maxIterations > 0
+      ? [
+        `- **MAX_ITERATIONS: ${maxIterations}** — you MUST stop the research loop and submit your findings after at most ${maxIterations} round(s). Do not continue past this limit under any circumstances.`,
+        ]
+      : []),
     "",
     "## MANDATORY: Write Report to KB (Step 1)",
     "Before outputting your final JSON summary, you MUST write the full report to KB.",


### PR DESCRIPTION
## Summary
- Add `ResearchConfig.maxIterations` to `MercuryConfig` (core types + frontend mirror)
- Orchestrator injects `MAX_ITERATIONS: N` directive into research agent prompt when set
- GUI adds **Research** tab in Settings with a number input (0 = unlimited)
- `deep-research/SKILL.md` updated to document the hard cap behaviour

## Behaviour
- `maxIterations = 0` (or unset): no limit — same as current default
- `maxIterations = N > 0`: research agent must stop after N rounds and submit findings
- Injected as a plain-text directive so the agent's skill enforces it; no orchestrator-level loop needed

## Test plan
- [ ] Type check passes for `packages/orchestrator` and `packages/gui`
- [ ] GUI Settings → Research tab shows the maxIterations input
- [ ] Saving with value 5 persists to `mercury.config.json` as `research.maxIterations: 5`
- [ ] Saving with value 0 omits the directive from research prompts
- [ ] Dispatching a research task with `maxIterations: 3` includes `MAX_ITERATIONS: 3` in the prompt

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)