### PR TITLE
chore: add build artifacts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ node_modules/
 dist/
 dist-ssr/
 *.local
+*.tsbuildinfo
+vite.config.js
+vite.config.d.ts
 
 # Rust/Tauri
 packages/gui/src-tauri/target/
@@ -43,6 +46,7 @@ $RECYCLE.BIN/
 # Claude Code
 .claude/plans/
 .claude/hooks/state/
+.claude/scheduled_tasks.lock
 .mercury/state/
 .claude/settings.local.json
 CLAUDE.md


### PR DESCRIPTION
## Summary
Add TypeScript build cache and Vite output files to .gitignore to prevent accumulation of untracked files.

## Changes
- `*.tsbuildinfo` — TypeScript incremental build cache
- `vite.config.js`, `vite.config.d.ts` — Vite build output
- `.claude/scheduled_tasks.lock` — Claude Code cron lock file

Also cleaned up 10 untracked files from working tree (research drafts whose final versions were already merged via PRs #153, #162).

Refs #164