### PR TITLE
fix(gui): forward sessionId to orchestrator on send_prompt (#134)

### DIFF
--- a/packages/gui/src-tauri/src/commands.rs
+++ b/packages/gui/src-tauri/src/commands.rs
@@ -394,13 +394,14 @@ pub async fn send_prompt(
     prompt: String,
     images: Option<serde_json::Value>,
     role: Option<String>,
+    session_id: Option<String>,
 ) -> Result<serde_json::Value, String> {
     let mgr = get_sidecar(&sidecar).await?;
-    mgr.send_request(
-        "send_prompt",
-        serde_json::json!({ "agentId": agent_id, "prompt": prompt, "images": images, "role": role }),
-    )
-    .await
+    let mut params = serde_json::json!({ "agentId": agent_id, "prompt": prompt, "images": images, "role": role });
+    if let Some(sid) = session_id {
+        params["sessionId"] = serde_json::Value::String(sid);
+    }
+    mgr.send_request("send_prompt", params).await
 }
 
 #[tauri::command]

--- a/packages/gui/src/lib/tauri-bridge.ts
+++ b/packages/gui/src/lib/tauri-bridge.ts
@@ -154,8 +154,9 @@ export async function sendPrompt(
   prompt: string,
   images?: ImageAttachment[],
   role?: string,
+  sessionId?: string,
 ): Promise<{ sessionId: string; role?: string; sessionName?: string; status?: string }> {
-  return invoke("send_prompt", { agentId, prompt, images: images ?? null, role: role ?? null });
+  return invoke("send_prompt", { agentId, prompt, images: images ?? null, role: role ?? null, sessionId: sessionId ?? null });
 }
 
 /**

--- a/packages/gui/src/stores/messages.ts
+++ b/packages/gui/src/stores/messages.ts
@@ -174,7 +174,7 @@ function setMessages(panelKey: string, msgs: DisplayMessage[]) {
  * @param panelKey - roleSlotKey "{role}:{agentId}"
  */
 async function sendPrompt(panelKey: string, prompt: string, images?: ImageAttachment[]) {
-  const { setStatus, setSessionInfo, parsePanelKey } = useAgentStore();
+  const { setStatus, setSessionInfo, parsePanelKey, getSession } = useAgentStore();
 
   // Parse panelKey to get role and agentId (supports both "{role}:{agentId}" and "{role}:{agentId}:{sid}")
   const { role, agentId } = parsePanelKey(panelKey);
@@ -260,7 +260,8 @@ async function sendPrompt(panelKey: string, prompt: string, images?: ImageAttach
   setStatus(panelKey, "active");
 
   try {
-    const result = await bridgeSendPrompt(agentId, prompt, images, role);
+    const currentSessionId = getSession(panelKey);
+    const result = await bridgeSendPrompt(agentId, prompt, images, role, currentSessionId);
     if (result?.sessionId) {
       setSessionInfo(panelKey, {
         sessionId: result.sessionId,

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -865,6 +865,9 @@ export class Orchestrator {
           (params.images as ImageAttachment[] | null) ?? undefined,
           (params.role as AgentRole | null) ?? undefined,
           (params.taskName as string | null) ?? undefined,
+          undefined, // systemPrompt
+          undefined, // taskId
+          (params.sessionId as string | null) ?? undefined, // hintSessionId
         );
       case "stop_session":
         return this.stopSession(
@@ -1576,6 +1579,7 @@ export class Orchestrator {
     taskName?: string,
     systemPrompt?: string,
     taskId?: string,
+    hintSessionId?: string,
   ): Promise<{ sessionId: string; role?: AgentRole; sessionName?: string; status?: SessionInfo["status"] }> {
     const adapter = this.registry.getAdapter(agentId);
     const config = this.registry.getConfig(agentId);
@@ -1590,7 +1594,8 @@ export class Orchestrator {
     //   (b) the existing session is completed/overflow (validated below)
     //   (c) adapter.resumeSession() throws (session state lost)
     // See: TASK-4d99b745 Bug 3 investigation — no orchestrator-side fix needed.
-    let sessionId = this.roleSessions.get(slotKey);
+    // Use hintSessionId if provided (from GUI — knows which specific session the user is in)
+    let sessionId = hintSessionId ?? this.roleSessions.get(slotKey);
     if (!sessionId) {
       const session = await this.startRoleSession(agentId, effectiveRole, taskName, systemPrompt);
       sessionId = session.sessionId;
@@ -1620,6 +1625,11 @@ export class Orchestrator {
       this.roleSessions.delete(slotKey);
       const session = await this.startRoleSession(agentId, effectiveRole, taskName, systemPrompt);
       sessionId = session.sessionId;
+    }
+    // If GUI provided a session hint that survived validation, bind it to the role slot
+    // so subsequent messages (without hint) also use this session.
+    if (hintSessionId && sessionId === hintSessionId) {
+      this.roleSessions.set(slotKey, sessionId);
     }
     if (taskId && effectiveRole !== "main") {
       this.taskManager.bindSession(taskId, sessionId);


### PR DESCRIPTION
## Summary
- GUI now passes the known `sessionId` through the full send_prompt chain: `messages.ts` → `tauri-bridge.ts` → `commands.rs` → orchestrator
- Orchestrator uses `hintSessionId` to override the `roleSessions` lookup, preventing new session creation when the GUI already knows which session to continue
- If the hinted session survives validation, it is bound to the role slot so subsequent messages (without hint) also reuse it

## Root cause
The GUI's `sendPrompt` path did NOT pass `sessionId` to the orchestrator. After MCP reconnects or when multiple sessions existed for the same role slot, `roleSessions` could return the wrong session or `undefined`, causing a brand new session to be created and losing all context.

## Changed files
| File | Change |
|------|--------|
| `packages/gui/src/stores/messages.ts` | Destructure `getSession`, pass `currentSessionId` to bridge |
| `packages/gui/src/lib/tauri-bridge.ts` | Add `sessionId?` parameter, forward to Rust invoke |
| `packages/gui/src-tauri/src/commands.rs` | Add `session_id: Option<String>`, include in JSON params |
| `packages/orchestrator/src/orchestrator.ts` | Add `hintSessionId` to `sendPrompt`, override `roleSessions` lookup, rebind slot on success |

## Test plan
- [ ] `cargo check` in `packages/gui/src-tauri` — passes
- [ ] TypeScript: `npx tsc --noEmit` in orchestrator — clean
- [ ] GUI: open existing sub-agent session → send message → same session continues (no new session)
- [ ] GUI: send message after MCP reconnect → session restored correctly

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)