### PR TITLE
feat(workflow): Issue-first workflow enforcement (#156)

### DIFF
--- a/.claude/hooks/pr-create-guard.sh
+++ b/.claude/hooks/pr-create-guard.sh
@@ -21,6 +21,10 @@ echo "$INPUT" | grep -qE '(--assignee|--add-assignee)' || MISSING="${MISSING}  -
 # Check --label or --add-label
 echo "$INPUT" | grep -qE '(--label|--add-label)' || MISSING="${MISSING}  - --label (required: bug/enhancement/etc.)\n"
 
+# Check Issue reference (Closes #N, Fixes #N, Refs #N, Resolves #N)
+# Require keyword+#N form to avoid false positives from bare #N in branch names/titles
+echo "$INPUT" | grep -qiE '(closes|fixes|resolves|refs)[[:space:]]+#[0-9]+' || MISSING="${MISSING}  - Issue reference in body (required: Closes #N or Refs #N)\n"
+
 # Extract --base value (supports --base develop, --base=develop, --base "develop")
 BASE_VAL=$(echo "$INPUT" | grep -oE '\-\-base[[:space:]=]+[^[:space:]"]+' | sed 's/.*[[:space:]=]//' | head -1)
 # Also check --base="value" form

--- a/.mercury/docs/guides/git-flow.md
+++ b/.mercury/docs/guides/git-flow.md
@@ -10,6 +10,8 @@
 | `master` | Stable — PR from develop only | Human / Main Agent |
 | `develop` | Integration baseline — **PR from feature only** | Main Agent via `gh pr merge` |
 | `feature/TASK-XXX` | Per-task work branch | Dev works here; Main creates, opens PR, and merges |
+| `fix/issue-N-slug` | Issue-linked bugfix | Same workflow as feature branches |
+| `feat/issue-N-slug` | Issue-linked feature | Same workflow as feature branches |
 
 ## Workflow
 

--- a/.mercury/docs/guides/issue-workflow.md
+++ b/.mercury/docs/guides/issue-workflow.md
@@ -39,7 +39,7 @@ GitHub Issues is the single source of truth for all task tracking in Mercury.
 ```
 1. Check for existing Issue (gh issue list)
 2. If none: create Issue (gh issue create --title "..." --label "..." --assignee ...)
-3. Create branch: feature/TASK-XXX (per git-flow guide), fix/issue-N-slug, or feat/issue-N-slug
+3. Create branch (feature/TASK-XXX for orchestrator-dispatched tasks; fix/issue-N-slug or feat/issue-N-slug for manual GitHub Issue work)
 4. Work, commit, push
 5. Post progress comment: gh issue comment N --body "Phase X complete: ..."
 6. Create PR with Closes/Fixes/Resolves #N or Refs #N in body

--- a/.mercury/docs/guides/issue-workflow.md
+++ b/.mercury/docs/guides/issue-workflow.md
@@ -12,6 +12,7 @@ GitHub Issues is the single source of truth for all task tracking in Mercury.
 ## Label Taxonomy
 
 ### Priority (mutually exclusive)
+
 | Label | Color | Use when |
 |-------|-------|----------|
 | `P0` | #B60205 | Production down, data loss, security vulnerability |
@@ -20,6 +21,7 @@ GitHub Issues is the single source of truth for all task tracking in Mercury.
 | `P3` | #0E8A16 | Nice to have, backlog |
 
 ### Type (one per issue)
+
 | Label | Color | Use when |
 |-------|-------|----------|
 | `bug` | #d73a4a | Something is broken |
@@ -30,13 +32,13 @@ GitHub Issues is the single source of truth for all task tracking in Mercury.
 
 ## Enforcement
 
-- `pr-create-guard.sh` blocks PRs without `--assignee`, `--label`, `--base develop`, and Issue reference (`Closes #N` / `Fixes #N` / `Resolves #N` / `Refs #N`)
-- CLAUDE.md MUST rule: "Issue-first workflow"
+- [`.claude/hooks/pr-create-guard.sh`](../../../.claude/hooks/pr-create-guard.sh) blocks PRs without `--assignee`, `--label`, `--base develop`, and Issue reference (`Closes #N` / `Fixes #N` / `Resolves #N` / `Refs #N`)
+- [CLAUDE.md](../../../CLAUDE.md) MUST rule: "Issue-first workflow"
 - Agents post milestone comments via `gh issue comment`
 
 ## Agent Workflow
 
-```
+```bash
 1. Check for existing Issue (gh issue list)
 2. If none: create Issue (gh issue create --title "..." --label "..." --assignee ...)
 3. Create branch (feature/TASK-XXX for orchestrator-dispatched tasks; fix/issue-N-slug or feat/issue-N-slug for manual GitHub Issue work)

--- a/.mercury/docs/guides/issue-workflow.md
+++ b/.mercury/docs/guides/issue-workflow.md
@@ -1,0 +1,47 @@
+# GitHub Issues Workflow
+
+GitHub Issues is the single source of truth for all task tracking in Mercury.
+
+## Rules
+
+1. **Every task starts as an Issue** — no work without an Issue number
+2. **PRs must reference Issues** — use `Closes #N` (auto-close on merge) or `Refs #N` (manual close)
+3. **Agent progress updates** — post comments on the Issue at milestone completion
+4. **No agent-memory-only tasks** — if it's worth doing, it's worth an Issue
+
+## Label Taxonomy
+
+### Priority (mutually exclusive)
+| Label | Color | Use when |
+|-------|-------|----------|
+| `P0` | #B60205 | Production down, data loss, security vulnerability |
+| `P1` | #D93F0B | Blocks current sprint, high-impact bug or feature |
+| `P2` | #FBCA04 | Important but not blocking, scheduled for next sprint |
+| `P3` | #0E8A16 | Nice to have, backlog |
+
+### Type (one per issue)
+| Label | Color | Use when |
+|-------|-------|----------|
+| `bug` | #d73a4a | Something is broken |
+| `enhancement` | #a2eeef | New feature or improvement to existing |
+| `strategic` | #FF6600 | Long-term, high-impact initiative |
+| `workflow` | #5319e7 | Process and workflow improvements |
+| `research` | #0E8A16 | Investigation or evaluation task |
+
+## Enforcement
+
+- `pr-create-guard.sh` blocks PRs without `--assignee`, `--label`, `--base develop`, and Issue reference (`Closes #N` / `Refs #N`)
+- CLAUDE.md MUST rule: "Issue-first workflow"
+- Agents post milestone comments via `gh issue comment`
+
+## Agent Workflow
+
+```
+1. Check for existing Issue (gh issue list)
+2. If none: create Issue (gh issue create --title "..." --label "..." --assignee ...)
+3. Create branch per git-flow guide (feature/TASK-XXX or fix/issue-N-description)
+4. Work, commit, push
+5. Post progress comment: gh issue comment N --body "Phase X complete: ..."
+6. Create PR with Closes #N or Refs #N in body
+7. After merge: Issue auto-closes (if Closes) or manually close
+```

--- a/.mercury/docs/guides/issue-workflow.md
+++ b/.mercury/docs/guides/issue-workflow.md
@@ -5,7 +5,7 @@ GitHub Issues is the single source of truth for all task tracking in Mercury.
 ## Rules
 
 1. **Every task starts as an Issue** — no work without an Issue number
-2. **PRs must reference Issues** — use `Closes #N` (auto-close on merge) or `Refs #N` (manual close)
+2. **PRs must reference Issues** — use `Closes #N` / `Fixes #N` / `Resolves #N` (auto-close on merge) or `Refs #N` (manual close)
 3. **Agent progress updates** — post comments on the Issue at milestone completion
 4. **No agent-memory-only tasks** — if it's worth doing, it's worth an Issue
 
@@ -26,11 +26,11 @@ GitHub Issues is the single source of truth for all task tracking in Mercury.
 | `enhancement` | #a2eeef | New feature or improvement to existing |
 | `strategic` | #FF6600 | Long-term, high-impact initiative |
 | `workflow` | #5319e7 | Process and workflow improvements |
-| `research` | #0E8A16 | Investigation or evaluation task |
+| `research` | #1D76DB | Investigation or evaluation task |
 
 ## Enforcement
 
-- `pr-create-guard.sh` blocks PRs without `--assignee`, `--label`, `--base develop`, and Issue reference (`Closes #N` / `Refs #N`)
+- `pr-create-guard.sh` blocks PRs without `--assignee`, `--label`, `--base develop`, and Issue reference (`Closes #N` / `Fixes #N` / `Resolves #N` / `Refs #N`)
 - CLAUDE.md MUST rule: "Issue-first workflow"
 - Agents post milestone comments via `gh issue comment`
 
@@ -39,9 +39,9 @@ GitHub Issues is the single source of truth for all task tracking in Mercury.
 ```
 1. Check for existing Issue (gh issue list)
 2. If none: create Issue (gh issue create --title "..." --label "..." --assignee ...)
-3. Create branch per git-flow guide (feature/TASK-XXX or fix/issue-N-description)
+3. Create branch: feature/TASK-XXX (per git-flow guide), fix/issue-N-slug, or feat/issue-N-slug
 4. Work, commit, push
 5. Post progress comment: gh issue comment N --body "Phase X complete: ..."
-6. Create PR with Closes #N or Refs #N in body
+6. Create PR with Closes/Fixes/Resolves #N or Refs #N in body
 7. After merge: Issue auto-closes (if Closes) or manually close
 ```

--- a/.mercury/docs/guides/issue-workflow.md
+++ b/.mercury/docs/guides/issue-workflow.md
@@ -5,7 +5,7 @@ GitHub Issues is the single source of truth for all task tracking in Mercury.
 ## Rules
 
 1. **Every task starts as an Issue** — no work without an Issue number
-2. **PRs must reference Issues** — use `Closes #N` / `Fixes #N` / `Resolves #N` (auto-close on merge) or `Refs #N` (manual close)
+2. **PRs must reference Issues** — accepted keywords are defined in [pr-create-guard.sh](../../../.claude/hooks/pr-create-guard.sh): `Closes #N` / `Fixes #N` / `Resolves #N` (auto-close) or `Refs #N` (manual close)
 3. **Agent progress updates** — post comments on the Issue at milestone completion
 4. **No agent-memory-only tasks** — if it's worth doing, it's worth an Issue
 
@@ -32,7 +32,7 @@ GitHub Issues is the single source of truth for all task tracking in Mercury.
 
 ## Enforcement
 
-- [`.claude/hooks/pr-create-guard.sh`](../../../.claude/hooks/pr-create-guard.sh) blocks PRs without `--assignee`, `--label`, `--base develop`, and Issue reference (`Closes #N` / `Fixes #N` / `Resolves #N` / `Refs #N`)
+- [`.claude/hooks/pr-create-guard.sh`](../../../.claude/hooks/pr-create-guard.sh) blocks PRs without `--assignee`, `--label`, `--base develop`, and a recognized Issue reference keyword (see Rule 2 above)
 - [CLAUDE.md](../../../CLAUDE.md) MUST rule: "Issue-first workflow"
 - Agents post milestone comments via `gh issue comment`
 
@@ -44,6 +44,6 @@ GitHub Issues is the single source of truth for all task tracking in Mercury.
 3. Create branch per git-flow rules (see .mercury/docs/guides/git-flow.md)
 4. Work, commit, push
 5. Post progress comment: gh issue comment N --body "Phase X complete: ..."
-6. Create PR with Closes/Fixes/Resolves #N or Refs #N in body
+6. Create PR with Issue reference keyword (e.g., Closes #N) in the gh pr create command
 7. After merge: Issue auto-closes (if Closes) or manually close
 ```

--- a/.mercury/docs/guides/issue-workflow.md
+++ b/.mercury/docs/guides/issue-workflow.md
@@ -41,7 +41,7 @@ GitHub Issues is the single source of truth for all task tracking in Mercury.
 ```bash
 1. Check for existing Issue (gh issue list)
 2. If none: create Issue (gh issue create --title "..." --label "..." --assignee ...)
-3. Create branch (feature/TASK-XXX for orchestrator-dispatched tasks; fix/issue-N-slug or feat/issue-N-slug for manual GitHub Issue work)
+3. Create branch per git-flow rules (see .mercury/docs/guides/git-flow.md)
 4. Work, commit, push
 5. Post progress comment: gh issue comment N --body "Phase X complete: ..."
 6. Create PR with Closes/Fixes/Resolves #N or Refs #N in body

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Read these docs on demand when you need the corresponding information:
 
 ## MUST
 
-- **Issue-first workflow**: every task must have a GitHub Issue before work begins. PRs must reference the Issue (`Closes #N` or `Refs #N`). Agent progress updates go on the Issue as comments.
+- **Issue-first workflow**: every task must have a GitHub Issue before work begins. PRs must reference the Issue (`Closes #N` / `Fixes #N` / `Resolves #N` / `Refs #N`). Agent progress updates go on the Issue as comments.
 - **Commit at every checkpoint**: every milestone must be committed and pushed.
 - **Dual-verify before commit**: every milestone must pass `/dual-verify` (parallel Claude Code deep-review + Codex code-audit) before committing. Do not use `/auto-verify` alone as the pre-commit gate.
 - **Web search before SDK/API code**: before writing ANY code that imports an external SDK, references an API signature, or claims a package version, you MUST use WebSearch/WebFetch to verify against the vendor's official documentation. GitHub source code alone is NOT sufficient. If verification is not possible, mark claims as UNVERIFIED.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,11 +18,13 @@ Read these docs on demand when you need the corresponding information:
 | Git branching rules | `.mercury/docs/guides/git-flow.md` |
 | KB directory structure | `.mercury/docs/guides/kb-structure.md` |
 | Project architecture | `.mercury/docs/guides/architecture.md` |
+| GitHub Issues workflow | `.mercury/docs/guides/issue-workflow.md` |
 | Dispatch prompt templates | `.mercury/templates/` |
 | Bundle templates | `Mercury_KB/99-templates/` |
 
 ## MUST
 
+- **Issue-first workflow**: every task must have a GitHub Issue before work begins. PRs must reference the Issue (`Closes #N` or `Refs #N`). Agent progress updates go on the Issue as comments.
 - **Commit at every checkpoint**: every milestone must be committed and pushed.
 - **Dual-verify before commit**: every milestone must pass `/dual-verify` (parallel Claude Code deep-review + Codex code-audit) before committing. Do not use `/auto-verify` alone as the pre-commit gate.
 - **Web search before SDK/API code**: before writing ANY code that imports an external SDK, references an API signature, or claims a package version, you MUST use WebSearch/WebFetch to verify against the vendor's official documentation. GitHub source code alone is NOT sufficient. If verification is not possible, mark claims as UNVERIFIED.
@@ -41,3 +43,4 @@ Read these docs on demand when you need the corresponding information:
 - Do not install software to C drive.
 - Do not bypass the SoT task flow.
 - Do not execute work outside your assigned role.
+- Do not create PRs without an associated GitHub Issue.


### PR DESCRIPTION
## Summary
- Add "Issue-first workflow" as MUST rule in CLAUDE.md — every task needs a GitHub Issue before work begins
- Enhance `pr-create-guard.sh` to require Issue reference (`Closes #N` / `Refs #N`) in PR body
- Add `issue-workflow.md` guide documenting label taxonomy, agent workflow, and enforcement rules

## Changes
| File | Change |
|------|--------|
| `CLAUDE.md` | +MUST: Issue-first workflow, +DO NOT: no PR without Issue, +nav link |
| `.claude/hooks/pr-create-guard.sh` | +Issue reference check (keyword+#N regex) |
| `.mercury/docs/guides/issue-workflow.md` | New guide: labels, workflow, enforcement |

## Test plan
- [ ] Verify `gh pr create` without Issue reference is blocked
- [ ] Verify `gh pr create --body "Closes #123"` passes
- [ ] Verify `Fixes #N`, `Refs #N`, `Resolves #N` all pass
- [ ] Verify bare `#N` without keyword does NOT pass (prevents false positives)

## Verification
```
dual-verify: PASS (Claude: PASS, Codex: PASS, 1 high regex fix applied)
```

Closes #156
Refs #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)