### PR TITLE
fix(orchestrator): research agent KB write failure and premature termination (#113)

### DIFF
--- a/packages/orchestrator/src/callback-queue.ts
+++ b/packages/orchestrator/src/callback-queue.ts
@@ -20,6 +20,12 @@ export interface TaskCallbackPayload {
   recommendations?: string[];
   /** Stable rework count used for idempotency key generation. */
   reworkCount?: number;
+  /**
+   * Explicit rework signal. true = rework was dispatched to dev agent;
+   * false = task closed (pass/blocked/fast-track). Use this instead of
+   * inferring from verdict to avoid misclassifying closed-partial as rework.
+   */
+  reworkTriggered?: boolean;
 }
 
 export interface CallbackQueueEntry {

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -3260,7 +3260,9 @@ export class Orchestrator {
         ? "Task has been verified and closed."
         : payload.verdict === "blocked"
           ? "Task is blocked. Manual intervention required."
-          : "Rework has been triggered. Dev agent will receive updated instructions.",
+          : payload.reworkTriggered === true
+            ? "Rework has been triggered. Dev agent will receive updated instructions."
+            : "Task closed (partial). KB write was not verified; findings are available in the task result.",
     );
 
     return lines.filter(Boolean).join("\n");
@@ -3369,6 +3371,7 @@ export class Orchestrator {
           originatorSessionId: task.originatorSessionId,
           verdict: "pass",
           reworkCount: task.reworkCount,
+          reworkTriggered: false,
         },
       );
 
@@ -3410,6 +3413,7 @@ export class Orchestrator {
           findings: results.findings,
           recommendations: results.recommendations,
           reworkCount: task.reworkCount,
+          reworkTriggered: true,
         },
       );
 
@@ -3432,6 +3436,7 @@ export class Orchestrator {
           findings: results.findings,
           recommendations: results.recommendations,
           reworkCount: task.reworkCount,
+          reworkTriggered: false,
         },
       );
 

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -2085,23 +2085,8 @@ export class Orchestrator {
           message: `[task] WARNING: Research task ${task.taskId} did not write expected KB file "${expectedKbFile}". Findings may be lost.`,
         });
         // Orchestrator-side KB recovery: write finalMessage as fallback if non-trivial
-        if (finalMessage.length > 200) {
-          try {
-            const fallbackContent = `# Research Fallback: ${task.title} [${task.taskId}]
-
-> Auto-recovered by orchestrator — agent did not write KB directly.
-
-${finalMessage}`;
-            await this.kb.write(expectedKbFile, fallbackContent);
-            kbWriteVerified = true;
-            this.transport.sendNotification("log", {
-              message: `[task] Orchestrator KB recovery succeeded for ${task.taskId}: wrote ${fallbackContent.length} bytes to "${expectedKbFile}"`,
-            });
-          } catch (writeErr) {
-            this.transport.sendNotification("log", {
-              message: `[task] Orchestrator KB recovery also failed for ${task.taskId}: ${writeErr instanceof Error ? writeErr.message : writeErr}`,
-            });
-          }
+        if (await this.attemptKbRecovery(task.taskId, task.title, "Research", finalMessage, expectedKbFile)) {
+          kbWriteVerified = true;
         }
       }
     }
@@ -2194,17 +2179,13 @@ ${finalMessage}`;
       try {
         const kbContent = await this.kb.read(designKbFile);
         designKbVerified = !!kbContent && kbContent.length > 100;
-      } catch { /* not found */ }
-      if (!designKbVerified && finalMessage.length > 200) {
-        try {
-          const fallback = `# Design Fallback: ${task.title} [${task.taskId}]
-
-> Auto-recovered by orchestrator.
-
-${finalMessage}`;
-          await this.kb.write(designKbFile, fallback);
+      } catch {
+        // KB file not found or not readable — will attempt recovery
+      }
+      if (!designKbVerified) {
+        if (await this.attemptKbRecovery(task.taskId, task.title, "Design", finalMessage, designKbFile)) {
           designKbVerified = true;
-        } catch { /* best-effort */ }
+        }
       }
     }
 
@@ -2345,6 +2326,36 @@ ${finalMessage}`;
       findings: this.readStringArray(parsed?.findings),
       recommendations: this.readStringArray(parsed?.recommendations),
     };
+  }
+
+  /**
+   * Attempt orchestrator-side KB recovery when an agent fails to write its KB file.
+   * Returns true if the fallback write succeeded, false otherwise.
+   */
+  private async attemptKbRecovery(
+    taskId: string,
+    taskTitle: string,
+    fallbackLabel: "Research" | "Design",
+    finalMessage: string,
+    expectedKbFile: string,
+  ): Promise<boolean> {
+    const MIN_FALLBACK_LENGTH = 200;
+    if (finalMessage.length <= MIN_FALLBACK_LENGTH) return false;
+    if (!this.kb?.isEnabled()) return false;
+
+    try {
+      const fallbackContent = `# ${fallbackLabel} Fallback: ${taskTitle} [${taskId}]\n\n> Auto-recovered by orchestrator — agent did not write KB directly.\n\n${finalMessage}`;
+      await this.kb.write(expectedKbFile, fallbackContent);
+      this.transport.sendNotification("log", {
+        message: `[task] Orchestrator KB recovery succeeded for ${taskId}: wrote ${fallbackContent.length} bytes to "${expectedKbFile}"`,
+      });
+      return true;
+    } catch (writeErr) {
+      this.transport.sendNotification("log", {
+        message: `[task] Orchestrator KB recovery also failed for ${taskId}: ${writeErr instanceof Error ? writeErr.message : writeErr}`,
+      });
+      return false;
+    }
   }
 
   private tryParseJsonRecord(content: string): Record<string, unknown> | null {

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -2205,6 +2205,8 @@ export class Orchestrator {
       completedAt: Date.now(),
     };
 
+    const designVerdict = (kbPaths.length > 0 && !designKbVerified) ? "partial" : "pass";
+
     // Fast-track through full state machine: in_progress → ... → closed
     try {
       this.taskManager.transitionTask(task.taskId, "implementation_done", agentId);
@@ -2212,11 +2214,19 @@ export class Orchestrator {
       this.taskManager.transitionTask(task.taskId, "main_review", agentId);
       this.taskManager.transitionTask(task.taskId, "acceptance", agentId);
 
+      if (designVerdict === "partial") {
+        this.transport.sendNotification("log", {
+          message: `[task] Design task ${task.taskId} verdict downgraded to partial — KB file not written: "${designKbFile}"`,
+        });
+      }
+
       // Persist synthetic acceptance so getTaskResult() returns verdict
       this.taskManager.persistSyntheticAcceptance(task.taskId, agentId, {
-        verdict: "pass",
+        verdict: designVerdict,
         findings: designFindings,
-        recommendations: designRecommendations,
+        recommendations: designVerdict === "partial"
+          ? [`KB file not written: ${designKbFile}`, ...designRecommendations]
+          : designRecommendations,
       });
 
       this.taskManager.transitionTask(task.taskId, "verified", agentId);
@@ -2233,7 +2243,7 @@ export class Orchestrator {
     this.bus.emit("orchestrator.task.callback", agentId, "orchestrator", {
       taskId: task.taskId,
       originatorSessionId: task.originatorSessionId,
-      verdict: "pass",
+      verdict: designVerdict,
       findings: designFindings,
       recommendations: designRecommendations,
       reworkCount: task.reworkCount,

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -2110,6 +2110,9 @@ export class Orchestrator {
 
     // Verdict: partial if expected KB file was not written, pass otherwise
     const verdict = (expectedKbFile && !kbWriteVerified) ? "partial" : "pass";
+    const finalRecommendations = verdict === "partial"
+      ? [`KB file not written: ${expectedKbFile}`, ...recommendationsArr]
+      : recommendationsArr;
 
     // Fast-track through full state machine: in_progress → implementation_done → main_review → acceptance → verified → closed
     try {
@@ -2128,9 +2131,7 @@ export class Orchestrator {
       this.taskManager.persistSyntheticAcceptance(task.taskId, agentId, {
         verdict,
         findings: findingsArr,
-        recommendations: verdict === "partial"
-          ? [`KB file not written: ${expectedKbFile}`, ...recommendationsArr]
-          : recommendationsArr,
+        recommendations: finalRecommendations,
       });
 
       this.taskManager.transitionTask(task.taskId, "verified", agentId);
@@ -2143,14 +2144,15 @@ export class Orchestrator {
       return;
     }
 
-    // Emit callback so originator is notified
+    // Emit callback so originator is notified; reworkTriggered: false distinguishes closed fast-track from rework
     this.bus.emit("orchestrator.task.callback", agentId, "orchestrator", {
       taskId: task.taskId,
       originatorSessionId: task.originatorSessionId,
       verdict,
       findings: findingsArr,
-      recommendations: recommendationsArr,
+      recommendations: finalRecommendations,
       reworkCount: task.reworkCount,
+      reworkTriggered: false,
     });
   }
 
@@ -2171,11 +2173,11 @@ export class Orchestrator {
     // Verify KB write when kbPaths are expected (same pattern as research)
     const kbPaths = (task.allowedWriteScope?.kbPaths ?? []).filter((p) => p.trim().length > 0);
     let designKbVerified = false;
-    let designKbFile: string | undefined;
-    if (kbPaths.length > 0 && this.kb?.isEnabled()) {
-      designKbFile = kbPaths[0].endsWith(".md")
-        ? kbPaths[0]
-        : `${kbPaths[0].replace(/\/+$/, "")}/${task.taskId}.md`;
+    // Derive designKbFile before the isEnabled() check so it is always defined when kbPaths.length > 0
+    const designKbFile = kbPaths.length > 0
+      ? (kbPaths[0].endsWith(".md") ? kbPaths[0] : `${kbPaths[0].replace(/\/+$/, "")}/${task.taskId}.md`)
+      : undefined;
+    if (designKbFile && this.kb?.isEnabled()) {
       try {
         const kbContent = await this.kb.read(designKbFile);
         designKbVerified = !!kbContent && kbContent.length > 100;
@@ -2206,6 +2208,9 @@ export class Orchestrator {
     };
 
     const designVerdict = (kbPaths.length > 0 && !designKbVerified) ? "partial" : "pass";
+    const finalDesignRecommendations = designVerdict === "partial"
+      ? [`KB file not written: ${designKbFile}`, ...designRecommendations]
+      : designRecommendations;
 
     // Fast-track through full state machine: in_progress → ... → closed
     try {
@@ -2224,9 +2229,7 @@ export class Orchestrator {
       this.taskManager.persistSyntheticAcceptance(task.taskId, agentId, {
         verdict: designVerdict,
         findings: designFindings,
-        recommendations: designVerdict === "partial"
-          ? [`KB file not written: ${designKbFile}`, ...designRecommendations]
-          : designRecommendations,
+        recommendations: finalDesignRecommendations,
       });
 
       this.taskManager.transitionTask(task.taskId, "verified", agentId);
@@ -2239,14 +2242,15 @@ export class Orchestrator {
       return;
     }
 
-    // Emit callback so originator is notified
+    // Emit callback so originator is notified; reworkTriggered: false distinguishes closed fast-track from rework
     this.bus.emit("orchestrator.task.callback", agentId, "orchestrator", {
       taskId: task.taskId,
       originatorSessionId: task.originatorSessionId,
       verdict: designVerdict,
       findings: designFindings,
-      recommendations: designRecommendations,
+      recommendations: finalDesignRecommendations,
       reworkCount: task.reworkCount,
+      reworkTriggered: false,
     });
   }
 
@@ -2816,7 +2820,7 @@ export class Orchestrator {
       const maxIterations = this.projectConfig?.research?.maxIterations;
       prompt = buildResearchPrompt(task, kbContext, maxIterations, tokenBudgetHint);
     } else if (role === "design") {
-      prompt = buildDesignPrompt(task, kbContext);
+      prompt = buildDesignPrompt(task, kbContext, tokenBudgetHint);
     } else {
       prompt = buildDevPrompt(task, kbContext, this.getProjectRoot());
     }

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -2084,6 +2084,25 @@ export class Orchestrator {
         this.transport.sendNotification("log", {
           message: `[task] WARNING: Research task ${task.taskId} did not write expected KB file "${expectedKbFile}". Findings may be lost.`,
         });
+        // Orchestrator-side KB recovery: write finalMessage as fallback if non-trivial
+        if (finalMessage.length > 200) {
+          try {
+            const fallbackContent = `# Research Fallback: ${task.title} [${task.taskId}]
+
+> Auto-recovered by orchestrator — agent did not write KB directly.
+
+${finalMessage}`;
+            await this.kb.write(expectedKbFile, fallbackContent);
+            kbWriteVerified = true;
+            this.transport.sendNotification("log", {
+              message: `[task] Orchestrator KB recovery succeeded for ${task.taskId}: wrote ${fallbackContent.length} bytes to "${expectedKbFile}"`,
+            });
+          } catch (writeErr) {
+            this.transport.sendNotification("log", {
+              message: `[task] Orchestrator KB recovery also failed for ${task.taskId}: ${writeErr instanceof Error ? writeErr.message : writeErr}`,
+            });
+          }
+        }
       }
     }
 
@@ -2164,18 +2183,44 @@ export class Orchestrator {
       message: `[task] Design task ${task.taskId} completed by ${agentId}, fast-tracking to closed`,
     });
 
+    // Verify KB write when kbPaths are expected (same pattern as research)
+    const kbPaths = (task.allowedWriteScope?.kbPaths ?? []).filter((p) => p.trim().length > 0);
+    let designKbVerified = false;
+    let designKbFile: string | undefined;
+    if (kbPaths.length > 0 && this.kb?.isEnabled()) {
+      designKbFile = kbPaths[0].endsWith(".md")
+        ? kbPaths[0]
+        : `${kbPaths[0].replace(/\/+$/, "")}/${task.taskId}.md`;
+      try {
+        const kbContent = await this.kb.read(designKbFile);
+        designKbVerified = !!kbContent && kbContent.length > 100;
+      } catch { /* not found */ }
+      if (!designKbVerified && finalMessage.length > 200) {
+        try {
+          const fallback = `# Design Fallback: ${task.title} [${task.taskId}]
+
+> Auto-recovered by orchestrator.
+
+${finalMessage}`;
+          await this.kb.write(designKbFile, fallback);
+          designKbVerified = true;
+        } catch { /* best-effort */ }
+      }
+    }
+
     const parsed = this.tryParseJsonRecord(finalMessage);
     const artifactsArr = this.readStringArray(parsed?.artifacts);
     const designFindings = this.readStringArray(parsed?.findings);
     const designRecommendations = this.readStringArray(parsed?.recommendations);
+    const docsUpdated = designKbVerified && designKbFile ? [designKbFile] : [];
     const receipt: ImplementationReceipt = {
       implementer: agentId,
       branch: "",
       summary: this.readString(parsed?.summary) ?? finalMessage.slice(0, 500),
       changedFiles: [],
       evidence: artifactsArr,
-      docsUpdated: [],
-      residualRisks: [],
+      docsUpdated,
+      residualRisks: (kbPaths.length > 0 && !designKbVerified) ? ["KB write not verified — design artifact may only exist in task result"] : [],
       completedAt: Date.now(),
     };
 

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -1142,8 +1142,9 @@ export function buildResearchPrompt(
     "## Step 2 (After JSON output): Write Report to KB",
     "After outputting the JSON summary above, write the full report to KB.",
     ...deriveKbWriteInstructions(task),
-    "If kb_write fails, retry once. If it still fails, add the error to your evidence list —",
-    "the JSON summary (Step 1) already ensures the receipt has your findings.",
+    "If kb_write fails, retry once. If it still fails, stop silently —",
+    "the orchestrator will recover the KB from your Step 1 JSON output automatically.",
+    "Do NOT send any additional messages after Step 1 JSON — the orchestrator reads only your last message.",
   ];
 
   if (kbContext) {
@@ -1202,8 +1203,9 @@ export function buildDesignPrompt(
     "## Step 2 (After JSON output): Write Report to KB",
     "After outputting the JSON summary above, write the full design report to KB.",
     ...deriveKbWriteInstructions(task),
-    "If kb_write fails, retry once. If it still fails, add the error to your artifacts list —",
-    "the JSON summary (Step 1) already ensures the receipt has your design.",
+    "If kb_write fails, retry once. If it still fails, stop silently —",
+    "the orchestrator will recover the KB from your Step 1 JSON output automatically.",
+    "Do NOT send any additional messages after Step 1 JSON — the orchestrator reads only your last message.",
   ];
 
   if (kbContext) {

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -1077,6 +1077,9 @@ function deriveKbWriteInstructions(task: TaskBundle): string[] {
   ];
 }
 
+/** Minimum context window tokens before skipping research and going straight to JSON output. */
+const RESEARCH_CONTEXT_BUDGET_THRESHOLD = 20_000;
+
 /**
  * Build a research-role dispatch prompt.
  * Research tasks produce findings/reports, not code commits.
@@ -1118,7 +1121,7 @@ export function buildResearchPrompt(
       : []),
     "",
     "## CRITICAL: Context Budget Check",
-    "Before starting research, check your remaining context window. If it is below 20,000 tokens,",
+    `Before starting research, check your remaining context window. If it is below ${RESEARCH_CONTEXT_BUDGET_THRESHOLD.toLocaleString()} tokens,`,
     "SKIP all research and go directly to Step 1 to output the JSON summary with what you know.",
     "",
     "## Step 1 (ALWAYS FIRST): Output JSON Summary",
@@ -1179,13 +1182,13 @@ export function buildDesignPrompt(
     "- Reference existing code patterns and KB docs as needed.",
     "- No code implementation expected.",
     "",
-    "## MANDATORY: Write Report to KB (Step 1)",
-    "Before outputting your final JSON summary, you MUST write the full report to KB.",
-    ...deriveKbWriteInstructions(task),
-    "If kb_write fails, retry once. If it still fails, do NOT proceed to Step 2 — report the error as your final message.",
+    "## CRITICAL: Context Budget Check",
+    `Before starting design work, check your remaining context window. If it is below ${RESEARCH_CONTEXT_BUDGET_THRESHOLD.toLocaleString()} tokens,`,
+    "SKIP all design work and go directly to Step 1 to output the JSON summary with what you know.",
     "",
-    "## Output Format (Step 2)",
-    "After writing the KB file, return a JSON design report as your final message:",
+    "## Step 1 (ALWAYS FIRST): Output JSON Summary",
+    "Your FINAL MESSAGE must be the JSON design report below. Output it BEFORE writing to KB.",
+    "This guarantees the receipt has content even if KB write fails or context exhausts.",
     "```json",
     JSON.stringify({
       designer: "",
@@ -1195,6 +1198,12 @@ export function buildDesignPrompt(
       completedAt: "",
     }, null, 2),
     "```",
+    "",
+    "## Step 2 (After JSON output): Write Report to KB",
+    "After outputting the JSON summary above, write the full design report to KB.",
+    ...deriveKbWriteInstructions(task),
+    "If kb_write fails, retry once. If it still fails, add the error to your artifacts list —",
+    "the JSON summary (Step 1) already ensures the receipt has your design.",
   ];
 
   if (kbContext) {

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -1161,6 +1161,7 @@ export function buildResearchPrompt(
 export function buildDesignPrompt(
   task: TaskBundle,
   kbContext?: string,
+  tokenBudgetHint?: number,
 ): string {
   const lines = [
     `# Design Task: ${task.title} [${task.taskId}]`,
@@ -1182,6 +1183,9 @@ export function buildDesignPrompt(
     "- Produce design artifacts (specs, diagrams, architecture docs) for the topic above.",
     "- Reference existing code patterns and KB docs as needed.",
     "- No code implementation expected.",
+    ...(tokenBudgetHint !== undefined && tokenBudgetHint > 0
+      ? [`- **TOKEN_BUDGET: ~${tokenBudgetHint.toLocaleString()} tokens remaining** — wrap up and submit design before reaching this limit.`]
+      : []),
     "",
     "## CRITICAL: Context Budget Check",
     `Before starting design work, check your remaining context window. If it is below ${RESEARCH_CONTEXT_BUDGET_THRESHOLD.toLocaleString()} tokens,`,

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -1117,13 +1117,13 @@ export function buildResearchPrompt(
       ? [`- **TOKEN_BUDGET: ~${tokenBudgetHint.toLocaleString()} tokens remaining** — wrap up and submit findings before reaching this limit.`]
       : []),
     "",
-    "## MANDATORY: Write Report to KB (Step 1)",
-    "Before outputting your final JSON summary, you MUST write the full report to KB.",
-    ...deriveKbWriteInstructions(task),
-    "If kb_write fails, retry once. If it still fails, do NOT proceed to Step 2 — report the error as your final message.",
+    "## CRITICAL: Context Budget Check",
+    "Before starting research, check your remaining context window. If it is below 20,000 tokens,",
+    "SKIP all research and go directly to Step 1 to output the JSON summary with what you know.",
     "",
-    "## Output Format (Step 2)",
-    "After writing the KB file, return a JSON summary as your final message.",
+    "## Step 1 (ALWAYS FIRST): Output JSON Summary",
+    "Your FINAL MESSAGE must be the JSON summary below. Output it BEFORE writing to KB.",
+    "This guarantees the receipt has content even if KB write fails or context exhausts.",
     "Keep each finding/recommendation as a cohesive paragraph (not split by line):",
     "```json",
     JSON.stringify({
@@ -1135,6 +1135,12 @@ export function buildResearchPrompt(
       completedAt: "",
     }, null, 2),
     "```",
+    "",
+    "## Step 2 (After JSON output): Write Report to KB",
+    "After outputting the JSON summary above, write the full report to KB.",
+    ...deriveKbWriteInstructions(task),
+    "If kb_write fails, retry once. If it still fails, add the error to your evidence list —",
+    "the JSON summary (Step 1) already ensures the receipt has your findings.",
   ];
 
   if (kbContext) {


### PR DESCRIPTION
## Summary
- Swap `buildResearchPrompt()` step order: JSON receipt is output **FIRST** (Step 1) before KB write (Step 2), preventing empty receipts when context window exhausts mid-session
- Add context budget check at prompt start: if remaining tokens <20k, skip research and go directly to JSON output
- Add orchestrator-side KB recovery in `handleResearchStreamComplete()`: when agent fails to write KB and `finalMessage` is substantial (>200 chars), orchestrator writes a fallback KB file with the agent's final message
- Add KB write verification + recovery to `handleDesignStreamComplete()` matching the research pattern — was previously missing entirely
- Design receipt now correctly sets `docsUpdated` and `residualRisks` based on KB verification result

## Root cause
Research agent context window exhaustion caused premature session termination **before** reaching the KB write step. Because the old prompt put KB write first, the implementation receipt was always empty when this happened.

## Test plan
- [ ] TypeScript compilation: `npx tsc --noEmit -p packages/orchestrator/tsconfig.json` — PASS (verified pre-commit)
- [ ] `buildResearchPrompt()` output: Step 1 JSON output section appears before Step 2 KB write section
- [ ] `handleResearchStreamComplete()`: fallback KB write triggered when `kbWriteVerified=false` and `finalMessage.length > 200`
- [ ] `handleDesignStreamComplete()`: KB verification + recovery code path present and correct

Generated with Claude Code