### PR TITLE
fix(orchestrator): research agent bugs — researchScope, getGitDiff, callback delivery, record_receipt

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -366,6 +366,7 @@ export interface TaskBundle {
   failedAt: string | null; // ISO 8601, set by TaskManager when status → failed
   assignedTo: string;
   role?: AgentRole; // Task dispatch role: dev, research, design (default: dev)
+  researchScope?: "deep" | "quick"; // Research depth mode: 'deep' activates the deep-research skill protocol
   assignee?: TaskAssignee; // Agents First: structured agent+model+session metadata
   branch?: string;
 

--- a/packages/orchestrator/src/mcp-server.ts
+++ b/packages/orchestrator/src/mcp-server.ts
@@ -168,6 +168,7 @@ function registerMcpTools(server: McpServer, orchestrator: Orchestrator): void {
       priority: z.enum(["P0", "P1", "P2", "P3"]).optional().describe("Task priority level"),
       assignedTo: agentId.optional().describe("Agent to assign (auto-selected if omitted)"),
       role: z.enum(["dev", "research", "design"]).optional().describe("Task dispatch role (default: dev)"),
+      researchScope: z.enum(["deep", "quick"]).optional().describe("Research depth mode: 'deep' activates the deep-research skill protocol"),
       description: z.string().optional().describe("Detailed task description"),
       context: z.string().describe("Task context for dev agent"),
       codeScope: z.record(z.string(), z.unknown()).optional().describe("Code scope boundaries"),

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -832,11 +832,16 @@ export class Orchestrator {
         return this.getTaskResult(params.taskId as string);
       case "list_tasks":
         return this.taskManager.listTasksAsync(params as { status?: TaskStatus; assignedTo?: string });
-      case "record_receipt":
+      case "record_receipt": {
+        let receipt = params.receipt as ImplementationReceipt;
+        if (typeof receipt === "string") {
+          try { receipt = JSON.parse(receipt) as ImplementationReceipt; } catch { /* keep as-is, will fail downstream */ }
+        }
         return this.recordReceiptAndTriggerReview(
           params.taskId as string,
-          params.receipt as ImplementationReceipt,
+          receipt,
         );
+      }
       case "main_review_result":
         return this.handleMainReviewResult(
           params.taskId as string,
@@ -2619,7 +2624,8 @@ export class Orchestrator {
 
   private async getGitDiff(task: TaskBundle): Promise<string> {
     const reviewConfig = this.getReviewConfig(task);
-    const diffBaseRef = reviewConfig.diffBaseRef ?? "develop...HEAD";
+    const defaultRef = task.branch ? `develop...${task.branch}` : "develop...HEAD";
+    const diffBaseRef = reviewConfig.diffBaseRef ?? defaultRef;
     const maxChars = reviewConfig.diffMaxChars ?? Orchestrator.DEFAULT_REVIEW_DIFF_MAX_CHARS;
     const result = await this.runCommand("git", ["diff", "--no-ext-diff", diffBaseRef], {
       cwd: this.getProjectRoot(),
@@ -3254,13 +3260,10 @@ export class Orchestrator {
    * Called when acceptance result (pass/fail/partial/blocked) is recorded.
    */
   private async deliverTaskCallback(payload: TaskCallbackPayload): Promise<void> {
-    // If originator is an external MCP client, broadcaster already delivered the event.
-    if (payload.originatorSessionId?.startsWith("mcp-http:")) {
-      this.transport.sendNotification("log", {
-        message: `[orchestrator] Task callback for ${payload.taskId} — MCP originator (${payload.originatorSessionId}), relying on broadcaster`,
-      });
-      return;
-    }
+    // Don't early-return for mcp-http originators — the broadcaster delivers
+    // to currently-connected sessions, but if that session is gone, the callback
+    // would be silently dropped. Always enqueue to the crash-safe queue too.
+    // The queue deduplicates, so double-delivery is safe.
 
     // Step 1: Persist to callback queue (crash-safe)
     if (this.shuttingDown) return;

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -833,13 +833,15 @@ export class Orchestrator {
       case "list_tasks":
         return this.taskManager.listTasksAsync(params as { status?: TaskStatus; assignedTo?: string });
       case "record_receipt": {
-        let receipt = params.receipt as ImplementationReceipt;
-        if (typeof receipt === "string") {
-          try { receipt = JSON.parse(receipt) as ImplementationReceipt; } catch { /* keep as-is, will fail downstream */ }
+        const rawReceipt = typeof params.receipt === "string"
+          ? (() => { try { return JSON.parse(params.receipt as string) as unknown; } catch { throw new Error("record_receipt: receipt is not valid JSON"); } })()
+          : params.receipt;
+        if (!rawReceipt || typeof rawReceipt !== "object" || Array.isArray(rawReceipt)) {
+          throw new Error("record_receipt: receipt must be a JSON object");
         }
         return this.recordReceiptAndTriggerReview(
           params.taskId as string,
-          receipt,
+          rawReceipt as ImplementationReceipt,
         );
       }
       case "main_review_result":
@@ -3679,7 +3681,10 @@ export class Orchestrator {
     const mainAgentId = this.findMainAgentId();
     if (!mainAgentId) return;
 
-    const reviewPrompt = buildMainReviewPrompt(task);
+    const reviewConfig = this.getReviewConfig(task);
+    const defaultRef = task.branch ? `develop...${task.branch}` : "develop...HEAD";
+    const diffBaseRef = reviewConfig.diffBaseRef ?? defaultRef;
+    const reviewPrompt = buildMainReviewPrompt(task, diffBaseRef);
     await this.sendPrompt(mainAgentId, reviewPrompt, undefined, "main", task.title, undefined, taskId);
   }
 

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -54,6 +54,7 @@ export interface CreateTaskParams {
   priority: TaskBundle["priority"];
   assignedTo?: string; // Optional: auto-assigned via G9 modelRecommendation if omitted
   role?: string; // Task dispatch role: dev, research, design (default: dev)
+  researchScope?: "deep" | "quick"; // Research depth mode: 'deep' activates the deep-research skill protocol
   branch?: string;
   codeScope: TaskBundle["codeScope"];
   readScope: TaskBundle["readScope"];
@@ -327,6 +328,7 @@ export class TaskManager {
       failedAt: null,
       assignedTo,
       role: requiredRole,
+      researchScope: params.researchScope,
       branch: params.branch,
       codeScope: params.codeScope,
       readScope: {
@@ -1204,6 +1206,11 @@ export function buildResearchPrompt(
     "- Use web search, codebase analysis, and KB resources as needed.",
     "- Produce structured findings with evidence and recommendations.",
     "- No code commits expected.",
+    ...(task.researchScope === "deep" ? [
+      "",
+      "## Deep Research Protocol",
+      "This task requires the `/deep-research` protocol. Type `/deep-research` at the start of your response to activate the Mercury Deep Research Protocol with full multi-round verification.",
+    ] : []),
     ...(maxIterations && maxIterations > 0
       ? [
         `- **MAX_ITERATIONS: ${maxIterations}** — you MUST stop the research loop and submit your findings after at most ${maxIterations} round(s). Do not continue past this limit under any circumstances.`,

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -266,6 +266,13 @@ export class TaskManager {
     if (!params.definitionOfDone?.length) errors.push("definitionOfDone must have at least 1 item");
     if (!params.codeScope) errors.push("codeScope is required");
     if (!params.readScope) errors.push("readScope is required");
+    if (params.researchScope !== undefined) {
+      if (params.researchScope !== "deep" && params.researchScope !== "quick") {
+        errors.push(`researchScope must be "deep" or "quick", got "${params.researchScope}"`);
+      } else if ((params.role ?? "dev") !== "research") {
+        errors.push(`researchScope is only valid for research tasks (role: "${params.role ?? "dev"}")`);
+      }
+    }
     const validPriorities = ["P0", "P1", "P2", "P3", "sev-0", "sev-1", "sev-2", "sev-3"];
     if (!validPriorities.includes(params.priority)) {
       errors.push(`priority must be one of P0, P1, P2, P3, got "${params.priority}"`);
@@ -1601,7 +1608,7 @@ function truncate(content: string, maxLen: number): string {
 }
 
 /** Build the Main Agent review prompt with sanitized pre-checks and diff. */
-export function buildMainReviewPrompt(task: TaskBundle): string {
+export function buildMainReviewPrompt(task: TaskBundle, diffBaseRef = "develop...HEAD"): string {
   const lines: string[] = [];
 
   lines.push(`# Main Agent Review: ${task.title} [${task.taskId}]`);
@@ -1629,7 +1636,7 @@ export function buildMainReviewPrompt(task: TaskBundle): string {
 
   const diffRaw = task.mainReview?.gitDiff?.trim() || "# No diff captured";
   const diffSafe = truncate(sanitizeFenceContent(diffRaw), MAX_DIFF_CHARS);
-  lines.push("## Git Diff (`develop...HEAD`)");
+  lines.push(`## Git Diff (\`${diffBaseRef}\`)`);
   lines.push("```diff");
   lines.push(diffSafe);
   lines.push("```");


### PR DESCRIPTION
## Summary

Four bugs fixed in the research agent and orchestrator review flow:

- **`researchScope` field missing**: `TaskBundle` had no `researchScope` field, so the `/deep-research` skill was never triggered. Added `researchScope?: "deep" | "quick"` to types, MCP schema, `CreateTaskParams`, and `buildResearchPrompt` now injects the `/deep-research` protocol trigger when set to `"deep"`
- **`getGitDiff` always empty for worktree tasks**: Default ref was `develop...HEAD` run from project root where HEAD IS develop. Fixed to use `develop...{task.branch}` when `task.branch` is set — correctly diffs any feature branch regardless of which worktree HEAD points to
- **`deliverTaskCallback` drops callbacks for MCP originators**: Early return for `mcp-http:` sessions relied on broadcaster, but if the session closed before callback fired, it was silently dropped. Removed early return — all callbacks now go through the crash-safe queue
- **`record_receipt` silent type failure**: `params.receipt` cast to `ImplementationReceipt` without runtime check — if a string was sent, stored silently. Added `JSON.parse` normalization with try/catch fallback

## Changes

- `packages/core/src/types.ts`: `researchScope?: "deep" | "quick"` added to `TaskBundle`
- `packages/orchestrator/src/mcp-server.ts`: `researchScope` optional enum field added to `create_task` schema
- `packages/orchestrator/src/task-manager.ts`: `researchScope` in `CreateTaskParams` and passed to task object; `buildResearchPrompt` injects deep-research trigger
- `packages/orchestrator/src/orchestrator.ts`: `getGitDiff` branch-aware default ref; `deliverTaskCallback` early-return removed; `record_receipt` JSON.parse normalization

## Test plan

- [ ] Create research task with `researchScope: "deep"` — prompt should include `/deep-research` trigger text
- [ ] Create dev task with branch name — `getGitDiff` should return non-empty diff
- [ ] Task callback from MCP-originated task reaches Main Agent even after MCP session rotation
- [ ] `record_receipt` with string `receipt` parses correctly

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)