### PR TITLE
refactor(skills): genericize review bot references (#164)

### DIFF
--- a/.agents/skills/auto-verify/SKILL.md
+++ b/.agents/skills/auto-verify/SKILL.md
@@ -58,7 +58,7 @@ npx eslint --max-warnings 0 <changed-files>
    - Count exported classes, functions, async functions, and const declarations, then count those with `/** ... */`
    - If coverage is below 50%, report which files are under the threshold
    - This scans the entire file, not just diff hunks
-   - This aligns with CodeRabbit's pre-merge check (`.coderabbit.yaml` threshold: 50%)
+   - This aligns with the review bot's pre-merge check (docstring threshold: 50%)
 
 ```powershell
 git diff --cached --name-only --diff-filter=ACMRT -- '*.ts' | ForEach-Object {

--- a/.agents/skills/pr-flow/SKILL.md
+++ b/.agents/skills/pr-flow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pr-flow
 description: |
-  Automate the full PR lifecycle: create PR, poll for CodeRabbit review, respond to ALL threads (inline + outside-diff), fix issues, resolve threads, re-review, and merge after approval. Use this skill when the user says "PR", "pull request", "create PR", "merge PR", "提PR", "合并", "PR流程", "开PR", "check PR status", "review comments", "标准PR流程". Use this skill after dev work reaches `implementation_done`, the branch is pushed, and the task has passed `main_review`. It replaces the manual C4-C7 steps in the Mercury workflow.
+  Automate the full PR lifecycle: create PR, poll for Argus review, respond to ALL threads (inline + outside-diff), fix issues, resolve threads, re-review, and merge after approval. Use this skill when the user says "PR", "pull request", "create PR", "merge PR", "提PR", "合并", "PR流程", "开PR", "check PR status", "review comments", "标准PR流程". Use this skill after dev work reaches `implementation_done`, the branch is pushed, and the task has passed `main_review`. It replaces the manual C4-C7 steps in the Mercury workflow.
 ---
 
 # PR Flow
@@ -67,7 +67,7 @@ When changes should be split by category:
 
 Do not rely on `git stash` in guarded Codex sessions.
 
-### Phase 2: Poll for CodeRabbit Review (Non-Blocking)
+### Phase 2: Poll for Argus Review (Non-Blocking)
 
 Do not use long blocking `sleep` loops for 10-minute review polling.
 
@@ -88,13 +88,13 @@ Each check should:
 2. fetch inline comments with `gh api repos/{owner}/{repo}/pulls/<N>/comments`
 3. detect new activity
 4. increment or clear the consecutive-no-activity counter
-5. after 3 consecutive quiet checks, trigger `@coderabbitai review` once if it has not already been requested
+5. after 3 consecutive quiet checks, trigger `/review` once if it has not already been requested
 
 ### Phase 3: Respond to ALL Review Threads
 
 Iteration cap: default `MAX_ITERATIONS=5`.
 
-Critical rule: every CodeRabbit comment must receive a response, even if you disagree.
+Critical rule: every Argus comment must receive a response, even if you disagree.
 
 This includes:
 - inline comments
@@ -113,11 +113,11 @@ This includes:
 
 These appear in the review body, not as inline threads.
 
-Always address them in a PR comment and include `@coderabbitai`:
+Always address them in a PR comment and include `@argus-review`:
 
 ```powershell
-gh pr comment <PR_NUMBER> --body "@coderabbitai
-## Addressed CodeRabbit review
+gh pr comment <PR_NUMBER> --body "@argus-review
+## Addressed Argus review
 ### Inline comments (N/N resolved):
 1. **Issue** - fixed in <sha>
 ### Outside-diff comments (N/N resolved):
@@ -249,14 +249,14 @@ Remove-Item .pr-flow-iteration-*, .pr-flow-check-count-*, .pr-flow-multi.txt -Er
 
 Rules:
 - even threads you disagree with must be commented on and resolved
-- when posting non-direct PR comments, include `@coderabbitai`
+- when posting non-direct PR comments, include `@argus-review`
 - outside-diff comments still count as required responses
 
 ## Output
 
 ```text
 PR: #<number> (<url>)
-CodeRabbit: approved | changes_requested | pending
+Argus: approved | changes_requested | pending
 Feedback: <N> inline, <N> outside-diff, <N> addressed, iteration=<N>
 Merge: merged | waiting | blocked
 Task: <taskId> -> done | pending

--- a/.agents/skills/pr-flow/SKILL.md
+++ b/.agents/skills/pr-flow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pr-flow
 description: |
-  Automate the full PR lifecycle: create PR, poll for Argus review, respond to ALL threads (inline + outside-diff), fix issues, resolve threads, re-review, and merge after approval. Use this skill when the user says "PR", "pull request", "create PR", "merge PR", "提PR", "合并", "PR流程", "开PR", "check PR status", "review comments", "标准PR流程". Use this skill after dev work reaches `implementation_done`, the branch is pushed, and the task has passed `main_review`. It replaces the manual C4-C7 steps in the Mercury workflow.
+  Automate the full PR lifecycle: create PR, poll for review bot, respond to ALL threads (inline + outside-diff), fix issues, resolve threads, re-review, and merge after approval. Use this skill when the user says "PR", "pull request", "create PR", "merge PR", "提PR", "合并", "PR流程", "开PR", "check PR status", "review comments", "标准PR流程". Use this skill after dev work reaches `implementation_done`, the branch is pushed, and the task has passed `main_review`. It replaces the manual C4-C7 steps in the Mercury workflow.
 ---
 
 # PR Flow
@@ -67,7 +67,7 @@ When changes should be split by category:
 
 Do not rely on `git stash` in guarded Codex sessions.
 
-### Phase 2: Poll for Argus Review (Non-Blocking)
+### Phase 2: Poll for Review Bot (Non-Blocking)
 
 Do not use long blocking `sleep` loops for 10-minute review polling.
 
@@ -94,7 +94,7 @@ Each check should:
 
 Iteration cap: default `MAX_ITERATIONS=5`.
 
-Critical rule: every Argus comment must receive a response, even if you disagree.
+Critical rule: every review bot comment must receive a response, even if you disagree.
 
 This includes:
 - inline comments
@@ -113,11 +113,11 @@ This includes:
 
 These appear in the review body, not as inline threads.
 
-Always address them in a PR comment and include `@argus-review`:
+Always address them in a PR comment and include `@<REVIEW_BOT>`:
 
 ```powershell
-gh pr comment <PR_NUMBER> --body "@argus-review
-## Addressed Argus review
+gh pr comment <PR_NUMBER> --body "@<REVIEW_BOT>
+## Addressed review feedback
 ### Inline comments (N/N resolved):
 1. **Issue** - fixed in <sha>
 ### Outside-diff comments (N/N resolved):
@@ -249,14 +249,14 @@ Remove-Item .pr-flow-iteration-*, .pr-flow-check-count-*, .pr-flow-multi.txt -Er
 
 Rules:
 - even threads you disagree with must be commented on and resolved
-- when posting non-direct PR comments, include `@argus-review`
+- when posting non-direct PR comments, include `@<REVIEW_BOT>`
 - outside-diff comments still count as required responses
 
 ## Output
 
 ```text
 PR: #<number> (<url>)
-Argus: approved | changes_requested | pending
+Review: approved | changes_requested | pending
 Feedback: <N> inline, <N> outside-diff, <N> addressed, iteration=<N>
 Merge: merged | waiting | blocked
 Task: <taskId> -> done | pending

--- a/.claude/skills/auto-verify/SKILL.md
+++ b/.claude/skills/auto-verify/SKILL.md
@@ -51,7 +51,7 @@ npx eslint --max-warnings 0 <changed-files>
    - If coverage < 50%, report which exports are missing JSDoc
    - Note: this scans the entire file, not just the diff hunks — pre-existing undocumented
      exports in a touched file will also count
-   - This aligns with CodeRabbit's pre-merge check (`.coderabbit.yaml` threshold: 50%)
+   - This aligns with the review bot's pre-merge check (docstring threshold: 50%)
 
 ```bash
 # Quick heuristic: count exports vs documented exports in changed .ts files.

--- a/.claude/skills/pr-flow/SKILL.md
+++ b/.claude/skills/pr-flow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pr-flow
 description: |
-  Automate the full PR lifecycle: create PR, poll for Argus review, respond to ALL threads (inline + outside-diff), fix issues, resolve threads, re-review, and merge after approval. Use this skill when the user says "PR", "pull request", "create PR", "merge PR", "提PR", "合并", "PR流程", "开PR", "check PR status", "review comments", "标准PR流程". Use this skill after dev work reaches `implementation_done`, the branch is pushed, and the task has passed `main_review`. It replaces the manual C4-C7 steps in the Mercury workflow.
+  Automate the full PR lifecycle: create PR, poll for review bot, respond to ALL threads (inline + outside-diff), fix issues, resolve threads, re-review, and merge after approval. Use this skill when the user says "PR", "pull request", "create PR", "merge PR", "提PR", "合并", "PR流程", "开PR", "check PR status", "review comments", "标准PR流程". Use this skill after dev work reaches `implementation_done`, the branch is pushed, and the task has passed `main_review`. It replaces the manual C4-C7 steps in the Mercury workflow.
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write, WebSearch, WebFetch, Agent, TodoWrite, CronCreate, CronDelete
 ---
@@ -57,7 +57,7 @@ When changes should be split by task category (e.g., feature + bugfix + UI):
 3. After all branches created: `git stash drop`
 4. Track all PR numbers for parallel review monitoring
 
-### Phase 2: Poll for Argus Review (Non-Blocking)
+### Phase 2: Poll for Review Bot (Non-Blocking)
 
 **DO NOT** use blocking `sleep` loops. Use `CronCreate` for periodic checks:
 
@@ -70,8 +70,8 @@ CronCreate:
 
 The check prompt should:
 1. Fetch review status for all tracked PRs via `gh pr view <N> --json reviews,reviewDecision`
-2. Check for new **inline** comments via `gh api repos/<OWNER>/<REPO>/pulls/<N>/comments --jq '[.[] | select(.user.login == "argus-review[bot]")]'`
-3. Check for new **outside-diff** comments (review body / PR-level) via `gh api repos/<OWNER>/<REPO>/issues/<N>/comments --jq '[.[] | select(.user.login == "argus-review[bot]")]'`
+2. Check for new **inline** comments via `gh api repos/<OWNER>/<REPO>/pulls/<N>/comments --jq '[.[] | select(.user.login == "<REVIEW_BOT>")]'`
+3. Check for new **outside-diff** comments (review body / PR-level) via `gh api repos/<OWNER>/<REPO>/issues/<N>/comments --jq '[.[] | select(.user.login == "<REVIEW_BOT>")]'`
 4. Track consecutive checks via file-based counter (cron jobs are stateless across invocations):
 
    ```bash
@@ -84,7 +84,7 @@ The check prompt should:
    fi
    ```
 
-5. After **3 consecutive checks with no Argus activity**, proactively trigger (with dedup):
+5. After **3 consecutive checks with no review bot activity**, proactively trigger (with dedup):
 
    ```bash
    if [ "$COUNT" -ge 3 ]; then
@@ -107,7 +107,7 @@ The check prompt should:
 - Post a PR comment notifying the user
 - Stop automatic rework and wait for human guidance
 
-**CRITICAL RULE**: Every Argus comment MUST receive a response, even if you disagree.
+**CRITICAL RULE**: Every review bot comment MUST receive a response, even if you disagree.
 This includes:
 - **Inline comments** (accessible via `gh api repos/{owner}/{repo}/pulls/<N>/comments`)
 - **Outside-diff comments** (embedded in review body, not inline — address in PR comment)
@@ -122,12 +122,12 @@ This includes:
 
 #### For outside-diff comments:
 1. These appear in the review body, not as inline threads
-2. **IMPORTANT**: When posting PR comments (non-direct thread replies), always include `@argus-review` mention so Argus can detect and track the response
+2. **IMPORTANT**: When posting PR comments (non-direct thread replies), always include `@<REVIEW_BOT>` mention so the review bot can detect and track the response
 3. Address them in a PR comment summarizing all fixes:
 
    ```bash
-   gh pr comment <PR_NUMBER> --body "@argus-review
-   ## Addressed Argus review
+   gh pr comment <PR_NUMBER> --body "@<REVIEW_BOT>
+   ## Addressed review feedback
    ### Inline comments (N/N resolved):
    1. **Issue** — fixed in <sha>
    ### Outside-diff comments (N/N resolved):
@@ -241,7 +241,7 @@ if [ "$ITER" -ge "$MAX_ITERATIONS" ]; then
 fi
 ```
 
-Return to **Phase 2** polling. Repeat the Phase 2-5 cycle until Argus approves.
+Return to **Phase 2** polling. Repeat the Phase 2-5 cycle until the review bot approves.
 
 Typical convergence: 1-2 iterations for most PRs. Clean up `$ITER_FILE` after merge.
 
@@ -371,14 +371,14 @@ When running multiple PRs in parallel:
 | Out-of-scope suggestion | Acknowledge, explain it is out of scope, resolve thread |
 
 **Rules**:
-- Even threads you disagree with MUST be commented on and resolved. Argus will not re-approve while unresolved threads remain.
-- When posting non-direct replies (PR comments instead of thread replies), always include `@argus-review` so Argus can detect the response.
+- Even threads you disagree with MUST be commented on and resolved. The review bot will not re-approve while unresolved threads remain.
+- When posting non-direct replies (PR comments instead of thread replies), always include `@<REVIEW_BOT>` so the review bot can detect the response.
 
 ## Output
 
 ```text
 PR: #<number> (<url>)
-Argus: approved | changes_requested | pending
+Review: approved | changes_requested | pending
 Feedback: <N> inline, <N> outside-diff, <N> addressed, iteration=<N>
 Merge: merged | waiting | blocked
 Task: <taskId> -> done | pending

--- a/.claude/skills/pr-flow/SKILL.md
+++ b/.claude/skills/pr-flow/SKILL.md
@@ -88,8 +88,8 @@ The check prompt should:
 
    ```bash
    if [ "$COUNT" -ge 3 ]; then
-     # Only trigger if no existing /review comment
-     if ! gh api repos/{owner}/{repo}/issues/${PR_NUMBER}/comments --jq '.[].body' | grep -Fq "/review"; then
+     # Only trigger if no existing standalone /review comment (exact line match)
+     if ! gh api repos/{owner}/{repo}/issues/${PR_NUMBER}/comments --jq '.[].body' | grep -xq '/review'; then
        gh pr comment "$PR_NUMBER" --body "/review"
      fi
      rm -f "$COUNT_FILE"

--- a/.claude/skills/pr-flow/SKILL.md
+++ b/.claude/skills/pr-flow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pr-flow
 description: |
-  Automate the full PR lifecycle: create PR, poll for CodeRabbit review, respond to ALL threads (inline + outside-diff), fix issues, resolve threads, re-review, and merge after approval. Use this skill when the user says "PR", "pull request", "create PR", "merge PR", "提PR", "合并", "PR流程", "开PR", "check PR status", "review comments", "标准PR流程". Use this skill after dev work reaches `implementation_done`, the branch is pushed, and the task has passed `main_review`. It replaces the manual C4-C7 steps in the Mercury workflow.
+  Automate the full PR lifecycle: create PR, poll for Argus review, respond to ALL threads (inline + outside-diff), fix issues, resolve threads, re-review, and merge after approval. Use this skill when the user says "PR", "pull request", "create PR", "merge PR", "提PR", "合并", "PR流程", "开PR", "check PR status", "review comments", "标准PR流程". Use this skill after dev work reaches `implementation_done`, the branch is pushed, and the task has passed `main_review`. It replaces the manual C4-C7 steps in the Mercury workflow.
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write, WebSearch, WebFetch, Agent, TodoWrite, CronCreate, CronDelete
 ---
@@ -57,7 +57,7 @@ When changes should be split by task category (e.g., feature + bugfix + UI):
 3. After all branches created: `git stash drop`
 4. Track all PR numbers for parallel review monitoring
 
-### Phase 2: Poll for CodeRabbit Review (Non-Blocking)
+### Phase 2: Poll for Argus Review (Non-Blocking)
 
 **DO NOT** use blocking `sleep` loops. Use `CronCreate` for periodic checks:
 
@@ -70,8 +70,8 @@ CronCreate:
 
 The check prompt should:
 1. Fetch review status for all tracked PRs via `gh pr view <N> --json reviews,reviewDecision`
-2. Check for new **inline** comments via `gh api repos/<OWNER>/<REPO>/pulls/<N>/comments --jq '[.[] | select(.user.login == "coderabbitai[bot]")]'`
-3. Check for new **outside-diff** comments (review body / PR-level) via `gh api repos/<OWNER>/<REPO>/issues/<N>/comments --jq '[.[] | select(.user.login == "coderabbitai[bot]")]'`
+2. Check for new **inline** comments via `gh api repos/<OWNER>/<REPO>/pulls/<N>/comments --jq '[.[] | select(.user.login == "argus-review[bot]")]'`
+3. Check for new **outside-diff** comments (review body / PR-level) via `gh api repos/<OWNER>/<REPO>/issues/<N>/comments --jq '[.[] | select(.user.login == "argus-review[bot]")]'`
 4. Track consecutive checks via file-based counter (cron jobs are stateless across invocations):
 
    ```bash
@@ -84,13 +84,13 @@ The check prompt should:
    fi
    ```
 
-5. After **3 consecutive checks with no CodeRabbit activity**, proactively trigger (with dedup):
+5. After **3 consecutive checks with no Argus activity**, proactively trigger (with dedup):
 
    ```bash
    if [ "$COUNT" -ge 3 ]; then
-     # Only trigger if no existing @coderabbitai review comment
-     if ! gh api repos/{owner}/{repo}/issues/${PR_NUMBER}/comments --jq '.[].body' | grep -Fq "@coderabbitai review"; then
-       gh pr comment "$PR_NUMBER" --body "@coderabbitai review"
+     # Only trigger if no existing /review comment
+     if ! gh api repos/{owner}/{repo}/issues/${PR_NUMBER}/comments --jq '.[].body' | grep -Fq "/review"; then
+       gh pr comment "$PR_NUMBER" --body "/review"
      fi
      rm -f "$COUNT_FILE"
    fi
@@ -107,7 +107,7 @@ The check prompt should:
 - Post a PR comment notifying the user
 - Stop automatic rework and wait for human guidance
 
-**CRITICAL RULE**: Every CodeRabbit comment MUST receive a response, even if you disagree.
+**CRITICAL RULE**: Every Argus comment MUST receive a response, even if you disagree.
 This includes:
 - **Inline comments** (accessible via `gh api repos/{owner}/{repo}/pulls/<N>/comments`)
 - **Outside-diff comments** (embedded in review body, not inline — address in PR comment)
@@ -122,12 +122,12 @@ This includes:
 
 #### For outside-diff comments:
 1. These appear in the review body, not as inline threads
-2. **IMPORTANT**: When posting PR comments (non-direct thread replies), always include `@coderabbitai` mention so CodeRabbit can detect and track the response
+2. **IMPORTANT**: When posting PR comments (non-direct thread replies), always include `@argus-review` mention so Argus can detect and track the response
 3. Address them in a PR comment summarizing all fixes:
 
    ```bash
-   gh pr comment <PR_NUMBER> --body "@coderabbitai
-   ## Addressed CodeRabbit review
+   gh pr comment <PR_NUMBER> --body "@argus-review
+   ## Addressed Argus review
    ### Inline comments (N/N resolved):
    1. **Issue** — fixed in <sha>
    ### Outside-diff comments (N/N resolved):
@@ -241,7 +241,7 @@ if [ "$ITER" -ge "$MAX_ITERATIONS" ]; then
 fi
 ```
 
-Return to **Phase 2** polling. Repeat the Phase 2-5 cycle until CodeRabbit approves.
+Return to **Phase 2** polling. Repeat the Phase 2-5 cycle until Argus approves.
 
 Typical convergence: 1-2 iterations for most PRs. Clean up `$ITER_FILE` after merge.
 
@@ -371,14 +371,14 @@ When running multiple PRs in parallel:
 | Out-of-scope suggestion | Acknowledge, explain it is out of scope, resolve thread |
 
 **Rules**:
-- Even threads you disagree with MUST be commented on and resolved. CodeRabbit will not re-approve while unresolved threads remain.
-- When posting non-direct replies (PR comments instead of thread replies), always include `@coderabbitai` so CodeRabbit can detect the response.
+- Even threads you disagree with MUST be commented on and resolved. Argus will not re-approve while unresolved threads remain.
+- When posting non-direct replies (PR comments instead of thread replies), always include `@argus-review` so Argus can detect the response.
 
 ## Output
 
 ```text
 PR: #<number> (<url>)
-CodeRabbit: approved | changes_requested | pending
+Argus: approved | changes_requested | pending
 Feedback: <N> inline, <N> outside-diff, <N> addressed, iteration=<N>
 Merge: merged | waiting | blocked
 Task: <taskId> -> done | pending

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,7 @@ mercury.config.json
 
 # Autoresearch state (standalone mode, transient)
 .research/
+
+# PR review agent (deployment-specific, use .pr_agent.toml.example as template)
+.pr_agent.toml
+.mercury/docs/guides/argus-review-guide.md

--- a/.mercury/skills/pr-coderabbit-flow/.skill_id
+++ b/.mercury/skills/pr-coderabbit-flow/.skill_id
@@ -1,1 +1,0 @@
-pr-coderabbit-flow__imp_3b8b96f8

--- a/.mercury/skills/pr-review-flow/.skill_id
+++ b/.mercury/skills/pr-review-flow/.skill_id
@@ -1,0 +1,1 @@
+pr-review-flow__imp_3b8b96f8

--- a/.mercury/skills/pr-review-flow/SKILL.md
+++ b/.mercury/skills/pr-review-flow/SKILL.md
@@ -1,13 +1,13 @@
 ---
-name: pr-coderabbit-flow
-description: Full PR lifecycle — create PR, wait for CodeRabbit review, address all threads, then merge.
+name: pr-review-flow
+description: Full PR lifecycle — create PR, wait for Argus review, address all threads, then merge.
 category: WORKFLOW
 roles:
   - dev
 origin: IMPORTED
 tags:
   - pr
-  - coderabbit
+  - argus
   - github
   - review
 generation: 0
@@ -19,7 +19,7 @@ total_fallbacks: 0
 last_validated_at: 2026-04-04T00:00:00.000Z
 ---
 
-# PR → CodeRabbit → Merge Flow
+# PR → Argus → Merge Flow
 
 ## Steps
 
@@ -37,7 +37,7 @@ last_validated_at: 2026-04-04T00:00:00.000Z
    )"
    ```
 
-2. **Wait for CodeRabbit** — poll every 30s
+2. **Wait for Argus** — poll every 30s
    ```bash
    gh pr checks <PR_NUMBER> --watch
    ```
@@ -49,17 +49,17 @@ last_validated_at: 2026-04-04T00:00:00.000Z
 
 4. **Request re-review** — after all threads are addressed
    ```bash
-   gh pr comment <PR_NUMBER> --body "@coderabbitai All threads addressed. Please re-review."
+   gh pr comment <PR_NUMBER> --body "@argusai All threads addressed. Please re-review."
    ```
 
-5. **Merge** — only after CodeRabbit approves (no pending changes)
+5. **Merge** — only after Argus approves (no pending changes)
    ```bash
    gh pr merge <PR_NUMBER> --squash --delete-branch
    ```
 
 ## Critical Rules
 
-- NEVER merge before CodeRabbit review completes
+- NEVER merge before Argus review completes
 - NEVER force-push to `develop` or `master`
 - NEVER resolve PR threads yourself — that is the reviewer's action
 - Always push after every commit: `git push`

--- a/.mercury/skills/pr-review-flow/SKILL.md
+++ b/.mercury/skills/pr-review-flow/SKILL.md
@@ -7,7 +7,7 @@ roles:
 origin: IMPORTED
 tags:
   - pr
-  - argus
+  - review-bot
   - github
   - review
 generation: 0
@@ -49,7 +49,7 @@ last_validated_at: 2026-04-04T00:00:00.000Z
 
 4. **Request re-review** — after all threads are addressed
    ```bash
-   gh pr comment <PR_NUMBER> --body "@argusai All threads addressed. Please re-review."
+   gh pr comment <PR_NUMBER> --body "/review"
    ```
 
 5. **Merge** — only after the review bot approves (no pending changes)

--- a/.mercury/skills/pr-review-flow/SKILL.md
+++ b/.mercury/skills/pr-review-flow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-review-flow
-description: Full PR lifecycle — create PR, wait for Argus review, address all threads, then merge.
+description: Full PR lifecycle — create PR, wait for review bot, address all threads, then merge.
 category: WORKFLOW
 roles:
   - dev
@@ -19,7 +19,7 @@ total_fallbacks: 0
 last_validated_at: 2026-04-04T00:00:00.000Z
 ---
 
-# PR → Argus → Merge Flow
+# PR → Review → Merge Flow
 
 ## Steps
 
@@ -37,7 +37,7 @@ last_validated_at: 2026-04-04T00:00:00.000Z
    )"
    ```
 
-2. **Wait for Argus** — poll every 30s
+2. **Wait for the review bot** — poll every 30s
    ```bash
    gh pr checks <PR_NUMBER> --watch
    ```
@@ -52,14 +52,14 @@ last_validated_at: 2026-04-04T00:00:00.000Z
    gh pr comment <PR_NUMBER> --body "@argusai All threads addressed. Please re-review."
    ```
 
-5. **Merge** — only after Argus approves (no pending changes)
+5. **Merge** — only after the review bot approves (no pending changes)
    ```bash
    gh pr merge <PR_NUMBER> --squash --delete-branch
    ```
 
 ## Critical Rules
 
-- NEVER merge before Argus review completes
+- NEVER merge before review bot check completes
 - NEVER force-push to `develop` or `master`
 - NEVER resolve PR threads yourself — that is the reviewer's action
 - Always push after every commit: `git push`

--- a/.pr_agent.toml.example
+++ b/.pr_agent.toml.example
@@ -1,0 +1,22 @@
+# Mercury — PR-Agent Configuration (repo-level overrides)
+# Copy this file to .pr_agent.toml and customize for your PR review agent.
+# This file is read by self-hosted PR-Agent instances (e.g., Qodo Merge, Argus).
+# Docs: https://qodo-merge-docs.qodo.ai/usage-guide/configuration_options/
+
+[pr_reviewer]
+extra_instructions = """\
+Review instructions for your PR review bot go here.
+Customize focus areas, review language, and priority rules.
+"""
+
+[pr_description]
+extra_instructions = """\
+PR description generation instructions go here.
+"""
+
+[config]
+# Ignore generated/non-essential files
+ignore_files = [
+    "**/*.lock",
+    "dist/**",
+]


### PR DESCRIPTION
## Summary
- Replace all CodeRabbit/Argus hardcoded references with generic "review bot" language in pr-flow and auto-verify skills
- Rename `.mercury/skills/pr-coderabbit-flow/` → `pr-review-flow/`
- Add `.pr_agent.toml.example` as template for PR review agent config
- Add `.pr_agent.toml` and `argus-review-guide.md` to `.gitignore` (deployment-specific)
- Standardize review trigger command to `/review`

## Test plan
- [x] No remaining Argus/CodeRabbit hardcoded references in skill files (grep verified)
- [x] Three skill variants (.claude, .agents, .mercury) are consistent
- [x] .gitignore entries correct
- [x] Dual-verify passed (3 issues found and fixed)

Refs #164

Generated with Claude Code