### PR TITLE
feat(orchestrator): native skill engine — BM25 retrieval, 10 seed skills, acceptance capture (#141)

### DIFF
--- a/.agents/skills/TRIGGER-STRATEGY.md
+++ b/.agents/skills/TRIGGER-STRATEGY.md
@@ -7,6 +7,7 @@ This note defines how `.agents/skills/` should use `openai.yaml` in the Codex en
 - `dispatch-task`: `allow_implicit_invocation: false`
 - `acceptance-review`: `allow_implicit_invocation: false`
 - `pr-flow`: `allow_implicit_invocation: false`
+- `dual-verify`: `allow_implicit_invocation: false`
 - `web-research`: `allow_implicit_invocation: true`
 - `deep-research`: `allow_implicit_invocation: true`
 - `sot-workflow`: `allow_implicit_invocation: true`

--- a/.agents/skills/dual-verify/SKILL.md
+++ b/.agents/skills/dual-verify/SKILL.md
@@ -10,32 +10,38 @@ Run a full code audit of the current branch vs develop, produce structured findi
 
 > Platform note: examples use PowerShell syntax. For bash, replace `2>$null` with `2>/dev/null`.
 
-> **Execution path note:** This skill must be invoked via `! codex "..."` in the terminal (interactive mode), **not** via the rescue subagent or MCP tool. Both `codex-rescue` subagent and `mcp__codex__codex` run through `codex-companion.mjs` in headless/unattended mode with `sandbox: "workspace-write"`, which blocks `tsc`, `node`, `pnpm`, and `npx`. The terminal `! codex` path uses Codex CLI interactive mode where each command gets user approval and compilers/interpreters can run.
+> **Role boundary:** Codex handles code logic, style, edge cases, metrics completeness, and Windows compat.
+> TypeScript compilation (`tsc --noEmit`) is Claude Code's responsibility — do not attempt to run it here.
+> Rescue subagent and MCP both operate in headless sandbox; file-reading audit is fully supported.
 
 ## When
 
 - Before marking any PR as ready for merge.
 - When explicitly asked to run dual-verify or parallel review.
-- As a replacement for single-agent code-review when paired with Claude Code.
+- Invoked as rescue subagent in a Claude Code session.
 
 ## Step 1 — Collect diff
 
 ```powershell
 git diff develop...HEAD --stat
-git diff develop...HEAD
+git diff develop...HEAD -- packages/orchestrator/src/
 ```
 
 ## Step 2 — Codex audit
 
-Check the following:
+Read and analyze changed files. Check:
 
-1. **Code style**: naming conventions, consistency, no dead code left in.
-2. **Edge cases**: null/undefined handling, array bounds, empty collection paths.
-3. **Error handling**: all async paths have `.catch()` or try/catch; no swallowed errors except intentional best-effort.
-4. **Metrics completeness**: for skill engine changes — verify all four metric paths (recordSelection, recordApplied, recordCompletion, recordFallback) are wired and called in the correct lifecycle events.
-5. **Package versions**: any new `import` statements — verify package exists and version is accurate via web search.
-6. **Windows/PowerShell compatibility**: no Unix-only shell assumptions in scripts; paths use forward slashes or `join()`.
-7. **Memory leaks**: Maps and Sets populated during task lifecycle are cleaned up on all terminal paths (PASS, FAIL, BLOCKED).
+1. **Code style**: naming conventions, consistency, no dead code or stray debug artifacts.
+2. **Edge cases**: null/undefined handling, empty collection paths, missing guard clauses.
+3. **Error handling**: all async paths have `.catch()` or try/catch; no silently swallowed errors except explicitly labeled best-effort.
+4. **Metrics completeness**: verify all four OpenSpace-compatible metric paths are wired:
+   - `recordSelection()` — called when skill is retrieved for dispatch
+   - `recordApplied()` — called at receipt submission (proxy for "agent used skill")
+   - `recordCompletion()` — called on acceptance PASS
+   - `recordFallback()` — called on terminal failure (maxReworks exceeded or BLOCKED)
+5. **Memory leak**: `injectedSkillsByTask` Map entries deleted on ALL terminal acceptance paths (PASS, FAIL-maxReworks, BLOCKED). Rework cycles intentionally retain entries until terminal state.
+6. **Windows/PowerShell compat**: no Unix-only shell assumptions; paths use `join()` not string concat.
+7. **Package accuracy**: new `import` statements — verify package name and version match codebase expectations.
 
 ## Step 3 — Produce results
 
@@ -49,50 +55,30 @@ Critical: N  High: N  Medium: N  Low: N
 - [HIGH] <description>
 - [MEDIUM] <description>
 
-Overall: PASS | FAIL | NEEDS-CHANGES
+Overall: PASS | NEEDS-CHANGES
 ```
 
-## Step 4 — Fix and mark review
+## Step 4 — Report back
 
-1. Fix Critical and High issues within scope.
-2. Run type-check:
-
-```powershell
-cd packages/orchestrator
-npx tsc --noEmit
-```
-
-3. Mark review complete:
-
-```powershell
-powershell -File scripts/codex/guard.ps1 mark-review
-```
-
-4. Commit and push using git-safe:
-
-```powershell
-powershell -File scripts/codex/git-safe.ps1 commit -Message "fix: <description>"
-powershell -File scripts/codex/git-safe.ps1 push origin feat/<branch>
-```
+Return results to the Claude Code session for consolidation. Do not mark review complete unilaterally.
 
 ## Evidence
 
-Record in receipt:
+When included in receipt:
 
 ```text
-dual-verify: PASS (Codex: PASS, N critical fixed, M high fixed)
+dual-verify/codex: PASS (logic audit clean, metrics wired, memory leak fixed on all paths)
 ```
 
 ## Notes
 
 - Report findings even on PASS so Claude's consolidation has full data.
-- Do not mark the PR ready unilaterally — dual-verify requires both sides to agree.
-- Codex-only findings should be flagged clearly so Claude can cross-reference.
+- Codex-only findings (Windows compat, edge cases, metrics gaps) should be flagged clearly.
+- TypeScript type errors are Claude Code's responsibility — flag only if apparent upon inspection.
 
 ## Fallback
 
-If Claude Code is unavailable or the dual-verify session cannot be coordinated:
-- Run the `auto-verify` skill (Codex built-in quality gate) as the sole reviewer.
+If Claude Code is unavailable:
+- Use the `auto-verify` skill (Codex built-in quality gate) as the sole reviewer.
 - Document in the PR description that dual-verify was attempted but Claude Code was unavailable.
-- `auto-verify` covers type-check, scope, lint, and docstring coverage — use it for low-risk changes.
 - High-risk PRs (orchestrator core, auth, schema changes) should wait for Claude Code availability.

--- a/.agents/skills/dual-verify/SKILL.md
+++ b/.agents/skills/dual-verify/SKILL.md
@@ -86,3 +86,11 @@ dual-verify: PASS (Codex: PASS, N critical fixed, M high fixed)
 - Report findings even on PASS so Claude's consolidation has full data.
 - Do not mark the PR ready unilaterally — dual-verify requires both sides to agree.
 - Codex-only findings should be flagged clearly so Claude can cross-reference.
+
+## Fallback
+
+If Claude Code is unavailable or the dual-verify session cannot be coordinated:
+- Run the `auto-verify` skill (Codex built-in quality gate) as the sole reviewer.
+- Document in the PR description that dual-verify was attempted but Claude Code was unavailable.
+- `auto-verify` covers type-check, scope, lint, and docstring coverage — use it for low-risk changes.
+- High-risk PRs (orchestrator core, auth, schema changes) should wait for Claude Code availability.

--- a/.agents/skills/dual-verify/SKILL.md
+++ b/.agents/skills/dual-verify/SKILL.md
@@ -10,6 +10,8 @@ Run a full code audit of the current branch vs develop, produce structured findi
 
 > Platform note: examples use PowerShell syntax. For bash, replace `2>$null` with `2>/dev/null`.
 
+> **Execution path note:** This skill must be invoked via `! codex "..."` in the terminal (interactive mode), **not** via the rescue subagent or MCP tool. Both `codex-rescue` subagent and `mcp__codex__codex` run through `codex-companion.mjs` in headless/unattended mode with `sandbox: "workspace-write"`, which blocks `tsc`, `node`, `pnpm`, and `npx`. The terminal `! codex` path uses Codex CLI interactive mode where each command gets user approval and compilers/interpreters can run.
+
 ## When
 
 - Before marking any PR as ready for merge.

--- a/.agents/skills/dual-verify/SKILL.md
+++ b/.agents/skills/dual-verify/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: dual-verify
+description: |
+  Run parallel Claude Code deep-review and Codex code-audit, then consolidate findings before marking PR ready. Use instead of auto-verify when doing pre-merge review. Trigger on: "dual verify", "dual-verify", "parallel review", "run dual verify", "双路验证", "双向验证", "并行review", "双路review".
+---
+
+# Dual-Verify (Codex)
+
+Run a full code audit of the current branch vs develop, produce structured findings, and coordinate with the Claude Code deep review.
+
+> Platform note: examples use PowerShell syntax. For bash, replace `2>$null` with `2>/dev/null`.
+
+## When
+
+- Before marking any PR as ready for merge.
+- When explicitly asked to run dual-verify or parallel review.
+- As a replacement for single-agent code-review when paired with Claude Code.
+
+## Step 1 — Collect diff
+
+```powershell
+git diff develop...HEAD --stat
+git diff develop...HEAD
+```
+
+## Step 2 — Codex audit
+
+Check the following:
+
+1. **Code style**: naming conventions, consistency, no dead code left in.
+2. **Edge cases**: null/undefined handling, array bounds, empty collection paths.
+3. **Error handling**: all async paths have `.catch()` or try/catch; no swallowed errors except intentional best-effort.
+4. **Metrics completeness**: for skill engine changes — verify all four metric paths (recordSelection, recordApplied, recordCompletion, recordFallback) are wired and called in the correct lifecycle events.
+5. **Package versions**: any new `import` statements — verify package exists and version is accurate via web search.
+6. **Windows/PowerShell compatibility**: no Unix-only shell assumptions in scripts; paths use forward slashes or `join()`.
+7. **Memory leaks**: Maps and Sets populated during task lifecycle are cleaned up on all terminal paths (PASS, FAIL, BLOCKED).
+
+## Step 3 — Produce results
+
+```text
+## Codex Review Results
+Branch: <branch-name>
+Critical: N  High: N  Medium: N  Low: N
+
+### Findings:
+- [CRITICAL] <description>
+- [HIGH] <description>
+- [MEDIUM] <description>
+
+Overall: PASS | FAIL | NEEDS-CHANGES
+```
+
+## Step 4 — Fix and mark review
+
+1. Fix Critical and High issues within scope.
+2. Run type-check:
+
+```powershell
+cd packages/orchestrator
+npx tsc --noEmit
+```
+
+3. Mark review complete:
+
+```powershell
+powershell -File scripts/codex/guard.ps1 mark-review
+```
+
+4. Commit and push using git-safe:
+
+```powershell
+powershell -File scripts/codex/git-safe.ps1 commit -Message "fix: <description>"
+powershell -File scripts/codex/git-safe.ps1 push origin feat/<branch>
+```
+
+## Evidence
+
+Record in receipt:
+
+```text
+dual-verify: PASS (Codex: PASS, N critical fixed, M high fixed)
+```
+
+## Notes
+
+- Report findings even on PASS so Claude's consolidation has full data.
+- Do not mark the PR ready unilaterally — dual-verify requires both sides to agree.
+- Codex-only findings should be flagged clearly so Claude can cross-reference.

--- a/.agents/skills/dual-verify/openai.yaml
+++ b/.agents/skills/dual-verify/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/.claude/hooks/post-review-flag.sh
+++ b/.claude/hooks/post-review-flag.sh
@@ -4,8 +4,8 @@
 
 INPUT=$(cat)
 
-# Detect review-related tool usage
-if echo "$INPUT" | grep -qi '"review"'; then
+# Detect review-related tool usage (single-agent review or dual-verify)
+if echo "$INPUT" | grep -qi '"review"\|"dual-verify"\|"dual_verify"'; then
   STATE_DIR="$(dirname "$0")/state"
   mkdir -p "$STATE_DIR"
   date -u +%Y-%m-%dT%H:%M:%SZ > "$STATE_DIR/review-passed" 2>/dev/null || echo "flagged" > "$STATE_DIR/review-passed"

--- a/.claude/hooks/pre-commit-guard.sh
+++ b/.claude/hooks/pre-commit-guard.sh
@@ -51,7 +51,7 @@ fi
 
 cat >&2 <<'MSG'
 BLOCKED: Code review required before commit (CLAUDE.md MUST rule).
-Run /code-review or perform a diff-based review first.
+Run /dual-verify (preferred) or /code-review before committing.
 To bypass: touch .claude/hooks/state/review-passed
 MSG
 exit 2

--- a/.claude/skills/dual-verify/skill.md
+++ b/.claude/skills/dual-verify/skill.md
@@ -16,6 +16,12 @@ Run Claude Code deep review and Codex code audit in parallel, then consolidate f
 - As a replacement for single-agent /code-review.
 - Whenever CLAUDE.md requires code review before commit.
 
+## Codex execution path
+
+> **Important:** Codex must be invoked via `! codex "..."` in the terminal — **not** via rescue subagent or MCP.
+> Both `codex-rescue` and `mcp__codex__codex` run in headless sandbox (`workspace-write`) which blocks
+> `tsc`, `node`, `pnpm`, `npx`. The `! codex` terminal path uses interactive mode where compilers can run.
+
 ## Step 1 — Launch parallel reviewers
 
 **Claude Code deep review** (this session):

--- a/.claude/skills/dual-verify/skill.md
+++ b/.claude/skills/dual-verify/skill.md
@@ -16,33 +16,31 @@ Run Claude Code deep review and Codex code audit in parallel, then consolidate f
 - As a replacement for single-agent /code-review.
 - Whenever CLAUDE.md requires code review before commit.
 
-## Codex execution path
+## Division of responsibility
 
-> **Important:** Codex must be invoked via `! codex "..."` in the terminal — **not** via rescue subagent or MCP.
-> Both `codex-rescue` and `mcp__codex__codex` run in headless sandbox (`workspace-write`) which blocks
-> `tsc`, `node`, `pnpm`, `npx`. The `! codex` terminal path uses interactive mode where compilers can run.
+| Responsibility | Owner |
+|----------------|-------|
+| TypeScript `tsc --noEmit` | Claude Code |
+| Architecture / logic / integration correctness | Claude Code |
+| Code style / edge cases / error handling | Codex rescue subagent |
+| Metrics completeness (all 4 paths wired) | Codex rescue subagent |
+| Memory leak (Map cleanup on all terminal paths) | Codex rescue subagent |
+| Windows/PowerShell compat | Codex rescue subagent |
+
+Codex is invoked via `Agent` tool (rescue subagent) — no manual terminal step required.
 
 ## Step 1 — Launch parallel reviewers
 
 **Claude Code deep review** (this session):
-
-Perform a full diff review of the current branch against develop:
 
 ```bash
 git diff develop...HEAD --stat
 git diff develop...HEAD
 ```
 
-Check: TypeScript correctness, logic correctness, integration correctness, OpenSpace schema compliance (for skill engine changes), missing metric paths, memory leaks, security issues.
+Check: TypeScript correctness (run `npx tsc --noEmit`), logic correctness, integration points, OpenSpace schema compliance, missing metric paths, memory leaks.
 
-**Codex audit** (separate session — launch via Agent tool or manually):
-
-```bash
-# Prompt for Codex:
-# "Audit all changes on feat/<branch> vs develop.
-#  Check: code style, edge cases, missing error handling,
-#  metrics completeness, package version accuracy, Windows/PowerShell compat."
-```
+**Codex audit** (rescue subagent — launch via Agent tool with `subagent_type: codex:codex-rescue`):
 
 ## Step 2 — Collect results
 

--- a/.claude/skills/dual-verify/skill.md
+++ b/.claude/skills/dual-verify/skill.md
@@ -89,3 +89,10 @@ dual-verify: PASS (Claude: PASS, Codex: PASS, N issues fixed)
 - Both reviewers must return PASS before proceeding to merge.
 - Fix before merge — do not proceed on a split verdict.
 - Codex surfaces Windows-specific and platform concerns that may not be visible in Claude's review.
+
+## Fallback
+
+If Codex is unavailable or the session cannot be started:
+- Use `/code-review` (Claude Code built-in) as the sole reviewer.
+- Document in the PR description that dual-verify was attempted but Codex was unavailable.
+- This fallback is acceptable for low-risk changes; high-risk PRs (orchestrator core, auth, schema changes) should wait for Codex availability.

--- a/.claude/skills/dual-verify/skill.md
+++ b/.claude/skills/dual-verify/skill.md
@@ -1,0 +1,91 @@
+---
+name: dual-verify
+description: |
+  Run parallel Claude Code deep-review and Codex code-audit, then consolidate findings before marking PR ready. Use instead of /code-review or auto-verify when doing pre-merge review. Trigger on: "dual verify", "dual-verify", "parallel review", "run dual verify", "双路验证", "双向验证", "并行review", "双路review".
+user-invocable: true
+allowed-tools: Bash, Read, Grep, Glob, Agent
+---
+
+# Dual-Verify
+
+Run Claude Code deep review and Codex code audit in parallel, then consolidate findings and mark review complete.
+
+## When
+
+- Before marking any PR as ready for merge.
+- As a replacement for single-agent /code-review.
+- Whenever CLAUDE.md requires code review before commit.
+
+## Step 1 — Launch parallel reviewers
+
+**Claude Code deep review** (this session):
+
+Perform a full diff review of the current branch against develop:
+
+```bash
+git diff develop...HEAD --stat
+git diff develop...HEAD
+```
+
+Check: TypeScript correctness, logic correctness, integration correctness, OpenSpace schema compliance (for skill engine changes), missing metric paths, memory leaks, security issues.
+
+**Codex audit** (separate session — launch via Agent tool or manually):
+
+```bash
+# Prompt for Codex:
+# "Audit all changes on feat/<branch> vs develop.
+#  Check: code style, edge cases, missing error handling,
+#  metrics completeness, package version accuracy, Windows/PowerShell compat."
+```
+
+## Step 2 — Collect results
+
+Each reviewer produces:
+
+```text
+## <Reviewer> Review Results
+Critical: N  High: N  Medium: N  Low: N
+- <finding>
+Overall: PASS | FAIL | NEEDS-CHANGES
+```
+
+## Step 3 — Cross-reference
+
+Produce a consolidated report:
+
+```text
+## Dual-Verify Consolidated Report
+Branch: <branch>
+Claude: PASS | NEEDS-CHANGES
+Codex:  PASS | NEEDS-CHANGES
+
+Agreed Issues: <list or none>
+Claude-only: <list or none>
+Codex-only: <list or none>
+
+Final Verdict: PASS | NEEDS-CHANGES
+```
+
+## Step 4 — Fix, verify, mark complete
+
+1. Fix all Critical + High issues.
+2. Run `auto-verify` (tsc --noEmit, scope, lint).
+3. Set the review-passed flag:
+
+```bash
+touch .claude/hooks/state/review-passed
+```
+
+4. Commit and push.
+
+## Evidence
+
+```text
+dual-verify: PASS (Claude: PASS, Codex: PASS, N issues fixed)
+```
+
+## Rules
+
+- Both reviewers must return PASS before proceeding to merge.
+- Fix before merge — do not proceed on a split verdict.
+- Codex surfaces Windows-specific and platform concerns that may not be visible in Claude's review.

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -15,7 +15,7 @@ MANDATORY: Before writing ANY code that imports an external SDK/API package or r
 6. Never commit or push directly on develop, master, or main
 7. If the current branch is protected or does not match feature/TASK-*, stop and move the work to a task branch before committing
 8. Use `powershell -File scripts/codex/git-safe.ps1 add ...`, `commit -Message "..."`, and `push ...` instead of raw `git add`, `git commit`, or `git push`
-9. Before every commit, complete a code review, invoke the auto-verify skill or equivalent local checks, run `powershell -File scripts/codex/guard.ps1 mark-review`, and then use `powershell -File scripts/codex/git-safe.ps1 commit -Message "..."`
+9. Before every commit on a PR branch, run the dual-verify skill (parallel Claude Code deep-review + Codex code-audit); for minor commits auto-verify is acceptable; then run `powershell -File scripts/codex/guard.ps1 mark-review` and use `powershell -File scripts/codex/git-safe.ps1 commit -Message "..."`
 10. Before every push, use `powershell -File scripts/codex/git-safe.ps1 push ...`; do not target develop, master, or main
 11. On Windows, do not assume Codex hooks will run; use `.codex/rules`, `.codex/config.toml`, repo skills, and `scripts/codex/*.ps1` as the enforcement path
 """

--- a/.mercury/skills/README.md
+++ b/.mercury/skills/README.md
@@ -6,7 +6,7 @@ Skills are automatically injected into agent dispatch prompts at task execution 
 
 ## Directory Structure
 
-```
+```text
 .mercury/skills/
   README.md               — this file
   {skill-name}/

--- a/.mercury/skills/README.md
+++ b/.mercury/skills/README.md
@@ -1,0 +1,67 @@
+# Mercury Skill Library
+
+Operational skill store for the Mercury orchestrator's native skill engine (Issue #141).
+
+Skills are automatically injected into agent dispatch prompts at task execution time, ranked by BM25 relevance to the task context.
+
+## Directory Structure
+
+```
+.mercury/skills/
+  README.md               — this file
+  {skill-name}/
+    SKILL.md              — skill definition (frontmatter + body)
+    .skill_id             — UUID sidecar: {name}__{imp|cap|fix}_{uuid8}
+  pending/
+    {draft-name}/         — captured drafts awaiting Main Agent review
+      SKILL.md
+      .skill_id
+```
+
+## SKILL.md Frontmatter Schema
+
+```yaml
+name: skill-slug-hyphenated          # required
+description: One-sentence for BM25   # required, max 120 chars
+category: TOOL_GUIDE|WORKFLOW|REFERENCE  # required
+roles: [dev, research, main, design, acceptance, critic]  # required (subset)
+origin: IMPORTED|CAPTURED|DERIVED|FIXED  # required
+source_task_id: TASK-xxxx            # required for CAPTURED+
+source_role: dev                     # required for CAPTURED+
+captured_at: ISO8601                 # required for CAPTURED+
+captured_by: acceptance-agent        # required for CAPTURED+
+tags: [tag1, tag2]                   # optional
+generation: 0                        # version DAG depth (0 = root)
+parent_skill_ids: []                 # lineage
+total_selections: 0                  # times BM25-selected for dispatch
+total_applied: 0                     # times agent applied the skill
+total_completions: 0                 # times task passed acceptance with skill
+total_fallbacks: 0                   # times skill injected but not applied
+last_validated_at: ISO8601           # reset on acceptance PASS
+```
+
+## Quality Thresholds
+
+| Metric | Threshold | Action |
+|--------|-----------|--------|
+| `last_validated_at` age | > 90 days | Flagged as STALE at startup |
+| `completion_rate` | < 0.3 with > 5 selections | Flagged as UNDERPERFORMING |
+
+## Lifecycle
+
+1. **IMPORTED** — manually authored seed skills (this directory)
+2. **CAPTURED** — auto-extracted after acceptance PASS, written to `pending/`
+3. **DERIVED** — future: enhanced version of a captured skill
+4. **FIXED** — future: repaired version of an underperforming skill
+
+Pending skills require Main Agent review before activation.
+
+## BM25 Field Weights
+
+| Field | Weight |
+|-------|--------|
+| description | 2.0 |
+| tags | 1.5 |
+| category | 0.5 |
+
+Max 3 skills injected per dispatch (~4500 tokens, ~5% context budget).

--- a/.mercury/skills/acceptance-receipt-check/.skill_id
+++ b/.mercury/skills/acceptance-receipt-check/.skill_id
@@ -1,0 +1,1 @@
+acceptance-receipt-check__imp_a8468fc2

--- a/.mercury/skills/acceptance-receipt-check/SKILL.md
+++ b/.mercury/skills/acceptance-receipt-check/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: acceptance-receipt-check
+description: Acceptance agent must verify ImplementationReceipt fields and evidence before rendering verdict.
+category: TOOL_GUIDE
+roles:
+  - acceptance
+  - main
+origin: IMPORTED
+tags:
+  - acceptance
+  - receipt
+  - verification
+generation: 0
+parent_skill_ids: []
+total_selections: 0
+total_applied: 0
+total_completions: 0
+total_fallbacks: 0
+last_validated_at: 2026-04-04T00:00:00.000Z
+---
+
+# Acceptance Receipt Validation
+
+## Receipt Fields to Verify
+
+Before calling `mcp__mercury-orchestrator__record_acceptance_result`, confirm these ImplementationReceipt fields:
+
+| Field | Check |
+|-------|-------|
+| `implementer` | Non-empty agent ID |
+| `branch` | Matches task bundle `branch` field |
+| `summary` | Non-empty description of what was done |
+| `changedFiles` | Non-empty list matching actual diff |
+| `evidence` | Matches `requiredEvidence` items from task bundle |
+| `docsUpdated` | Covers `docsMustUpdate` list if non-empty |
+| `completedAt` | Valid ISO8601 timestamp |
+
+## DoD Verification
+
+For each item in `definitionOfDone`:
+1. Locate evidence in the receipt or git diff
+2. If not found: verdict = `fail`, include the missing item in findings
+
+## Verdict Rules
+
+- `pass`: ALL DoD items satisfied, ALL required evidence present
+- `partial`: Most DoD items satisfied but minor gaps; include specific gaps in findings
+- `fail`: One or more critical DoD items missing; always include remediation steps
+- `blocked`: External blocker (infra, permissions) prevents completion
+
+## Record After Verdict
+
+After rendering verdict, call `mcp__mercury-orchestrator__record_receipt` to persist:
+- The final verdict
+- Specific findings (what failed or was noted)
+- Recommendations (what the dev agent should fix in rework)

--- a/.mercury/skills/branch-safety-protocol/.skill_id
+++ b/.mercury/skills/branch-safety-protocol/.skill_id
@@ -1,0 +1,1 @@
+branch-safety-protocol__imp_5bb86668

--- a/.mercury/skills/branch-safety-protocol/SKILL.md
+++ b/.mercury/skills/branch-safety-protocol/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: branch-safety-protocol
+description: Dev agents must never switch branches — always stay on the assigned branch and push after every commit.
+category: TOOL_GUIDE
+roles:
+  - dev
+origin: IMPORTED
+tags:
+  - git
+  - branch
+  - safety
+generation: 0
+parent_skill_ids: []
+total_selections: 0
+total_applied: 0
+total_completions: 0
+total_fallbacks: 0
+last_validated_at: 2026-04-04T00:00:00.000Z
+---
+
+# Branch Safety Protocol for Dev Agents
+
+## The Rule
+
+1. **Never switch branches** — work only on the branch specified in the TaskBundle
+2. **Push after every commit** — `git push` immediately after `git commit`
+3. **Verify branch before first commit** — `git branch --show-current`
+
+## Startup Checklist
+
+```bash
+# Verify you are on the correct branch before any writes
+git branch --show-current
+# Expected: <branch from TaskBundle>
+
+# If wrong branch:
+git checkout <correct-branch>
+```
+
+## Commit Loop
+
+```bash
+# After completing a milestone:
+git add <specific-files>   # Never "git add -A" — risks including secrets
+git commit -m "$(cat <<'EOF'
+feat(<scope>): <description>
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+git push
+```
+
+## Why Branch Switching is Forbidden
+
+A prior incident caused workspace regression when a dev agent switched branches mid-task:
+- Uncommitted changes from branch A were mixed with branch B work
+- The resulting PR contaminated unrelated features
+- Required manual revert and re-implementation
+
+## Recovery if You Are on Wrong Branch
+
+1. Do NOT commit anything yet
+2. Stash changes: `git stash`
+3. Switch to correct branch: `git checkout <correct-branch>`
+4. Apply stash: `git stash pop`
+5. Verify changes are on correct branch: `git status`

--- a/.mercury/skills/dispatch-scope-validation/.skill_id
+++ b/.mercury/skills/dispatch-scope-validation/.skill_id
@@ -1,0 +1,1 @@
+dispatch-scope-validation__imp_ed1ca151

--- a/.mercury/skills/dispatch-scope-validation/SKILL.md
+++ b/.mercury/skills/dispatch-scope-validation/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: dispatch-scope-validation
+description: Validate TaskBundle scope fields before dispatching — ensure readScope and allowedWriteScope are correctly populated.
+category: TOOL_GUIDE
+roles:
+  - main
+origin: IMPORTED
+tags:
+  - dispatch
+  - task
+  - scope
+  - validation
+generation: 0
+parent_skill_ids: []
+total_selections: 0
+total_applied: 0
+total_completions: 0
+total_fallbacks: 0
+last_validated_at: 2026-04-04T00:00:00.000Z
+---
+
+# Dispatch Scope Validation
+
+## Required Fields Before Dispatch
+
+Before calling `mcp__mercury-orchestrator__dispatch_task`, verify the TaskBundle has:
+
+1. **readScope.requiredDocs** — list of KB paths the agent must read (non-empty for research/design)
+2. **allowedWriteScope.repoPaths** — list of repo paths the agent may modify
+3. **allowedWriteScope.kbPaths** — list of KB paths the agent may write (required for research/design)
+4. **branch** — target git branch (required for dev tasks)
+5. **definitionOfDone** — non-empty checklist
+
+## Validation Checklist
+
+```
+[ ] taskId is non-empty and unique
+[ ] role is one of: dev, research, design
+[ ] branch is set (dev tasks)
+[ ] readScope.requiredDocs populated (research/design tasks)
+[ ] allowedWriteScope.kbPaths populated (research/design tasks)
+[ ] definitionOfDone has at least one item
+[ ] assignedTo refers to a known agent
+```
+
+## Common Mistakes
+
+- Dispatching research tasks without `kbPaths` → agent cannot write findings
+- Dispatching dev tasks without `branch` → agent commits to wrong branch
+- Empty `definitionOfDone` → acceptance agent has nothing to check
+- Missing `requiredDocs` → agent lacks context, may hallucinate

--- a/.mercury/skills/dispatch-scope-validation/SKILL.md
+++ b/.mercury/skills/dispatch-scope-validation/SKILL.md
@@ -26,14 +26,14 @@ last_validated_at: 2026-04-04T00:00:00.000Z
 Before calling `mcp__mercury-orchestrator__dispatch_task`, verify the TaskBundle has:
 
 1. **readScope.requiredDocs** — list of KB paths the agent must read (non-empty for research/design)
-2. **allowedWriteScope.repoPaths** — list of repo paths the agent may modify
+2. **allowedWriteScope.codePaths** — list of repo paths the agent may modify
 3. **allowedWriteScope.kbPaths** — list of KB paths the agent may write (required for research/design)
 4. **branch** — target git branch (required for dev tasks)
 5. **definitionOfDone** — non-empty checklist
 
 ## Validation Checklist
 
-```
+```text
 [ ] taskId is non-empty and unique
 [ ] role is one of: dev, research, design
 [ ] branch is set (dev tasks)

--- a/.mercury/skills/dual-verify/.skill_id
+++ b/.mercury/skills/dual-verify/.skill_id
@@ -1,0 +1,1 @@
+dual-verify__imp_a1b2c3d4

--- a/.mercury/skills/dual-verify/SKILL.md
+++ b/.mercury/skills/dual-verify/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: dual-verify
+description: Parallel Claude Code deep-review + Codex code-audit before PR readiness; replaces single-agent code-review
+category: WORKFLOW
+roles:
+  - main
+  - dev
+  - acceptance
+origin: IMPORTED
+source_task_id: TASK-141
+source_role: main
+captured_at: 2026-04-04T00:00:00Z
+captured_by: main-agent
+tags:
+  - code-review
+  - verification
+  - parallel
+  - pr
+generation: 0
+parent_skill_ids: []
+total_selections: 0
+total_applied: 0
+total_completions: 0
+total_fallbacks: 0
+last_validated_at: 2026-04-04T00:00:00Z
+---
+
+# Dual-Verify: Parallel Claude + Codex Code Review
+
+Run Claude Code deep review and Codex code audit in parallel, then consolidate findings before marking review complete.
+
+## When
+
+- Before marking any PR as ready for merge.
+- When the task is implementation-complete and you are preparing the final commit batch.
+- As a replacement for single-agent code-review — whenever review is required by CLAUDE.md.
+- On the same branch; no worktree isolation required.
+
+## Workflow
+
+### Step 1 — Launch both reviewers in parallel
+
+**Claude Code** (deep review — architecture, correctness, type safety, OpenSpace schema compliance):
+
+```bash
+# In Claude Code conversation:
+# Ask Claude to perform a deep review of the diff vs develop:
+# "Review all changes on this branch against develop. Check: TypeScript correctness,
+#  logic correctness, integration points, OpenSpace schema compliance, security."
+```
+
+**Codex** (code audit — style, edge cases, metrics completeness, dependency versions):
+
+```bash
+# In Codex session (separate terminal/tab):
+codex "Audit all changes on branch feat/<name> vs develop.
+Check: code style, edge cases, missing error handling,
+metrics completeness, package version accuracy."
+```
+
+### Step 2 — Collect results
+
+Both reviewers produce a structured result block:
+
+```text
+## <Reviewer> Review Results
+Critical: <count>  High: <count>  Medium: <count>  Low: <count>
+<finding-1>
+<finding-2>
+Overall: PASS | FAIL | NEEDS-CHANGES
+```
+
+### Step 3 — Cross-reference findings
+
+Consolidate into a unified report:
+
+```text
+## Dual-Verify Consolidated Report
+Branch: <branch-name>
+Claude: PASS | FAIL | NEEDS-CHANGES
+Codex:  PASS | FAIL | NEEDS-CHANGES
+
+### Agreed Issues (both flagged):
+- <issue>
+
+### Claude-only:
+- <issue>
+
+### Codex-only:
+- <issue>
+
+### Resolution Plan:
+- <action-1>
+- <action-2>
+
+### Final Verdict: PASS | NEEDS-CHANGES
+```
+
+### Step 4 — Fix and mark review
+
+1. Fix all Critical and High issues.
+2. Address or document Medium issues.
+3. Run `auto-verify` to confirm TypeScript and scope pass.
+4. Mark review flag:
+
+```bash
+touch .claude/hooks/state/review-passed
+# or: powershell -File scripts/codex/guard.ps1 mark-review
+```
+
+5. Commit and push.
+
+## Output Evidence
+
+Record in `implementationReceipt.evidence`:
+
+```text
+dual-verify: PASS (Claude: PASS, Codex: PASS, N critical fixed, M high fixed)
+```
+
+## Notes
+
+- Both reviewers must agree on PASS before the PR is marked ready.
+- If one reviewer returns NEEDS-CHANGES, fix before proceeding — do not merge on split verdict.
+- Codex may surface Windows/PowerShell-specific concerns not visible to Claude; always include Codex in the loop.
+- Cross-referencing catches false positives: an issue flagged by only one reviewer should be investigated, not auto-dismissed.

--- a/.mercury/skills/dual-verify/SKILL.md
+++ b/.mercury/skills/dual-verify/SKILL.md
@@ -63,12 +63,13 @@ npx tsc --noEmit  # Claude Code's responsibility
 
 **Codex** (logic audit — style, edge cases, metrics, memory leaks, Windows compat):
 
-```bash
-# Launch via Agent tool with subagent_type: codex:codex-rescue
-# Prompt: "Audit feat/<branch> vs develop. Check: code style, edge cases,
-# metrics completeness (all 4 paths), memory leak cleanup on terminal paths,
-# Windows compat. TypeScript typecheck is not required."
-```
+Invoke the Codex audit agent with this prompt:
+
+> Audit `feat/<branch>` vs `develop`. Check: code style, edge cases,
+> metrics completeness (all 4 paths), memory leak cleanup on terminal paths,
+> Windows compat. TypeScript typecheck is not required.
+
+*(Agent-specific invocation syntax is defined per-agent in `.claude/skills/dual-verify` or `.agents/skills/dual-verify`.)*
 
 ### Step 2 — Collect results
 

--- a/.mercury/skills/dual-verify/SKILL.md
+++ b/.mercury/skills/dual-verify/SKILL.md
@@ -124,3 +124,14 @@ dual-verify: PASS (Claude: PASS, Codex: PASS, N critical fixed, M high fixed)
 - If one reviewer returns NEEDS-CHANGES, fix before proceeding — do not merge on split verdict.
 - Codex may surface Windows/PowerShell-specific concerns not visible to Claude; always include Codex in the loop.
 - Cross-referencing catches false positives: an issue flagged by only one reviewer should be investigated, not auto-dismissed.
+
+## Fallback
+
+If one reviewer is unavailable, fall back to that reviewer's individual skill:
+
+| Unavailable | Fallback |
+|-------------|----------|
+| Codex | Claude Code `/code-review` skill (deep diff review) |
+| Claude Code | Codex `auto-verify` skill (type-check, scope, lint, docstring) |
+
+Document in the PR description that dual-verify was attempted but one side was unavailable. High-risk PRs (orchestrator core, auth, schema changes) should wait for both reviewers.

--- a/.mercury/skills/dual-verify/SKILL.md
+++ b/.mercury/skills/dual-verify/SKILL.md
@@ -38,28 +38,36 @@ Run Claude Code deep review and Codex code audit in parallel, then consolidate f
 
 ## Workflow
 
-> **Codex execution path:** Invoke Codex via `! codex "..."` in terminal (interactive mode), **not** via
-> rescue subagent or MCP. Headless modes (`codex-rescue`, `mcp__codex__codex`) run in `workspace-write`
-> sandbox which blocks `tsc`/`node`/`pnpm`/`npx`. Terminal interactive mode allows compilers to run.
+### Division of responsibility
+
+| Responsibility | Owner |
+|----------------|-------|
+| TypeScript `tsc --noEmit` | Claude Code |
+| Architecture / logic / integration | Claude Code |
+| Code style / edge cases / error handling | Codex (rescue subagent) |
+| Metrics completeness (all 4 paths wired) | Codex (rescue subagent) |
+| Memory leak (Map cleanup on all paths) | Codex (rescue subagent) |
+| Windows/PowerShell compat | Codex (rescue subagent) |
+
+Codex is invoked as rescue subagent — fully automated, no manual terminal step required.
 
 ### Step 1 — Launch both reviewers in parallel
 
-**Claude Code** (deep review — architecture, correctness, type safety, OpenSpace schema compliance):
+**Claude Code** (deep review — TypeScript correctness, architecture, integration, OpenSpace schema):
 
 ```bash
-# In Claude Code conversation:
-# Ask Claude to perform a deep review of the diff vs develop:
-# "Review all changes on this branch against develop. Check: TypeScript correctness,
-#  logic correctness, integration points, OpenSpace schema compliance, security."
+git diff develop...HEAD --stat
+git diff develop...HEAD
+npx tsc --noEmit  # Claude Code's responsibility
 ```
 
-**Codex** (code audit — style, edge cases, metrics completeness, dependency versions):
+**Codex** (logic audit — style, edge cases, metrics, memory leaks, Windows compat):
 
 ```bash
-# In Codex session (separate terminal/tab):
-codex "Audit all changes on branch feat/<name> vs develop.
-Check: code style, edge cases, missing error handling,
-metrics completeness, package version accuracy."
+# Launch via Agent tool with subagent_type: codex:codex-rescue
+# Prompt: "Audit feat/<branch> vs develop. Check: code style, edge cases,
+# metrics completeness (all 4 paths), memory leak cleanup on terminal paths,
+# Windows compat. TypeScript typecheck is not required."
 ```
 
 ### Step 2 — Collect results

--- a/.mercury/skills/dual-verify/SKILL.md
+++ b/.mercury/skills/dual-verify/SKILL.md
@@ -38,6 +38,10 @@ Run Claude Code deep review and Codex code audit in parallel, then consolidate f
 
 ## Workflow
 
+> **Codex execution path:** Invoke Codex via `! codex "..."` in terminal (interactive mode), **not** via
+> rescue subagent or MCP. Headless modes (`codex-rescue`, `mcp__codex__codex`) run in `workspace-write`
+> sandbox which blocks `tsc`/`node`/`pnpm`/`npx`. Terminal interactive mode allows compilers to run.
+
 ### Step 1 — Launch both reviewers in parallel
 
 **Claude Code** (deep review — architecture, correctness, type safety, OpenSpace schema compliance):

--- a/.mercury/skills/git-commit-heredoc-pattern/.skill_id
+++ b/.mercury/skills/git-commit-heredoc-pattern/.skill_id
@@ -1,0 +1,1 @@
+git-commit-heredoc-pattern__imp_476231cf

--- a/.mercury/skills/git-commit-heredoc-pattern/SKILL.md
+++ b/.mercury/skills/git-commit-heredoc-pattern/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: git-commit-heredoc-pattern
+description: Use a HEREDOC to pass multi-line git commit messages, always co-authored with Claude.
+category: TOOL_GUIDE
+roles:
+  - dev
+  - main
+  - research
+  - design
+origin: IMPORTED
+tags:
+  - git
+  - commit
+  - heredoc
+generation: 0
+parent_skill_ids: []
+total_selections: 0
+total_applied: 0
+total_completions: 0
+total_fallbacks: 0
+last_validated_at: 2026-04-04T00:00:00.000Z
+---
+
+# Git Commit with HEREDOC
+
+## Rule
+
+Always use a HEREDOC to pass git commit messages. This prevents shell escaping issues with special characters and ensures the co-author trailer is formatted correctly.
+
+## Template
+
+```bash
+git commit -m "$(cat <<'EOF'
+<type>(<scope>): <subject>
+
+<optional body — explain WHY, not WHAT>
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+## Common Types
+
+- `feat` — new feature
+- `fix` — bug fix
+- `refactor` — restructure without behavior change
+- `docs` — documentation only
+- `chore` — tooling, deps, config
+
+## Anti-Patterns
+
+- Do NOT use `git commit -m "message"` — breaks on quotes and newlines
+- Do NOT use `--no-verify` unless explicitly instructed
+- Do NOT amend published commits — create a new commit instead

--- a/.mercury/skills/git-commit-heredoc-pattern/SKILL.md
+++ b/.mercury/skills/git-commit-heredoc-pattern/SKILL.md
@@ -5,8 +5,6 @@ category: TOOL_GUIDE
 roles:
   - dev
   - main
-  - research
-  - design
 origin: IMPORTED
 tags:
   - git

--- a/.mercury/skills/issue-before-task/.skill_id
+++ b/.mercury/skills/issue-before-task/.skill_id
@@ -1,0 +1,1 @@
+issue-before-task__imp_0a672339

--- a/.mercury/skills/issue-before-task/SKILL.md
+++ b/.mercury/skills/issue-before-task/SKILL.md
@@ -29,7 +29,7 @@ Never create a Task without a corresponding Issue.
 
 ## Flow
 
-```
+```text
 Bug/Feature Identified
   → mcp__mercury-orchestrator__create_issue (type: bug|feature|improvement)
   → Issue triage (assign priority, label)

--- a/.mercury/skills/issue-before-task/SKILL.md
+++ b/.mercury/skills/issue-before-task/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: issue-before-task
+description: Always create a GitHub Issue before creating a Task for any bug or feature — never skip the Issue step.
+category: WORKFLOW
+roles:
+  - main
+origin: IMPORTED
+tags:
+  - issue
+  - workflow
+  - bug
+  - triage
+generation: 0
+parent_skill_ids: []
+total_selections: 0
+total_applied: 0
+total_completions: 0
+total_fallbacks: 0
+last_validated_at: 2026-04-04T00:00:00.000Z
+---
+
+# Issue-Before-Task Workflow
+
+## The Rule
+
+For ANY bug or feature request: **create a GitHub Issue first**, then create a Task linked to that Issue.
+
+Never create a Task without a corresponding Issue.
+
+## Flow
+
+```
+Bug/Feature Identified
+  → mcp__mercury-orchestrator__create_issue (type: bug|feature|improvement)
+  → Issue triage (assign priority, label)
+  → mcp__mercury-orchestrator__create_task (linked to issue)
+  → Dispatch
+```
+
+## create_issue Fields
+
+```json
+{
+  "title": "Short description",
+  "type": "bug|feature|improvement|question",
+  "priority": "P0|P1|P2|P3",
+  "source": { "reporterType": "main", "reporterId": "<agentId>" },
+  "description": {
+    "summary": "One paragraph",
+    "details": "Reproduction steps or context",
+    "evidence": ["<file:line>", "<error message>"]
+  },
+  "linkedTaskIds": []
+}
+```
+
+## Why This Matters
+
+Issues provide:
+1. Tracking — GitHub Issues are visible to the team
+2. Context — future agents can read the issue for background
+3. Triage — priority is set before work starts, not during
+4. Auditability — links task completion back to the reported problem
+
+Skipping the Issue step creates invisible work and makes it impossible to trace why a change was made.

--- a/.mercury/skills/kb-obsidian-access/.skill_id
+++ b/.mercury/skills/kb-obsidian-access/.skill_id
@@ -1,0 +1,1 @@
+kb-obsidian-access__imp_1ca5a6a3

--- a/.mercury/skills/kb-obsidian-access/SKILL.md
+++ b/.mercury/skills/kb-obsidian-access/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: kb-obsidian-access
+description: Access Mercury_KB via Obsidian MCP tools, never via filesystem paths from project CWD.
+category: TOOL_GUIDE
+roles:
+  - main
+  - research
+origin: IMPORTED
+tags:
+  - kb
+  - obsidian
+  - mcp
+generation: 0
+parent_skill_ids: []
+total_selections: 0
+total_applied: 0
+total_completions: 0
+total_fallbacks: 0
+last_validated_at: 2026-04-04T00:00:00.000Z
+---
+
+# Obsidian KB Access Pattern
+
+## Rule
+
+Mercury_KB lives in an Obsidian vault, not in the project directory. Always use Obsidian MCP server tools to read and write KB files. Never construct filesystem paths from project CWD — the vault path is separate.
+
+## Tool Naming
+
+Obsidian MCP tools are prefixed with `mcp__obsidian__`:
+- `mcp__obsidian__read_file` — read a KB file
+- `mcp__obsidian__create_or_update_file` — write a KB file
+- `mcp__obsidian__search` — keyword search across KB
+
+All paths are vault-relative, e.g. `Mercury_KB/04-research/RESEARCH-FOO.md`
+
+## Task Bundle Path
+
+The task bundle JSON is at vault-relative path: `10-tasks/<taskId>.json`
+
+## Anti-Patterns
+
+- Do NOT use the Read tool or readFileSync with Mercury_KB paths
+- Do NOT assume vault path equals project CWD
+- Do NOT write KB files without the correct vault-relative path prefix

--- a/.mercury/skills/pr-coderabbit-flow/.skill_id
+++ b/.mercury/skills/pr-coderabbit-flow/.skill_id
@@ -1,0 +1,1 @@
+pr-coderabbit-flow__imp_3b8b96f8

--- a/.mercury/skills/pr-coderabbit-flow/SKILL.md
+++ b/.mercury/skills/pr-coderabbit-flow/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: pr-coderabbit-flow
+description: Full PR lifecycle — create PR, wait for CodeRabbit review, address all threads, then merge.
+category: WORKFLOW
+roles:
+  - dev
+origin: IMPORTED
+tags:
+  - pr
+  - coderabbit
+  - github
+  - review
+generation: 0
+parent_skill_ids: []
+total_selections: 0
+total_applied: 0
+total_completions: 0
+total_fallbacks: 0
+last_validated_at: 2026-04-04T00:00:00.000Z
+---
+
+# PR → CodeRabbit → Merge Flow
+
+## Steps
+
+1. **Create PR** — target `develop`, not `master`
+   ```bash
+   gh pr create --title "<title>" --body "$(cat <<'EOF'
+   ## Summary
+   - <bullet>
+
+   ## Test plan
+   - [ ] <check>
+
+   🤖 Generated with Claude Code
+   EOF
+   )"
+   ```
+
+2. **Wait for CodeRabbit** — poll every 30s
+   ```bash
+   gh pr checks <PR_NUMBER> --watch
+   ```
+
+3. **Address all threads** — respond to every inline comment and outside-diff comment
+   - Fix code issues in new commits
+   - Reply to informational comments with acknowledgement
+   - Do NOT resolve threads — let the reviewer resolve after your fix
+
+4. **Request re-review** — after all threads are addressed
+   ```bash
+   gh pr review --request-changes --body "Addressed all threads."
+   ```
+
+5. **Merge** — only after CodeRabbit approves (no pending changes)
+   ```bash
+   gh pr merge <PR_NUMBER> --squash --delete-branch
+   ```
+
+## Critical Rules
+
+- NEVER merge before CodeRabbit review completes
+- NEVER force-push to `develop` or `master`
+- NEVER resolve PR threads yourself — that is the reviewer's action
+- Always push after every commit: `git push`

--- a/.mercury/skills/pr-coderabbit-flow/SKILL.md
+++ b/.mercury/skills/pr-coderabbit-flow/SKILL.md
@@ -49,7 +49,7 @@ last_validated_at: 2026-04-04T00:00:00.000Z
 
 4. **Request re-review** — after all threads are addressed
    ```bash
-   gh pr review --request-changes --body "Addressed all threads."
+   gh pr comment <PR_NUMBER> --body "@coderabbitai All threads addressed. Please re-review."
    ```
 
 5. **Merge** — only after CodeRabbit approves (no pending changes)

--- a/.mercury/skills/research-deep-protocol/.skill_id
+++ b/.mercury/skills/research-deep-protocol/.skill_id
@@ -1,0 +1,1 @@
+research-deep-protocol__imp_97cbcac2

--- a/.mercury/skills/research-deep-protocol/SKILL.md
+++ b/.mercury/skills/research-deep-protocol/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: research-deep-protocol
+description: Multi-round deep research protocol — activate with /deep-research, verify all claims via web, output structured JSON summary.
+category: WORKFLOW
+roles:
+  - research
+origin: IMPORTED
+tags:
+  - research
+  - deep-research
+  - protocol
+  - web-verify
+generation: 0
+parent_skill_ids: []
+total_selections: 0
+total_applied: 0
+total_completions: 0
+total_fallbacks: 0
+last_validated_at: 2026-04-04T00:00:00.000Z
+---
+
+# Mercury Deep Research Protocol
+
+## Activation
+
+Type `/deep-research` at the start of your response when the task has `researchScope: "deep"` or when the task requires 3+ research questions, cross-source verification, or architectural decision analysis.
+
+## Protocol Steps
+
+### Step 1 — Context Budget Check
+Before starting, check your remaining context window.
+- If below 20,000 tokens: skip research, output JSON summary with what you know
+- If above 20,000 tokens: proceed with full protocol
+
+### Step 2 — Question Decomposition
+Break the research goal into 3-7 specific questions. For each question:
+- State what claim you are verifying
+- State the authoritative source you will check
+
+### Step 3 — Multi-Round Research
+For each question:
+1. `WebSearch` with current year in query
+2. `WebFetch` on the primary source URL
+3. Cross-check against a second source
+4. Record: claim, source URL, confidence (high/medium/low/unverified)
+
+### Step 4 — Synthesis
+- Group findings by theme
+- Flag contradictions between sources
+- Mark claims that could not be verified as `UNVERIFIED`
+
+### Step 5 — Output JSON Summary (ALWAYS LAST)
+Output the structured summary as your FINAL message before writing to KB.
+
+```json
+{
+  "researcher": "<agent-id>",
+  "summary": "<one paragraph>",
+  "findings": ["<finding 1>", "<finding 2>"],
+  "recommendations": ["<recommendation 1>"],
+  "verification_score": 4.2,
+  "sources": ["<url1>", "<url2>"]
+}
+```
+
+## Quality Gate
+
+`verification_score` is 0-5 scale:
+- 5.0: All claims web-verified against official docs
+- 4.0-4.9: Most claims verified, minor gaps noted
+- 3.0-3.9: Partial verification, some claims marked UNVERIFIED
+- Below 3.0: Too many unverified claims — flag for additional research round

--- a/.mercury/skills/research-deep-protocol/SKILL.md
+++ b/.mercury/skills/research-deep-protocol/SKILL.md
@@ -28,16 +28,19 @@ Type `/deep-research` at the start of your response when the task has `researchS
 ## Protocol Steps
 
 ### Step 1 — Context Budget Check
+
 Before starting, check your remaining context window.
 - If below 20,000 tokens: skip research, output JSON summary with what you know
 - If above 20,000 tokens: proceed with full protocol
 
 ### Step 2 — Question Decomposition
+
 Break the research goal into 3-7 specific questions. For each question:
 - State what claim you are verifying
 - State the authoritative source you will check
 
 ### Step 3 — Multi-Round Research
+
 For each question:
 1. `WebSearch` with current year in query
 2. `WebFetch` on the primary source URL
@@ -45,11 +48,13 @@ For each question:
 4. Record: claim, source URL, confidence (high/medium/low/unverified)
 
 ### Step 4 — Synthesis
+
 - Group findings by theme
 - Flag contradictions between sources
 - Mark claims that could not be verified as `UNVERIFIED`
 
 ### Step 5 — Output JSON Summary (ALWAYS LAST)
+
 Output the structured summary as your FINAL message before writing to KB.
 
 ```json

--- a/.mercury/skills/research-web-verify/.skill_id
+++ b/.mercury/skills/research-web-verify/.skill_id
@@ -1,0 +1,1 @@
+research-web-verify__imp_aefd62ce

--- a/.mercury/skills/research-web-verify/SKILL.md
+++ b/.mercury/skills/research-web-verify/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: research-web-verify
+description: Always verify external SDK/API/CLI claims via WebSearch before writing code or documentation.
+category: TOOL_GUIDE
+roles:
+  - research
+  - dev
+  - main
+origin: IMPORTED
+tags:
+  - web-search
+  - verification
+  - api
+  - sdk
+generation: 0
+parent_skill_ids: []
+total_selections: 0
+total_applied: 0
+total_completions: 0
+total_fallbacks: 0
+last_validated_at: 2026-04-04T00:00:00.000Z
+---
+
+# Web Verification Protocol for External References
+
+## Mandatory Rule
+
+Before writing ANY code or documentation that:
+- Imports an external package
+- References an API method signature
+- Claims a package version number
+- References a CLI flag or command
+
+You MUST run WebSearch or WebFetch against the vendor's official documentation first.
+
+## Protocol
+
+1. **Search**: `WebSearch` with query: `<package-name> npm API <method> <year>`
+2. **Fetch**: `WebFetch` on the official docs URL if available
+3. **Cross-check**: Verify against npm registry page for versions
+4. **Record**: Include source URLs when writing findings to KB
+
+## When You Cannot Verify
+
+If web verification fails (blocked, rate-limited, no results):
+- Mark the claim as `UNVERIFIED` in the KB report
+- Do not write code that depends on the unverified claim
+- Escalate to Main Agent with the uncertainty noted
+
+## Why This Matters
+
+Training data is frozen at a cutoff date. Package APIs change, versions are deprecated, and signatures shift. A single unverified assumption can cascade into hours of debugging for the dev agent.

--- a/.mercury/skills/rework-context-preservation/.skill_id
+++ b/.mercury/skills/rework-context-preservation/.skill_id
@@ -1,0 +1,1 @@
+rework-context-preservation__imp_8e1cc942

--- a/.mercury/skills/rework-context-preservation/SKILL.md
+++ b/.mercury/skills/rework-context-preservation/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: rework-context-preservation
+description: During rework, address only acceptance findings and preserve all passing work without scope creep.
+category: WORKFLOW
+roles:
+  - dev
+origin: IMPORTED
+tags:
+  - rework
+  - acceptance
+  - context
+generation: 0
+parent_skill_ids: []
+total_selections: 0
+total_applied: 0
+total_completions: 0
+total_fallbacks: 0
+last_validated_at: 2026-04-04T00:00:00.000Z
+---
+
+# Rework Context Preservation
+
+## Situation
+
+You received a rework request (acceptance verdict: `fail` or `partial`). Your task is to fix ONLY the identified gaps without undoing passing work.
+
+## Protocol
+
+1. **Read the findings list** — each item is a specific gap needing a fix
+2. **Read the recommendations** — suggested remediation steps by the acceptance agent
+3. **Check what already passed** — do NOT modify accepted code
+4. **Fix the gaps** — targeted changes only
+5. **Re-verify** — confirm each finding is addressed before committing
+
+## Rework Commit Template
+
+```bash
+git commit -m "$(cat <<'EOF'
+fix(<scope>): address acceptance findings — <brief description>
+
+Findings addressed:
+- <finding 1>
+- <finding 2>
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+git push
+```
+
+## Anti-Patterns
+
+- Do NOT refactor passing code during rework — acceptance may fail on different grounds
+- Do NOT skip reading the findings — guessing wastes cycles
+- Do NOT add new features during rework — scope creep causes re-rejection
+- Do NOT commit without addressing every finding in the list
+
+## Receipt Update
+
+When submitting the rework receipt, reference each finding by index:
+```
+evidence: ["Finding 1: fixed in src/foo.ts:42", "Finding 2: added test in test/bar.test.ts"]
+```

--- a/Mercury_KB/08-skills/INDEX.md
+++ b/Mercury_KB/08-skills/INDEX.md
@@ -1,0 +1,61 @@
+# Mercury Skill Library — Index
+
+**Section**: 08-skills  
+**Created**: 2026-04-04  
+**Maintained by**: Main Agent  
+**Implementation**: Issue #141
+
+This section stores the KB mirror of all active Mercury skills. The operational skill store lives in `.mercury/skills/` — these KB entries provide long-term archival, Obsidian search indexing, and human review.
+
+---
+
+## Active Skills
+
+| Skill | Category | Roles | Origin | Generation |
+|-------|----------|-------|--------|------------|
+| [git-commit-heredoc-pattern](git-commit-heredoc-pattern.md) | TOOL_GUIDE | dev, main, research, design | IMPORTED | 0 |
+| [pr-coderabbit-flow](pr-coderabbit-flow.md) | WORKFLOW | dev | IMPORTED | 0 |
+| [kb-obsidian-access](kb-obsidian-access.md) | TOOL_GUIDE | main, research | IMPORTED | 0 |
+| [dispatch-scope-validation](dispatch-scope-validation.md) | TOOL_GUIDE | main | IMPORTED | 0 |
+| [research-web-verify](research-web-verify.md) | TOOL_GUIDE | research, dev, main | IMPORTED | 0 |
+| [acceptance-receipt-check](acceptance-receipt-check.md) | TOOL_GUIDE | acceptance, main | IMPORTED | 0 |
+| [branch-safety-protocol](branch-safety-protocol.md) | TOOL_GUIDE | dev | IMPORTED | 0 |
+| [issue-before-task](issue-before-task.md) | WORKFLOW | main | IMPORTED | 0 |
+| [rework-context-preservation](rework-context-preservation.md) | WORKFLOW | dev | IMPORTED | 0 |
+| [research-deep-protocol](research-deep-protocol.md) | WORKFLOW | research | IMPORTED | 0 |
+
+## Pending Review
+
+Skills captured after acceptance PASS are written to `.mercury/skills/pending/` by the skill capturer. Main Agent reviews and promotes them to active status.
+
+| File | Source Task | Captured At |
+|------|-------------|-------------|
+| _(none yet)_ | | |
+
+---
+
+## Structure
+
+```
+Mercury_KB/08-skills/
+  INDEX.md                        — this file
+  {skill-name}.md                 — KB mirror of each active skill
+.mercury/skills/
+  {skill-name}/
+    SKILL.md                      — operational skill (loaded by SkillRegistry)
+    .skill_id                     — UUID sidecar
+  pending/
+    {draft-name}/
+      SKILL.md                    — draft, pending Main Agent review
+      .skill_id
+```
+
+## Quality Metrics Legend
+
+Skills in `.mercury/skills/` track:
+- `total_selections`: times injected into a dispatch prompt
+- `total_completions`: times the task passed acceptance while skill was injected
+- `total_fallbacks`: times the skill was injected but task did not use it
+- `completion_rate` = total_completions / total_applied
+- Staleness: skills with `last_validated_at` older than 90 days are flagged at startup
+- Underperforming: skills with completion_rate < 0.3 and > 5 selections are flagged

--- a/packages/orchestrator/package.json
+++ b/packages/orchestrator/package.json
@@ -9,7 +9,9 @@
     "@mercury/sdk-adapters": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "better-sqlite3": "12.8.0",
+    "fast-bm25": "^0.0.5",
     "js-yaml": "^4.1.1",
+    "write-file-atomic": "^7.0.1",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -34,6 +34,9 @@ import type {
 import { AgentRegistry } from "./agent-registry.js";
 import type { KnowledgeService } from "./knowledge-service.js";
 import type { RpcTransport } from "./rpc-transport.js";
+import { SkillRegistry } from "./skill-registry.js";
+import type { SkillMeta } from "./skill-registry.js";
+import { SkillCapturer } from "./skill-capturer.js";
 import {
   TaskManager,
   buildDevPrompt,
@@ -135,6 +138,12 @@ export class Orchestrator {
   private sharedContext: string = "";
   /** Cached role-only context built from obsidian.roleContextFiles[role]. */
   private roleContexts: Partial<Record<RoleContextKey, string>> = {};
+  /** Skill registry — BM25 index of accumulated agent skills in .mercury/skills/. */
+  private skillRegistry: SkillRegistry = new SkillRegistry();
+  /** Skill capturer — writes draft skills to .mercury/skills/pending/ after acceptance PASS. */
+  private skillCapturer: SkillCapturer | null = null;
+  /** Skills injected per task (taskId → skill names), for post-task metric recording. */
+  private injectedSkillsByTask = new Map<string, string[]>();
 
   constructor(
     registry: AgentRegistry,
@@ -266,9 +275,43 @@ export class Orchestrator {
     await this.recoverOrphanedTasks();
     // Build and inject shared context from KB if autoInjectContext is enabled
     await this.buildAndInjectContext();
+    // Initialize skill registry — scan .mercury/skills/ and build BM25 index
+    await this.initSkillRegistry();
   }
 
   private shuttingDown = false;
+
+  /**
+   * Initialize skill registry: scan .mercury/skills/, build BM25 index, log stale skills.
+   * Also initializes the skill capturer for post-acceptance-pass capture.
+   */
+  private async initSkillRegistry(): Promise<void> {
+    const skillDir = join(this.getProjectRoot(), ".mercury", "skills");
+    try {
+      await this.skillRegistry.init(skillDir);
+
+      this.skillCapturer = new SkillCapturer(skillDir);
+
+      const staleSkills = this.skillRegistry.listSkills().filter((s) => s.staleness);
+      if (staleSkills.length > 0) {
+        this.transport.sendNotification("log", {
+          message: `[skill-registry] ${staleSkills.length} skill(s) flagged: ${
+            staleSkills.map((s) => `${s.name}(${s.staleness})`).join(", ")
+          }`,
+        });
+      }
+
+      const total = this.skillRegistry.listSkills().length;
+      this.transport.sendNotification("log", {
+        message: `[skill-registry] Loaded ${total} skill(s) from ${skillDir}`,
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.transport.sendNotification("log", {
+        message: `[skill-registry] Init failed (non-fatal): ${msg}`,
+      });
+    }
+  }
 
   /** Graceful shutdown — quiesce drain, clean up queue, close SQLite. */
   async shutdown(): Promise<void> {
@@ -2956,15 +2999,32 @@ export class Orchestrator {
     // Determine if the assigned agent is a Claude Code instance (codex plugin is CC-only)
     const codexEnabled = this.getAgentCli(task.assignedTo) === "claude";
 
+    // Retrieve relevant skills (max 3) for dev/research roles, inject body into _body field
+    let relevantSkills: SkillMeta[] | undefined;
+    if (this.skillRegistry.isReady() && (role === "dev" || role === "research")) {
+      const query = `${task.title} ${task.context.slice(0, 300)}`;
+      const rawSkills = this.skillRegistry.searchSkills(query, [role], 3);
+      if (rawSkills.length > 0) {
+        relevantSkills = await Promise.all(
+          rawSkills.map(async (s) => {
+            const body = await this.skillRegistry.loadSkillBody(s).catch(() => "");
+            this.skillRegistry.recordSelection(s.name);
+            return { ...s, _body: body } as SkillMeta & { _body: string };
+          }),
+        );
+        this.injectedSkillsByTask.set(task.taskId, rawSkills.map((s) => s.name));
+      }
+    }
+
     // Build role-appropriate prompt
     let prompt: string;
     if (role === "research") {
       const maxIterations = this.projectConfig?.research?.maxIterations;
-      prompt = buildResearchPrompt(task, kbContext, maxIterations, tokenBudgetHint, this.projectConfig?.obsidian?.vaultPath ?? undefined, codexEnabled);
+      prompt = buildResearchPrompt(task, kbContext, maxIterations, tokenBudgetHint, this.projectConfig?.obsidian?.vaultPath ?? undefined, codexEnabled, relevantSkills);
     } else if (role === "design") {
       prompt = buildDesignPrompt(task, kbContext, tokenBudgetHint, this.projectConfig?.obsidian?.vaultPath ?? undefined, codexEnabled);
     } else {
-      prompt = buildDevPrompt(task, kbContext, this.getProjectRoot());
+      prompt = buildDevPrompt(task, kbContext, this.getProjectRoot(), relevantSkills);
     }
 
     return {
@@ -3572,6 +3632,23 @@ export class Orchestrator {
       // Acceptance passed → verified → closed
       this.taskManager.transitionTask(task.taskId, "verified", acceptance.acceptor);
       this.taskManager.transitionTask(task.taskId, "closed", "orchestrator");
+
+      // Update skill completion metrics for skills injected into this task's dispatch
+      const injectedSkills = this.injectedSkillsByTask.get(task.taskId);
+      if (injectedSkills && injectedSkills.length > 0) {
+        for (const skillName of injectedSkills) {
+          this.skillRegistry.recordCompletion(skillName);
+        }
+        this.injectedSkillsByTask.delete(task.taskId);
+      }
+
+      // Post-acceptance capture: extract reusable skill patterns (fire-and-forget, non-blocking)
+      const receipt = task.implementationReceipt;
+      if (receipt && this.skillCapturer) {
+        const capturer = this.skillCapturer;
+        const gitDiff = task.mainReview?.gitDiff;
+        void capturer.captureFromAcceptancePass({ task, receipt, gitDiff }).catch(() => {});
+      }
 
       // Callback to Main Agent
       this.bus.emit(

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -2314,10 +2314,21 @@ export class Orchestrator {
         message: `[task] Research fast-track failed for ${task.taskId} at status ${this.taskManager.getTask(task.taskId)?.status ?? "unknown"}: ${err instanceof Error ? err.message : err}`,
       });
       try { this.taskManager.transitionTask(task.taskId, "failed", agentId); } catch { /* already terminal */ }
+      this.injectedSkillsByTask.delete(task.taskId); // clean up on fast-track failure
       return;
     }
 
-    // Emit callback so originator is notified; reworkTriggered: false distinguishes closed fast-track from rework
+    // Record skill metrics (research bypasses review/acceptance cycle, so update here)
+    const researchSkills = this.injectedSkillsByTask.get(task.taskId);
+    if (researchSkills && researchSkills.length > 0) {
+      for (const skillName of researchSkills) {
+        this.skillRegistry.recordApplied(skillName);
+        this.skillRegistry.recordCompletion(skillName);
+      }
+      this.injectedSkillsByTask.delete(task.taskId);
+    }
+
+    // Emit callback so originator is notified
     this.bus.emit("orchestrator.task.callback", agentId, "orchestrator", {
       taskId: task.taskId,
       originatorSessionId: task.originatorSessionId,
@@ -2412,10 +2423,21 @@ export class Orchestrator {
         message: `[task] Design fast-track failed for ${task.taskId} at status ${this.taskManager.getTask(task.taskId)?.status ?? "unknown"}: ${err instanceof Error ? err.message : err}`,
       });
       try { this.taskManager.transitionTask(task.taskId, "failed", agentId); } catch { /* already terminal */ }
+      this.injectedSkillsByTask.delete(task.taskId); // clean up on fast-track failure
       return;
     }
 
-    // Emit callback so originator is notified; reworkTriggered: false distinguishes closed fast-track from rework
+    // Record skill metrics (design bypasses review/acceptance cycle, so update here)
+    const designSkills = this.injectedSkillsByTask.get(task.taskId);
+    if (designSkills && designSkills.length > 0) {
+      for (const skillName of designSkills) {
+        this.skillRegistry.recordApplied(skillName);
+        this.skillRegistry.recordCompletion(skillName);
+      }
+      this.injectedSkillsByTask.delete(task.taskId);
+    }
+
+    // Emit callback so originator is notified
     this.bus.emit("orchestrator.task.callback", agentId, "orchestrator", {
       taskId: task.taskId,
       originatorSessionId: task.originatorSessionId,
@@ -3791,11 +3813,14 @@ export class Orchestrator {
   ): Promise<TaskBundle> {
     const task = this.taskManager.recordReceipt(taskId, receipt);
 
-    // Record applied metric: receipt submission = agent completed task with skills in context
-    const injectedSkillsAtReceipt = this.injectedSkillsByTask.get(taskId);
-    if (injectedSkillsAtReceipt && injectedSkillsAtReceipt.length > 0) {
-      for (const skillName of injectedSkillsAtReceipt) {
-        this.skillRegistry.recordApplied(skillName);
+    // Record applied metric on first receipt only — rework receipts (reworkCount > 0) skip this
+    // because skills are not re-injected into rework prompts (especially true for newSession reworks).
+    if ((task.reworkCount ?? 0) === 0) {
+      const injectedSkillsAtReceipt = this.injectedSkillsByTask.get(taskId);
+      if (injectedSkillsAtReceipt && injectedSkillsAtReceipt.length > 0) {
+        for (const skillName of injectedSkillsAtReceipt) {
+          this.skillRegistry.recordApplied(skillName);
+        }
       }
     }
 
@@ -3879,7 +3904,14 @@ export class Orchestrator {
       );
 
       if (!reworked) {
-        // maxReworks exceeded — task transitioned to failed
+        // maxReworks exceeded — task transitioned to failed; record fallback and clean up
+        const sendBackFailedSkills = this.injectedSkillsByTask.get(taskId);
+        if (sendBackFailedSkills) {
+          for (const skillName of sendBackFailedSkills) {
+            this.skillRegistry.recordFallback(skillName);
+          }
+          this.injectedSkillsByTask.delete(taskId);
+        }
         return { decision: effectiveDecision, nextAction: "failed_max_reworks" };
       }
 

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -2971,6 +2971,7 @@ export class Orchestrator {
     prompt: string;
     rolePrompt: string;
     baseRolePrompt: string;
+    injectedSkillNames: string[];
   }> {
     const task = await this.taskManager.getTaskAsync(taskId);
     if (!task) throw new Error(`Task not found: ${taskId}`);
@@ -3035,18 +3036,23 @@ export class Orchestrator {
 
     // Retrieve relevant skills (max 3) for dev/research roles and build SkillInjection objects
     let relevantSkills: SkillInjection[] | undefined;
+    let injectedSkillNames: string[] = [];
     if (this.skillRegistry.isReady() && (role === "dev" || role === "research")) {
       const query = `${task.title} ${task.context.slice(0, 300)}`;
       const rawSkills = this.skillRegistry.searchSkills(query, [role], 3);
       if (rawSkills.length > 0) {
-        relevantSkills = await Promise.all(
+        // Filter out skills whose body fails to load — don't record or inject them
+        const loaded = await Promise.all(
           rawSkills.map(async (s) => {
             const body = await this.skillRegistry.loadSkillBody(s).catch(() => "");
-            this.skillRegistry.recordSelection(s.name);
-            return { ...s, body } satisfies SkillInjection;
+            return body ? ({ ...s, body } satisfies SkillInjection) : null;
           }),
         );
-        this.injectedSkillsByTask.set(task.taskId, rawSkills.map((s) => s.name));
+        relevantSkills = loaded.filter((s): s is SkillInjection => s !== null);
+        for (const skill of relevantSkills) {
+          this.skillRegistry.recordSelection(skill.name);
+        }
+        injectedSkillNames = relevantSkills.map((s) => s.name);
       }
     }
 
@@ -3066,6 +3072,7 @@ export class Orchestrator {
       prompt,
       rolePrompt: this.buildSystemRolePrompt(role, task, tokenBudgetHint),
       baseRolePrompt: this.buildSystemRolePrompt(role),
+      injectedSkillNames,
     };
   }
 
@@ -3089,8 +3096,11 @@ export class Orchestrator {
       };
     }
 
-    const { task, prompt, rolePrompt, baseRolePrompt } =
+    const { task, prompt, rolePrompt, baseRolePrompt, injectedSkillNames } =
       await this.prepareBundleTaskExecution(taskId);
+    if (injectedSkillNames.length > 0) {
+      this.injectedSkillsByTask.set(task.taskId, injectedSkillNames);
+    }
     const agentId = task.assignedTo;
     const role: AgentRole = task.role ?? "dev";
     const adapter = this.registry.getAdapter(agentId);
@@ -3256,7 +3266,7 @@ export class Orchestrator {
         // This try/catch only catches synchronous failures (session creation,
         // state transitions). Streaming failures trigger G2 crash recovery
         // in streamMessages() catch handler — automatic re-dispatch.
-        const { task: freshTask, prompt, rolePrompt } = await this.prepareBundleTaskExecution(taskId);
+        const { task: freshTask, prompt, rolePrompt, injectedSkillNames } = await this.prepareBundleTaskExecution(taskId);
         const role: AgentRole = freshTask.role ?? "dev";
 
         // Transition: drafted → dispatched → in_progress
@@ -3266,6 +3276,10 @@ export class Orchestrator {
 
         // Start role-scoped session for assigned agent
         const session = await this.startRoleSession(freshTask.assignedTo, role, freshTask.title, rolePrompt);
+        // Record injected skills only after session is confirmed started
+        if (injectedSkillNames.length > 0) {
+          this.injectedSkillsByTask.set(freshTask.taskId, injectedSkillNames);
+        }
         this.taskManager.bindSession(taskId, session.sessionId);
 
         // Transition to in_progress (only if not already there)

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -271,12 +271,12 @@ export class Orchestrator {
 
     await this.taskManager.init();
     await this.restoreSessions();
-    // G2: Detect orphaned in-progress tasks and queue re-dispatch
-    await this.recoverOrphanedTasks();
+    // Initialize skill registry before orphan recovery so re-dispatched tasks get skill injection
+    await this.initSkillRegistry();
     // Build and inject shared context from KB if autoInjectContext is enabled
     await this.buildAndInjectContext();
-    // Initialize skill registry — scan .mercury/skills/ and build BM25 index
-    await this.initSkillRegistry();
+    // G2: Detect orphaned in-progress tasks and queue re-dispatch
+    await this.recoverOrphanedTasks();
   }
 
   private shuttingDown = false;

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -35,7 +35,7 @@ import { AgentRegistry } from "./agent-registry.js";
 import type { KnowledgeService } from "./knowledge-service.js";
 import type { RpcTransport } from "./rpc-transport.js";
 import { SkillRegistry } from "./skill-registry.js";
-import type { SkillMeta } from "./skill-registry.js";
+import type { SkillInjection } from "./skill-registry.js";
 import { SkillCapturer } from "./skill-capturer.js";
 import {
   TaskManager,
@@ -291,6 +291,18 @@ export class Orchestrator {
       await this.skillRegistry.init(skillDir);
 
       this.skillCapturer = new SkillCapturer(skillDir);
+
+      // Wire LLMCaller lazily: resolves main agent at call time (after sessions established)
+      // Uses executeOneShot — same pattern as DoD pre-verification (orchestrator.ts:verifyDoDAtCompletion)
+      this.skillCapturer.setLLMCaller(async (prompt: string): Promise<string> => {
+        const mainAgentId = this.findMainAgentId();
+        if (!mainAgentId) return "[]";
+        const adapter = this.registry.getAdapter(mainAgentId);
+        if (!adapter.executeOneShot) return "[]";
+        const cwd = this.agentCwds.get(mainAgentId) ?? process.cwd();
+        const result = await adapter.executeOneShot(prompt, cwd);
+        return result.finalMessage ?? "[]";
+      });
 
       const staleSkills = this.skillRegistry.listSkills().filter((s) => s.staleness);
       if (staleSkills.length > 0) {
@@ -2999,8 +3011,8 @@ export class Orchestrator {
     // Determine if the assigned agent is a Claude Code instance (codex plugin is CC-only)
     const codexEnabled = this.getAgentCli(task.assignedTo) === "claude";
 
-    // Retrieve relevant skills (max 3) for dev/research roles, inject body into _body field
-    let relevantSkills: SkillMeta[] | undefined;
+    // Retrieve relevant skills (max 3) for dev/research roles and build SkillInjection objects
+    let relevantSkills: SkillInjection[] | undefined;
     if (this.skillRegistry.isReady() && (role === "dev" || role === "research")) {
       const query = `${task.title} ${task.context.slice(0, 300)}`;
       const rawSkills = this.skillRegistry.searchSkills(query, [role], 3);
@@ -3009,7 +3021,7 @@ export class Orchestrator {
           rawSkills.map(async (s) => {
             const body = await this.skillRegistry.loadSkillBody(s).catch(() => "");
             this.skillRegistry.recordSelection(s.name);
-            return { ...s, _body: body } as SkillMeta & { _body: string };
+            return { ...s, body } satisfies SkillInjection;
           }),
         );
         this.injectedSkillsByTask.set(task.taskId, rawSkills.map((s) => s.name));
@@ -3647,7 +3659,11 @@ export class Orchestrator {
       if (receipt && this.skillCapturer) {
         const capturer = this.skillCapturer;
         const gitDiff = task.mainReview?.gitDiff;
-        void capturer.captureFromAcceptancePass({ task, receipt, gitDiff }).catch(() => {});
+        void capturer.captureFromAcceptancePass({ task, receipt, gitDiff }).catch((err: unknown) => {
+          void this.transport.sendNotification("log", {
+            message: `[skill-capturer] capture failed: ${err instanceof Error ? err.message : String(err)}`,
+          });
+        });
       }
 
       // Callback to Main Agent
@@ -3677,7 +3693,14 @@ export class Orchestrator {
       );
 
       if (!reworked) {
-        // maxReworks exceeded — task transitioned to failed
+        // maxReworks exceeded — task transitioned to failed; record fallback and clean up map
+        const failedSkills = this.injectedSkillsByTask.get(task.taskId);
+        if (failedSkills) {
+          for (const skillName of failedSkills) {
+            this.skillRegistry.recordFallback(skillName);
+          }
+          this.injectedSkillsByTask.delete(task.taskId);
+        }
         return { verdict: results.verdict, reworkTriggered: false, newSession: false };
       }
 
@@ -3726,6 +3749,15 @@ export class Orchestrator {
     if (results.verdict === "blocked") {
       this.taskManager.transitionTask(task.taskId, "blocked", acceptance.acceptor);
 
+      // Record fallback and clean up injected skills map
+      const blockedSkills = this.injectedSkillsByTask.get(task.taskId);
+      if (blockedSkills) {
+        for (const skillName of blockedSkills) {
+          this.skillRegistry.recordFallback(skillName);
+        }
+        this.injectedSkillsByTask.delete(task.taskId);
+      }
+
       // Callback to Main Agent for blocked
       this.bus.emit(
         "orchestrator.task.callback",
@@ -3758,6 +3790,15 @@ export class Orchestrator {
     receipt: ImplementationReceipt,
   ): Promise<TaskBundle> {
     const task = this.taskManager.recordReceipt(taskId, receipt);
+
+    // Record applied metric: receipt submission = agent completed task with skills in context
+    const injectedSkillsAtReceipt = this.injectedSkillsByTask.get(taskId);
+    if (injectedSkillsAtReceipt && injectedSkillsAtReceipt.length > 0) {
+      for (const skillName of injectedSkillsAtReceipt) {
+        this.skillRegistry.recordApplied(skillName);
+      }
+    }
+
     const preChecks = await this.runPreChecks(task);
     const gitDiff = await this.getGitDiff(task);
 

--- a/packages/orchestrator/src/skill-capturer.ts
+++ b/packages/orchestrator/src/skill-capturer.ts
@@ -215,6 +215,8 @@ function parsePatterns(response: string): ExtractedPattern[] {
         typeof p["description"] === "string" &&
         typeof p["category"] === "string" &&
         Array.isArray(p["roles"]) &&
+        (p["roles"] as unknown[]).length > 0 &&
+        (p["roles"] as unknown[]).every((r) => typeof r === "string") &&
         typeof p["body"] === "string"
       );
     });

--- a/packages/orchestrator/src/skill-capturer.ts
+++ b/packages/orchestrator/src/skill-capturer.ts
@@ -1,0 +1,235 @@
+/**
+ * Mercury Skill Capturer — extracts reusable skills from completed tasks.
+ *
+ * Triggered after Acceptance PASS. Receives the task, receipt, and git diff,
+ * makes an LLM call to identify 0-2 reusable patterns, then writes draft SKILL.md
+ * files to .mercury/skills/pending/ for Main Agent review.
+ *
+ * Packages (verified via npm/GitHub 2026-04-04):
+ * - write-file-atomic v7.0.1: atomic temp-rename writes, Promise-based (no callback needed)
+ */
+
+import { createRequire } from "node:module";
+import { mkdir } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import type { TaskBundle, ImplementationReceipt } from "@mercury/core";
+
+// write-file-atomic: CommonJS module — ESM interop via createRequire
+const _require = createRequire(import.meta.url);
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+const writeFileAtomic = _require("write-file-atomic") as (path: string, data: string) => Promise<void>;
+
+// ─── Types ───
+
+export interface CaptureInput {
+  task: TaskBundle;
+  receipt: ImplementationReceipt;
+  gitDiff?: string;
+}
+
+export interface DraftSkill {
+  name: string;
+  filePath: string;
+}
+
+export type LLMCaller = (prompt: string) => Promise<string>;
+
+// ─── Skill Capturer ───
+
+export class SkillCapturer {
+  private readonly pendingDir: string;
+  private llmCaller: LLMCaller | null = null;
+
+  constructor(skillDir: string) {
+    this.pendingDir = join(skillDir, "pending");
+  }
+
+  /** Inject LLM caller for pattern extraction. If not set, capture is a no-op. */
+  setLLMCaller(caller: LLMCaller): void {
+    this.llmCaller = caller;
+  }
+
+  /**
+   * Attempt to extract 0-2 reusable skill patterns from the completed task.
+   * Writes drafts to .mercury/skills/pending/ — does NOT activate them.
+   * Non-blocking: caller should fire-and-forget (void).
+   */
+  async captureFromAcceptancePass(input: CaptureInput): Promise<DraftSkill[]> {
+    if (!this.llmCaller) return [];
+
+    try {
+      await this.ensurePendingDir();
+      const patterns = await this.extractPatterns(input);
+      const drafts: DraftSkill[] = [];
+
+      for (const pattern of patterns.slice(0, 2)) {
+        const draft = await this.writeDraftSkill(pattern, input.task);
+        if (draft) drafts.push(draft);
+      }
+
+      return drafts;
+    } catch {
+      // Capture is always best-effort — never throw to caller
+      return [];
+    }
+  }
+
+  // ─── Private ───
+
+  private async ensurePendingDir(): Promise<void> {
+    if (!existsSync(this.pendingDir)) {
+      await mkdir(this.pendingDir, { recursive: true });
+    }
+  }
+
+  private async extractPatterns(input: CaptureInput): Promise<ExtractedPattern[]> {
+    const prompt = buildCapturePrompt(input);
+    const response = await this.llmCaller!(prompt);
+    return parsePatterns(response);
+  }
+
+  private async writeDraftSkill(
+    pattern: ExtractedPattern,
+    task: TaskBundle,
+  ): Promise<DraftSkill | null> {
+    const name = sanitizeSlug(pattern.name);
+    if (!name) return null;
+
+    const skillDir = join(this.pendingDir, name);
+    await mkdir(skillDir, { recursive: true });
+
+    const filePath = join(skillDir, "SKILL.md");
+    const skillId = `${name}__cap_${randomUUID().slice(0, 8)}`;
+    const now = new Date().toISOString();
+
+    const content = [
+      "---",
+      `name: ${name}`,
+      `description: ${pattern.description}`,
+      `category: ${pattern.category}`,
+      `roles:`,
+      ...pattern.roles.map((r) => `  - ${r}`),
+      `origin: CAPTURED`,
+      `source_task_id: ${task.taskId}`,
+      `source_role: ${task.role ?? "dev"}`,
+      `captured_at: ${now}`,
+      `captured_by: acceptance-agent`,
+      `tags: []`,
+      `generation: 0`,
+      `parent_skill_ids: []`,
+      `total_selections: 0`,
+      `total_applied: 0`,
+      `total_completions: 0`,
+      `total_fallbacks: 0`,
+      "---",
+      "",
+      `# ${pattern.title}`,
+      "",
+      pattern.body,
+      "",
+      `<!-- Draft skill — pending Main Agent review. Source: ${task.taskId} -->`,
+    ].join("\n");
+
+    await writeFileAtomic(filePath, content);
+    await writeFileAtomic(join(skillDir, ".skill_id"), skillId);
+
+    return { name, filePath };
+  }
+}
+
+// ─── Prompt builder ───
+
+function buildCapturePrompt(input: CaptureInput): string {
+  const { task, receipt, gitDiff } = input;
+
+  const diffSection = gitDiff
+    ? `\n## Git Diff (first 3000 chars)\n\`\`\`\n${gitDiff.slice(0, 3000)}\n\`\`\``
+    : "";
+
+  return `You are a skill extraction agent for the Mercury multi-agent system.
+
+Analyze the completed task below and identify 0 to 2 reusable agent skills.
+
+A skill is reusable if:
+1. It describes a HOW-TO pattern, not a project-specific solution
+2. It remains meaningful after removing task IDs, file paths, and domain-specific names
+3. It would help future agents avoid repeated exploration or mistakes
+4. It fits: TOOL_GUIDE (how to use a tool), WORKFLOW (multi-step process), or REFERENCE (key facts)
+
+## Task
+- ID: ${task.taskId}
+- Title: ${task.title}
+- Role: ${task.role ?? "dev"}
+- Context: ${task.context.slice(0, 800)}
+
+## Receipt Summary
+${receipt.summary}
+
+## Changed Files
+${(receipt.changedFiles ?? []).slice(0, 10).join(", ")}
+${diffSection}
+
+## Output Format
+
+Return a JSON array of 0-2 skills. If no reusable pattern exists, return [].
+
+\`\`\`json
+[
+  {
+    "name": "hyphenated-skill-slug",
+    "title": "Human-readable title",
+    "description": "One sentence for retrieval (max 120 chars)",
+    "category": "TOOL_GUIDE|WORKFLOW|REFERENCE",
+    "roles": ["dev", "research", "main", "design"],
+    "body": "## Instructions\\n\\nMarkdown body with the reusable pattern..."
+  }
+]
+\`\`\`
+
+Return ONLY the JSON array. No other text.`;
+}
+
+// ─── Pattern parser ───
+
+interface ExtractedPattern {
+  name: string;
+  title: string;
+  description: string;
+  category: string;
+  roles: string[];
+  body: string;
+}
+
+function parsePatterns(response: string): ExtractedPattern[] {
+  try {
+    const jsonMatch = response.match(/```(?:json)?\s*([\s\S]*?)\s*```/);
+    const jsonStr = jsonMatch ? jsonMatch[1] : response.trim();
+    const parsed = JSON.parse(jsonStr) as unknown;
+    if (!Array.isArray(parsed)) return [];
+
+    return parsed.filter((item): item is ExtractedPattern => {
+      if (typeof item !== "object" || item === null) return false;
+      const p = item as Record<string, unknown>;
+      return (
+        typeof p["name"] === "string" &&
+        typeof p["description"] === "string" &&
+        typeof p["category"] === "string" &&
+        Array.isArray(p["roles"]) &&
+        typeof p["body"] === "string"
+      );
+    });
+  } catch {
+    return [];
+  }
+}
+
+function sanitizeSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 60);
+}

--- a/packages/orchestrator/src/skill-capturer.ts
+++ b/packages/orchestrator/src/skill-capturer.ts
@@ -11,7 +11,6 @@
 
 import { createRequire } from "node:module";
 import { mkdir } from "node:fs/promises";
-import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 import type { TaskBundle, ImplementationReceipt } from "@mercury/core";
@@ -76,9 +75,7 @@ export class SkillCapturer {
   // ─── Private ───
 
   private async ensurePendingDir(): Promise<void> {
-    if (!existsSync(this.pendingDir)) {
-      await mkdir(this.pendingDir, { recursive: true });
-    }
+    await mkdir(this.pendingDir, { recursive: true });
   }
 
   private async extractPatterns(input: CaptureInput): Promise<ExtractedPattern[]> {
@@ -94,7 +91,9 @@ export class SkillCapturer {
     const name = sanitizeSlug(pattern.name);
     if (!name) return null;
 
-    const skillDir = join(this.pendingDir, name);
+    // Append UUID suffix to avoid silent overwrite when the same slug is captured again
+    const uuid8 = randomUUID().slice(0, 8);
+    const skillDir = join(this.pendingDir, `${name}_${uuid8}`);
     await mkdir(skillDir, { recursive: true });
 
     const filePath = join(skillDir, "SKILL.md");
@@ -212,6 +211,7 @@ function parsePatterns(response: string): ExtractedPattern[] {
       const p = item as Record<string, unknown>;
       return (
         typeof p["name"] === "string" &&
+        typeof p["title"] === "string" &&
         typeof p["description"] === "string" &&
         typeof p["category"] === "string" &&
         Array.isArray(p["roles"]) &&

--- a/packages/orchestrator/src/skill-capturer.ts
+++ b/packages/orchestrator/src/skill-capturer.ts
@@ -59,21 +59,18 @@ export class SkillCapturer {
   async captureFromAcceptancePass(input: CaptureInput): Promise<DraftSkill[]> {
     if (!this.llmCaller) return [];
 
-    try {
-      await this.ensurePendingDir();
-      const patterns = await this.extractPatterns(input);
-      const drafts: DraftSkill[] = [];
+    // No internal catch — errors propagate to the caller's .catch() for transport logging.
+    // Best-effort is enforced at the call site (fire-and-forget void + .catch()).
+    await this.ensurePendingDir();
+    const patterns = await this.extractPatterns(input);
+    const drafts: DraftSkill[] = [];
 
-      for (const pattern of patterns.slice(0, 2)) {
-        const draft = await this.writeDraftSkill(pattern, input.task);
-        if (draft) drafts.push(draft);
-      }
-
-      return drafts;
-    } catch {
-      // Capture is always best-effort — never throw to caller
-      return [];
+    for (const pattern of patterns.slice(0, 2)) {
+      const draft = await this.writeDraftSkill(pattern, input.task);
+      if (draft) drafts.push(draft);
     }
+
+    return drafts;
   }
 
   // ─── Private ───

--- a/packages/orchestrator/src/skill-capturer.ts
+++ b/packages/orchestrator/src/skill-capturer.ts
@@ -142,7 +142,7 @@ function buildCapturePrompt(input: CaptureInput): string {
   const { task, receipt, gitDiff } = input;
 
   const diffSection = gitDiff
-    ? `\n## Git Diff (first 3000 chars)\n\`\`\`\n${gitDiff.slice(0, 3000)}\n\`\`\``
+    ? `\n## Git Diff (first 3000 chars)\n\`\`\`\n${gitDiff.slice(0, 3000).replace(/```/g, "` ` `")}\n\`\`\``
     : "";
 
   return `You are a skill extraction agent for the Mercury multi-agent system.

--- a/packages/orchestrator/src/skill-capturer.ts
+++ b/packages/orchestrator/src/skill-capturer.ts
@@ -101,7 +101,8 @@ export class SkillCapturer {
     await mkdir(skillDir, { recursive: true });
 
     const filePath = join(skillDir, "SKILL.md");
-    const skillId = `${name}__cap_${randomUUID().slice(0, 8)}`;
+    // OpenSpace convention: evolved/captured skills use __v{gen}_{uuid8} format
+    const skillId = `${name}__v0_${randomUUID().slice(0, 8)}`;
     const now = new Date().toISOString();
 
     const content = [

--- a/packages/orchestrator/src/skill-capturer.ts
+++ b/packages/orchestrator/src/skill-capturer.ts
@@ -105,13 +105,13 @@ export class SkillCapturer {
     const content = [
       "---",
       `name: ${name}`,
-      `description: ${pattern.description}`,
-      `category: ${pattern.category}`,
+      `description: ${yamlEscape(pattern.description)}`,
+      `category: ${yamlEscape(pattern.category)}`,
       `roles:`,
-      ...pattern.roles.map((r) => `  - ${r}`),
+      ...pattern.roles.map((r) => `  - ${yamlEscape(r)}`),
       `origin: CAPTURED`,
       `source_task_id: ${task.taskId}`,
-      `source_role: ${task.role ?? "dev"}`,
+      `source_role: ${yamlEscape(task.role ?? "dev")}`,
       `captured_at: ${now}`,
       `captured_by: acceptance-agent`,
       `tags: []`,
@@ -221,6 +221,15 @@ function parsePatterns(response: string): ExtractedPattern[] {
   } catch {
     return [];
   }
+}
+
+/** Escape a string for safe YAML scalar value (inline, unquoted style). */
+function yamlEscape(str: string): string {
+  // Wrap in double quotes if the value contains characters that break YAML scalars
+  if (/[:\n\r"'#\[\]{}|>&*!?,]/.test(str) || str.startsWith(" ") || str.startsWith("-")) {
+    return `"${str.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n").replace(/\r/g, "\\r")}"`;
+  }
+  return str;
 }
 
 function sanitizeSlug(name: string): string {

--- a/packages/orchestrator/src/skill-registry.ts
+++ b/packages/orchestrator/src/skill-registry.ts
@@ -263,10 +263,11 @@ export class SkillRegistry {
     return this.skills.get(name);
   }
 
-  /** Read the full SKILL.md body (text after the frontmatter block). */
-  async loadSkillBody(skill: SkillMeta): Promise<string> {
+  /** Read the SKILL.md body (text after the frontmatter block), capped at 4500 chars for prompt budget. */
+  async loadSkillBody(skill: SkillMeta, maxChars = 4500): Promise<string> {
     const content = await readFile(skill.filePath, "utf-8");
-    return content.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, "").trimStart();
+    const body = content.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, "").trimStart();
+    return body.length > maxChars ? body.slice(0, maxChars) + "\n\n[…truncated]" : body;
   }
 
   /** Return all loaded skills. */

--- a/packages/orchestrator/src/skill-registry.ts
+++ b/packages/orchestrator/src/skill-registry.ts
@@ -37,6 +37,8 @@ export type SkillRole = "dev" | "research" | "main" | "design" | "acceptance" | 
  * Loaded from YAML frontmatter of each SKILL.md.
  */
 export interface SkillMeta {
+  /** Internal skill_id loaded from .skill_id sidecar (OpenSpace-compatible) */
+  skillId?: string;
   /** Hyphenated slug, e.g. "git-commit-heredoc-pattern" */
   name: string;
   /** One-sentence description used for BM25 retrieval */
@@ -65,6 +67,15 @@ export interface SkillMeta {
   staleness?: "STALE" | "UNDERPERFORMING";
 }
 
+/**
+ * SkillInjection — SkillMeta enriched with the loaded body text for prompt injection.
+ * Created by orchestrator at dispatch time; not persisted to disk.
+ */
+export interface SkillInjection extends SkillMeta {
+  /** Full SKILL.md body text (everything after the frontmatter block) */
+  body: string;
+}
+
 // ─── Frontmatter helpers ───
 
 function parseFrontmatter(content: string): Record<string, unknown> {
@@ -84,9 +95,12 @@ function parseFrontmatter(content: string): Record<string, unknown> {
   };
 
   for (const line of lines) {
+    // Skip blank lines and YAML comments
+    if (!line.trim() || line.trimStart().startsWith("#")) continue;
+
     const listMatch = line.match(/^  ?- (.+)$/);
     if (listMatch && currentKey) {
-      listItems.push(listMatch[1].trim());
+      listItems.push(listMatch[1].trim().replace(/^['"]|['"]$/g, ""));
       continue;
     }
     if (listItems.length > 0) flushList();
@@ -94,19 +108,22 @@ function parseFrontmatter(content: string): Record<string, unknown> {
     const kvMatch = line.match(/^([a-zA-Z_][a-zA-Z0-9_-]*):\s*(.*)$/);
     if (!kvMatch) continue;
     currentKey = kvMatch[1];
-    const rawVal = kvMatch[2].trim();
+    const rawVal = kvMatch[2].trim().replace(/#.*$/, "").trimEnd(); // strip inline comments
 
-    if (rawVal === "" || rawVal === "[]") {
-      if (rawVal === "[]") out[currentKey] = [];
+    if (rawVal === "" || rawVal === "~" || rawVal === "null") {
+      out[currentKey] = null;
       continue;
     }
+    if (rawVal === "[]") { out[currentKey] = []; continue; }
+    if (rawVal === "true") { out[currentKey] = true; continue; }
+    if (rawVal === "false") { out[currentKey] = false; continue; }
     const inlineList = rawVal.match(/^\[(.+)\]$/);
     if (inlineList) {
       out[currentKey] = inlineList[1].split(",").map((s) => s.trim().replace(/^['"]|['"]$/g, ""));
       continue;
     }
     const num = Number(rawVal);
-    if (!Number.isNaN(num)) { out[currentKey] = num; continue; }
+    if (!Number.isNaN(num) && rawVal !== "") { out[currentKey] = num; continue; }
     out[currentKey] = rawVal.replace(/^['"]|['"]$/g, "");
   }
   if (listItems.length > 0) flushList();
@@ -290,6 +307,21 @@ export class SkillRegistry {
     void this.persistStats(meta);
   }
 
+  /**
+   * Increment total_applied for a skill.
+   * Called when the task that received this skill reaches acceptance (receipt recorded).
+   * This is Mercury's proxy for OpenSpace's "agent applied the skill" signal —
+   * since Mercury cannot directly observe in-session tool usage, receipt submission
+   * is the closest observable confirmation that the agent completed the task with
+   * the skill in context.
+   */
+  recordApplied(skillName: string): void {
+    const meta = this.skills.get(skillName);
+    if (!meta) return;
+    meta.totalApplied++;
+    void this.persistStats(meta);
+  }
+
   /** Increment total_fallbacks for a skill. */
   recordFallback(skillName: string): void {
     const meta = this.skills.get(skillName);
@@ -317,13 +349,19 @@ export class SkillRegistry {
       } catch {
         continue;
       }
-      const meta = await this.loadSkillMeta(skillMdPath);
-      if (meta) metas.push(meta);
+      const meta = await this.loadSkillMeta(skillMdPath, join(dir, entry));
+      if (!meta) continue;
+      // Slug collision detection: warn and skip duplicate (first wins)
+      if (metas.some((m) => m.name === meta.name)) {
+        console.warn(`[skill-registry] Duplicate skill slug "${meta.name}" at ${skillMdPath} — skipped`);
+        continue;
+      }
+      metas.push(meta);
     }
     return metas;
   }
 
-  private async loadSkillMeta(filePath: string): Promise<SkillMeta | null> {
+  private async loadSkillMeta(filePath: string, skillDir?: string): Promise<SkillMeta | null> {
     let content: string;
     try {
       content = await readFile(filePath, "utf-8");
@@ -334,6 +372,14 @@ export class SkillRegistry {
     const fm = parseFrontmatter(content);
     const name = String(fm["name"] ?? basename(filePath));
     if (!name) return null;
+
+    // Load .skill_id sidecar (OpenSpace-compatible)
+    let skillId: string | undefined;
+    if (skillDir) {
+      try {
+        skillId = (await readFile(join(skillDir, ".skill_id"), "utf-8")).trim();
+      } catch { /* sidecar is optional */ }
+    }
 
     const safeArr = (v: unknown): string[] => {
       if (Array.isArray(v)) return v.map(String);
@@ -353,6 +399,7 @@ export class SkillRegistry {
       tags: safeArr(fm["tags"]),
       generation: safeNum(fm["generation"]),
       filePath,
+      skillId,
       lastValidatedAt: safeStr(fm["last_validated_at"]),
       totalSelections: safeNum(fm["total_selections"]),
       totalApplied: safeNum(fm["total_applied"]),

--- a/packages/orchestrator/src/skill-registry.ts
+++ b/packages/orchestrator/src/skill-registry.ts
@@ -1,0 +1,384 @@
+/**
+ * Mercury Skill Registry — BM25-based retrieval of accumulated agent skills.
+ *
+ * Skills are stored as SKILL.md files in .mercury/skills/{name}/SKILL.md.
+ * The registry scans the directory on init(), builds an in-memory BM25 index,
+ * and provides searchSkills() for role-filtered retrieval at dispatch time.
+ *
+ * Packages (verified via npm/web 2026-04-04):
+ * - fast-bm25 v0.0.5: BM25 class, search() returns {index,score}[], fieldBoosts supported
+ * - write-file-atomic v7.0.1: CommonJS default export, Promise<void>, atomic temp-rename writes
+ */
+
+import { createRequire } from "node:module";
+import { readdir, readFile, stat } from "node:fs/promises";
+import { existsSync, mkdirSync } from "node:fs";
+import { join, basename } from "node:path";
+import { BM25 } from "fast-bm25";
+
+// write-file-atomic is CommonJS — ESM interop via createRequire
+const _require = createRequire(import.meta.url);
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+const writeFileAtomic = _require("write-file-atomic") as (path: string, data: string) => Promise<void>;
+
+// ─── Public Types ───
+
+/** Skill category mirroring OpenSpace SkillCategory enum */
+export type SkillCategory = "TOOL_GUIDE" | "WORKFLOW" | "REFERENCE";
+
+/** Skill origin mirroring OpenSpace SkillOrigin enum */
+export type SkillOrigin = "IMPORTED" | "CAPTURED" | "DERIVED" | "FIXED";
+
+/** Agent roles that can receive skill injection */
+export type SkillRole = "dev" | "research" | "main" | "design" | "acceptance" | "critic";
+
+/**
+ * SkillMeta — lightweight in-memory representation used for BM25 indexing and retrieval.
+ * Loaded from YAML frontmatter of each SKILL.md.
+ */
+export interface SkillMeta {
+  /** Hyphenated slug, e.g. "git-commit-heredoc-pattern" */
+  name: string;
+  /** One-sentence description used for BM25 retrieval */
+  description: string;
+  category: SkillCategory;
+  roles: SkillRole[];
+  origin: SkillOrigin;
+  tags: string[];
+  generation: number;
+  /** Absolute path to the SKILL.md file */
+  filePath: string;
+  /** ISO8601 timestamp — used for staleness detection (last_validated_at in frontmatter) */
+  lastValidatedAt?: string;
+  /** Quality metrics */
+  totalSelections: number;
+  totalApplied: number;
+  totalCompletions: number;
+  totalFallbacks: number;
+  /** Lineage */
+  sourceTaskId?: string;
+  sourceRole?: string;
+  capturedAt?: string;
+  capturedBy?: string;
+  parentSkillIds: string[];
+  /** Staleness flag set during init() */
+  staleness?: "STALE" | "UNDERPERFORMING";
+}
+
+// ─── Frontmatter helpers ───
+
+function parseFrontmatter(content: string): Record<string, unknown> {
+  const fmMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!fmMatch) return {};
+
+  const out: Record<string, unknown> = {};
+  const lines = fmMatch[1].split(/\r?\n/);
+  let currentKey: string | null = null;
+  let listItems: string[] = [];
+
+  const flushList = () => {
+    if (currentKey && listItems.length > 0) {
+      out[currentKey] = [...listItems];
+      listItems = [];
+    }
+  };
+
+  for (const line of lines) {
+    const listMatch = line.match(/^  ?- (.+)$/);
+    if (listMatch && currentKey) {
+      listItems.push(listMatch[1].trim());
+      continue;
+    }
+    if (listItems.length > 0) flushList();
+
+    const kvMatch = line.match(/^([a-zA-Z_][a-zA-Z0-9_-]*):\s*(.*)$/);
+    if (!kvMatch) continue;
+    currentKey = kvMatch[1];
+    const rawVal = kvMatch[2].trim();
+
+    if (rawVal === "" || rawVal === "[]") {
+      if (rawVal === "[]") out[currentKey] = [];
+      continue;
+    }
+    const inlineList = rawVal.match(/^\[(.+)\]$/);
+    if (inlineList) {
+      out[currentKey] = inlineList[1].split(",").map((s) => s.trim().replace(/^['"]|['"]$/g, ""));
+      continue;
+    }
+    const num = Number(rawVal);
+    if (!Number.isNaN(num)) { out[currentKey] = num; continue; }
+    out[currentKey] = rawVal.replace(/^['"]|['"]$/g, "");
+  }
+  if (listItems.length > 0) flushList();
+
+  return out;
+}
+
+function serializeFrontmatterField(key: string, val: unknown): string {
+  if (Array.isArray(val)) {
+    if (val.length === 0) return `${key}: []`;
+    return `${key}:\n${(val as unknown[]).map((v) => `  - ${String(v)}`).join("\n")}`;
+  }
+  return `${key}: ${String(val)}`;
+}
+
+function updateFrontmatterFields(content: string, updates: Record<string, unknown>): string {
+  const fmMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!fmMatch) return content;
+
+  const fmLines = fmMatch[1].split(/\r?\n/);
+  const updatedLines: string[] = [];
+  const handled = new Set<string>();
+
+  let i = 0;
+  while (i < fmLines.length) {
+    const line = fmLines[i];
+    const kvMatch = line.match(/^([a-zA-Z_][a-zA-Z0-9_-]*):\s*/);
+    if (kvMatch && kvMatch[1] in updates) {
+      const key = kvMatch[1];
+      handled.add(key);
+      updatedLines.push(serializeFrontmatterField(key, updates[key]));
+      i++;
+      while (i < fmLines.length && /^\s+-/.test(fmLines[i])) i++;
+      continue;
+    }
+    updatedLines.push(line);
+    i++;
+  }
+
+  for (const [key, val] of Object.entries(updates)) {
+    if (!handled.has(key)) {
+      updatedLines.push(serializeFrontmatterField(key, val));
+    }
+  }
+
+  return content.replace(fmMatch[0], `---\n${updatedLines.join("\n")}\n---`);
+}
+
+// ─── Constants ───
+
+const STALE_DAYS = 90;
+const LOW_COMPLETION_RATE = 0.3;
+const MIN_SELECTIONS_FOR_RATE = 5;
+
+// ─── SkillRegistry ───
+
+export class SkillRegistry {
+  private skills = new Map<string, SkillMeta>();
+  private bm25: BM25 | null = null;
+  private indexedNames: string[] = [];
+  private skillDir = "";
+
+  /**
+   * Scan skillDir for SKILL.md files, build BM25 index, run staleness detection.
+   * Safe to call multiple times (re-initializes state).
+   */
+  async init(skillDir: string): Promise<void> {
+    this.skillDir = skillDir;
+    this.skills.clear();
+    this.indexedNames = [];
+
+    if (!existsSync(skillDir)) {
+      mkdirSync(skillDir, { recursive: true });
+    }
+
+    const metas = await this.scanSkillDir(skillDir);
+    const docs: Array<Record<string, string>> = [];
+
+    for (const meta of metas) {
+      this.skills.set(meta.name, meta);
+      docs.push({
+        description: meta.description,
+        tags: meta.tags.join(" "),
+        category: meta.category.toLowerCase().replace(/_/g, " "),
+      });
+      this.indexedNames.push(meta.name);
+
+      // Staleness detection
+      if (meta.lastValidatedAt) {
+        const ageMs = Date.now() - new Date(meta.lastValidatedAt).getTime();
+        if (ageMs > STALE_DAYS * 24 * 60 * 60 * 1000) {
+          meta.staleness = "STALE";
+        }
+      }
+      if (
+        meta.totalSelections > MIN_SELECTIONS_FOR_RATE &&
+        meta.totalApplied > 0 &&
+        meta.totalCompletions / meta.totalApplied < LOW_COMPLETION_RATE
+      ) {
+        meta.staleness = meta.staleness === "STALE" ? "STALE" : "UNDERPERFORMING";
+      }
+    }
+
+    if (docs.length > 0) {
+      this.bm25 = new BM25(docs, {
+        fieldBoosts: { description: 2.0, tags: 1.5, category: 0.5 },
+      });
+    }
+  }
+
+  /**
+   * Search skills by query, filtered to the given roles.
+   * Returns up to `limit` results ordered by BM25 relevance.
+   */
+  searchSkills(query: string, roles: string[], limit = 3): SkillMeta[] {
+    if (!this.bm25 || this.skills.size === 0) return [];
+
+    const topK = Math.min(this.skills.size, limit * 6);
+    const results = this.bm25.search(query, topK) as Array<{ index: number; score: number }>;
+
+    const filtered: SkillMeta[] = [];
+    for (const result of results) {
+      const name = this.indexedNames[result.index];
+      if (!name) continue;
+      const meta = this.skills.get(name);
+      if (!meta) continue;
+      if (roles.length > 0 && !roles.some((r) => meta.roles.includes(r as SkillRole))) continue;
+      filtered.push(meta);
+      if (filtered.length >= limit) break;
+    }
+
+    return filtered;
+  }
+
+  /** Look up a skill by exact name. */
+  getSkill(name: string): SkillMeta | undefined {
+    return this.skills.get(name);
+  }
+
+  /** Read the full SKILL.md body (text after the frontmatter block). */
+  async loadSkillBody(skill: SkillMeta): Promise<string> {
+    const content = await readFile(skill.filePath, "utf-8");
+    return content.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, "").trimStart();
+  }
+
+  /** Return all loaded skills. */
+  listSkills(): SkillMeta[] {
+    return Array.from(this.skills.values());
+  }
+
+  /** Whether any skills are loaded and searchable. */
+  isReady(): boolean {
+    return this.skills.size > 0;
+  }
+
+  /** Returns the configured skill directory path. */
+  getSkillDir(): string {
+    return this.skillDir;
+  }
+
+  // ─── Metric recording (non-blocking, best-effort) ───
+
+  /** Increment total_selections for a skill. */
+  recordSelection(skillName: string): void {
+    const meta = this.skills.get(skillName);
+    if (!meta) return;
+    meta.totalSelections++;
+    void this.persistStats(meta);
+  }
+
+  /**
+   * Increment total_completions for a skill and refresh last_validated_at.
+   * Called after Acceptance PASS for each skill that was injected into that dispatch.
+   */
+  recordCompletion(skillName: string): void {
+    const meta = this.skills.get(skillName);
+    if (!meta) return;
+    meta.totalCompletions++;
+    meta.lastValidatedAt = new Date().toISOString();
+    meta.staleness = undefined;
+    void this.persistStats(meta);
+  }
+
+  /** Increment total_fallbacks for a skill. */
+  recordFallback(skillName: string): void {
+    const meta = this.skills.get(skillName);
+    if (!meta) return;
+    meta.totalFallbacks++;
+    void this.persistStats(meta);
+  }
+
+  // ─── Private ───
+
+  private async scanSkillDir(dir: string): Promise<SkillMeta[]> {
+    let entries: string[];
+    try {
+      entries = await readdir(dir) as string[];
+    } catch {
+      return [];
+    }
+
+    const metas: SkillMeta[] = [];
+    for (const entry of entries) {
+      if (entry === "pending" || entry.startsWith(".") || entry.endsWith(".md")) continue;
+      const skillMdPath = join(dir, entry, "SKILL.md");
+      try {
+        await stat(skillMdPath);
+      } catch {
+        continue;
+      }
+      const meta = await this.loadSkillMeta(skillMdPath);
+      if (meta) metas.push(meta);
+    }
+    return metas;
+  }
+
+  private async loadSkillMeta(filePath: string): Promise<SkillMeta | null> {
+    let content: string;
+    try {
+      content = await readFile(filePath, "utf-8");
+    } catch {
+      return null;
+    }
+
+    const fm = parseFrontmatter(content);
+    const name = String(fm["name"] ?? basename(filePath));
+    if (!name) return null;
+
+    const safeArr = (v: unknown): string[] => {
+      if (Array.isArray(v)) return v.map(String);
+      if (typeof v === "string" && v) return [v];
+      return [];
+    };
+    const safeNum = (v: unknown): number => (typeof v === "number" ? v : 0);
+    const safeStr = (v: unknown): string | undefined =>
+      typeof v === "string" && v ? v : undefined;
+
+    return {
+      name,
+      description: String(fm["description"] ?? ""),
+      category: (String(fm["category"] ?? "TOOL_GUIDE").toUpperCase()) as SkillCategory,
+      roles: safeArr(fm["roles"]) as SkillRole[],
+      origin: (String(fm["origin"] ?? "IMPORTED").toUpperCase()) as SkillOrigin,
+      tags: safeArr(fm["tags"]),
+      generation: safeNum(fm["generation"]),
+      filePath,
+      lastValidatedAt: safeStr(fm["last_validated_at"]),
+      totalSelections: safeNum(fm["total_selections"]),
+      totalApplied: safeNum(fm["total_applied"]),
+      totalCompletions: safeNum(fm["total_completions"]),
+      totalFallbacks: safeNum(fm["total_fallbacks"]),
+      sourceTaskId: safeStr(fm["source_task_id"]),
+      sourceRole: safeStr(fm["source_role"]),
+      capturedAt: safeStr(fm["captured_at"]),
+      capturedBy: safeStr(fm["captured_by"]),
+      parentSkillIds: safeArr(fm["parent_skill_ids"]),
+    };
+  }
+
+  private async persistStats(meta: SkillMeta): Promise<void> {
+    try {
+      const content = await readFile(meta.filePath, "utf-8");
+      const updated = updateFrontmatterFields(content, {
+        total_selections: meta.totalSelections,
+        total_applied: meta.totalApplied,
+        total_completions: meta.totalCompletions,
+        total_fallbacks: meta.totalFallbacks,
+        last_validated_at: meta.lastValidatedAt ?? "",
+      });
+      await writeFileAtomic(meta.filePath, updated);
+    } catch {
+      // Best-effort — a failed stat update does not break the skill engine
+    }
+  }
+}

--- a/packages/orchestrator/src/skill-registry.ts
+++ b/packages/orchestrator/src/skill-registry.ts
@@ -13,7 +13,7 @@
 import { createRequire } from "node:module";
 import { readdir, readFile, stat } from "node:fs/promises";
 import { existsSync, mkdirSync } from "node:fs";
-import { join, basename } from "node:path";
+import { join, basename, dirname } from "node:path";
 import { BM25 } from "fast-bm25";
 
 // write-file-atomic is CommonJS — ESM interop via createRequire
@@ -370,7 +370,7 @@ export class SkillRegistry {
     }
 
     const fm = parseFrontmatter(content);
-    const name = String(fm["name"] ?? basename(filePath));
+    const name = String(fm["name"] ?? basename(dirname(filePath)));
     if (!name) return null;
 
     // Load .skill_id sidecar (OpenSpace-compatible)

--- a/packages/orchestrator/src/skill-registry.ts
+++ b/packages/orchestrator/src/skill-registry.ts
@@ -108,7 +108,8 @@ function parseFrontmatter(content: string): Record<string, unknown> {
     const kvMatch = line.match(/^([a-zA-Z_][a-zA-Z0-9_-]*):\s*(.*)$/);
     if (!kvMatch) continue;
     currentKey = kvMatch[1];
-    const rawVal = kvMatch[2].trim().replace(/#.*$/, "").trimEnd(); // strip inline comments
+    // Strip unquoted inline comments only (avoid truncating quoted values containing '#')
+    const rawVal = kvMatch[2].trim().replace(/(?<!['"#])\s+#.*$/, "").trimEnd();
 
     if (rawVal === "" || rawVal === "~" || rawVal === "null") {
       out[currentKey] = null;
@@ -219,7 +220,7 @@ export class SkillRegistry {
         }
       }
       if (
-        meta.totalSelections > MIN_SELECTIONS_FOR_RATE &&
+        meta.totalSelections >= MIN_SELECTIONS_FOR_RATE &&
         meta.totalApplied > 0 &&
         meta.totalCompletions / meta.totalApplied < LOW_COMPLETION_RATE
       ) {

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -960,7 +960,7 @@ function buildSkillsBlock(skills: SkillInjection[]): string {
   for (const skill of skills) {
     sections.push(`\n### ${skill.name} [${skill.category}]`);
     sections.push(`_${skill.description}_`);
-    if (skill.body) sections.push(skill.body);
+    if (skill.body) sections.push(skill.body.replace(/```/g, "` ` `"));
   }
   return sections.join("\n");
 }

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -11,6 +11,7 @@ import { readFileSync } from "node:fs";
 import { basename, resolve, sep } from "node:path";
 import type { EventBus } from "@mercury/core";
 import { normalizePriority } from "@mercury/core";
+import type { SkillMeta } from "./skill-registry.js";
 import type {
   TaskBundle,
   TaskStatus,
@@ -948,6 +949,24 @@ function formatWriteScope(scope: TaskBundle["allowedWriteScope"]): string {
  * preload + cache at TaskManager.init() with mtime-based refresh (tracked in TASK-WF-001).
  */
 /**
+ * Build the "## Accumulated Skills" block injected into dev/research prompts.
+ * Skills carry a pre-loaded `_body` property set by the orchestrator before passing here.
+ * Token budget: max 3 skills × ~1500 tokens each = ~4500 tokens (~5% context).
+ */
+function buildSkillsBlock(skills: SkillMeta[]): string {
+  if (skills.length === 0) return "";
+  const sections = ["\n\n## Accumulated Skills (Mercury Skill Library)"];
+  sections.push("These reusable patterns were accumulated through prior tasks. Apply when relevant:");
+  for (const skill of skills) {
+    sections.push(`\n### ${skill.name} [${skill.category}]`);
+    sections.push(`_${skill.description}_`);
+    const body = (skill as SkillMeta & { _body?: string })._body;
+    if (body) sections.push(body);
+  }
+  return sections.join("\n");
+}
+
+/**
  * Build a git log section for dev dispatch prompts.
  * Returns a markdown block with the last 20 commits on the task branch (best-effort).
  */
@@ -974,6 +993,7 @@ export function buildDevPrompt(
   task: TaskBundle,
   kbContext?: string,
   basePath = process.cwd(),
+  relevantSkills?: SkillMeta[],
 ): string {
   const templatePath = resolve(basePath, ".mercury", "templates", "dispatch-prompt.template.md");
   let template: string;
@@ -1046,6 +1066,10 @@ export function buildDevPrompt(
   let result = template.replace(placeholderPattern, (match) => placeholders[match] ?? match);
 
   result += buildGitLogSection(task.branch, basePath);
+
+  if (relevantSkills && relevantSkills.length > 0) {
+    result += buildSkillsBlock(relevantSkills);
+  }
 
   if (kbContext) {
     result += `
@@ -1190,6 +1214,7 @@ export function buildResearchPrompt(
   tokenBudgetHint?: number,
   vaultPath?: string,
   codexEnabled?: boolean,
+  relevantSkills?: SkillMeta[],
 ): string {
   const lines = [
     `# Research Task: ${task.title} [${task.taskId}]`,
@@ -1271,6 +1296,10 @@ export function buildResearchPrompt(
     ...deriveKbWriteInstructions(task, vaultPath),
     "Do NOT send any additional messages after Step 1 JSON — the orchestrator reads only your last message.",
   ];
+
+  if (relevantSkills && relevantSkills.length > 0) {
+    lines.push(...buildSkillsBlock(relevantSkills).split("\n"));
+  }
 
   if (kbContext) {
     lines.push("", "## Project Knowledge Base Context", kbContext);

--- a/packages/orchestrator/src/task-manager.ts
+++ b/packages/orchestrator/src/task-manager.ts
@@ -11,7 +11,7 @@ import { readFileSync } from "node:fs";
 import { basename, resolve, sep } from "node:path";
 import type { EventBus } from "@mercury/core";
 import { normalizePriority } from "@mercury/core";
-import type { SkillMeta } from "./skill-registry.js";
+import type { SkillInjection } from "./skill-registry.js";
 import type {
   TaskBundle,
   TaskStatus,
@@ -950,18 +950,17 @@ function formatWriteScope(scope: TaskBundle["allowedWriteScope"]): string {
  */
 /**
  * Build the "## Accumulated Skills" block injected into dev/research prompts.
- * Skills carry a pre-loaded `_body` property set by the orchestrator before passing here.
- * Token budget: max 3 skills × ~1500 tokens each = ~4500 tokens (~5% context).
+ * Each SkillInjection carries a `body` field (SKILL.md text after frontmatter).
+ * Token budget: max 3 skills × ~300 tokens each = ~900 tokens (~1% context).
  */
-function buildSkillsBlock(skills: SkillMeta[]): string {
+function buildSkillsBlock(skills: SkillInjection[]): string {
   if (skills.length === 0) return "";
   const sections = ["\n\n## Accumulated Skills (Mercury Skill Library)"];
   sections.push("These reusable patterns were accumulated through prior tasks. Apply when relevant:");
   for (const skill of skills) {
     sections.push(`\n### ${skill.name} [${skill.category}]`);
     sections.push(`_${skill.description}_`);
-    const body = (skill as SkillMeta & { _body?: string })._body;
-    if (body) sections.push(body);
+    if (skill.body) sections.push(skill.body);
   }
   return sections.join("\n");
 }
@@ -993,7 +992,7 @@ export function buildDevPrompt(
   task: TaskBundle,
   kbContext?: string,
   basePath = process.cwd(),
-  relevantSkills?: SkillMeta[],
+  relevantSkills?: SkillInjection[],
 ): string {
   const templatePath = resolve(basePath, ".mercury", "templates", "dispatch-prompt.template.md");
   let template: string;
@@ -1214,7 +1213,7 @@ export function buildResearchPrompt(
   tokenBudgetHint?: number,
   vaultPath?: string,
   codexEnabled?: boolean,
-  relevantSkills?: SkillMeta[],
+  relevantSkills?: SkillInjection[],
 ): string {
   const lines = [
     `# Research Task: ${task.title} [${task.taskId}]`,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,9 +96,15 @@ importers:
       better-sqlite3:
         specifier: 12.8.0
         version: 12.8.0
+      fast-bm25:
+        specifier: ^0.0.5
+        version: 0.0.5(typescript@5.9.3)
       js-yaml:
         specifier: ^4.1.1
         version: 4.1.1
+      write-file-atomic:
+        specifier: ^7.0.1
+        version: 7.0.1
       zod:
         specifier: ^4.0.0
         version: 4.3.6
@@ -1185,6 +1191,12 @@ packages:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
 
+  fast-bm25@0.0.5:
+    resolution: {integrity: sha512-6HTiLmPkgeqcPJHccN0pXdqnA7OzhaEQZTFzWnfjIyPoX5sGVKUUpfRc2K2o6zMwK+g009miRhADYn/f2Ax0Mg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      typescript: ^5.6.3
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -1441,6 +1453,9 @@ packages:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
 
+  porter2@1.1.0:
+    resolution: {integrity: sha512-Io2cLEdZn0O1dH60pRsjmr/cH/qJJ/j6Cjubz8wQWi0b6vPdQIUxSBQKyx9d+8CN7fSnY+5uOU3rErMFjNqcLw==}
+
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -1560,6 +1575,10 @@ packages:
   side-channel@1.1.0:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
 
   simple-concat@1.0.1:
     resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
@@ -1740,6 +1759,10 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  write-file-atomic@7.0.1:
+    resolution: {integrity: sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   zod-to-json-schema@3.25.1:
     resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
@@ -2627,6 +2650,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  fast-bm25@0.0.5(typescript@5.9.3):
+    dependencies:
+      porter2: 1.1.0
+      typescript: 5.9.3
+
   fast-deep-equal@3.1.3: {}
 
   fast-uri@3.1.0: {}
@@ -2856,6 +2884,8 @@ snapshots:
 
   pkce-challenge@5.0.1: {}
 
+  porter2@1.1.0: {}
+
   postcss@8.5.8:
     dependencies:
       nanoid: 3.3.11
@@ -3051,6 +3081,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  signal-exit@4.1.0: {}
+
   simple-concat@1.0.1: {}
 
   simple-get@4.0.1:
@@ -3209,6 +3241,10 @@ snapshots:
       isexe: 2.0.0
 
   wrappy@1.0.2: {}
+
+  write-file-atomic@7.0.1:
+    dependencies:
+      signal-exit: 4.1.0
 
   zod-to-json-schema@3.25.1(zod@4.3.6):
     dependencies:


### PR DESCRIPTION
## Summary

### Core: TypeScript-native skill engine (Issue #141)
- **`skill-registry.ts`**: `SkillRegistry` — scans `.mercury/skills/`, builds fast-bm25 index (description×2.0, tags×1.5, category×0.5), `searchSkills(query, roles, limit=3)`, quality metrics via `write-file-atomic`, stale/underperforming detection on startup, `SkillInjection` interface, `.skill_id` sidecar support
- **`skill-capturer.ts`**: `SkillCapturer` — triggered after Acceptance PASS, LLM-extracts 0-2 reusable patterns, writes drafts to `.mercury/skills/pending/`; LLMCaller wired lazily via `executeOneShot`
- **`orchestrator.ts`**: full metric lifecycle wiring — `recordSelection` at dispatch, `recordApplied` on first receipt, `recordCompletion` on PASS, `recordFallback` on all terminal failure paths; research/design fast-track paths also wired; `injectedSkillsByTask` map cleaned on all terminal paths
- **`task-manager.ts`**: `buildDevPrompt` / `buildResearchPrompt` accept `SkillInjection[]`, render `## Accumulated Skills` block using `skill.body` directly
- **`.mercury/skills/`**: 10 hand-authored seed skills (SKILL.md + .skill_id) covering git, PR, KB, dispatch, research, acceptance, branch safety, issue flow, rework context, deep research

### dual-verify skill (replaces single-agent code-review)
- **`.mercury/skills/dual-verify/`**: Mercury skill library entry (IMPORTED, roles: main/dev/acceptance)
- **`.claude/skills/dual-verify/`**: Claude Code user-invocable `/dual-verify`
- **`.agents/skills/dual-verify/`**: Codex variant + openai.yaml (allow_implicit_invocation: false)
- Division: Claude owns tsc + architecture review; Codex rescue subagent owns logic/style/metrics/edge-case audit
- Fallback: Claude → `/code-review`; Codex → `auto-verify`
- Hook updates: `post-review-flag.sh` detects `dual-verify`; pre-commit blocked message updated
- `.codex/config.toml`: dual-verify replaces auto-verify as pre-merge standard

## Technical Decisions

- No Python/OpenSpace runtime — pure TypeScript in orchestrator
- fast-bm25 v0.0.5, write-file-atomic v7.0.1 via `createRequire` ESM interop
- `recordApplied()` guarded to first receipt only (rework receipts skip — skills not re-injected)
- `captureFromAcceptancePass` errors propagate to `.catch()` for transport logging (no internal blanket catch)
- Codex rescue subagent used for logic audit; tsc validation on Claude side (headless sandbox limitation)

## Dual-verify results

- Claude deep review: PASS (0 Critical, 0 High)
- Codex logic audit: surfaced 1 High + 3 Medium → all fixed in this PR
- tsc --noEmit: exit 0

## Test plan

- [x] `tsc --noEmit` exits 0
- [ ] Orchestrator startup: `[skill-registry] Loaded 10 skill(s)` log appears
- [ ] Task dispatch for dev/research role: `## Accumulated Skills` block visible in prompt
- [ ] Acceptance PASS: `last_validated_at` updates in SKILL.md files, capture fires
- [ ] Stale detection: skills with 90-day-old `last_validated_at` flagged at startup
- [ ] `/dual-verify` skill invocable in Claude Code session

🤖 Generated with [Claude Code](https://claude.com/claude-code)