### PR TITLE
chore: add Argus PR review agent configuration (#164)

### DIFF
--- a/.mercury/docs/guides/argus-review-guide.md
+++ b/.mercury/docs/guides/argus-review-guide.md
@@ -1,0 +1,69 @@
+# Argus — Automated PR Review Agent
+
+Self-hosted PR review agent for Mercury, replacing CodeRabbit SaaS.
+
+## Identity
+
+- **GitHub App**: [Argus-review](https://github.com/apps/argus-review)
+- **Bot user**: `argus-review[bot]`
+- **Backend**: PR-Agent 0.34 + GPT-5.3-Codex
+- **Deployed on**: QNAP NAS via Docker + Cloudflare Tunnel
+
+## Commands
+
+Post these as PR comments to trigger Argus:
+
+| Command | Action |
+|---------|--------|
+| `/review` | Full review: summary (GitHub Review object) + inline threads on code lines |
+| `/improve` | Code suggestions as inline threads with committable blocks |
+| `/describe` | Auto-generate PR description |
+| `/ask <question>` | Ask a question about the PR |
+
+## Auto Triggers
+
+On PR open: `/describe` + `/review` + `/improve`
+On new commit push: `/describe` + `/review`
+
+## Review Output Format
+
+`/review` posts a **single GitHub Review** containing:
+1. **Summary body**: PR Reviewer Guide (effort, security, ticket compliance)
+2. **Inline threads**: Key issues on specific code lines, each with:
+   - Severity badge (Critical/Major/Medium/Minor)
+   - Problem description
+   - `🤖 Prompt for AI Agents` (collapsible, English)
+
+`/improve` posts **inline code threads** with:
+- Severity + label
+- `📝 Committable suggestion` (one-click apply)
+- `🤖 Prompt for AI Agents`
+
+## Configuration
+
+Repo-level overrides: `.pr_agent.toml` (in Mercury repo root)
+Server-level config: `configuration.toml` (on NAS, managed via [Argus repo](https://github.com/392fyc/Argus))
+
+## User Whitelist
+
+Only users listed in `ARGUS_ALLOWED_USERS` env var on the NAS can trigger reviews. Bot users (`[bot]`) are auto-allowed.
+
+## Infrastructure
+
+| Component | Location |
+|-----------|----------|
+| Repo | https://github.com/392fyc/Argus |
+| Webhook URL | `https://argus.fyc-space.uk/api/v1/github_webhooks` |
+| NAS config | `/share/homes/392fyc/argus/` |
+| CI/CD | Push to Argus master → auto-deploy to NAS via GitHub Actions + cloudflared SSH |
+| Domain | `fyc-space.uk` (Cloudflare Tunnel) |
+
+## Differences from CodeRabbit
+
+| Aspect | CodeRabbit | Argus |
+|--------|-----------|-------|
+| Trigger | `@coderabbitai review` | `/review` |
+| CI check | Creates CI check | No CI check (uses GitHub Review objects) |
+| Approval | Can submit APPROVED | Cannot self-approve owner PRs |
+| Hosting | SaaS | Self-hosted on NAS |
+| Cost | $24/mo/dev | ~$0.10/review (API tokens) |

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,45 @@
+# Mercury — PR-Agent Configuration (repo-level overrides)
+# This file is read by the self-hosted PR-Agent instance.
+# Docs: https://qodo-merge-docs.qodo.ai/usage-guide/configuration_options/
+
+[pr_reviewer]
+extra_instructions = """\
+You are an ASSERTIVE code reviewer for the Mercury project.
+Mercury is a multi-agent orchestration framework built on Claude Code.
+Monorepo structure: packages/orchestrator, packages/sdk-adapters, packages/core, packages/gui.
+
+Review language: Chinese (zh-CN).
+
+Focus areas by path:
+- packages/orchestrator/: task state machine consistency, event bus naming, scope \
+  validation, async flow completeness, system design impact
+- packages/sdk-adapters/: adapter interface consistency, error handling, session \
+  lifecycle, MCP protocol compatibility
+- packages/core/: TypeScript type safety, interface backward compatibility, \
+  dependency management
+- packages/gui/: Tauri 2 API usage, Vue 3 reactivity, memory leaks
+- .mercury/: role definition consistency, template placeholder completeness, \
+  doc cross-reference correctness
+
+General rules:
+- Flag bugs, security vulnerabilities, and logic errors as high priority
+- Check async/await correctness and error handling completeness
+- Verify git branching rules (no direct push to develop/master)
+- Estimate code review effort
+"""
+
+[pr_description]
+extra_instructions = """\
+Generate PR description in Chinese (zh-CN).
+Include: high-level summary, walkthrough of changes, related issues.
+"""
+
+[config]
+# Ignore generated/non-essential files
+ignore_files = [
+    "**/*.lock",
+    "dist/**",
+    "Mercury_KB/**",
+    ".mercury/transcripts/**",
+    ".mercury/sessions.json",
+]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@ Read these docs on demand when you need the corresponding information:
 | KB directory structure | `.mercury/docs/guides/kb-structure.md` |
 | Project architecture | `.mercury/docs/guides/architecture.md` |
 | GitHub Issues workflow | `.mercury/docs/guides/issue-workflow.md` |
+| Argus PR review agent | `.mercury/docs/guides/argus-review-guide.md` |
 | Dispatch prompt templates | `.mercury/templates/` |
 | Bundle templates | `Mercury_KB/99-templates/` |
 


### PR DESCRIPTION
## Summary
- Commit `.pr_agent.toml` — repo-level review rules for Argus (PR-Agent)
- Add `argus-review-guide.md` — commands, format, infrastructure docs
- Update `CLAUDE.md` navigation table with Argus guide link

Zero behavioral change — configuration and documentation only.

## Test plan
- [ ] Verify `.pr_agent.toml` is accessible at repo root
- [ ] Verify guide doc renders correctly on GitHub

Closes #164 (partial — PR 1 of 5)
Refs #132