### PR TITLE
fix(pr-flow): add worktree cleanup to Phase 7

### DIFF
--- a/.claude/skills/pr-flow/SKILL.md
+++ b/.claude/skills/pr-flow/SKILL.md
@@ -294,14 +294,20 @@ git worktree list --porcelain | awk -v ref="branch refs/heads/$BRANCH" '
 ' | while IFS= read -r wt_path; do
   [ -z "$wt_path" ] && continue
   if [ -n "$(git -C "$wt_path" status --porcelain 2>/dev/null)" ]; then
-    echo "WARNING: worktree $wt_path has uncommitted changes, skipping removal"
+    echo "WARNING: worktree $wt_path has uncommitted changes — skipping worktree and branch removal"
+    exit 1  # exit subshell (pipe), skip branch deletion below
   else
     git worktree remove "$wt_path"
   fi
 done
+WT_EXIT=$?
 
-# Delete local branch (remote already deleted by --delete-branch in merge)
-git branch -d "$BRANCH" 2>/dev/null || true
+# Delete local branch only if worktree cleanup succeeded or no worktree existed
+if [ "${WT_EXIT:-0}" -eq 0 ]; then
+  git branch -d "$BRANCH" 2>/dev/null || true
+else
+  echo "Skipping branch deletion — worktree still active"
+fi
 ```
 
 Update related issues and Mercury task state if applicable.

--- a/.claude/skills/pr-flow/SKILL.md
+++ b/.claude/skills/pr-flow/SKILL.md
@@ -292,7 +292,7 @@ while IFS= read -r wt_path; do
   [ -z "$wt_path" ] && continue
   if ! git -C "$wt_path" status --porcelain >/dev/null 2>&1; then
     echo "WARNING: worktree $wt_path is inaccessible — pruning stale record"
-    git worktree prune
+    git worktree prune || WT_FAIL=1
   elif [ -n "$(git -C "$wt_path" status --porcelain)" ]; then
     echo "WARNING: worktree $wt_path has uncommitted changes — skipping"
     WT_FAIL=1
@@ -306,7 +306,7 @@ done < <(git worktree list --porcelain | awk -v ref="branch refs/heads/$BRANCH" 
 
 # Delete local branch only if all worktree cleanup succeeded
 if [ "$WT_FAIL" -eq 0 ]; then
-  git branch -d "$BRANCH" 2>/dev/null || true
+  git branch -d "$BRANCH" || echo "NOTE: local branch $BRANCH could not be deleted"
 else
   echo "Skipping branch deletion — worktree cleanup incomplete"
 fi

--- a/.claude/skills/pr-flow/SKILL.md
+++ b/.claude/skills/pr-flow/SKILL.md
@@ -299,7 +299,7 @@ if [ "$WT_FAIL" -eq 0 ]; then
       echo "WARNING: worktree $wt_path is inaccessible — pruning"
       git worktree prune || { WT_FAIL=1; continue; }
       # Verify prune actually removed the association
-      if echo "$(git worktree list --porcelain)" | grep -q "branch refs/heads/$BRANCH"; then
+      if git worktree list --porcelain | grep -Fq "branch refs/heads/$BRANCH"; then
         echo "WARNING: branch still associated after prune"
         WT_FAIL=1
       fi

--- a/.claude/skills/pr-flow/SKILL.md
+++ b/.claude/skills/pr-flow/SKILL.md
@@ -279,9 +279,19 @@ gh pr merge "$PR_NUMBER" --squash --delete-branch
 rm -f .pr-flow-iteration-* .pr-flow-check-count-* .pr-flow-multi.txt
 
 BRANCH=$(gh pr view "$PR_NUMBER" --json headRefName --jq '.headRefName')
+
+# Clean up worktree if branch was worked on in one
+WORKTREE_PATH=$(git worktree list --porcelain | grep -B2 "branch refs/heads/$BRANCH" | grep "^worktree " | sed 's/^worktree //')
+if [ -n "$WORKTREE_PATH" ]; then
+  git worktree remove "$WORKTREE_PATH" 2>/dev/null || git worktree remove --force "$WORKTREE_PATH" 2>/dev/null
+fi
+
+# Switch off branch if currently on it
 if [ "$(git rev-parse --abbrev-ref HEAD)" = "$BRANCH" ]; then
   git switch develop 2>/dev/null || git checkout develop
 fi
+
+# Delete local branch (remote already deleted by --delete-branch in merge)
 git branch -d "$BRANCH" 2>/dev/null || true
 ```
 

--- a/.claude/skills/pr-flow/SKILL.md
+++ b/.claude/skills/pr-flow/SKILL.md
@@ -286,27 +286,29 @@ if [ "$(git rev-parse --abbrev-ref HEAD)" = "$BRANCH" ]; then
 fi
 
 # Clean up worktree(s) if branch was worked on in one
-# Parse porcelain output: each worktree block is separated by blank lines
-# Match exact branch ref to avoid partial matches
-git worktree list --porcelain | awk -v ref="branch refs/heads/$BRANCH" '
+# Collect worktree paths into array (avoids pipe subshell exit code issues)
+WT_FAIL=0
+while IFS= read -r wt_path; do
+  [ -z "$wt_path" ] && continue
+  if ! git -C "$wt_path" status --porcelain >/dev/null 2>&1; then
+    echo "WARNING: worktree $wt_path is inaccessible — skipping"
+    WT_FAIL=1
+  elif [ -n "$(git -C "$wt_path" status --porcelain)" ]; then
+    echo "WARNING: worktree $wt_path has uncommitted changes — skipping"
+    WT_FAIL=1
+  else
+    git worktree remove "$wt_path" || WT_FAIL=1
+  fi
+done < <(git worktree list --porcelain | awk -v ref="branch refs/heads/$BRANCH" '
   /^worktree / { path = substr($0, 10) }
   $0 == ref { print path }
-' | while IFS= read -r wt_path; do
-  [ -z "$wt_path" ] && continue
-  if [ -n "$(git -C "$wt_path" status --porcelain 2>/dev/null)" ]; then
-    echo "WARNING: worktree $wt_path has uncommitted changes — skipping worktree and branch removal"
-    exit 1  # exit subshell (pipe), skip branch deletion below
-  else
-    git worktree remove "$wt_path"
-  fi
-done
-WT_EXIT=$?
+')
 
-# Delete local branch only if worktree cleanup succeeded or no worktree existed
-if [ "${WT_EXIT:-0}" -eq 0 ]; then
+# Delete local branch only if all worktree cleanup succeeded
+if [ "$WT_FAIL" -eq 0 ]; then
   git branch -d "$BRANCH" 2>/dev/null || true
 else
-  echo "Skipping branch deletion — worktree still active"
+  echo "Skipping branch deletion — worktree cleanup incomplete"
 fi
 ```
 

--- a/.claude/skills/pr-flow/SKILL.md
+++ b/.claude/skills/pr-flow/SKILL.md
@@ -291,8 +291,8 @@ WT_FAIL=0
 while IFS= read -r wt_path; do
   [ -z "$wt_path" ] && continue
   if ! git -C "$wt_path" status --porcelain >/dev/null 2>&1; then
-    echo "WARNING: worktree $wt_path is inaccessible — skipping"
-    WT_FAIL=1
+    echo "WARNING: worktree $wt_path is inaccessible — pruning stale record"
+    git worktree prune
   elif [ -n "$(git -C "$wt_path" status --porcelain)" ]; then
     echo "WARNING: worktree $wt_path has uncommitted changes — skipping"
     WT_FAIL=1

--- a/.claude/skills/pr-flow/SKILL.md
+++ b/.claude/skills/pr-flow/SKILL.md
@@ -286,23 +286,34 @@ if [ "$(git rev-parse --abbrev-ref HEAD)" = "$BRANCH" ]; then
 fi
 
 # Clean up worktree(s) if branch was worked on in one
-# Collect worktree paths into array (avoids pipe subshell exit code issues)
 WT_FAIL=0
-while IFS= read -r wt_path; do
-  [ -z "$wt_path" ] && continue
-  if ! git -C "$wt_path" status --porcelain >/dev/null 2>&1; then
-    echo "WARNING: worktree $wt_path is inaccessible — pruning stale record"
-    git worktree prune || WT_FAIL=1
-  elif [ -n "$(git -C "$wt_path" status --porcelain)" ]; then
-    echo "WARNING: worktree $wt_path has uncommitted changes — skipping"
-    WT_FAIL=1
-  else
-    git worktree remove "$wt_path" || WT_FAIL=1
-  fi
-done < <(git worktree list --porcelain | awk -v ref="branch refs/heads/$BRANCH" '
-  /^worktree / { path = substr($0, 10) }
-  $0 == ref { print path }
-')
+WT_LIST=$(git worktree list --porcelain 2>&1) || {
+  echo "WARNING: git worktree list failed — skipping worktree and branch cleanup"
+  WT_FAIL=1
+}
+
+if [ "$WT_FAIL" -eq 0 ]; then
+  while IFS= read -r wt_path; do
+    [ -z "$wt_path" ] && continue
+    if ! git -C "$wt_path" status --porcelain >/dev/null 2>&1; then
+      echo "WARNING: worktree $wt_path is inaccessible — pruning"
+      git worktree prune || { WT_FAIL=1; continue; }
+      # Verify prune actually removed the association
+      if echo "$(git worktree list --porcelain)" | grep -q "branch refs/heads/$BRANCH"; then
+        echo "WARNING: branch still associated after prune"
+        WT_FAIL=1
+      fi
+    elif [ -n "$(git -C "$wt_path" status --porcelain)" ]; then
+      echo "WARNING: worktree $wt_path has uncommitted changes — skipping"
+      WT_FAIL=1
+    else
+      git worktree remove "$wt_path" || WT_FAIL=1
+    fi
+  done < <(echo "$WT_LIST" | awk -v ref="branch refs/heads/$BRANCH" '
+    /^worktree / { path = substr($0, 10) }
+    $0 == ref { print path }
+  ')
+fi
 
 # Delete local branch only if all worktree cleanup succeeded
 if [ "$WT_FAIL" -eq 0 ]; then

--- a/.claude/skills/pr-flow/SKILL.md
+++ b/.claude/skills/pr-flow/SKILL.md
@@ -280,16 +280,25 @@ rm -f .pr-flow-iteration-* .pr-flow-check-count-* .pr-flow-multi.txt
 
 BRANCH=$(gh pr view "$PR_NUMBER" --json headRefName --jq '.headRefName')
 
-# Clean up worktree if branch was worked on in one
-WORKTREE_PATH=$(git worktree list --porcelain | grep -B2 "branch refs/heads/$BRANCH" | grep "^worktree " | sed 's/^worktree //')
-if [ -n "$WORKTREE_PATH" ]; then
-  git worktree remove "$WORKTREE_PATH" 2>/dev/null || git worktree remove --force "$WORKTREE_PATH" 2>/dev/null
-fi
-
-# Switch off branch if currently on it
+# Switch off branch first (must happen before worktree/branch removal)
 if [ "$(git rev-parse --abbrev-ref HEAD)" = "$BRANCH" ]; then
   git switch develop 2>/dev/null || git checkout develop
 fi
+
+# Clean up worktree(s) if branch was worked on in one
+# Parse porcelain output: each worktree block is separated by blank lines
+# Match exact branch ref to avoid partial matches
+git worktree list --porcelain | awk -v ref="branch refs/heads/$BRANCH" '
+  /^worktree / { path = substr($0, 10) }
+  $0 == ref { print path }
+' | while IFS= read -r wt_path; do
+  [ -z "$wt_path" ] && continue
+  if [ -n "$(git -C "$wt_path" status --porcelain 2>/dev/null)" ]; then
+    echo "WARNING: worktree $wt_path has uncommitted changes, skipping removal"
+  else
+    git worktree remove "$wt_path"
+  fi
+done
 
 # Delete local branch (remote already deleted by --delete-branch in merge)
 git branch -d "$BRANCH" 2>/dev/null || true

--- a/.claude/skills/pr-flow/SKILL.md
+++ b/.claude/skills/pr-flow/SKILL.md
@@ -280,24 +280,32 @@ rm -f .pr-flow-iteration-* .pr-flow-check-count-* .pr-flow-multi.txt
 
 BRANCH=$(gh pr view "$PR_NUMBER" --json headRefName --jq '.headRefName')
 
-# Switch off branch first (must happen before worktree/branch removal)
-if [ "$(git rev-parse --abbrev-ref HEAD)" = "$BRANCH" ]; then
-  git switch develop 2>/dev/null || git checkout develop
-fi
-
-# Clean up worktree(s) if branch was worked on in one
+# Snapshot worktree paths BEFORE switching branch (switch changes main repo's association)
 WT_FAIL=0
 WT_LIST=$(git worktree list --porcelain 2>&1) || {
   echo "WARNING: git worktree list failed — skipping worktree and branch cleanup"
   WT_FAIL=1
 }
+WT_PATHS=""
+if [ "$WT_FAIL" -eq 0 ]; then
+  WT_PATHS=$(echo "$WT_LIST" | awk -v ref="branch refs/heads/$BRANCH" '
+    /^worktree / { path = substr($0, 10) }
+    $0 == ref { print path }
+  ')
+fi
 
+# Switch off branch (must happen before branch deletion)
+if [ "$(git rev-parse --abbrev-ref HEAD)" = "$BRANCH" ]; then
+  git switch develop 2>/dev/null || git checkout develop
+fi
+
+# Clean up worktree(s) using pre-switch snapshot
 if [ "$WT_FAIL" -eq 0 ]; then
   while IFS= read -r wt_path; do
     [ -z "$wt_path" ] && continue
     if ! git -C "$wt_path" status --porcelain >/dev/null 2>&1; then
       echo "WARNING: worktree $wt_path is inaccessible — pruning"
-      git worktree prune || { WT_FAIL=1; continue; }
+      git worktree prune --expire=now || { WT_FAIL=1; continue; }
       # Verify prune actually removed the association
       if git worktree list --porcelain | grep -Fq "branch refs/heads/$BRANCH"; then
         echo "WARNING: branch still associated after prune"
@@ -309,10 +317,7 @@ if [ "$WT_FAIL" -eq 0 ]; then
     else
       git worktree remove "$wt_path" || WT_FAIL=1
     fi
-  done < <(echo "$WT_LIST" | awk -v ref="branch refs/heads/$BRANCH" '
-    /^worktree / { path = substr($0, 10) }
-    $0 == ref { print path }
-  ')
+  done <<< "$WT_PATHS"
 fi
 
 # Delete local branch only if all worktree cleanup succeeded


### PR DESCRIPTION
## Summary
- Add git worktree detection and removal in pr-flow Phase 7 cleanup
- Worktree is removed before local branch deletion to avoid orphaned worktrees

Generated with Claude Code