### PR TITLE
feat(task-manager): extend Codex delegation guide to all CC-facing prompts (#128)

### DIFF
--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -2883,13 +2883,19 @@ export class Orchestrator {
       ? Math.floor(rawBudget * 0.9)
       : undefined;
 
+    // Determine if the assigned agent is a Claude Code instance (codex plugin is CC-only)
+    const assignedAgentCli = (() => {
+      try { return this.registry.getConfig(task.assignedTo).cli; } catch { return undefined; }
+    })();
+    const codexEnabled = assignedAgentCli === "claude";
+
     // Build role-appropriate prompt
     let prompt: string;
     if (role === "research") {
       const maxIterations = this.projectConfig?.research?.maxIterations;
-      prompt = buildResearchPrompt(task, kbContext, maxIterations, tokenBudgetHint, this.projectConfig?.obsidian?.vaultPath ?? undefined);
+      prompt = buildResearchPrompt(task, kbContext, maxIterations, tokenBudgetHint, this.projectConfig?.obsidian?.vaultPath ?? undefined, codexEnabled);
     } else if (role === "design") {
-      prompt = buildDesignPrompt(task, kbContext, tokenBudgetHint, this.projectConfig?.obsidian?.vaultPath ?? undefined);
+      prompt = buildDesignPrompt(task, kbContext, tokenBudgetHint, this.projectConfig?.obsidian?.vaultPath ?? undefined, codexEnabled);
     } else {
       prompt = buildDevPrompt(task, kbContext, this.getProjectRoot());
     }
@@ -3462,7 +3468,10 @@ export class Orchestrator {
       }
 
       const reworkRole: AgentRole = task.role ?? "dev";
-      const reworkPrompt = buildReworkPrompt(task, acceptance);
+      const reworkAgentCli = (() => {
+        try { return this.registry.getConfig(task.assignedTo).cli; } catch { return undefined; }
+      })();
+      const reworkPrompt = buildReworkPrompt(task, acceptance, reworkAgentCli === "claude");
       if (newSession) {
         const reworkRolePrompt = this.buildSystemRolePrompt(reworkRole, task);
         const session = await this.startRoleSession(
@@ -3621,7 +3630,10 @@ export class Orchestrator {
 
       // Send rework directive to the agent in its original role
       const reworkRole: AgentRole = task.role ?? "dev";
-      const reworkPrompt = buildSendBackPrompt(task, effectiveReason ?? "Main Agent review: sent back for rework");
+      const sendBackAgentCli = (() => {
+        try { return this.registry.getConfig(task.assignedTo).cli; } catch { return undefined; }
+      })();
+      const reworkPrompt = buildSendBackPrompt(task, effectiveReason ?? "Main Agent review: sent back for rework", sendBackAgentCli === "claude");
       if (newSession) {
         const reworkRolePrompt = this.buildSystemRolePrompt(reworkRole, task);
         const session = await this.startRoleSession(

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -2884,10 +2884,7 @@ export class Orchestrator {
       : undefined;
 
     // Determine if the assigned agent is a Claude Code instance (codex plugin is CC-only)
-    const assignedAgentCli = (() => {
-      try { return this.registry.getConfig(task.assignedTo).cli; } catch { return undefined; }
-    })();
-    const codexEnabled = assignedAgentCli === "claude";
+    const codexEnabled = this.getAgentCli(task.assignedTo) === "claude";
 
     // Build role-appropriate prompt
     let prompt: string;
@@ -3151,6 +3148,15 @@ export class Orchestrator {
     }
     // Fallback: find first agent with main role in config
     return this.registry.listAgents().find((a) => a.roles.includes("main"))?.id;
+  }
+
+  /** Return the CLI type for an agent, or undefined if the agent is not registered. */
+  private getAgentCli(agentId: string): string | undefined {
+    try {
+      return this.registry.getConfig(agentId).cli;
+    } catch {
+      return undefined;
+    }
   }
 
   /**
@@ -3468,10 +3474,7 @@ export class Orchestrator {
       }
 
       const reworkRole: AgentRole = task.role ?? "dev";
-      const reworkAgentCli = (() => {
-        try { return this.registry.getConfig(task.assignedTo).cli; } catch { return undefined; }
-      })();
-      const reworkPrompt = buildReworkPrompt(task, acceptance, reworkAgentCli === "claude");
+      const reworkPrompt = buildReworkPrompt(task, acceptance, this.getAgentCli(task.assignedTo) === "claude");
       if (newSession) {
         const reworkRolePrompt = this.buildSystemRolePrompt(reworkRole, task);
         const session = await this.startRoleSession(
@@ -3630,10 +3633,7 @@ export class Orchestrator {
 
       // Send rework directive to the agent in its original role
       const reworkRole: AgentRole = task.role ?? "dev";
-      const sendBackAgentCli = (() => {
-        try { return this.registry.getConfig(task.assignedTo).cli; } catch { return undefined; }
-      })();
-      const reworkPrompt = buildSendBackPrompt(task, effectiveReason ?? "Main Agent review: sent back for rework", sendBackAgentCli === "claude");
+      const reworkPrompt = buildSendBackPrompt(task, effectiveReason ?? "Main Agent review: sent back for rework", this.getAgentCli(task.assignedTo) === "claude");
       if (newSession) {
         const reworkRolePrompt = this.buildSystemRolePrompt(reworkRole, task);
         const session = await this.startRoleSession(

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -1159,6 +1159,19 @@ if (CODEX_DELEGATION_THRESHOLD <= RESEARCH_CONTEXT_BUDGET_THRESHOLD) {
 const CODEX_SUBAGENT_ID = "codex:codex-rescue";
 
 /**
+ * Compact Codex sub-agent hint for non-research prompts (design, rework, send-back).
+ * Omits the full research protocol to minimise context consumption at session start.
+ * Only injected when the target agent is a Claude Code instance (cli === "claude").
+ */
+function buildCodexHint(): string[] {
+  return [
+    "## Codex Sub-Agent Delegation",
+    `If \`codex@openai-codex\` is installed: delegate to \`${CODEX_SUBAGENT_ID}\` via the Agent tool when your token budget drops below ${CODEX_DELEGATION_THRESHOLD.toLocaleString()} tokens or a task requires scanning 5+ files sequentially.`,
+    "",
+  ];
+}
+
+/**
  * Build a research-role dispatch prompt.
  * Research tasks produce findings/reports, not code commits.
  */
@@ -1168,6 +1181,7 @@ export function buildResearchPrompt(
   maxIterations?: number,
   tokenBudgetHint?: number,
   vaultPath?: string,
+  codexEnabled?: boolean,
 ): string {
   const lines = [
     `# Research Task: ${task.title} [${task.taskId}]`,
@@ -1198,25 +1212,27 @@ export function buildResearchPrompt(
     ...(tokenBudgetHint !== undefined && tokenBudgetHint > 0
       ? [`- **TOKEN_BUDGET: ~${tokenBudgetHint.toLocaleString()} tokens remaining** — wrap up and submit findings before reaching this limit.`]
       : []),
-    "",
-    "## Codex Sub-Agent Delegation",
-    `If the \`codex@openai-codex\` plugin is installed and enabled, use \`${CODEX_SUBAGENT_ID}\` via the Agent tool for token-intensive file scanning.`,
-    "**Delegate when (plugin enabled):**",
-    `- Your token budget drops below ${CODEX_DELEGATION_THRESHOLD.toLocaleString()} tokens AND you still need file scanning`,
-    "- A task requires scanning 5+ files sequentially with Grep/Read",
-    "- You need broad codebase pattern analysis across many directories",
-    "",
-    "**How to delegate (Agent tool call):**",
-    "```",
-    `Agent tool: subagent_type="${CODEX_SUBAGENT_ID}"`,
-    "prompt: \"[RESEARCH PROTOCOL] Evidence-over-claims: report only what you find, not assumptions.",
-    "Search iteratively with multiple patterns before concluding 'not found'.",
-    "Return file:line references for all findings.",
-    "Task: <focused scanning task description>\"",
-    "```",
-    "The sub-agent's usage counts toward your shared Codex budget. Plan delegation conservatively and monitor actual token consumption via runtime feedback.",
-    "Use its output as raw evidence in your Step 1 JSON; you write the final synthesis.",
-    "If the plugin is not installed or the Agent tool call fails, continue with local Grep/Read and narrow scope early to protect remaining budget.",
+    ...(codexEnabled ? [
+      "",
+      "## Codex Sub-Agent Delegation",
+      `If the \`codex@openai-codex\` plugin is installed and enabled, use \`${CODEX_SUBAGENT_ID}\` via the Agent tool for token-intensive file scanning.`,
+      "**Delegate when (plugin enabled):**",
+      `- Your token budget drops below ${CODEX_DELEGATION_THRESHOLD.toLocaleString()} tokens AND you still need file scanning`,
+      "- A task requires scanning 5+ files sequentially with Grep/Read",
+      "- You need broad codebase pattern analysis across many directories",
+      "",
+      "**How to delegate (Agent tool call):**",
+      "```",
+      `Agent tool: subagent_type="${CODEX_SUBAGENT_ID}"`,
+      "prompt: \"[RESEARCH PROTOCOL] Evidence-over-claims: report only what you find, not assumptions.",
+      "Search iteratively with multiple patterns before concluding 'not found'.",
+      "Return file:line references for all findings.",
+      "Task: <focused scanning task description>\"",
+      "```",
+      "The sub-agent's usage counts toward your shared Codex budget. Plan delegation conservatively and monitor actual token consumption via runtime feedback.",
+      "Use its output as raw evidence in your Step 1 JSON; you write the final synthesis.",
+      "If the plugin is not installed or the Agent tool call fails, continue with local Grep/Read and narrow scope early to protect remaining budget.",
+    ] : []),
     "",
     "## CRITICAL: Context Budget Check",
     `Before starting research, check your remaining context window. If it is below ${RESEARCH_CONTEXT_BUDGET_THRESHOLD.toLocaleString()} tokens,`,
@@ -1259,6 +1275,7 @@ export function buildDesignPrompt(
   kbContext?: string,
   tokenBudgetHint?: number,
   vaultPath?: string,
+  codexEnabled?: boolean,
 ): string {
   const lines = [
     `# Design Task: ${task.title} [${task.taskId}]`,
@@ -1283,7 +1300,7 @@ export function buildDesignPrompt(
     ...(tokenBudgetHint !== undefined && tokenBudgetHint > 0
       ? [`- **TOKEN_BUDGET: ~${tokenBudgetHint.toLocaleString()} tokens remaining** — wrap up and submit design before reaching this limit.`]
       : []),
-    "",
+    ...(codexEnabled ? buildCodexHint() : []),
     "## CRITICAL: Context Budget Check",
     `Before starting design work, check your remaining context window. If it is below ${RESEARCH_CONTEXT_BUDGET_THRESHOLD.toLocaleString()} tokens,`,
     "SKIP all design work and go directly to Step 1 to output the JSON summary with what you know.",
@@ -1439,6 +1456,7 @@ function fallbackAcceptanceTemplate(): string {
 export function buildReworkPrompt(
   task: TaskBundle,
   acceptance: AcceptanceBundle,
+  codexEnabled?: boolean,
 ): string {
   const lines: string[] = [];
 
@@ -1484,6 +1502,9 @@ export function buildReworkPrompt(
     lines.push("");
   }
 
+  if (codexEnabled) {
+    lines.push(...buildCodexHint());
+  }
   lines.push("## Instructions");
   lines.push("Address the findings above within your current scope. Do not start from scratch.");
   lines.push("Learn from previous attempts listed in the rework history — do not repeat the same mistakes.");
@@ -1493,7 +1514,7 @@ export function buildReworkPrompt(
 }
 
 /** Build the rework prompt sent to the Dev Agent after Main Agent SEND_BACK decision. */
-export function buildSendBackPrompt(task: TaskBundle, reason: string): string {
+export function buildSendBackPrompt(task: TaskBundle, reason: string, codexEnabled?: boolean): string {
   const lines: string[] = [];
 
   lines.push(`# Rework Required [${task.taskId}]`);
@@ -1545,6 +1566,9 @@ export function buildSendBackPrompt(task: TaskBundle, reason: string): string {
     lines.push("");
   }
 
+  if (codexEnabled) {
+    lines.push(...buildCodexHint());
+  }
   lines.push("## Instructions");
   lines.push("Address the reason stated above. Do not start from scratch.");
   lines.push("Review the task specification and previous receipt to understand what needs to change.");


### PR DESCRIPTION
## Summary
- Extends Codex sub-agent delegation instructions to `buildDesignPrompt`, `buildReworkPrompt`, and `buildSendBackPrompt` (previously research-only)
- Non-research prompts receive a compact 2-line hint to minimise session-start context cost; `buildResearchPrompt` retains the full protocol
- Injection is gated on `cli === "claude"` — non-CC adapters receive no Codex instructions
- `CODEX_DELEGATION_THRESHOLD` and `CODEX_SUBAGENT_ID` constants reused across all builders

## Changes
- `task-manager.ts`: `buildCodexHint()` helper + `codexEnabled?: boolean` param on all four builders; gate existing research section
- `orchestrator.ts`: derive `codexEnabled` from `AgentConfig.cli` at `prepareBundleTaskExecution`, rework, and send-back callsites

## Test plan
- [ ] Build passes with no TypeScript errors
- [ ] Research prompt with CC agent includes full Codex protocol; non-CC agent receives no Codex section
- [ ] Design/rework/send-back prompts with CC agent include compact 2-line hint only
- [ ] Non-CC agents (codex, opencode) receive none of the above

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)