### PR TITLE
fix(kb-dispatch): Obsidian CLI write + KB path instructions + role validation (#123 #124)

### DIFF
--- a/packages/orchestrator/src/knowledge-service.ts
+++ b/packages/orchestrator/src/knowledge-service.ts
@@ -312,12 +312,13 @@ export class KnowledgeService {
   async write(name: string, content: string): Promise<void> {
     // For large content, bypass CLI entirely — passing multi-KB content as a single
     // argv entry exceeds Windows CreateProcess limits and will always fail.
-    if (content.length > KnowledgeService.CLI_WRITE_SIZE_THRESHOLD) {
+    const byteCount = Buffer.byteLength(content, "utf8");
+    if (byteCount > KnowledgeService.CLI_WRITE_SIZE_THRESHOLD) {
       const filePath = this.resolveVaultFilePath(name);
       if (filePath) {
         await fs.mkdir(path.dirname(filePath), { recursive: true });
         await fs.writeFile(filePath, content, "utf-8");
-        console.warn(`[knowledge] Large content (${content.length} chars) — wrote directly to fs: ${filePath}`);
+        console.warn(`[knowledge] Large content (${byteCount} bytes) — wrote directly to fs: ${filePath}`);
         return;
       }
       // No vaultPath — fall through to CLI attempt which will surface a clear error

--- a/packages/orchestrator/src/knowledge-service.ts
+++ b/packages/orchestrator/src/knowledge-service.ts
@@ -47,6 +47,14 @@ export class KnowledgeService {
   private resolveObsidianBin(configuredBin?: string): string {
     const explicitBin = configuredBin?.trim();
     if (explicitBin) {
+      // If the configured path is a directory (e.g. "D:\Programs\Obsidian"),
+      // try appending the executable name before returning as-is.
+      if (process.platform === "win32" && !explicitBin.toLowerCase().endsWith(".exe")) {
+        const withExe = path.join(explicitBin, "Obsidian.exe");
+        if (existsSync(withExe)) {
+          return withExe;
+        }
+      }
       return explicitBin;
     }
 
@@ -297,8 +305,23 @@ export class KnowledgeService {
     }
   }
 
+  /** Content size above which we skip the CLI and write directly to the vault filesystem. */
+  private static readonly CLI_WRITE_SIZE_THRESHOLD = 8192;
+
   /** Write a file to the vault via CLI, falling back to direct fs write if CLI fails. */
   async write(name: string, content: string): Promise<void> {
+    // For large content, bypass CLI entirely — passing multi-KB content as a single
+    // argv entry exceeds Windows CreateProcess limits and will always fail.
+    if (content.length > KnowledgeService.CLI_WRITE_SIZE_THRESHOLD) {
+      const filePath = this.resolveVaultFilePath(name);
+      if (filePath) {
+        await fs.mkdir(path.dirname(filePath), { recursive: true });
+        await fs.writeFile(filePath, content, "utf-8");
+        console.warn(`[knowledge] Large content (${content.length} chars) — wrote directly to fs: ${filePath}`);
+        return;
+      }
+      // No vaultPath — fall through to CLI attempt which will surface a clear error
+    }
     try {
       await this.exec(["create", `name=${name}`, `content=${content}`]);
     } catch (error) {

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -2825,9 +2825,9 @@ export class Orchestrator {
     let prompt: string;
     if (role === "research") {
       const maxIterations = this.projectConfig?.research?.maxIterations;
-      prompt = buildResearchPrompt(task, kbContext, maxIterations, tokenBudgetHint);
+      prompt = buildResearchPrompt(task, kbContext, maxIterations, tokenBudgetHint, this.projectConfig?.obsidian?.vaultPath ?? undefined);
     } else if (role === "design") {
-      prompt = buildDesignPrompt(task, kbContext, tokenBudgetHint);
+      prompt = buildDesignPrompt(task, kbContext, tokenBudgetHint, this.projectConfig?.obsidian?.vaultPath ?? undefined);
     } else {
       prompt = buildDevPrompt(task, kbContext, this.getProjectRoot());
     }

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -8,7 +8,7 @@
 import { randomUUID } from "node:crypto";
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { basename, resolve, sep } from "node:path";
 import type { EventBus } from "@mercury/core";
 import { normalizePriority } from "@mercury/core";
 import type {
@@ -1080,24 +1080,45 @@ function deriveKbWriteInstructions(task: TaskBundle, vaultPath?: string): string
   if (kbPaths.length === 0) {
     return ["No KB output path configured for this task."];
   }
-  const target = kbPaths[0].endsWith(".md")
+  const rawTarget = kbPaths[0].endsWith(".md")
     ? kbPaths[0]
     : `${kbPaths[0].replace(/\/+$/, "")}/${task.taskId}.md`;
 
-  const absolutePath = vaultPath ? resolve(vaultPath, ...target.split("/")) : null;
-  const fallbackPath = absolutePath
-    ? absolutePath.replace(/\\/g, "/")
-    : `.mercury/docs/research/${task.taskId}.md`;
+  // Strip leading vault-name prefix to prevent double-path segments
+  // (e.g. "Mercury_KB/04-research/foo.md" → "04-research/foo.md")
+  let normalizedTarget = rawTarget.replace(/\\/g, "/");
+  if (vaultPath) {
+    const vaultBaseName = basename(vaultPath);
+    const prefix = `${vaultBaseName}/`;
+    if (normalizedTarget.startsWith(prefix)) {
+      normalizedTarget = normalizedTarget.slice(prefix.length);
+    }
+  }
+
+  // Derive safe absolute path with traversal guard (mirrors KnowledgeService.resolveVaultFilePath)
+  let safePath: string | null = null;
+  if (vaultPath) {
+    const segments = normalizedTarget.split(/[\\/]+/).filter(Boolean);
+    const resolved = resolve(vaultPath, ...segments);
+    const normalizedVault = resolve(vaultPath);
+    if (resolved.startsWith(normalizedVault + sep) || resolved === normalizedVault) {
+      safePath = resolved.replace(/\\/g, "/");
+    }
+  }
 
   return [
     "## KB Write Instructions (3-tier priority)",
     "**Tier 1 — MCP (preferred)**: call `mcp__mercury-orchestrator__kb_write`:",
-    `  - \`name\`: \`${target}\``,
+    `  - \`name\`: \`${normalizedTarget}\``,
     "  - `content`: your complete Markdown report",
-    ...(absolutePath ? [`  - Absolute path: \`${absolutePath.replace(/\\/g, "/")}\``] : []),
-    "**Tier 2 — direct file write (if MCP unavailable)**: write the report directly to:",
-    `  \`${fallbackPath}\``,
-    "  Create parent directories as needed.",
+    ...(safePath ? [`  - Absolute path: \`${safePath}\``] : []),
+    ...(safePath
+      ? [
+          "**Tier 2 — direct file write (if MCP unavailable)**: write the report directly to:",
+          `  \`${safePath}\``,
+          "  Create parent directories as needed.",
+        ]
+      : ["**Tier 2 — unavailable**: no safe vault path configured; use Tier 3 if Tier 1 fails."]),
     "**Tier 3 — embed in Step 1 JSON**: if both Tier 1 and Tier 2 fail, include the full report text",
     "  inside the `findings` array of your Step 1 JSON output — as part of that same output, NOT as a",
     "  subsequent assistant message. Do NOT send additional messages after Step 1 to patch or augment",

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -1098,7 +1098,10 @@ function deriveKbWriteInstructions(task: TaskBundle, vaultPath?: string): string
     "**Tier 2 — direct file write (if MCP unavailable)**: write the report directly to:",
     `  \`${fallbackPath}\``,
     "  Create parent directories as needed.",
-    "**Tier 3 — embed in receipt**: if both fail, include the full report text in your Step 1 JSON `findings` field.",
+    "**Tier 3 — embed in Step 1 JSON**: if both Tier 1 and Tier 2 fail, include the full report text",
+    "  inside the `findings` array of your Step 1 JSON output — as part of that same output, NOT as a",
+    "  subsequent assistant message. Do NOT send additional messages after Step 1 to patch or augment",
+    "  the findings; the complete report must be present within the single Step 1 JSON response.",
     "Do NOT stop silently — always persist the report by one of these three methods.",
   ];
 }

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -860,6 +860,13 @@ export class TaskManager {
       return `Task ${taskId} exceeded max dispatch attempts (${task.dispatchAttempts}/${task.maxDispatchAttempts})`;
     }
     // Research/design tasks must have at least one non-empty kbPath for report output
+    const VALID_ROLES = ["dev", "research", "design"] as const;
+    if (task.role !== undefined && task.role !== null && !(VALID_ROLES as readonly string[]).includes(task.role)) {
+      return `Task ${taskId} has invalid role "${task.role}"; expected one of: ${VALID_ROLES.join(", ")}`;
+    }
+    if (task.role === undefined || task.role === null) {
+      console.warn(`[TaskManager] Task ${taskId} has no role set; defaulting to "dev" for dispatch`);
+    }
     const role = task.role ?? "dev";
     if (role === "research" || role === "design") {
       const validKbPaths = (task.allowedWriteScope?.kbPaths ?? []).filter((p) => p.trim().length > 0);
@@ -1068,7 +1075,7 @@ function fallbackDevTemplate(): string {
  * Note: validateDispatch() ensures research/design tasks always have at least
  * one kbPath, so the empty-array branch is only reachable for dev tasks.
  */
-function deriveKbWriteInstructions(task: TaskBundle): string[] {
+function deriveKbWriteInstructions(task: TaskBundle, vaultPath?: string): string[] {
   const kbPaths = task.allowedWriteScope?.kbPaths ?? [];
   if (kbPaths.length === 0) {
     return ["No KB output path configured for this task."];
@@ -1076,11 +1083,23 @@ function deriveKbWriteInstructions(task: TaskBundle): string[] {
   const target = kbPaths[0].endsWith(".md")
     ? kbPaths[0]
     : `${kbPaths[0].replace(/\/+$/, "")}/${task.taskId}.md`;
+
+  const absolutePath = vaultPath ? resolve(vaultPath, ...target.split("/")) : null;
+  const fallbackPath = absolutePath
+    ? absolutePath.replace(/\\/g, "/")
+    : `.mercury/docs/research/${task.taskId}.md`;
+
   return [
-    "Write your full report to the knowledge base using `mcp__mercury-orchestrator__kb_write`:",
+    "## KB Write Instructions (3-tier priority)",
+    "**Tier 1 — MCP (preferred)**: call `mcp__mercury-orchestrator__kb_write`:",
     `  - \`name\`: \`${target}\``,
     "  - `content`: your complete Markdown report",
-    "This persists the report for future reference.",
+    ...(absolutePath ? [`  - Absolute path: \`${absolutePath.replace(/\\/g, "/")}\``] : []),
+    "**Tier 2 — direct file write (if MCP unavailable)**: write the report directly to:",
+    `  \`${fallbackPath}\``,
+    "  Create parent directories as needed.",
+    "**Tier 3 — embed in receipt**: if both fail, include the full report text in your Step 1 JSON `findings` field.",
+    "Do NOT stop silently — always persist the report by one of these three methods.",
   ];
 }
 
@@ -1115,6 +1134,7 @@ export function buildResearchPrompt(
   kbContext?: string,
   maxIterations?: number,
   tokenBudgetHint?: number,
+  vaultPath?: string,
 ): string {
   const lines = [
     `# Research Task: ${task.title} [${task.taskId}]`,
@@ -1187,9 +1207,7 @@ export function buildResearchPrompt(
     "",
     "## Step 2 (After JSON output): Write Report to KB",
     "After outputting the JSON summary above, write the full report to KB.",
-    ...deriveKbWriteInstructions(task),
-    "If kb_write fails, retry once. If it still fails, stop silently —",
-    "the orchestrator will recover the KB from your Step 1 JSON output automatically.",
+    ...deriveKbWriteInstructions(task, vaultPath),
     "Do NOT send any additional messages after Step 1 JSON — the orchestrator reads only your last message.",
   ];
 
@@ -1208,6 +1226,7 @@ export function buildDesignPrompt(
   task: TaskBundle,
   kbContext?: string,
   tokenBudgetHint?: number,
+  vaultPath?: string,
 ): string {
   const lines = [
     `# Design Task: ${task.title} [${task.taskId}]`,
@@ -1252,9 +1271,7 @@ export function buildDesignPrompt(
     "",
     "## Step 2 (After JSON output): Write Report to KB",
     "After outputting the JSON summary above, write the full design report to KB.",
-    ...deriveKbWriteInstructions(task),
-    "If kb_write fails, retry once. If it still fails, stop silently —",
-    "the orchestrator will recover the KB from your Step 1 JSON output automatically.",
+    ...deriveKbWriteInstructions(task, vaultPath),
     "Do NOT send any additional messages after Step 1 JSON — the orchestrator reads only your last message.",
   ];
 

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -1102,7 +1102,9 @@ function deriveKbWriteInstructions(task: TaskBundle, vaultPath?: string): string
     const resolved = resolve(vaultPath, ...segments);
     const normalizedVault = resolve(vaultPath);
     if (resolved.startsWith(normalizedVault + sep) || resolved === normalizedVault) {
-      safePath = resolved.replace(/\\/g, "/");
+      safePath = resolved; // preserve platform-native separators
+    } else {
+      console.warn(`[task-manager] KB path traversal blocked for task ${task.taskId}: ${normalizedTarget}`);
     }
   }
 

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -1266,6 +1266,7 @@ export function buildDesignPrompt(
     JSON.stringify({
       designer: "",
       summary: "",
+      findings: [""],
       designDoc: "",
       artifacts: [""],
       completedAt: "",


### PR DESCRIPTION
## Summary
- **Bug 4 (#123)**: Fix Obsidian CLI write failures and improve KB path instructions
- **Bug 5 (#124)**: Reject explicitly invalid role values in validateDispatch()

## Changes

### knowledge-service.ts
- resolveObsidianBin(): if configured path is a directory on Win32, auto-append Obsidian.exe
- write(): add CLI_WRITE_SIZE_THRESHOLD=8192 — content >8KB bypasses CLI entirely via fs.writeFile

### task-manager.ts
- deriveKbWriteInstructions(): new vaultPath param; 3-tier instructions (MCP preferred, direct file write with absolute path, embed in receipt); removes silent-stop instruction
- buildResearchPrompt() / buildDesignPrompt(): new vaultPath param forwarded to deriveKbWriteInstructions
- validateDispatch(): rejects invalid role values; warns when role is missing before defaulting to dev

### orchestrator.ts
- Passes projectConfig.obsidian.vaultPath to buildResearchPrompt and buildDesignPrompt

## Test plan
- [ ] Write call with 10KB content skips CLI, writes directly to Mercury_KB/ via fs
- [ ] mercury.config.json with obsidianBin pointing to directory resolves to Obsidian.exe
- [ ] Research task prompt includes absolute vault path and 3-tier fallback instructions
- [ ] validateDispatch() returns error for invalid role, warns for undefined role
- [ ] TypeScript build passes: npx tsc -p packages/orchestrator/tsconfig.json --noEmit

Closes #123
Closes #124

Generated with Claude Code