### PR TITLE
fix(session-routing): route loop-detection warning to exact sessionId (#122)

### DIFF
--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -1564,6 +1564,31 @@ export class Orchestrator {
     };
   }
 
+  /**
+   * Send a prompt directly to a known sessionId, bypassing role-slot lookup.
+   * Used for best-effort injections (e.g. loop-detection warnings) where the
+   * exact session is already known and must not be misrouted to a rebound slot.
+   */
+  private sendPromptToSession(agentId: string, sessionId: string, prompt: string): void {
+    const adapter = this.registry.getAdapter(agentId);
+    const session = this.sessions.get(sessionId);
+    this.appendTranscriptMessage(sessionId, {
+      role: "user",
+      content: prompt,
+      timestamp: Date.now(),
+    });
+    this.bus.emit("agent.message.send", agentId, sessionId, {
+      prompt: prompt.slice(0, 200),
+      hasImages: 0,
+      role: session?.role,
+    });
+    void this.streamMessages(adapter, agentId, sessionId, prompt)
+      .then((result) =>
+        this.handleStreamCompletion(agentId, sessionId, session?.role ?? "dev", undefined, result),
+      )
+      .catch(() => { /* best-effort warning injection */ });
+  }
+
   private async streamMessages(
     adapter: ReturnType<AgentRegistry["getAdapter"]>,
     agentId: string,
@@ -1604,13 +1629,11 @@ export class Orchestrator {
           if (yielded.toolName && yielded.eventKind === "tool_start") {
             if (this.detectToolLoop(sessionId, yielded.toolName)) {
               // Inject warning into the current session's role slot
-              const loopSession = this.sessions.get(sessionId);
-              void this.sendPrompt(
+              this.sendPromptToSession(
                 agentId,
+                sessionId,
                 `[LOOP DETECTED] You have called "${yielded.toolName}" ${Orchestrator.LOOP_DETECTION_THRESHOLD}+ times consecutively. This suggests a loop. Stop repeating the same action and try a different approach.`,
-                undefined,
-                loopSession?.role,
-              ).catch(() => { /* best-effort warning injection */ });
+              );
             }
           }
           continue;

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -1622,6 +1622,8 @@ export class Orchestrator {
       }
     } catch {
       // Best-effort: never propagate errors from internal prompt injection
+    } finally {
+      this.transport.sendNotification("agent_stream_end", { agentId, sessionId });
     }
   }
 

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -1582,11 +1582,47 @@ export class Orchestrator {
       hasImages: 0,
       role: session?.role,
     });
-    void this.streamMessages(adapter, agentId, sessionId, prompt)
-      .then((result) =>
-        this.handleStreamCompletion(agentId, sessionId, session?.role ?? "dev", undefined, result),
-      )
-      .catch(() => { /* best-effort warning injection */ });
+    void this.streamInternalPrompt(adapter, agentId, sessionId, prompt);
+  }
+
+  private async streamInternalPrompt(
+    adapter: ReturnType<AgentRegistry["getAdapter"]>,
+    agentId: string,
+    sessionId: string,
+    prompt: string,
+  ): Promise<void> {
+    try {
+      for await (const yielded of adapter.sendPrompt(sessionId, prompt)) {
+        if (isStreamingEvent(yielded)) {
+          this.transport.sendNotification("agent_streaming", {
+            agentId,
+            sessionId,
+            event: {
+              eventKind: yielded.eventKind,
+              content: yielded.content,
+              toolName: yielded.toolName,
+              toolInput: yielded.toolInput,
+              tokenCount: yielded.tokenCount,
+              timestamp: yielded.timestamp,
+            },
+          });
+          continue;
+        }
+        const message = yielded as AgentMessage;
+        this.bus.emit("agent.message.receive", agentId, sessionId, {
+          contentPreview: message.content.slice(0, 200),
+        });
+        this.appendTranscriptMessage(sessionId, {
+          role: message.role,
+          content: message.content,
+          timestamp: message.timestamp,
+          images: message.images,
+          metadata: message.metadata,
+        });
+      }
+    } catch {
+      // Best-effort: never propagate errors from internal prompt injection
+    }
   }
 
   private async streamMessages(


### PR DESCRIPTION
## Summary
- Add `sendPromptToSession(agentId, sessionId, prompt)` private method that bypasses role-slot lookup and delivers directly to a known session
- Replace `void sendPrompt(..., loopSession?.role)` in loop-detection path with `sendPromptToSession(..., sessionId)` — uses the `sessionId` already in scope from the `streamMessages` call

## Root cause fixed
`sendPrompt()` routes via `makeRoleSlotKey(role, agentId) → roleSessions.get(slotKey)`. If the role slot is rebound between sessions (new task dispatched), the `[LOOP DETECTED]` warning injects into a different task's fresh session. The new method bypasses this lookup entirely.

## Test plan
- [ ] Loop detection warning appears in the same session that triggered the loop, not a sibling session
- [ ] No regression when role slot is empty at warning time (method is fire-and-forget, errors are swallowed)
- [ ] TypeScript build passes: `npx tsc -p packages/orchestrator/tsconfig.json --noEmit`

Closes #122

Generated with Claude Code