### PR TITLE
fix(task-lifecycle): enforce maxReworks + enrich SEND_BACK rework prompt (#120 #121)

### DIFF
--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -42,6 +42,7 @@ import {
   buildReferencePrompt,
   buildAcceptancePrompt,
   buildReworkPrompt,
+  buildSendBackPrompt,
   buildMainReviewPrompt,
   buildCriticPrompt,
 } from "./task-manager.js";
@@ -3387,12 +3388,17 @@ export class Orchestrator {
 
     if (results.verdict === "fail" || results.verdict === "partial") {
       // Trigger rework with full context
-      const { newSession } = this.taskManager.triggerRework(
+      const { reworked, newSession } = this.taskManager.triggerRework(
         task.taskId,
         results.findings.join("\n"),
         acceptanceId,
         results.findings,
       );
+
+      if (!reworked) {
+        // maxReworks exceeded — task transitioned to failed
+        return { verdict: results.verdict, reworkTriggered: false, newSession: false };
+      }
 
       if (!newSession) {
         // Send rework prompt to existing dev session
@@ -3534,14 +3540,19 @@ export class Orchestrator {
     }
 
     if (effectiveDecision === "SEND_BACK") {
-      const { newSession } = this.taskManager.triggerRework(
+      const { reworked, newSession } = this.taskManager.triggerRework(
         taskId,
         effectiveReason ?? "Main Agent review: sent back for rework",
       );
 
+      if (!reworked) {
+        // maxReworks exceeded — task transitioned to failed
+        return { decision: effectiveDecision, nextAction: "failed_max_reworks" };
+      }
+
       // Send rework directive to the agent in its original role
       const reworkRole: AgentRole = task.role ?? "dev";
-      const reworkPrompt = `# Rework Required [${task.taskId}]\n\nMain Agent review returned this task for rework.\n\n**Reason:** ${effectiveReason ?? "Unspecified"}\n\nPlease address and resubmit.`;
+      const reworkPrompt = buildSendBackPrompt(task, effectiveReason ?? "Main Agent review: sent back for rework");
       if (newSession) {
         const reworkRolePrompt = this.buildSystemRolePrompt(reworkRole, task);
         const session = await this.startRoleSession(

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -3400,19 +3400,27 @@ export class Orchestrator {
         return { verdict: results.verdict, reworkTriggered: false, newSession: false };
       }
 
-      if (!newSession) {
-        // Send rework prompt to existing dev session
-        const reworkPrompt = buildReworkPrompt(task, acceptance);
-        await this.sendPrompt(
+      const reworkRole: AgentRole = task.role ?? "dev";
+      const reworkPrompt = buildReworkPrompt(task, acceptance);
+      if (newSession) {
+        const reworkRolePrompt = this.buildSystemRolePrompt(reworkRole, task);
+        const session = await this.startRoleSession(
           task.assignedTo,
-          reworkPrompt,
-          undefined,
-          "dev",
+          reworkRole,
           task.title,
-          this.buildSystemRolePrompt("dev", task),
-          task.taskId,
+          reworkRolePrompt,
         );
+        this.taskManager.bindSession(task.taskId, session.sessionId);
       }
+      await this.sendPrompt(
+        task.assignedTo,
+        reworkPrompt,
+        undefined,
+        reworkRole,
+        task.title,
+        this.buildSystemRolePrompt(reworkRole, task),
+        task.taskId,
+      );
 
       // Callback to Main Agent for fail/partial (after rework dispatch to avoid premature notification)
       this.bus.emit(

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -34,8 +34,8 @@ const VALID_TRANSITIONS: Record<TaskStatus, TaskStatus[]> = {
   dispatched: ["in_progress"],
   in_progress: ["implementation_done", "failed", "blocked", "dispatched"], // dispatched: G2 crash recovery re-dispatch
   implementation_done: ["main_review"],
-  main_review: ["acceptance", "in_progress"],
-  acceptance: ["verified", "in_progress"],
+  main_review: ["acceptance", "in_progress", "failed"],
+  acceptance: ["verified", "in_progress", "failed"],
   verified: ["closed"],
   blocked: ["in_progress", "failed"],
   failed: [],
@@ -601,7 +601,13 @@ export class TaskManager {
     }
 
     task.reworkCount += 1;
-    const needsNewSession = task.reworkCount > task.maxReworks;
+
+    if (task.reworkCount > task.maxReworks) {
+      this.transitionTask(taskId, "failed", task.assignedTo ?? "orchestrator");
+      return { reworked: false, newSession: false };
+    }
+
+    const needsNewSession = task.reworkCount >= task.maxReworks;
 
     // Transition back to in_progress via state machine
     if (task.status === "acceptance" || task.status === "main_review") {
@@ -1437,6 +1443,67 @@ export function buildReworkPrompt(
   lines.push("## Instructions");
   lines.push("Address the findings above within your current scope. Do not start from scratch.");
   lines.push("Learn from previous attempts listed in the rework history — do not repeat the same mistakes.");
+  lines.push("When complete, output an updated JSON receipt.");
+
+  return lines.join("\n");
+}
+
+/** Build the rework prompt sent to the Dev Agent after Main Agent SEND_BACK decision. */
+export function buildSendBackPrompt(task: TaskBundle, reason: string): string {
+  const lines: string[] = [];
+
+  lines.push(`# Rework Required [${task.taskId}]`);
+  lines.push(`This is attempt **${task.reworkCount}/${task.maxReworks}** — returned by Main Agent review.`);
+  lines.push("");
+
+  lines.push("## Send-Back Context");
+  const meta = {
+    taskId: task.taskId,
+    reworkCount: task.reworkCount,
+    maxReworks: task.maxReworks,
+    reason,
+  };
+  lines.push("```json");
+  lines.push(JSON.stringify(meta, null, 2));
+  lines.push("```");
+  lines.push("");
+
+  lines.push("## Task Specification");
+  const spec = {
+    taskId: task.taskId,
+    title: task.title,
+    context: task.context,
+    definitionOfDone: task.definitionOfDone,
+    allowedWriteScope: task.allowedWriteScope,
+    readScope: task.readScope,
+  };
+  lines.push("```json");
+  lines.push(JSON.stringify(spec, null, 2));
+  lines.push("```");
+  lines.push("");
+
+  if (task.implementationReceipt) {
+    lines.push("## Previous Implementation Receipt");
+    lines.push("```json");
+    lines.push(truncate(sanitizeFenceContent(JSON.stringify(task.implementationReceipt, null, 2)), MAX_PRECHECKS_CHARS));
+    lines.push("```");
+    lines.push("");
+  }
+
+  if (task.reworkHistory.length > 0) {
+    lines.push("## Rework History");
+    const historyEntries = task.reworkHistory.slice(-5);
+    for (const entry of historyEntries) {
+      lines.push(`### Attempt ${entry.attempt}`);
+      lines.push(`- Findings: ${entry.findings.join("; ") || "none"}`);
+      lines.push(`- Timestamp: ${new Date(entry.timestamp).toISOString()}`);
+    }
+    lines.push("");
+  }
+
+  lines.push("## Instructions");
+  lines.push("Address the reason stated above. Do not start from scratch.");
+  lines.push("Review the task specification and previous receipt to understand what needs to change.");
   lines.push("When complete, output an updated JSON receipt.");
 
   return lines.join("\n");

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -572,7 +572,7 @@ export class TaskManager {
 
   triggerRework(
     taskId: string,
-    _feedback: string,
+    feedback: string,
     acceptanceId?: string,
     findings?: string[],
   ): { reworked: boolean; newSession: boolean } {
@@ -595,7 +595,7 @@ export class TaskManager {
         attempt: task.reworkCount + 1,
         receipt: { ...task.implementationReceipt },
         acceptanceId: acceptanceId ?? "",
-        findings: findings ?? [],
+        findings: findings?.length ? findings : (feedback.trim() ? [feedback.trim()] : []),
         timestamp: Date.now(),
       });
     }
@@ -1464,7 +1464,7 @@ export function buildSendBackPrompt(task: TaskBundle, reason: string): string {
     reason,
   };
   lines.push("```json");
-  lines.push(JSON.stringify(meta, null, 2));
+  lines.push(sanitizeFenceContent(JSON.stringify(meta, null, 2)));
   lines.push("```");
   lines.push("");
 
@@ -1478,7 +1478,7 @@ export function buildSendBackPrompt(task: TaskBundle, reason: string): string {
     readScope: task.readScope,
   };
   lines.push("```json");
-  lines.push(JSON.stringify(spec, null, 2));
+  lines.push(sanitizeFenceContent(JSON.stringify(spec, null, 2)));
   lines.push("```");
   lines.push("");
 


### PR DESCRIPTION
## Summary
- **Bug 3 (#120)**: `triggerRework()` now enforces `maxReworks` — tasks exceeding the cap transition to `failed` instead of looping indefinitely. Added `main_review→failed` and `acceptance→failed` state transitions.
- **Bug 2 (#121)**: SEND_BACK path now uses `buildSendBackPrompt()` with full task specification, send-back context, truncated implementation receipt, and capped rework history (last 5 entries). Replaces the bare 3-line inline string.

## Changes
- `task-manager.ts`: `VALID_TRANSITIONS`, `triggerRework()` guard, `buildSendBackPrompt()` helper
- `orchestrator.ts`: both `triggerRework()` callers updated; `buildSendBackPrompt` imported

## Test plan
- [ ] Task with `maxReworks: 3` and `reworkCount: 3` → next `triggerRework()` call transitions to `failed`, returns `{reworked: false}`
- [ ] SEND_BACK prompt received by dev agent includes full task spec and rework history
- [ ] TypeScript build passes: `npx tsc -p packages/orchestrator/tsconfig.json --noEmit`

Closes #120
Closes #121

Generated with Claude Code