### PR TITLE
feat(orchestrator): Phase 2.1/2.2/2.3 harness improvements (#101/#109)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -47,5 +47,6 @@ export type {
   TaskPriority,
   TaskStatus,
   TransportsConfig,
+  DoDVerification,
   ModelRecommendation,
 } from "./types.js";

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -125,6 +125,12 @@ export interface ResearchConfig {
    * When the agent reaches this limit it must stop looping and submit its findings.
    */
   maxIterations?: number;
+  /**
+   * Cumulative token budget for a single research task (informational hint injected into prompt).
+   * The agent is instructed to wrap up before exceeding this budget.
+   * 0 or undefined means no budget hint is injected.
+   */
+  cumulativeTokenBudget?: number;
 }
 
 export interface MercuryConfig {
@@ -340,6 +346,14 @@ export interface ReviewConfig {
   diffMaxChars?: number;
 }
 
+/** Pre-completion DoD verification result (set before receipt is recorded). */
+export interface DoDVerification {
+  verdict: "PASS" | "FAIL" | "PARTIAL";
+  summary: string;
+  checkedAt: number;
+  verifiedItems: { item: string; passed: boolean; reason?: string }[];
+}
+
 /** SoT task bundle: tracks a unit of work through its full lifecycle. */
 export interface TaskBundle {
   taskId: string;
@@ -382,6 +396,7 @@ export interface TaskBundle {
     gitDiff: string;
     result?: StructuredReviewResult;
     reviewedAt?: number;
+    dodVerification?: DoDVerification;
   };
 
   // Critic review (spec-driven verification, parallel to main_review)
@@ -410,6 +425,12 @@ export interface TaskBundle {
 
   // Rework history: accumulated across attempts for iterative context
   reworkHistory: ReworkHistoryEntry[];
+
+  /** Optional per-task token budget hint (informational, injected into role prompt). */
+  resourceBudget?: {
+    tokenBudget?: number;
+    warningThresholdPercent?: number;
+  };
 }
 
 export interface ReworkHistoryEntry {

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -26,6 +26,7 @@ import type {
   RoleSlotKey,
   SessionInfo,
   SlashCommand,
+  CriticResult,
   DoDVerification,
   TaskBundle,
   TaskStatus,
@@ -1910,9 +1911,10 @@ export class Orchestrator {
       return;
     }
     const receipt = this.parseImplementationReceipt(task, agentId, finalMessage, completedAt);
-    // Phase 2.2: fire-and-forget DoD pre-verification (non-blocking)
-    void this.verifyDoDAtCompletion(task, agentId).catch(() => {});
     await this.recordReceiptAndTriggerReview(task.taskId, receipt);
+    // Phase 2.2: fire-and-forget DoD pre-verification after receipt is persisted (non-blocking)
+    const freshTask = await this.taskManager.getTaskAsync(task.taskId);
+    if (freshTask) void this.verifyDoDAtCompletion(freshTask, agentId).catch(() => {});
   }
 
   /**
@@ -1940,37 +1942,57 @@ export class Orchestrator {
       ]);
       rawResult = raceResult.finalMessage ?? "";
     } catch {
-      // Timeout or error — store PARTIAL verdict
+      // Timeout or error — store PARTIAL verdict (merge-safe)
       const partial: DoDVerification = {
         verdict: "PARTIAL",
         summary: "DoD pre-check timed out or failed.",
         checkedAt: Date.now(),
         verifiedItems: [],
       };
+      const currentMR1 = this.taskManager.getTask(task.taskId)?.mainReview;
       this.taskManager.updateTaskField(task.taskId, "mainReview", {
-        ...(task.mainReview ?? { preChecks: [], gitDiff: "" }),
+        ...(currentMR1 ?? { preChecks: [], gitDiff: "" }),
         dodVerification: partial,
       });
       return;
     }
 
-    // Parse verdict from LLM response: look for PASS/FAIL/PARTIAL keyword
-    const upper = rawResult.toUpperCase();
-    const verdict: DoDVerification["verdict"] =
-      upper.includes("PASS") ? "PASS" : upper.includes("FAIL") ? "FAIL" : "PARTIAL";
+    // Parse verdict from Critic JSON output; fall back to keyword heuristic
+    let verdict: DoDVerification["verdict"] = "PARTIAL";
+    let verifiedItems: DoDVerification["verifiedItems"] = [];
+    let parsedSummary = rawResult.slice(0, 500);
+    try {
+      const jsonMatch = rawResult.match(/```json\s*([\s\S]*?)```|({[\s\S]*})/);
+      const parsed = JSON.parse(jsonMatch ? (jsonMatch[1] ?? jsonMatch[2]) : rawResult) as Partial<CriticResult>;
+      const ov = parsed.overallVerdict?.toLowerCase();
+      verdict = ov === "pass" ? "PASS" : ov === "fail" ? "FAIL" : "PARTIAL";
+      if (Array.isArray(parsed.items)) {
+        verifiedItems = parsed.items.map((it) => ({
+          item: it.dodItem ?? "",
+          passed: it.verdict === "pass",
+          reason: it.detail ?? it.evidence,
+        }));
+      }
+    } catch {
+      // Not valid JSON — fall back to keyword scan
+      const upper = rawResult.toUpperCase();
+      verdict = upper.includes("PASS") && !upper.includes("FAIL") ? "PASS"
+        : upper.includes("FAIL") ? "FAIL"
+        : "PARTIAL";
+      verifiedItems = task.definitionOfDone.map((item) => ({ item, passed: verdict === "PASS" }));
+    }
 
     const dodVerification: DoDVerification = {
       verdict,
-      summary: rawResult.slice(0, 500),
+      summary: parsedSummary,
       checkedAt: Date.now(),
-      verifiedItems: task.definitionOfDone.map((item) => ({
-        item,
-        passed: verdict === "PASS",
-      })),
+      verifiedItems,
     };
 
+    // Merge-safe: read fresh mainReview snapshot before writing
+    const currentMR2 = this.taskManager.getTask(task.taskId)?.mainReview;
     this.taskManager.updateTaskField(task.taskId, "mainReview", {
-      ...(task.mainReview ?? { preChecks: [], gitDiff: "" }),
+      ...(currentMR2 ?? { preChecks: [], gitDiff: "" }),
       dodVerification,
     });
   }

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -26,6 +26,7 @@ import type {
   RoleSlotKey,
   SessionInfo,
   SlashCommand,
+  DoDVerification,
   TaskBundle,
   TaskStatus,
 } from "@mercury/core";
@@ -302,7 +303,7 @@ export class Orchestrator {
     return process.cwd();
   }
 
-  private buildSystemRolePrompt(role: AgentRole, task?: TaskBundle): string {
+  private buildSystemRolePrompt(role: AgentRole, task?: TaskBundle, tokenBudgetHint?: number): string {
     const overrides = this.projectConfig?.obsidian?.roleInstructionOverrides;
     const overrideKey = role as keyof NonNullable<typeof overrides>;
     const roleInstructions = overrides && overrideKey in overrides
@@ -315,6 +316,7 @@ export class Orchestrator {
       this.getRoleSpecificContext(role),
       roleInstructions,
       this.getProjectRoot(),
+      tokenBudgetHint,
     );
   }
 
@@ -1908,7 +1910,69 @@ export class Orchestrator {
       return;
     }
     const receipt = this.parseImplementationReceipt(task, agentId, finalMessage, completedAt);
+    // Phase 2.2: fire-and-forget DoD pre-verification (non-blocking)
+    void this.verifyDoDAtCompletion(task, agentId).catch(() => {});
     await this.recordReceiptAndTriggerReview(task.taskId, receipt);
+  }
+
+  /**
+   * Phase 2.2: Pre-completion DoD verification.
+   * Runs a lightweight LLM check against the task's Definition of Done using the Critic prompt.
+   * Results are stored in task.mainReview.dodVerification (non-blocking, 10s timeout).
+   */
+  private async verifyDoDAtCompletion(task: TaskBundle, agentId: string): Promise<void> {
+    if (!task.definitionOfDone?.length) return;
+    const adapter = this.registry.getAdapter(agentId);
+    if (!adapter.executeOneShot) return;
+
+    const prompt = buildCriticPrompt(task, this.getProjectRoot());
+    const systemPrompt = this.buildSystemRolePrompt("critic", task);
+    const cwd = this.agentCwds.get(agentId) ?? process.cwd();
+
+    let rawResult: string;
+    try {
+      const timeoutMs = 10_000;
+      const raceResult = await Promise.race([
+        adapter.executeOneShot(this.wrapPromptWithRoleContext(prompt, systemPrompt), cwd),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error("DoD pre-check timeout")), timeoutMs),
+        ),
+      ]);
+      rawResult = raceResult.finalMessage ?? "";
+    } catch {
+      // Timeout or error — store PARTIAL verdict
+      const partial: DoDVerification = {
+        verdict: "PARTIAL",
+        summary: "DoD pre-check timed out or failed.",
+        checkedAt: Date.now(),
+        verifiedItems: [],
+      };
+      this.taskManager.updateTaskField(task.taskId, "mainReview", {
+        ...(task.mainReview ?? { preChecks: [], gitDiff: "" }),
+        dodVerification: partial,
+      });
+      return;
+    }
+
+    // Parse verdict from LLM response: look for PASS/FAIL/PARTIAL keyword
+    const upper = rawResult.toUpperCase();
+    const verdict: DoDVerification["verdict"] =
+      upper.includes("PASS") ? "PASS" : upper.includes("FAIL") ? "FAIL" : "PARTIAL";
+
+    const dodVerification: DoDVerification = {
+      verdict,
+      summary: rawResult.slice(0, 500),
+      checkedAt: Date.now(),
+      verifiedItems: task.definitionOfDone.map((item) => ({
+        item,
+        passed: verdict === "PASS",
+      })),
+    };
+
+    this.taskManager.updateTaskField(task.taskId, "mainReview", {
+      ...(task.mainReview ?? { preChecks: [], gitDiff: "" }),
+      dodVerification,
+    });
   }
 
   private async handleMainReviewStreamComplete(
@@ -2652,11 +2716,17 @@ export class Orchestrator {
       }
     }
 
+    // Derive token budget hint from task.resourceBudget (apply 90% safety margin)
+    const rawBudget = task.resourceBudget?.tokenBudget;
+    const tokenBudgetHint = rawBudget !== undefined
+      ? Math.floor(rawBudget * 0.9)
+      : undefined;
+
     // Build role-appropriate prompt
     let prompt: string;
     if (role === "research") {
       const maxIterations = this.projectConfig?.research?.maxIterations;
-      prompt = buildResearchPrompt(task, kbContext, maxIterations);
+      prompt = buildResearchPrompt(task, kbContext, maxIterations, tokenBudgetHint);
     } else if (role === "design") {
       prompt = buildDesignPrompt(task, kbContext);
     } else {
@@ -2666,7 +2736,7 @@ export class Orchestrator {
     return {
       task,
       prompt,
-      rolePrompt: this.buildSystemRolePrompt(role, task),
+      rolePrompt: this.buildSystemRolePrompt(role, task, tokenBudgetHint),
       baseRolePrompt: this.buildSystemRolePrompt(role),
     };
   }

--- a/packages/orchestrator/src/role-prompt-builder.ts
+++ b/packages/orchestrator/src/role-prompt-builder.ts
@@ -30,6 +30,7 @@ export function buildRoleSystemPrompt(
   roleProjectContext?: string,
   roleInstructions?: string,
   basePath?: string,
+  tokenBudgetHint?: number,
 ): string {
   const card = loadRoleCard(role, basePath);
   const lines: string[] = [];
@@ -106,6 +107,16 @@ export function buildRoleSystemPrompt(
   if (roleProjectContext) {
     lines.push("## Role-Specific Project Context");
     lines.push(roleProjectContext);
+    lines.push("");
+  }
+
+  if (tokenBudgetHint !== undefined && tokenBudgetHint > 0) {
+    lines.push("## Token Budget");
+    lines.push(
+      `Your estimated remaining token budget for this task is approximately **${tokenBudgetHint.toLocaleString()} tokens**.`,
+    );
+    lines.push("- Prioritize completing the core implementation within this budget.");
+    lines.push("- If approaching the limit, wrap up current work and summarize remaining steps in the receipt.");
     lines.push("");
   }
 

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -6,6 +6,7 @@
  */
 
 import { randomUUID } from "node:crypto";
+import { execSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import type { EventBus } from "@mercury/core";
@@ -916,6 +917,29 @@ function formatWriteScope(scope: TaskBundle["allowedWriteScope"]): string {
  * NOTE: Template is loaded synchronously per call. Future optimization:
  * preload + cache at TaskManager.init() with mtime-based refresh (tracked in TASK-WF-001).
  */
+/**
+ * Build a git log section for dev dispatch prompts.
+ * Returns a markdown block with the last 20 commits on the task branch (best-effort).
+ */
+function buildGitLogSection(branch: string | undefined, basePath: string): string {
+  if (!branch) return "";
+  try {
+    const log = execSync(`git -C "${basePath}" log ${branch} -20 --oneline`, {
+      timeout: 5000,
+      encoding: "utf-8",
+    }).trim();
+    if (!log) return "";
+    return `
+
+## Recent Commits on Branch (${branch})
+\`\`\`
+${log}
+\`\`\``;
+  } catch {
+    return "";
+  }
+}
+
 export function buildDevPrompt(
   task: TaskBundle,
   kbContext?: string,
@@ -991,8 +1015,13 @@ export function buildDevPrompt(
   );
   let result = template.replace(placeholderPattern, (match) => placeholders[match] ?? match);
 
+  result += buildGitLogSection(task.branch, basePath);
+
   if (kbContext) {
-    result += `\n\n## Project Knowledge Base Context\n${kbContext}`;
+    result += `
+
+## Project Knowledge Base Context
+${kbContext}`;
   }
 
   return result;
@@ -1054,6 +1083,7 @@ export function buildResearchPrompt(
   task: TaskBundle,
   kbContext?: string,
   maxIterations?: number,
+  tokenBudgetHint?: number,
 ): string {
   const lines = [
     `# Research Task: ${task.title} [${task.taskId}]`,
@@ -1080,6 +1110,9 @@ export function buildResearchPrompt(
       ? [
         `- **MAX_ITERATIONS: ${maxIterations}** — you MUST stop the research loop and submit your findings after at most ${maxIterations} round(s). Do not continue past this limit under any circumstances.`,
         ]
+      : []),
+    ...(tokenBudgetHint !== undefined && tokenBudgetHint > 0
+      ? [`- **TOKEN_BUDGET: ~${tokenBudgetHint.toLocaleString()} tokens remaining** — wrap up and submit findings before reaching this limit.`]
       : []),
     "",
     "## MANDATORY: Write Report to KB (Step 1)",

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -6,7 +6,7 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import type { EventBus } from "@mercury/core";
@@ -68,6 +68,7 @@ export interface CreateTaskParams {
   modelRecommendation?: TaskBundle["modelRecommendation"];
   maxReworks?: number;
   maxDispatchAttempts?: number;
+  resourceBudget?: TaskBundle["resourceBudget"];
 }
 
 export interface CreateIssueParams {
@@ -344,6 +345,7 @@ export class TaskManager {
       maxReworks: params.maxReworks ?? 3,
       linkedIssueIds: [],
       reworkHistory: [],
+      resourceBudget: params.resourceBudget,
     };
 
     // Agents First: populate structured assignee from agent config
@@ -924,10 +926,10 @@ function formatWriteScope(scope: TaskBundle["allowedWriteScope"]): string {
 function buildGitLogSection(branch: string | undefined, basePath: string): string {
   if (!branch) return "";
   try {
-    const log = execSync(`git -C "${basePath}" log ${branch} -20 --oneline`, {
+    const log = execFileSync("git", ["-C", basePath, "log", "--max-count=20", "--oneline", branch], {
       timeout: 5000,
       encoding: "utf-8",
-    }).trim();
+    }).replace(/```/g, "` ` `").trim();
     if (!log) return "";
     return `
 


### PR DESCRIPTION
## Summary

- **Phase 2.1 — Git log injection**: `buildDevPrompt()` now appends the last 20 commits on the task branch as a markdown block, giving dev agents branch history context to avoid redundant rework.
- **Phase 2.2 — Pre-completion DoD check**: `verifyDoDAtCompletion()` fires-and-forgets a Critic-role LLM verdict (10s timeout → PARTIAL) after each dev task completes. Result stored in `mainReview.dodVerification` as `DoDVerification`.
- **Phase 2.3 — Token budget injection**: `TaskBundle.resourceBudget.tokenBudget` (90% safety margin) flows through `prepareBundleTaskExecution()` into `buildRoleSystemPrompt()` and `buildResearchPrompt()`, informing agents of their remaining token budget.

New types: `DoDVerification`, `resourceBudget` field on `TaskBundle`. All changes are non-blocking and fail-safe (try/catch everywhere, timeout = PARTIAL, missing budget = no injection).

## Test plan

- [ ] TypeScript builds clean (`tsc --noEmit`: PASS)
- [ ] `buildDevPrompt()` with a branch that has commits shows `## Recent Commits on Branch` section
- [ ] `buildDevPrompt()` with no branch skips the git log section
- [ ] Dispatching a research task with `resourceBudget.tokenBudget: 50000` shows `TOKEN_BUDGET` line in research prompt
- [ ] `verifyDoDAtCompletion()` stores verdict in `task.mainReview.dodVerification` after dev completion
- [ ] 10s timeout path stores `PARTIAL` verdict without blocking receipt recording

🤖 Generated with [Claude Code](https://claude.com/claude-code)