### PR TITLE
refactor(gui): generalize PR monitor for multi-bot review (#164)

### DIFF
--- a/packages/gui/src-tauri/src/commands.rs
+++ b/packages/gui/src-tauri/src/commands.rs
@@ -1089,7 +1089,7 @@ pub async fn stop_pr_polling(
 }
 
 #[tauri::command]
-pub async fn trigger_coderabbit_review(
+pub async fn trigger_bot_review(
     root: State<'_, ProjectRoot>,
     pr_number: u32,
 ) -> Result<serde_json::Value, String> {
@@ -1098,7 +1098,7 @@ pub async fn trigger_coderabbit_review(
     }
     let project_root = root.0.clone();
     tokio::task::spawn_blocking(move || {
-        crate::pr_monitor::trigger_coderabbit_review_blocking(&project_root, pr_number)
+        crate::pr_monitor::trigger_bot_review_blocking(&project_root, pr_number)
     })
     .await
     .map_err(|e| format!("Task join error: {}", e))??;

--- a/packages/gui/src-tauri/src/lib.rs
+++ b/packages/gui/src-tauri/src/lib.rs
@@ -186,7 +186,7 @@ pub fn run() {
             commands::get_pr_monitor_state,
             commands::start_pr_polling,
             commands::stop_pr_polling,
-            commands::trigger_coderabbit_review,
+            commands::trigger_bot_review,
             commands::merge_pr,
         ])
         .build(tauri::generate_context!())

--- a/packages/gui/src-tauri/src/pr_monitor.rs
+++ b/packages/gui/src-tauri/src/pr_monitor.rs
@@ -15,7 +15,7 @@ pub struct PrReview {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
-pub enum CodeRabbitStatus {
+pub enum ReviewBotStatus {
     Pending,
     Commented,
     Approved,
@@ -32,7 +32,7 @@ pub struct PullRequest {
     pub updated_at: String,
     pub url: String,
     pub review_decision: Option<String>,
-    pub coderabbit_status: CodeRabbitStatus,
+    pub review_status: ReviewBotStatus,
     pub timeout_alert: bool,
     pub reviews: Vec<PrReview>,
 }
@@ -287,25 +287,25 @@ fn fetch_prs_blocking(project_root: &str) -> Result<Vec<PullRequest>, String> {
     let prs = gh_prs
         .into_iter()
         .map(|pr| {
-            let coderabbit_reviews: Vec<&GhReview> = pr
+            let bot_reviews: Vec<&GhReview> = pr
                 .reviews
                 .iter()
-                .filter(|r| r.author.login == "coderabbitai")
+                .filter(|r| r.author.login == "coderabbitai" || r.author.login == "argus-review[bot]")
                 .collect();
 
-            let coderabbit_status = if let Some(latest) = coderabbit_reviews.last() {
+            let review_status = if let Some(latest) = bot_reviews.last() {
                 match latest.state.as_str() {
-                    "APPROVED" => CodeRabbitStatus::Approved,
-                    "CHANGES_REQUESTED" => CodeRabbitStatus::ChangesRequested,
-                    "COMMENTED" => CodeRabbitStatus::Commented,
-                    _ => CodeRabbitStatus::Pending,
+                    "APPROVED" => ReviewBotStatus::Approved,
+                    "CHANGES_REQUESTED" => ReviewBotStatus::ChangesRequested,
+                    "COMMENTED" => ReviewBotStatus::Commented,
+                    _ => ReviewBotStatus::Pending,
                 }
             } else {
-                CodeRabbitStatus::Pending
+                ReviewBotStatus::Pending
             };
 
-            // Timeout alert: PR created > 10min ago and still no CodeRabbit review
-            let timeout_alert = if coderabbit_reviews.is_empty() {
+            // Timeout alert: PR created > 10min ago and still no bot review
+            let timeout_alert = if bot_reviews.is_empty() {
                 parse_iso_to_ms(&pr.created_at)
                     .map(|created_ms| now_ms.saturating_sub(created_ms) > 10 * 60 * 1000)
                     .unwrap_or(false)
@@ -331,7 +331,7 @@ fn fetch_prs_blocking(project_root: &str) -> Result<Vec<PullRequest>, String> {
                 updated_at: pr.updated_at,
                 url: pr.url,
                 review_decision: pr.review_decision,
-                coderabbit_status,
+                review_status,
                 timeout_alert,
                 reviews,
             }
@@ -341,8 +341,8 @@ fn fetch_prs_blocking(project_root: &str) -> Result<Vec<PullRequest>, String> {
     Ok(prs)
 }
 
-/// Post a comment on a PR to trigger CodeRabbit review.
-pub fn trigger_coderabbit_review_blocking(
+/// Post a comment on a PR to trigger review bot.
+pub fn trigger_bot_review_blocking(
     project_root: &str,
     pr_number: u32,
 ) -> Result<(), String> {
@@ -352,7 +352,7 @@ pub fn trigger_coderabbit_review_blocking(
             "comment",
             &pr_number.to_string(),
             "--body",
-            "@coderabbitai review",
+            "/review",
         ])
         .current_dir(project_root)
         .env("LANG", "en_US.UTF-8")

--- a/packages/gui/src/components/PRMonitorPanel.vue
+++ b/packages/gui/src/components/PRMonitorPanel.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { onMounted, onUnmounted, ref, reactive } from "vue";
 import { usePrMonitorStore } from "../stores/pr-monitor";
-import type { PullRequest, CodeRabbitStatus } from "../lib/tauri-bridge";
+import type { PullRequest, ReviewBotStatus } from "../lib/tauri-bridge";
 
 const emit = defineEmits<{ close: [] }>();
 const {
@@ -13,7 +13,7 @@ const {
   fetchPrs,
   startPolling,
   stopPolling,
-  requestCoderabbitReview,
+  requestBotReview,
   requestMerge,
   syncState,
   initPrMonitorListeners,
@@ -51,8 +51,8 @@ onUnmounted(() => {
   stopPolling();
 });
 
-function codeRabbitLabel(status: CodeRabbitStatus): string {
-  const labels: Record<CodeRabbitStatus, string> = {
+function reviewBotLabel(status: ReviewBotStatus): string {
+  const labels: Record<ReviewBotStatus, string> = {
     pending: "Pending",
     commented: "Reviewing",
     approved: "Approved",
@@ -61,8 +61,8 @@ function codeRabbitLabel(status: CodeRabbitStatus): string {
   return labels[status] ?? "Unknown";
 }
 
-function codeRabbitColor(status: CodeRabbitStatus): string {
-  const colors: Record<CodeRabbitStatus, string> = {
+function reviewBotColor(status: ReviewBotStatus): string {
+  const colors: Record<ReviewBotStatus, string> = {
     pending: "var(--text-muted)",
     commented: "var(--accent-main)",
     approved: "var(--accent-success)",
@@ -96,7 +96,7 @@ async function handleTriggerReview(pr: PullRequest) {
   if (pending[pr.number]) return;
   pending[pr.number] = true;
   try {
-    await requestCoderabbitReview(pr.number);
+    await requestBotReview(pr.number);
     await fetchPrs();
   } catch {
     // Error already stored in lastError by the store
@@ -194,13 +194,13 @@ function onKeydown(e: KeyboardEvent) {
           </div>
           <div class="pr-card-status">
             <div class="status-row">
-              <span class="status-label">CodeRabbit:</span>
+              <span class="status-label">Review:</span>
               <span
                 class="status-value"
-                :style="{ color: codeRabbitColor(pr.coderabbit_status) }"
+                :style="{ color: reviewBotColor(pr.review_status) }"
               >
-                <span class="status-dot" :style="{ background: codeRabbitColor(pr.coderabbit_status) }"></span>
-                {{ codeRabbitLabel(pr.coderabbit_status) }}
+                <span class="status-dot" :style="{ background: reviewBotColor(pr.review_status) }"></span>
+                {{ reviewBotLabel(pr.review_status) }}
               </span>
               <span v-if="pr.timeout_alert" class="timeout-badge">TIMEOUT</span>
             </div>
@@ -213,9 +213,9 @@ function onKeydown(e: KeyboardEvent) {
             <button
               class="action-btn review-btn"
               :disabled="pending[pr.number]"
-              title="@coderabbitai review"
+              title="/review"
               @click="handleTriggerReview(pr)"
-            >🐰 Request Review</button>
+            >Request Review</button>
             <button
               v-if="confirmMerge !== pr.number"
               class="action-btn merge-btn"

--- a/packages/gui/src/lib/tauri-bridge.ts
+++ b/packages/gui/src/lib/tauri-bridge.ts
@@ -720,7 +720,7 @@ export function onRemoteControlLog(
 
 // ─── PR Monitor Operations ───
 
-export type CodeRabbitStatus = "pending" | "commented" | "approved" | "changes_requested";
+export type ReviewBotStatus = "pending" | "commented" | "approved" | "changes_requested";
 
 export interface PrReview {
   author: string;
@@ -736,7 +736,7 @@ export interface PullRequest {
   updated_at: string;
   url: string;
   review_decision: string | null;
-  coderabbit_status: CodeRabbitStatus;
+  review_status: ReviewBotStatus;
   timeout_alert: boolean;
   reviews: PrReview[];
 }
@@ -769,9 +769,9 @@ export async function stopPrPolling(): Promise<{ ok: true }> {
   return invoke("stop_pr_polling");
 }
 
-/** Post "@coderabbitai review" comment on a PR. */
-export async function triggerCoderabbitReview(prNumber: number): Promise<{ ok: true }> {
-  return invoke("trigger_coderabbit_review", { prNumber });
+/** Post "/review" comment on a PR to trigger review bot. */
+export async function triggerBotReview(prNumber: number): Promise<{ ok: true }> {
+  return invoke("trigger_bot_review", { prNumber });
 }
 
 /** Squash-merge a PR (with delete-branch). */

--- a/packages/gui/src/stores/pr-monitor.ts
+++ b/packages/gui/src/stores/pr-monitor.ts
@@ -4,7 +4,7 @@ import {
   getPrMonitorState,
   startPrPolling,
   stopPrPolling,
-  triggerCoderabbitReview,
+  triggerBotReview,
   mergePr,
   onPrListUpdated,
   type PullRequest,
@@ -67,9 +67,9 @@ async function stopPollingAction() {
   }
 }
 
-async function requestCoderabbitReview(prNumber: number) {
+async function requestBotReview(prNumber: number) {
   try {
-    await triggerCoderabbitReview(prNumber);
+    await triggerBotReview(prNumber);
   } catch (e) {
     lastError.value = String(e);
     throw e;
@@ -137,7 +137,7 @@ export function usePrMonitorStore() {
     fetchPrs,
     startPolling,
     stopPolling: stopPollingAction,
-    requestCoderabbitReview,
+    requestBotReview,
     requestMerge,
     syncState,
     initPrMonitorListeners,


### PR DESCRIPTION
## Summary
- Rename `CodeRabbitStatus` → `ReviewBotStatus` across Rust, TypeScript, and Vue
- PR monitor now filters reviews from both `coderabbitai` and `argus-review[bot]`
- Review trigger command changed from `@coderabbitai review` to `/review`
- UI labels generalized: "CodeRabbit:" → "Review:", rabbit emoji removed

## Test plan
- [x] Rust type/field renames consistent across pr_monitor.rs, commands.rs, lib.rs
- [x] TypeScript types match Rust serde output (snake_case)
- [x] Vue template uses updated function/type names
- [x] Store exports match component imports
- [x] Dual-verify passed (no issues)

Refs #164

Generated with Claude Code