### PR TITLE
fix(orchestrator): raise loop detection threshold and cap research dispatch retries (#109)

### DIFF
--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -173,8 +173,15 @@ export class Orchestrator {
 
   /** Track recent tool calls per session for loop detection. */
   private recentToolCalls = new Map<string, string[]>();
-  private static readonly LOOP_DETECTION_WINDOW = 6;
-  private static readonly LOOP_DETECTION_THRESHOLD = 3;
+  /**
+   * Loop detection window and threshold.
+   * Research/design agents regularly call the same search tool (Grep/WebSearch)
+   * many times in sequence — a threshold of 3 fires too aggressively and injects
+   * disruptive warnings into their context. 8 consecutive same-tool calls is a
+   * more reliable signal of a genuine loop across all roles.
+   */
+  private static readonly LOOP_DETECTION_WINDOW = 12;
+  private static readonly LOOP_DETECTION_THRESHOLD = 8;
 
   /** Inject optional knowledge service + wire up task persistence (with optional SQLite dual-write). */
   setKnowledgeService(kb: KnowledgeService) {

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -227,7 +227,10 @@ export class TaskManager {
     try {
       const { tasks, acceptances, issues } = await this.persistence.loadAll();
       for (const t of tasks) {
-        // Backfill dispatch retry fields for legacy tasks (pre-RESILIENCE-001)
+        // Backfill dispatch retry fields for legacy tasks (pre-RESILIENCE-001).
+        // Note: legacy tasks always get maxDispatchAttempts = 5 regardless of role
+        // for backward compatibility. New tasks created after this change receive
+        // role-aware defaults via createTask() (research/design → 1, dev → 5).
         if (t.dispatchAttempts === undefined) t.dispatchAttempts = 0;
         if (t.maxDispatchAttempts === undefined) t.maxDispatchAttempts = 5;
         this.tasks.set(t.taskId, t);

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -340,7 +340,11 @@ export class TaskManager {
       handoffToAcceptance: params.handoffToAcceptance,
       modelRecommendation: params.modelRecommendation,
       dispatchAttempts: 0,
-      maxDispatchAttempts: params.maxDispatchAttempts ?? 5,
+      // Research and design roles run long single-pass sessions; context exhaustion
+      // is not a retriable error — re-dispatching from scratch wastes resources and
+      // produces no output. Default to 1 for these roles. Dev tasks keep 5 so that
+      // transient failures (session crash, network blip) are automatically retried.
+      maxDispatchAttempts: params.maxDispatchAttempts ?? (requiredRole === "research" || requiredRole === "design" ? 1 : 5),
       reworkCount: 0,
       maxReworks: params.maxReworks ?? 3,
       linkedIssueIds: [],


### PR DESCRIPTION
## Summary
- Raise `LOOP_DETECTION_THRESHOLD` from 3 to 8 (window 6→12): research agents calling Grep/WebSearch iteratively hit the old threshold constantly, injecting loop warnings into their context and polluting handoff sessions with those warnings as the first message of the new session
- Make `maxDispatchAttempts` role-aware: research/design defaults to 1 (context exhaustion is not retriable), dev keeps 5 (for crash/network-blip recovery). Prevents the 6-session cascade where all sessions hit token limits with zero output

## Root cause
Phase 3 research dispatch failed with `dispatchAttempts: 6` / zero KB output because:
1. Grep called 3x in a row → loop warning injected → polluted handoff context
2. Each handoff/re-dispatch session started from the loop warning prompt, exhausted context immediately, and the cycle repeated 5 more times (maxDispatchAttempts=5)

## Test plan
- [ ] Research task dispatch with `maxDispatchAttempts` unset → verify task bundle shows `maxDispatchAttempts: 1`
- [ ] Dev task dispatch with `maxDispatchAttempts` unset → verify task bundle shows `maxDispatchAttempts: 5`
- [ ] Calling same tool 7 consecutive times → no loop warning injected
- [ ] Calling same tool 8 consecutive times → loop warning fires once, resets

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)