### PR TITLE
fix(orchestrator): robust session restore — null-safe roleSessions + fallback binding (#139)

### DIFF
--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -615,7 +615,8 @@ export class Orchestrator {
       if (this.roleSessions.has(slotKey)) continue; // already restored — don't overwrite
       const existingId = fallbackBindings.get(slotKey);
       const existingTs = existingId ? (this.sessions.get(existingId)?.lastActiveAt ?? 0) : 0;
-      if (!existingId || info.lastActiveAt > existingTs) {
+      const candidateTs = info.lastActiveAt ?? 0;
+      if (!existingId || candidateTs > existingTs) {
         fallbackBindings.set(slotKey, sessionId);
       }
     }

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -588,23 +588,47 @@ export class Orchestrator {
           continue;
         }
         this.sessions.set(sessionId, resumed);
-      } catch {
-        // Session no longer valid — skip silently
+      } catch (err) {
+        // Session no longer resumable — log for diagnostics, skip
+        this.transport.sendNotification("log", {
+          message: `[persist] Skipped session ${sessionId} (${info.frozenRole}): ${err instanceof Error ? err.message : String(err)}`,
+        });
         continue;
       }
     }
 
-    // Restore roleSessions (only for sessions that survived resume)
-    for (const [key, sessionId] of Object.entries(state.roleSessions)) {
+    // Restore roleSessions from persisted map (null-safe: old state files may omit this field)
+    for (const [key, sessionId] of Object.entries(state.roleSessions ?? {})) {
       if (this.sessions.has(sessionId)) {
         this.roleSessions.set(key as RoleSlotKey, sessionId);
       }
     }
 
+    // Fallback: if roleSessions is still empty (old state file or all bindings failed to restore),
+    // auto-bind the most recently active surviving session per role slot so the next send_prompt
+    // reuses prior context instead of starting a fresh session.
+    if (this.roleSessions.size === 0) {
+      for (const [sessionId, info] of this.sessions) {
+        if (!info.frozenRole || (info.status !== "active" && info.status !== "paused")) continue;
+        const slotKey = makeRoleSlotKey(info.frozenRole, info.agentId);
+        const existingId = this.roleSessions.get(slotKey);
+        const existingTs = existingId ? (this.sessions.get(existingId)?.lastActiveAt ?? 0) : 0;
+        if (!existingId || info.lastActiveAt > existingTs) {
+          this.roleSessions.set(slotKey, sessionId);
+        }
+      }
+      if (this.roleSessions.size > 0) {
+        this.transport.sendNotification("log", {
+          message: `[persist] roleSessions absent — auto-bound ${this.roleSessions.size} slot(s) from restored sessions`,
+        });
+      }
+    }
+
     const restored = this.sessions.size;
+    const roleSlotsBound = this.roleSessions.size;
     if (restored > 0) {
       this.transport.sendNotification("log", {
-        message: `[persist] Restored ${restored} session(s) from disk`,
+        message: `[persist] Restored ${restored} session(s), ${roleSlotsBound} role slot(s) from disk`,
       });
     }
     if (approvalsChanged) {

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -604,24 +604,28 @@ export class Orchestrator {
       }
     }
 
-    // Fallback: if roleSessions is still empty (old state file or all bindings failed to restore),
-    // auto-bind the most recently active surviving session per role slot so the next send_prompt
-    // reuses prior context instead of starting a fresh session.
-    if (this.roleSessions.size === 0) {
-      for (const [sessionId, info] of this.sessions) {
-        if (!info.frozenRole || (info.status !== "active" && info.status !== "paused")) continue;
-        const slotKey = makeRoleSlotKey(info.frozenRole, info.agentId);
-        const existingId = this.roleSessions.get(slotKey);
-        const existingTs = existingId ? (this.sessions.get(existingId)?.lastActiveAt ?? 0) : 0;
-        if (!existingId || info.lastActiveAt > existingTs) {
-          this.roleSessions.set(slotKey, sessionId);
-        }
+    // Fallback: for any role slot not already restored above (e.g. old state file missing
+    // roleSessions, or the persisted binding pointed to a session that failed to resume),
+    // auto-bind the most recently active surviving session for that slot so the next
+    // send_prompt reuses prior context instead of starting a fresh session.
+    const fallbackBindings = new Map<RoleSlotKey, string>();
+    for (const [sessionId, info] of this.sessions) {
+      if (!info.frozenRole || (info.status !== "active" && info.status !== "paused")) continue;
+      const slotKey = makeRoleSlotKey(info.frozenRole, info.agentId);
+      if (this.roleSessions.has(slotKey)) continue; // already restored — don't overwrite
+      const existingId = fallbackBindings.get(slotKey);
+      const existingTs = existingId ? (this.sessions.get(existingId)?.lastActiveAt ?? 0) : 0;
+      if (!existingId || info.lastActiveAt > existingTs) {
+        fallbackBindings.set(slotKey, sessionId);
       }
-      if (this.roleSessions.size > 0) {
-        this.transport.sendNotification("log", {
-          message: `[persist] roleSessions absent — auto-bound ${this.roleSessions.size} slot(s) from restored sessions`,
-        });
-      }
+    }
+    for (const [slotKey, sessionId] of fallbackBindings) {
+      this.roleSessions.set(slotKey, sessionId);
+    }
+    if (fallbackBindings.size > 0) {
+      this.transport.sendNotification("log", {
+        message: `[persist] Auto-bound ${fallbackBindings.size} missing role slot(s) from restored sessions`,
+      });
     }
 
     const restored = this.sessions.size;

--- a/packages/orchestrator/src/session-persistence.ts
+++ b/packages/orchestrator/src/session-persistence.ts
@@ -8,7 +8,8 @@ import { join } from "node:path";
 import type { ApprovalMode, ApprovalRequest, SessionInfo } from "@mercury/core";
 
 export interface PersistedSessionState {
-  roleSessions: Record<string, string>;
+  /** Map of roleSlotKey → sessionId. Optional for backward compatibility with older state files. */
+  roleSessions?: Record<string, string>;
   sessions: Record<string, SessionInfo>;
   agentCwds: Record<string, string>;
   approvalMode?: ApprovalMode;


### PR DESCRIPTION
## Summary

Three improvements to `restoreSessions()` in `orchestrator.ts` to prevent session context loss after orchestrator restart (Issue #139):

- **Diagnostic logging on resume failure**: `catch` block was silently skipping sessions that failed `adapter.resumeSession()`; now logs the session ID, frozen role, and error reason so failures are visible in Mercury logs
- **Null-safe `roleSessions` restore**: `Object.entries(state.roleSessions)` throws `TypeError` if the field is absent in old state files (pre-dating this field); added `?? {}` null-coalesce guard for backward compatibility
- **Fallback role-slot binding**: if `roleSessions` is still empty after the primary restore (old state file or all saved bindings pointed to sessions that failed to resume), auto-binds the most recently active surviving session per role slot — so the next `send_prompt` reuses prior conversation context instead of starting a fresh session

Also makes `roleSessions` optional in `PersistedSessionState` interface to reflect that old state files may not have this field.

## Root Cause (Issue #139)

The orchestrator already had session restore logic on startup. The context-loss bug could occur when:
1. State file was written before `roleSessions` was tracked → `Object.entries(undefined)` throws → restore aborts
2. All saved `roleSessions` bindings point to sessions that failed `adapter.resumeSession()` → `roleSessions` stays empty → next `send_prompt` creates a new session

## Test plan

- [ ] Verify TypeScript compiles without new errors (`npx tsc --noEmit`)
- [ ] Verify: after orchestrator restart with a valid state file, `roleSessions` is correctly restored and next `send_prompt` reuses the prior session
- [ ] Verify: after orchestrator restart with a state file lacking `roleSessions`, the fallback auto-binds surviving sessions

Generated with Claude Code