### PR TITLE
feat(skills): add gh-project-flow + dev-pipeline + PHILOSOPHY (Phase 1)

### DIFF
--- a/.claude/agents/acceptance.md
+++ b/.claude/agents/acceptance.md
@@ -1,3 +1,10 @@
+---
+name: acceptance
+description: Blind acceptance reviewer. Use after a dev agent has completed implementation and pushed code. Receives only the AcceptanceBundle (definition-of-done + acceptance criteria) and a blind receipt (changed files only — NO dev reasoning/narrative). Reads code + runs tests + inspects runtime output. Returns a structured JSON verdict (pass | partial | fail | blocked) with findings + recommendations. MUST NOT read dev agent self-assessment.
+tools: Read, Glob, Grep, Bash
+model: inherit
+---
+
 # Role: Acceptance Agent
 
 Reviewer: blind acceptance testing on completed tasks.

--- a/.claude/agents/critic.md
+++ b/.claude/agents/critic.md
@@ -1,3 +1,10 @@
+---
+name: critic
+description: Spec-driven verifier. Use when a completion checklist needs independent verification — for each checklist item, the critic locates evidence in the diff/runtime output and returns PASS/FAIL/PARTIAL/SKIP with file:line citations. Different analytical perspective than dev or acceptance. SHOULD run on a different model than dev to avoid self-congratulation bias.
+tools: Read, Glob, Grep, Bash
+model: inherit
+---
+
 # Role: Critic Agent
 
 Spec-driven verifier: validates implementation against completion checklist.

--- a/.claude/agents/design.md
+++ b/.claude/agents/design.md
@@ -1,3 +1,10 @@
+---
+name: design
+description: Architecture designer. Use when a specification, design document, or technical evaluation is needed — produces structured proposals + trade-off analyses. Hands implementation back to Main for dispatch (does NOT itself dispatch dev or modify code).
+tools: Read, Write, Glob, Grep, WebSearch, WebFetch
+model: inherit
+---
+
 # Role: Design Agent
 
 Designer: generates specs, architecture proposals, design decisions.

--- a/.claude/agents/dev.md
+++ b/.claude/agents/dev.md
@@ -1,3 +1,10 @@
+---
+name: dev
+description: Implementation worker. Use proactively when a well-scoped coding task needs to be implemented — receives a TaskBundle with definition-of-done + allowed write scope, writes code, runs scoped tests, commits + pushes on the current branch, and returns a structured JSON receipt. Does NOT switch branches, never modifies files outside scope, never performs acceptance testing.
+tools: Read, Write, Edit, Glob, Grep, Bash, WebSearch, WebFetch
+model: inherit
+---
+
 # Role: Dev Agent
 
 Worker: receives task descriptions, writes code, returns implementation receipts.

--- a/.claude/agents/main.md
+++ b/.claude/agents/main.md
@@ -1,3 +1,10 @@
+---
+name: main
+description: Mercury orchestrator role definition. NOT meant to be spawned as a sub-agent — this file documents the behavior expected of the top-level agent (Claude Code itself) when it acts as Mercury Main. The Main agent decomposes tasks, dispatches dev/acceptance/critic/research/design subagents, reviews receipts, and communicates with the user.
+tools: Read, Write, Edit, Glob, Grep, Bash, WebSearch, WebFetch, Agent(dev, acceptance, critic, research, design)
+model: inherit
+---
+
 # Role: Main Agent
 
 Orchestrator: decomposes tasks, delegates to sub-agents, reviews results, communicates with user.

--- a/.claude/agents/research.md
+++ b/.claude/agents/research.md
@@ -1,3 +1,10 @@
+---
+name: research
+description: Research analyst. Use when a question requires web search, official documentation lookup, or KB review — returns a research summary with sources. NEVER writes code, NEVER makes architectural decisions (information only; decisions belong to main/design).
+tools: Read, Glob, Grep, WebSearch, WebFetch
+model: inherit
+---
+
 # Role: Research Agent
 
 Analyst: reads docs, searches web, answers questions. No code writing.

--- a/.claude/skills/dev-pipeline/PHILOSOPHY.md
+++ b/.claude/skills/dev-pipeline/PHILOSOPHY.md
@@ -1,0 +1,68 @@
+# Why a Preset Dev Pipeline?
+
+> This document is the methodology narrative behind Mercury's `dev-pipeline` skill. It targets external readers — open-source users, video viewers, blog readers — who want to understand the reasoning, not just the recipe.
+
+## The problem
+
+When AI agents do real engineering work, two failure modes dominate.
+
+**Failure 1: the soliloquy.** A single agent implements, tests, and judges its own work. Because it remembers writing the code, it remembers being convinced the code was right, and it grades itself accordingly. Modern models are well-calibrated at the token level and badly calibrated at the "is this whole thing actually done" level. They reach the end of an implementation and report success because that is the conversational gravity of their own narrative arc, not because the code passes.
+
+**Failure 2: the orchestrator tax.** The natural reaction to Failure 1 is to build a multi-agent orchestration framework: a coordinator agent that creates plans, dispatches workers, polls statuses, retries on failure, escalates on stuck. This solves the soliloquy problem and immediately introduces a worse one. The orchestrator becomes the product. Every iteration of the underlying model is now bottlenecked by the orchestrator's assumptions about what the model can or cannot do. When the model improves, the orchestrator does not get better — it gets in the way.
+
+Mercury was originally Failure 2. Phase 0 archived that orchestrator. Phase 1 had to answer: if not orchestration, then what?
+
+## The answer: preset chains
+
+A **preset chain** is a fixed, hand-designed sequence of agent invocations that solves one specific shape of problem. It is not dynamic. It does not decide what to do. It does not branch on intent. The only thing it knows how to do is run a single coding task end-to-end with two roles in the loop: **Dev** writes, **Acceptance** judges blind.
+
+That is the entire dev pipeline. Two roles. One direction. No branching except a bounded retry loop.
+
+Why this works:
+
+1. **It solves the soliloquy without inventing orchestration.** Dev does not grade itself. Acceptance does not write code. The hand-off is one-way and the receiver is structurally prevented out of seeing the senders narrative. Calibration improves because the judge has no stake in the conviction of the implementer.
+
+2. **It gets out of the model's way.** The chain has no opinion about *how* to implement. It only specifies *what* to verify. As the model improves, the implementation gets better. The chain does not need to be rewritten.
+
+3. **It is small enough to read in five minutes.** A preset chain is a `.md` file. No DAG engine, no event bus, no state machine framework. The whole specification fits on one screen, which is the right size for a methodology you want other developers to copy.
+
+## Why blind acceptance
+
+The blindness is the load-bearing constraint. If acceptance reads the dev agent's notes, evidence pointers, or risk callouts, it inherits the dev agent's framing, and the verification collapses back into Failure 1 with extra steps.
+
+Blindness is enforced two ways:
+
+- **Structurally**: the prompt template strips narrative fields out of the receipt before passing it to acceptance. The acceptance agent literally cannot read what dev concluded.
+- **Behaviorally**: the acceptance agent's role definition explicitly forbids inferring or asking about dev's reasoning.
+
+This is uncomfortable. It feels wasteful — surely letting acceptance see what dev was thinking would be more efficient? It is not. Efficiency is the wrong axis. The whole point of a second agent is *independent judgment*, and independence dies the moment the second agent is told what the first agent believed.
+
+## Why a maximum of three iterations
+
+The retry loop exists because acceptance sometimes catches a real bug and dev should fix it. But infinite retries are how agents quietly burn budget on convergence failures. The cap is mechanical — three iterations and the chain escalates to the human, no judgment call.
+
+Three is not magic. Two is too few (one mistake, one fix, no slack). Four is too many (by then the failure mode is usually that acceptance keeps surfacing the same finding because dev is fixing the wrong thing — and the fourth pass will do the same). Three forces the human in the loop early enough that the divergence is still cheap to repair.
+
+## What this skill is NOT
+
+- **Not an orchestrator.** It does not pick tasks, decide priorities, or coordinate parallel work. The user does that. If the user wants parallel tasks, the user opens another session.
+- **Not a workflow engine.** It does not retry on infrastructure flake, manage queues, or persist state between runs. Each invocation is a fresh chain.
+- **Not a quality gate replacement.** Phase 2 will mount real quality gates (lint, type-check, test enforcement) via external project submodules. The dev pipeline assumes those gates exist in the repo it runs against; it does not implement them.
+
+## What it IS
+
+A 220-line markdown file that says: when a coding task is well-scoped and you want a second opinion, run it through this loop. Copy the file into any GitHub-based repository that has `.claude/agents/dev.md` and `.claude/agents/acceptance.md` defined, strip the Mercury-specific `/gh-project-flow` line out of Phase 6, and you are done.
+
+The methodology is the asset. The skill file is the artifact.
+
+## Extending it
+
+Three obvious extensions, none of which belong in the baseline:
+
+- **Add a critic pass on a different model.** Useful when the dev model and acceptance model are the same — a third independent perspective on a different model substrate breaks self-congratulation bias completely. Out of scope until Phase 2.
+- **Persist learnings between runs.** When dev keeps making the same mistake across tasks, that mistake should become a constraint in the next TaskBundle. This is the Memory Layer story (Phase 3).
+- **Parallel task fan-out.** Mercury explicitly does not do this. If you want it, open multiple sessions. Parallel coordination across sessions is the agent-teams story, not the dev-pipeline story.
+
+## Closing
+
+The temptation, when you watch agents fail at coding, is to build more machinery around them. The lesson Mercury keeps relearning is that more machinery is what made them fail in the first place. The dev pipeline is small on purpose. The two agents in it are dumb on purpose. The chain has no policy on purpose. What it has, and what nothing else gives you, is **independent judgment under structural blindness** — and that turns out to be the only thing the soliloquy problem actually responds to.

--- a/.claude/skills/dev-pipeline/SKILL.md
+++ b/.claude/skills/dev-pipeline/SKILL.md
@@ -134,28 +134,31 @@ Checklist:
 
 ## Phase 4: Dispatch Acceptance (BLIND)
 
-Build the **blindReceipt** by stripping dev's narrative fields:
+Build the **blindReceipt** by stripping dev's narrative fields. **Preserve original JSON types** — `changedFiles` and `verifyResults` are arrays in the dev receipt and MUST remain arrays here, not stringified placeholders:
 
 ```json
 {
-  "taskId": "[copied out of receipt]",
-  "changedFiles": "[copied out of receipt]",
-  "commitSha": "[copied out of receipt]",
-  "verifyResults": "[copied out of receipt]"
+  "taskId": "task-slug",
+  "changedFiles": ["path/to/file1.ts", "path/to/file2.ts"],
+  "commitSha": "abc123def",
+  "verifyResults": [
+    {"command": "pnpm test packages/foo", "exitCode": 0, "summary": "12 passed"},
+    {"command": "pnpm lint", "exitCode": 0, "summary": "0 issues"}
+  ]
 }
 ```
 
-Note what was REMOVED: evidence, risks, escalationReason. The acceptance agent must form its own conclusions out of code and tests, not out of dev's self-assessment.
+Note what was REMOVED relative to the dev receipt: `evidence`, `risks`, `escalationReason`. The acceptance agent must form its own conclusions out of code and tests, not out of dev's self-assessment.
 
-Build the **AcceptanceBundle**:
+Build the **AcceptanceBundle** (also preserve original types — `definitionOfDone`, `acceptanceCriteria`, `verifyCommands` are arrays, not strings):
 
 ```json
 {
-  "taskId": "[copied out of TaskBundle]",
-  "title": "[copied out of TaskBundle]",
-  "definitionOfDone": "[copied out of TaskBundle]",
-  "acceptanceCriteria": "[copied out of TaskBundle]",
-  "verifyCommands": "[copied out of TaskBundle]"
+  "taskId": "task-slug",
+  "title": "one-line summary",
+  "definitionOfDone": ["criterion 1", "criterion 2"],
+  "acceptanceCriteria": ["check 1", "check 2"],
+  "verifyCommands": ["pnpm test packages/foo", "pnpm lint"]
 }
 ```
 

--- a/.claude/skills/dev-pipeline/SKILL.md
+++ b/.claude/skills/dev-pipeline/SKILL.md
@@ -221,12 +221,16 @@ This runs on `pass`, `blocked`, escalation after `partial`/`fail`, and on iterat
 
 ## Phase 6: Hand-off
 
+Phase 6 is reached **only on `pass`**. Cleanup for non-pass terminal exits is handled inside Phase 5 — do not duplicate it here.
+
 On pass:
-1. Confirm commit is pushed (git status)
-2. **Clean up scratch state**: `rm -f "$SHA_FILE"` — see the Cleanup block in Phase 5 for the full mandatory list of exit paths.
-3. If user requested PR: invoke /pr-flow
-4. Mark related GitHub Project item Done (via /gh-project-flow if Mercury self-dev) or via Closes #N in PR (general case)
-5. Summarize in Chinese for the user
+1. Confirm commit is pushed (`git status`)
+2. If user requested PR: invoke `/pr-flow`
+3. Mark related GitHub Project item Done (via `/gh-project-flow` if Mercury self-dev) or via `Closes #N` in PR (general case)
+4. Summarize in Chinese for the user
+5. Run the Phase 5 Cleanup block (`rm -f "$SHA_FILE"`) as the final action
+
+**Single source of truth**: the Phase 5 Cleanup block is the only authoritative description of when `$SHA_FILE` is removed. Phase 6 only reaches it via the `pass` branch above. If you find yourself debating "should I clean up here", re-read Phase 5.
 
 ## Detachability
 

--- a/.claude/skills/dev-pipeline/SKILL.md
+++ b/.claude/skills/dev-pipeline/SKILL.md
@@ -202,20 +202,28 @@ Based on the acceptance verdict:
 
 | Verdict | Action |
 |---|---|
-| pass | Pipeline complete. Summarize result for user (Chinese for milestones). Hand off to /pr-flow if a PR is the next step. |
-| partial | Re-dispatch dev with the **original full TaskBundle** plus a `priorFindings` array containing acceptance's findings. Constraints (definitionOfDone, allowedWriteScope, mustNotTouch, readScope) MUST be carried over verbatim from iteration 1 — never widened, never dropped. Increment iteration. |
-| fail | Same as partial: dispatch with full original TaskBundle + priorFindings + priorRecommendations. Constraints carried verbatim. Increment iteration. |
-| blocked | Escalate to user. Acceptance hit an environmental block; user must resolve. |
+| pass | Pipeline complete. Summarize result for user (Chinese for milestones). Hand off to /pr-flow if a PR is the next step. **Run cleanup (see below).** |
+| partial | Re-dispatch dev with the **original full TaskBundle** plus a `priorFindings` array containing acceptance's findings. Constraints (definitionOfDone, allowedWriteScope, mustNotTouch, readScope) MUST be carried over verbatim from iteration 1 — never widened, never dropped. Increment iteration. **Do NOT clean up `$SHA_FILE` between iterations** — Phase 3 needs it on every retry. |
+| fail | Same as partial: dispatch with full original TaskBundle + priorFindings + priorRecommendations. Constraints carried verbatim. Increment iteration. **Do NOT clean up between iterations.** |
+| blocked | Escalate to user. Acceptance hit an environmental block; user must resolve. **Run cleanup.** |
 
 **Constraint preservation**: every retry dispatch must include the EXACT original `definitionOfDone`, `allowedWriteScope`, `mustNotTouch`, and `readScope` from iteration 1. Adding a new constraint is OK; widening or dropping an existing one is forbidden — that defeats the purpose of the bundle as a contract.
 
-**Iteration cap**: if iteration is at least 3 and verdict is still not pass, **escalate to user** with the full history. Do not silently keep looping.
+**Iteration cap**: if iteration is at least 3 and verdict is still not pass, **escalate to user** with the full history and **run cleanup**. Do not silently keep looping.
+
+### Cleanup (mandatory on every terminal exit path)
+
+```bash
+rm -f "$SHA_FILE"
+```
+
+This runs on `pass`, `blocked`, escalation after `partial`/`fail`, and on iteration-cap escalation. The ONLY paths that skip cleanup are intra-iteration dev re-dispatches (because Phase 3 still needs the SHA). If the loop terminates without reaching one of these branches (e.g. host crash), the file at `${TMPDIR:-/tmp}/dev-pipeline-task-start-sha-$$` will be cleaned up by OS tmp eviction; PID-suffix prevents collision.
 
 ## Phase 6: Hand-off
 
 On pass:
 1. Confirm commit is pushed (git status)
-2. **Clean up scratch state**: `rm -f "$SHA_FILE"` (the task-start SHA file from Phase 2). On any exit path (pass, escalate, blocked), this MUST run.
+2. **Clean up scratch state**: `rm -f "$SHA_FILE"` — see the Cleanup block in Phase 5 for the full mandatory list of exit paths.
 3. If user requested PR: invoke /pr-flow
 4. Mark related GitHub Project item Done (via /gh-project-flow if Mercury self-dev) or via Closes #N in PR (general case)
 5. Summarize in Chinese for the user

--- a/.claude/skills/dev-pipeline/SKILL.md
+++ b/.claude/skills/dev-pipeline/SKILL.md
@@ -71,6 +71,13 @@ Before invoking this skill, the following must be true:
 
 ## Phase 2: Dispatch Dev
 
+**Before dispatching**, capture the task-start SHA so Phase 3 can compute the diff range correctly (do not rely on `HEAD~1`):
+
+```bash
+TASK_START_SHA=$(git rev-parse HEAD)
+echo "$TASK_START_SHA" > .pr-flow-task-start-sha
+```
+
 Use the Agent tool with subagent_type set to dev. The prompt template:
 
 ```
@@ -121,7 +128,7 @@ Checklist:
 - [ ] commitSha matches latest commit on the branch
 - [ ] All verifyCommands listed in the bundle have a verifyResults entry with exitCode 0
 - [ ] evidence cites at least one file:line per definitionOfDone item
-- [ ] No file outside allowedWriteScope was touched (run git diff --name-only HEAD~1)
+- [ ] No file outside allowedWriteScope was touched. Use the **task-start SHA** captured before Phase 2 dispatch as the comparison base (`TASK_START_SHA=$(git rev-parse HEAD)` before dispatch, then `git diff --name-only "$TASK_START_SHA..HEAD"` after). Do NOT use `HEAD~1` — it breaks on first commits, squashed commits, and multi-commit dev runs.
 
 **Gate**: if any check fails, send a correction prompt to dev (still iteration 1) with the specific deficiency. Do not advance to acceptance with an incomplete receipt.
 

--- a/.claude/skills/dev-pipeline/SKILL.md
+++ b/.claude/skills/dev-pipeline/SKILL.md
@@ -1,0 +1,234 @@
+---
+name: dev-pipeline
+description: |
+  Mercury's preset Main → Dev → Acceptance chain for executing a single, well-scoped coding task end-to-end with blind acceptance review. Use this skill when the user says "dev pipeline", "dispatch task", "派发任务", "dev → acceptance", "跑完整开发流程", "dev pipeline 验证", "blind review", "完整开发链", or when a task is ready to be implemented and verified by separate agents (instead of doing it inline). The skill spawns the dev subagent to implement, then spawns the acceptance subagent to blind-review the result, then loops or completes based on the verdict. Independent of Mercury's other modules — works in any repo that has .claude/agents/dev.md + .claude/agents/acceptance.md defined.
+user-invocable: true
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Agent, WebSearch, WebFetch
+---
+
+# Dev Pipeline — Main → Dev → Acceptance Preset Chain
+
+A linear, single-task pipeline. The Main agent (you, the orchestrator running this skill) coordinates two sub-agent invocations and decides loopback vs completion.
+
+> **Why a preset, not dynamic orchestration?** See PHILOSOPHY.md in this directory.
+
+## Prerequisites
+
+Before invoking this skill, the following must be true:
+
+1. **Agents discoverable**: .claude/agents/dev.md and .claude/agents/acceptance.md exist with valid YAML frontmatter (name dev / name acceptance). Verify by running the `claude agents` command or by inspecting the files directly. If they do not exist, this skill cannot run — fall back to inline implementation.
+2. **Task is well-scoped**: clear definition of done, bounded write scope, listed acceptance criteria. If the task is ambiguous, run a research/design pass first instead of dispatching dev.
+3. **Branch is correct**: you are on a feature branch (not develop or master). Dev agent will commit and push to whatever branch is current.
+4. **Issue exists**: every task must have a GitHub Issue (Mercury rule). PR will reference it via Closes #N.
+
+## Iron Rules
+
+| Rule | Why |
+|---|---|
+| **One task per pipeline run** | Mercury's preset is linear single-task, not parallel multi-task. For parallelism, the user opens multiple sessions. |
+| **TaskBundle is inline JSON, not Obsidian** | This skill is dependency-free. The Memory Layer / Obsidian KB integration ships in Phase 3 — until then, the bundle is constructed inline by Main and passed to the dev subagent in the prompt. |
+| **Acceptance is blind** | The acceptance subagent MUST NOT receive the dev subagent's reasoning, narrative, self-assessment, or risk evaluation. It receives only the AcceptanceBundle (criteria) plus a blindReceipt containing changed-file paths and test results. |
+| **Max 3 dev iterations** | If acceptance returns fail 3 times, escalate to user — do not loop forever. |
+| **Main does not write code** | Main coordinates, reviews receipts, decides next action. Implementation belongs to dev. Verification belongs to acceptance. |
+| **Sub-agents cannot spawn sub-agents** | Per Claude Code documented constraint. Only the Main thread (running this skill) can dispatch dev or acceptance. Dev cannot call acceptance directly. |
+
+
+## Phase 1: Build TaskBundle
+
+**MANDATORY** before any dispatch. Main constructs the TaskBundle inline based on the user's request, the GitHub Issue body, and any referenced design docs.
+
+```json
+{
+  "taskId": "<short-slug>",
+  "issue": "<owner/repo#N>",
+  "title": "<one-line summary>",
+  "context": "<2-5 sentences why this task exists>",
+  "definitionOfDone": [
+    "<verifiable criterion 1>",
+    "<verifiable criterion 2>"
+  ],
+  "allowedWriteScope": [
+    "<file or glob 1>",
+    "<file or glob 2>"
+  ],
+  "mustNotTouch": [
+    "<file or glob>"
+  ],
+  "readScope": [
+    "<file paths the dev should read first>"
+  ],
+  "acceptanceCriteria": [
+    "<what acceptance will check 1>",
+    "<what acceptance will check 2>"
+  ],
+  "verifyCommands": [
+    "<exact bash command to validate, e.g. pnpm test packages/foo>"
+  ]
+}
+```
+
+**Gate**: every field non-empty. If definitionOfDone contains a subjective phrase (clean, elegant, good), rewrite it as a measurable criterion or escalate to the user.
+
+## Phase 2: Dispatch Dev
+
+Use the Agent tool with subagent_type set to dev. The prompt template:
+
+```
+You are operating under the dev agent role (.claude/agents/dev.md). Implement the following task and return a JSON receipt as your final message.
+
+## TaskBundle
+[paste TaskBundle JSON built in Phase 1]
+
+## Execution Protocol
+1. Read every file listed in readScope.
+2. Implement within allowedWriteScope only. Touching anything in mustNotTouch is forbidden.
+3. Run every command in verifyCommands. ALL must pass before you commit.
+4. Self-fix once if a verifyCommand fails. If it still fails, STOP and report — do NOT commit broken code.
+5. Commit with format type(scope): summary (Mercury convention).
+6. Push to current branch.
+7. Output the JSON receipt below as your FINAL message.
+
+## Receipt template
+{
+  "taskId": "[copied out of the bundle]",
+  "status": "completed|blocked|escalated",
+  "changedFiles": ["path", "..."],
+  "commitSha": "sha",
+  "verifyResults": [
+    {"command": "cmd", "exitCode": 0, "summary": "one line"}
+  ],
+  "evidence": "file:line citations supporting definition-of-done",
+  "risks": "known risks or follow-up needed",
+  "escalationReason": "only if status is not completed"
+}
+
+## Forbidden
+- git switch, git checkout, git branch, git reset, git rebase, git merge, git push --force
+- git add -A or git add .
+- Modifying CLAUDE.md or any file under .claude/agents/
+- Picking up additional work after the receipt is filed
+```
+
+**Gate**: dev must return a JSON receipt with status completed. If blocked or escalated, jump to Phase 5 (escalate to user).
+
+
+## Phase 3: Receipt Review (Main)
+
+Main checks receipt completeness — NOT correctness (that is acceptance's job).
+
+Checklist:
+- [ ] All changedFiles exist in the diff
+- [ ] commitSha matches latest commit on the branch
+- [ ] All verifyCommands listed in the bundle have a verifyResults entry with exitCode 0
+- [ ] evidence cites at least one file:line per definitionOfDone item
+- [ ] No file outside allowedWriteScope was touched (run git diff --name-only HEAD~1)
+
+**Gate**: if any check fails, send a correction prompt to dev (still iteration 1) with the specific deficiency. Do not advance to acceptance with an incomplete receipt.
+
+## Phase 4: Dispatch Acceptance (BLIND)
+
+Build the **blindReceipt** by stripping dev's narrative fields:
+
+```json
+{
+  "taskId": "[copied out of receipt]",
+  "changedFiles": "[copied out of receipt]",
+  "commitSha": "[copied out of receipt]",
+  "verifyResults": "[copied out of receipt]"
+}
+```
+
+Note what was REMOVED: evidence, risks, escalationReason. The acceptance agent must form its own conclusions out of code and tests, not out of dev's self-assessment.
+
+Build the **AcceptanceBundle**:
+
+```json
+{
+  "taskId": "[copied out of TaskBundle]",
+  "title": "[copied out of TaskBundle]",
+  "definitionOfDone": "[copied out of TaskBundle]",
+  "acceptanceCriteria": "[copied out of TaskBundle]",
+  "verifyCommands": "[copied out of TaskBundle]"
+}
+```
+
+Use the Agent tool with subagent_type set to acceptance. Prompt template:
+
+```
+You are operating under the acceptance agent role (.claude/agents/acceptance.md). BLIND REVIEW: you are FORBIDDEN from inferring or asking about the dev agent's reasoning, narrative, or self-assessment.
+
+## AcceptanceBundle
+[paste AcceptanceBundle JSON]
+
+## Blind Receipt (changed files only — NO dev narrative)
+[paste blindReceipt JSON]
+
+## Instructions
+1. Read every file listed in changedFiles at the latest commit.
+2. Run every command in verifyCommands. Capture exit codes and output.
+3. Evaluate each acceptanceCriteria and definitionOfDone item against the actual code and runtime output. Cite file:line evidence.
+4. Output your verdict as JSON.
+
+## Verdict template
+{
+  "verdict": "pass|partial|fail|blocked",
+  "criteriaResults": [
+    {"criterion": "text", "verdict": "pass|fail|partial", "evidence": "file:line or test output"}
+  ],
+  "findings": ["problem 1", "problem 2"],
+  "recommendations": ["actionable fix 1"]
+}
+```
+
+**Gate**: capture the verdict.
+
+## Phase 5: Decide Next Action
+
+Based on the acceptance verdict:
+
+| Verdict | Action |
+|---|---|
+| pass | Pipeline complete. Summarize result for user (Chinese for milestones). Hand off to /pr-flow if a PR is the next step. |
+| partial | Re-dispatch dev with the **original full TaskBundle** plus a `priorFindings` array containing acceptance's findings. Constraints (definitionOfDone, allowedWriteScope, mustNotTouch, readScope) MUST be carried over verbatim from iteration 1 — never widened, never dropped. Increment iteration. |
+| fail | Same as partial: dispatch with full original TaskBundle + priorFindings + priorRecommendations. Constraints carried verbatim. Increment iteration. |
+| blocked | Escalate to user. Acceptance hit an environmental block; user must resolve. |
+
+**Constraint preservation**: every retry dispatch must include the EXACT original `definitionOfDone`, `allowedWriteScope`, `mustNotTouch`, and `readScope` from iteration 1. Adding a new constraint is OK; widening or dropping an existing one is forbidden — that defeats the purpose of the bundle as a contract.
+
+**Iteration cap**: if iteration is at least 3 and verdict is still not pass, **escalate to user** with the full history. Do not silently keep looping.
+
+## Phase 6: Hand-off
+
+On pass:
+1. Confirm commit is pushed (git status)
+2. If user requested PR: invoke /pr-flow
+3. Mark related GitHub Project item Done (via /gh-project-flow if Mercury self-dev) or via Closes #N in PR (general case)
+4. Summarize in Chinese for the user
+
+## Detachability
+
+This skill is designed to be portable to any repository that uses GitHub + Claude Code, provided:
+- .claude/agents/dev.md and .claude/agents/acceptance.md exist with valid frontmatter
+- The target repo uses **GitHub Issues + GitHub PRs** (the protocol references `Closes #N`, `gh pr create`, and Mercury's `/pr-flow` skill — all GitHub-specific). Non-GitHub repos would need protocol adaptation.
+- The repo has a sane verifyCommands story (tests, lint, build commands that exit non-zero on failure)
+- The user is on a feature branch (not main, develop, or master)
+
+The `/gh-project-flow` reference in Phase 6 is **Mercury-specific** and should be removed or replaced when porting elsewhere — it is mentioned only because Mercury self-development uses Project #3 for task tracking.
+
+To use it elsewhere, copy this skill directory plus the two agent files, then strip the `/gh-project-flow` line from Phase 6. No other Mercury dependency.
+
+## Known Limitations
+
+- **No parallel tasks**. By design — Mercury's preset chain is linear single-task. For parallelism, open another session.
+- **No persistent memory between invocations**. Each pipeline run is fresh. Phase 3 Memory Layer will lift this constraint.
+- **Subagent context is independent**. The dev and acceptance subagents do NOT see the main session's history — only the prompt you send them. Be explicit; do not assume shared context.
+- **Critic agent not included by default**. If you want a third independent verification pass (different model), add a Phase 4.5 dispatch to subagent_type critic. Out of scope for the baseline pipeline.
+
+## Failure Modes
+
+| Symptom | Likely Cause | Fix |
+|---|---|---|
+| Agent tool returns unknown subagent type dev | Frontmatter missing or invalid in .claude/agents/dev.md | Check that name dev is the first non-divider line; restart session |
+| Dev commits files outside allowedWriteScope | Bundle scope was too vague, or dev hallucinated needed files | Tighten scope; if hallucination, fix and re-dispatch with explicit prohibition |
+| Acceptance returns pass but obvious bug exists | Acceptance criteria did not cover the bug class | Update bundle criteria; this is a design failure of the bundle, not the agent |
+| Pipeline loops 3+ times on the same finding | Dev keeps fixing the wrong thing | Escalate immediately; usually means the finding text is ambiguous |

--- a/.claude/skills/dev-pipeline/SKILL.md
+++ b/.claude/skills/dev-pipeline/SKILL.md
@@ -71,12 +71,16 @@ Before invoking this skill, the following must be true:
 
 ## Phase 2: Dispatch Dev
 
-**Before dispatching**, capture the task-start SHA so Phase 3 can compute the diff range correctly (do not rely on `HEAD~1`):
+**Before dispatching**, capture the task-start SHA so Phase 3 can compute the diff range correctly (do not rely on `HEAD~1`). Store it OUTSIDE the working tree to avoid repo pollution:
 
 ```bash
 TASK_START_SHA=$(git rev-parse HEAD)
-echo "$TASK_START_SHA" > .pr-flow-task-start-sha
+SHA_FILE="${TMPDIR:-/tmp}/dev-pipeline-task-start-sha-$$"
+echo "$TASK_START_SHA" > "$SHA_FILE"
+# Phase 6 cleanup: rm -f "$SHA_FILE"
 ```
+
+The file is named with `$$` (current shell PID) so concurrent pipelines do not collide. Phase 6 hand-off must remove it.
 
 Use the Agent tool with subagent_type set to dev. The prompt template:
 
@@ -211,9 +215,10 @@ Based on the acceptance verdict:
 
 On pass:
 1. Confirm commit is pushed (git status)
-2. If user requested PR: invoke /pr-flow
-3. Mark related GitHub Project item Done (via /gh-project-flow if Mercury self-dev) or via Closes #N in PR (general case)
-4. Summarize in Chinese for the user
+2. **Clean up scratch state**: `rm -f "$SHA_FILE"` (the task-start SHA file from Phase 2). On any exit path (pass, escalate, blocked), this MUST run.
+3. If user requested PR: invoke /pr-flow
+4. Mark related GitHub Project item Done (via /gh-project-flow if Mercury self-dev) or via Closes #N in PR (general case)
+5. Summarize in Chinese for the user
 
 ## Detachability
 

--- a/.claude/skills/gh-project-flow/SKILL.md
+++ b/.claude/skills/gh-project-flow/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: gh-project-flow
+description: |
+  BOOTSTRAP-ONLY task management for Mercury self-development via GitHub Project #3. Lets the main agent pull the next Phase + P0 Todo task, mark it In Progress, link work products (PR/Issue), and move items to Done. Use this skill when the user says "next task", "下一个任务", "拉任务", "认领任务", "标记 in progress", "project status", "更新 project", "Mercury 项目看板", "Phase 1 任务", "gh-project-flow". DO NOT use this skill for general (non-Mercury) project development — those scenarios will use Memory Layer (Phase 3) + Dev Pipeline (Phase 1 self-output) instead. This skill exists to bootstrap Mercury's own buildout and will be retired when Phase 3 lands.
+user-invocable: true
+allowed-tools: Bash, Read, Grep, Write, Edit
+---
+
+# gh-project-flow — Bootstrap Task Management for Mercury Self-Dev
+
+> **BOOTSTRAP-ONLY**. This skill drives Mercury's *own* development task board (GitHub Project #3, owner `392fyc`). It is not a general-purpose project tracker. Mercury's vision for general dev is Memory Layer + Dev Pipeline, which arrive in Phase 3. When that ships, this skill is deprecated.
+
+## When This Applies
+
+- The user is working on Mercury itself and asks for the next task
+- A new Mercury Phase milestone needs to be picked up
+- A PR / Issue created for Mercury work needs to be linked back to the project board
+- Status of a Mercury Phase item needs to flip (Todo → In Progress → Done)
+
+**Do NOT use** when the user is working in another repo, building a feature for an external project, or asking for general Kanban automation.
+
+## Verified API Surface (2026-04)
+
+Verified directly against the local `gh` CLI and against [GitHub CLI manual](https://cli.github.com/manual/gh_project_item-list):
+
+| Command | Default `--limit` | Notes |
+|---|---|---|
+| `gh project item-list <N> --owner <login> --format json` | **30** | ⚠️ Mercury Project #3 has 37+ items. ALWAYS pass `--limit 100` (or higher) explicitly, otherwise Phase 1 P0 items are silently truncated. |
+| `gh project field-list <N> --owner <login> --format json` | **30** | Project #3 currently has 12 fields, fits within default — but pass `--limit 100` defensively (matches the rule below). |
+| `gh project item-edit --id <item-id> --field-id <field-id> --project-id <project-id> --single-select-option-id <option-id>` | n/a | Single-field-per-invocation. Issue items require `--project-id`; draft items don't. |
+| `gh project view <N> --owner <login> --format json` | n/a | Returns project node ID (`PVT_*`) needed by `--project-id`. |
+
+Sources:
+- https://cli.github.com/manual/gh_project_item-list
+- https://cli.github.com/manual/gh_project_item-edit
+- https://cli.github.com/manual/gh_project_field-list
+
+### JSON shape returned by `item-list`
+
+`item-list --format json` returns `{items: [...], totalCount: N}`. Each item:
+
+```jsonc
+{
+  "id": "PVTI_lAHO...",            // project item ID — pass to item-edit --id
+  "title": "...",                   // resolved title (issue title or draft body)
+  "status": "Todo",                 // resolved single-select VALUE (not option ID)
+  "phase": "Phase 1",               // custom single-select VALUE
+  "priority": "P0",                 // custom single-select VALUE
+  "labels": ["enhancement"],
+  "assignees": ["392fyc"],
+  "content": {
+    "type": "Issue",                // "Issue" | "DraftIssue" | "PullRequest"
+    "number": 178,                  // null for DraftIssue
+    "title": "...",
+    "url": "https://github.com/...",
+    "body": "...",
+    "repository": "392fyc/Mercury"
+  }
+}
+```
+
+**Important**: `status`, `phase`, `priority` come back as the human-readable VALUE (e.g. `"Todo"`), not the option ID. To EDIT them, you must look up the option ID via `field-list` first.
+
+## Mercury Project #3 Cached IDs
+
+These are stable as of 2026-04-07. Re-run `field-list` if `item-edit` returns "field not found".
+
+```bash
+PROJECT_NUMBER=3
+PROJECT_OWNER=392fyc
+PROJECT_ID=PVT_kwHOBiaNmM4BT4Nv
+
+# Status field
+STATUS_FIELD_ID=PVTSSF_lAHOBiaNmM4BT4NvzhBEE4c
+STATUS_TODO=f75ad846
+STATUS_IN_PROGRESS=47fc9ee4
+STATUS_DONE=98236657
+
+# Phase field
+PHASE_FIELD_ID=PVTSSF_lAHOBiaNmM4BT4NvzhBEE_o
+PHASE_0=3332c598
+PHASE_1=23142fd5
+PHASE_2=2b168873
+PHASE_3=1dfe92b6
+PHASE_4=befb60c6
+PHASE_5=60c7cd9b
+
+# Priority field
+PRIORITY_FIELD_ID=PVTSSF_lAHOBiaNmM4BT4NvzhBEFA4
+PRIORITY_P0=a2c3f4ac
+PRIORITY_P1=3d4d12f9
+PRIORITY_P2=e555ac5d
+```
+
+To regenerate the cache from scratch:
+
+```bash
+gh project field-list 3 --owner 392fyc --format json --limit 100 | jq '.fields[] | select(.type=="ProjectV2SingleSelectField") | {name, id, options}'
+gh project view 3 --owner 392fyc --format json --jq '.id'
+```
+
+## Operation 1 — `next-task`
+
+Pull the highest-priority Todo item for a given Phase. Caller passes the Phase explicitly; this skill does NOT auto-detect "active" phase (that's a workflow decision belonging to Main, not the skill).
+
+```bash
+PHASE="${1:-Phase 1}"
+
+# NOTE: gh --jq does NOT accept --arg. Pipe to standalone jq to pass shell variables safely.
+# Sort_by on strings "P0"/"P1"/"P2" yields P0 first lexicographically, so .[0] is the highest priority.
+gh project item-list 3 --owner 392fyc --format json --limit 100 \
+  | jq --arg phase "$PHASE" '
+    .items
+    | map(select(.status=="Todo" and .phase==$phase))
+    | sort_by(.priority)
+    | .[0]
+    | {
+        id,
+        title,
+        priority,
+        phase,
+        type: .content.type,
+        number: .content.number,
+        url: .content.url
+      }
+  '
+```
+
+Returns one item or `null`. Issue items have a `number` and `url`; draft items have `null` for both. To restrict to P0 only, use the explicit P0 filter below.
+
+To list all P0 Todo for a Phase (not just one):
+
+```bash
+gh project item-list 3 --owner 392fyc --format json --limit 100 \
+  | jq --arg phase "$PHASE" '
+    .items
+    | map(select(.status=="Todo" and .phase==$phase and .priority=="P0"))
+    | map({id, title, type: .content.type, number: .content.number})
+  '
+```
+
+## Operation 2 — `start <item-id>`
+
+Move an item Todo → In Progress.
+
+```bash
+ITEM_ID="$1"
+
+gh project item-edit \
+  --id "$ITEM_ID" \
+  --field-id "$STATUS_FIELD_ID" \
+  --project-id "$PROJECT_ID" \
+  --single-select-option-id "$STATUS_IN_PROGRESS"
+```
+
+This works for both Issue items and Draft items because we pass `--project-id` either way (it's only optional for drafts, never harmful).
+
+## Operation 3 — `link <item-id> --pr <N>` / `--issue <N>`
+
+For **issue-backed items**: linking is automatic. When the PR's body or commit messages contain `Closes #N` / `Fixes #N` / `Resolves #N`, GitHub auto-moves the linked Issue's project item to Done on PR merge. No skill action needed.
+
+For **draft items**: there's no native link. The skill convention is to convert the draft to a real Issue first if linking matters, OR record the PR number in the draft body via `gh project item-edit --title` or by editing the draft body. Recommended: convert to Issue using:
+
+```bash
+# Read draft body, then create real Issue, then archive draft.
+ITEM_ID="$1"
+gh project item-list 3 --owner 392fyc --format json --limit 100 \
+  | jq --arg id "$ITEM_ID" '.items[] | select(.id==$id) | .content'
+# Then `gh issue create` with that body, then add the new issue to the project.
+```
+
+(In practice for Phase 1 we will lift each draft into a real Issue before starting work, so this conversion path stays rare.)
+
+## Operation 4 — `done <item-id>`
+
+For **issue items**: prefer letting `Closes #N` in the merged PR auto-move it. Manual override only if the PR was merged without the keyword:
+
+```bash
+gh project item-edit \
+  --id "$ITEM_ID" \
+  --field-id "$STATUS_FIELD_ID" \
+  --project-id "$PROJECT_ID" \
+  --single-select-option-id "$STATUS_DONE"
+```
+
+For **draft items**: always manual (drafts have no PR link). Use the same `item-edit` invocation above.
+
+## Iron Rules
+
+1. **Always pass `--limit 100`** to `item-list`. Default 30 silently truncates Mercury's 37+ items.
+2. **Never invent option IDs**. Use the cached values above; if they fail, regenerate via `field-list`.
+3. **One field per `item-edit` call**. The CLI does not support multi-field updates in one invocation.
+4. **Issue-first**. When practical, convert draft items to real Issues before starting work — that's the only way `Closes #N` automation kicks in. The full Mercury workflow expects an Issue per task.
+5. **BOOTSTRAP-ONLY scope**. Do not extend this skill to support arbitrary projects, users, or non-Mercury repos. If general project automation is needed, build it in `dev-pipeline` or wait for Phase 3.
+
+## Windows Path Mangling
+
+`gh project` subcommands take no `/`-prefixed arguments, so `MSYS_NO_PATHCONV=1` is **not** required for any command in this skill. If you ever pipe through `gh api /...`, prefix with `MSYS_NO_PATHCONV=1`.
+
+## Failure Modes
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `next-task` returns null but you expect items | Default `--limit 30` truncated past your phase | Confirm `--limit 100` is in the command |
+| `item-edit` errors `field not found` | Cached field ID out of date | Re-run `field-list` and update the cache section above |
+| `Closes #N` didn't move item to Done | PR didn't actually contain the keyword, OR the linked Issue isn't in this project | Verify both, then manual `done` |
+| Draft item shows `content.number: null` | Expected — drafts have no issue number | Convert to Issue if linking needed |
+| Multiple items returned by `next-task` query | jq filter missing `.[0]` | Use the canonical filter above |

--- a/.claude/skills/gh-project-flow/SKILL.md
+++ b/.claude/skills/gh-project-flow/SKILL.md
@@ -66,6 +66,9 @@ Sources:
 These are stable as of 2026-04-07. **The cache is fragile**: if Project #3 fields are recreated, deleted, or migrated, every ID below becomes garbage and `item-edit` will fail. Run the verify snippet at the bottom of this section before any high-stakes batch operation, and re-run `field-list` if `item-edit` ever returns "field not found".
 
 ```bash
+# IMPORTANT: run the cache-verify snippet (further below in this section) before
+# trusting these constants for any batch operation. They are static and will go
+# stale silently if the Project field schema changes.
 PROJECT_NUMBER=3
 PROJECT_OWNER=392fyc
 PROJECT_ID=PVT_kwHOBiaNmM4BT4Nv
@@ -123,10 +126,13 @@ PRIORITY="${2:-P0}"
 
 # NOTE: gh --jq does NOT accept --arg. Pipe to standalone jq to pass shell variables safely.
 # Canonical: filter by phase + status + priority explicitly. Do NOT rely on sort_by for priority semantics.
+# Stable order: sort by content.number (issue items) ascending, then by item id (drafts).
+# This makes "next-task" deterministic across runs even if GitHub returns items in different order.
 gh project item-list 3 --owner 392fyc --format json --limit 100 \
   | jq --arg phase "$PHASE" --arg pri "$PRIORITY" '
     .items
     | map(select(.status=="Todo" and .phase==$phase and .priority==$pri))
+    | sort_by([(.content.number // 999999), .id])
     | .[0]
     | {
         id,

--- a/.claude/skills/gh-project-flow/SKILL.md
+++ b/.claude/skills/gh-project-flow/SKILL.md
@@ -63,7 +63,7 @@ Sources:
 
 ## Mercury Project #3 Cached IDs
 
-These are stable as of 2026-04-07. Re-run `field-list` if `item-edit` returns "field not found".
+These are stable as of 2026-04-07. **The cache is fragile**: if Project #3 fields are recreated, deleted, or migrated, every ID below becomes garbage and `item-edit` will fail. Run the verify snippet at the bottom of this section before any high-stakes batch operation, and re-run `field-list` if `item-edit` ever returns "field not found".
 
 ```bash
 PROJECT_NUMBER=3
@@ -99,20 +99,34 @@ gh project field-list 3 --owner 392fyc --format json --limit 100 | jq '.fields[]
 gh project view 3 --owner 392fyc --format json --jq '.id'
 ```
 
+To **verify** the cache against current Project state (run this before any batch operation that depends on the IDs):
+
+```bash
+# Compare cached IDs against live values; nonzero exit means drift.
+# tr -d '\r' guards against CRLF when running under git bash on Windows.
+LIVE=$(gh project field-list 3 --owner 392fyc --format json --limit 100 \
+  | jq -r '.fields[] | select(.type=="ProjectV2SingleSelectField") | "\(.name)=\(.id)"' | tr -d '\r' | sort)
+EXPECTED=$(printf '%s\n' \
+  "Status=PVTSSF_lAHOBiaNmM4BT4NvzhBEE4c" \
+  "Phase=PVTSSF_lAHOBiaNmM4BT4NvzhBEE_o" \
+  "Priority=PVTSSF_lAHOBiaNmM4BT4NvzhBEFA4" | sort)
+diff <(echo "$LIVE") <(echo "$EXPECTED") && echo "cache OK" || { echo "DRIFT — regenerate cache"; exit 1; }
+```
+
 ## Operation 1 — `next-task`
 
-Pull the highest-priority Todo item for a given Phase. Caller passes the Phase explicitly; this skill does NOT auto-detect "active" phase (that's a workflow decision belonging to Main, not the skill).
+Pull the next P0 Todo item for a given Phase. Caller passes the Phase explicitly; this skill does NOT auto-detect "active" phase (that's a workflow decision belonging to Main, not the skill).
 
 ```bash
 PHASE="${1:-Phase 1}"
+PRIORITY="${2:-P0}"
 
 # NOTE: gh --jq does NOT accept --arg. Pipe to standalone jq to pass shell variables safely.
-# Sort_by on strings "P0"/"P1"/"P2" yields P0 first lexicographically, so .[0] is the highest priority.
+# Canonical: filter by phase + status + priority explicitly. Do NOT rely on sort_by for priority semantics.
 gh project item-list 3 --owner 392fyc --format json --limit 100 \
-  | jq --arg phase "$PHASE" '
+  | jq --arg phase "$PHASE" --arg pri "$PRIORITY" '
     .items
-    | map(select(.status=="Todo" and .phase==$phase))
-    | sort_by(.priority)
+    | map(select(.status=="Todo" and .phase==$phase and .priority==$pri))
     | .[0]
     | {
         id,
@@ -126,7 +140,7 @@ gh project item-list 3 --owner 392fyc --format json --limit 100 \
   '
 ```
 
-Returns one item or `null`. Issue items have a `number` and `url`; draft items have `null` for both. To restrict to P0 only, use the explicit P0 filter below.
+Returns one item or `null`. Issue items have a `number` and `url`; draft items have `null` for both. To fall back to lower priorities when no P0 remains, call again with `PRIORITY=P1`, then `P2`. The skill does NOT auto-fall-back — that is a workflow decision the caller owns.
 
 To list all P0 Todo for a Phase (not just one):
 

--- a/.claude/skills/pr-flow/PHILOSOPHY.md
+++ b/.claude/skills/pr-flow/PHILOSOPHY.md
@@ -1,0 +1,80 @@
+# Why pr-flow Exists
+
+> Methodology document behind Mercury's `pr-flow` skill. Targets external readers who want to understand the design decisions, not just the operational steps.
+
+## The problem
+
+PR review is where AI agent productivity goes to die.
+
+A coding agent finishes work, opens a PR, and then a human (or a review bot) leaves comments. The agent reads the comments, decides what to fix, fixes some of them, replies to others, pushes a new commit. The reviewer comes back, sees the fixes, possibly resolves threads, possibly adds new findings. This cycle repeats until merge. In a reasonable engineering culture, it might take five rounds for a non-trivial PR.
+
+Every round in that cycle has at least three failure modes for an unaided agent:
+
+1. **The agent claims work is done when it is not.** It pushes a commit that addresses *most* of a thread's concern and posts "Fixed in 1a2b3c", quietly leaving the load-bearing part untouched. Reviewers either trust it (bad) or have to manually re-verify (defeats the purpose).
+
+2. **The agent argues the wrong battles.** A reviewer flags something the agent disagrees with. The agent should explain its reasoning calmly. Instead, in the worst case, it apologizes, makes a meaningless change to satisfy the reviewer, and creates noise. In the second-worst case, it argues stubbornly past the point where the reviewer has made a legitimate call.
+
+3. **The agent loses the plot across rounds.** By round three, the agent forgets which threads are resolved, which are pending fix, and which are pending discussion. It re-fixes things that were already fixed, ignores things that were already raised, and the PR drifts into entropy.
+
+A good pr-flow skill solves all three by making the loop *mechanical* — by handing each decision a deterministic gate and refusing to advance until the gate passes.
+
+## Why the loop is sequential, not async
+
+Mercury's pr-flow runs each phase as a hard gate: create PR, wait for review, fix findings, push, wait again, possibly merge. There is no parallelism. There is no event-driven dispatch. The agent runs one phase, blocks on the gate, then runs the next.
+
+This is unfashionable. Most automation literature would suggest the agent should subscribe to webhooks, react to review events, and process them asynchronously. We tried that. It produces the worst of both worlds: agent behavior that is hard to reason about *and* still fundamentally bottlenecked on human review latency.
+
+Sequential is better because:
+- The agent's mental model at any point is just "what phase am I in, what gate am I waiting on" — no concurrent state to track
+- Failure modes are localized to a phase
+- A human can stop the loop at any phase, intervene, and resume — there is no in-flight async work to clean up
+- The skill file becomes readable as a linear protocol, not a state machine
+
+The cost is real: the agent literally sits idle waiting for review. We accept that cost because the alternative is debugging concurrent agent reasoning, which is a much higher-variance failure mode.
+
+## The fix-detection contract with the review bot
+
+Mercury's pr-flow is built around a specific assumption about how the review bot (Argus) behaves:
+
+- **Fix-detection resolve**: when the agent pushes a commit that touches the file and lines flagged by an open thread, the bot auto-resolves that thread. The agent does NOT manually mark threads resolved.
+- **No "Fixed in 1a2b3c" comments**: the diff is the explanation. Posting fix announcements clutters the thread without adding signal.
+- **APPROVE only on zero new findings**: the bot returns COMMENT (not APPROVE) until a review iteration produces no new findings AND all prior threads are resolved.
+- **Reply-aware resolution**: when the agent disagrees with a finding, it replies with reasoning. The bot's LLM classifies the reply as ACCEPT, REJECT, or ESCALATE, and resolves accordingly. Maximum three reply rounds before a thread escalates to a human.
+
+These rules are not abstract. They are baked into the protocol because they short-circuit the three failure modes above.
+
+- The agent cannot claim work is done — only the bot's fix detection can resolve a thread.
+- The agent cannot argue wrong battles indefinitely — the reply-round cap forces escalation.
+- The agent cannot lose the plot — thread state lives in the bot, not in the agent's head.
+
+## Why the agent never resolves threads itself
+
+This is the most counterintuitive rule and the one engineers push back on the hardest. Surely the agent should be able to mark its own work resolved when it has clearly fixed something?
+
+No. Because "clearly fixed" is exactly the failure mode. Self-resolution is the soliloquy problem applied to PR review. The point of having a separate review bot is having an independent judge of whether a thread is closed. If the agent overrides that judge, the bot becomes ceremonial.
+
+The behavior is uncomfortable in the short term — the agent commits a fix and the thread sits open until the bot's next pass — and it is correct in the long term, because it forces the agent to write fixes that are *visible* in the diff at the precise location the bot can detect them. That is also a nudge toward better fixes: targeted edits at the flagged lines, not sprawling refactors that incidentally happen to touch the area.
+
+## Why a maximum of five iterations
+
+The loop cap mirrors the dev-pipeline cap (three iterations) but is set higher because PR review is structurally noisier — review bots sometimes flag the same class of thing across multiple files, and some legitimate PRs need three or four passes just because the diff is large. Five is the empirical sweet spot where:
+- legitimate large PRs converge in time
+- pathological cases (the agent stuck in a fix-find-fix loop on the same finding) hit the cap and escalate
+- the cap is low enough that escalation is cheap
+
+Above five iterations, every additional round dramatically increases the chance the agent is "fixing" the wrong thing.
+
+## What this skill is NOT
+
+- **Not a code review tool.** It does not generate review comments. That is the bot's job.
+- **Not a CI integration layer.** It assumes CI runs separately. If CI fails, the human resolves it; the skill does not interpret CI output.
+- **Not a merge policy engine.** It does not enforce branch protection rules. GitHub does that. The skill just respects them.
+- **Not a generic GitHub automation.** It is specifically the Mercury PR loop with the Argus bot's fix-detection contract. Replace Argus with a bot that does not auto-resolve, and the skill needs adaptation.
+
+## What it IS
+
+A protocol that says: open a PR, wait for review, fix or reply per finding, push, wait for the bot's next pass, repeat until APPROVE, then merge. With one critical behavioral constraint: never claim work yourself, never resolve threads yourself, never argue past three reply rounds. The protocol is short. The constraints are the methodology.
+
+## Closing
+
+PR review is one of the highest-leverage moments in any software engineering workflow. It is also the moment where AI agents most commonly underperform, because every PR cycle is a small calibration test and agents are bad at calibrating themselves. pr-flow does not try to make the agent better at calibration. It removes the agent's ability to self-judge and delegates the judgment to the review bot, which is the only independent voice in the loop. That delegation is the entire trick.


### PR DESCRIPTION
## Summary
- Add YAML frontmatter to all six `.claude/agents/*.md` so Claude Code can discover them as subagents (previously had none — would not load). `main.md` uses `Agent(dev,acceptance,critic,research,design)` allowlist instead of bare `Agent`.
- New skill `.claude/skills/gh-project-flow/SKILL.md`: BOOTSTRAP-ONLY task management for Mercury self-dev via GitHub Project #3. Caches field/option IDs, always passes `--limit 100` (default 30 silently truncates Mercury's 37+ items), pipes to standalone `jq` because `gh --jq` does not accept `--arg`.
- New skill `.claude/skills/dev-pipeline/SKILL.md`: preset Main → Dev → Acceptance chain with blind acceptance review, max 3 iterations, explicit constraint preservation across retries. GitHub-portable with one Mercury-specific line marked for stripping when ported.
- Methodology docs: `dev-pipeline/PHILOSOPHY.md` (why preset chains beat orchestration; why blind acceptance) and `pr-flow/PHILOSOPHY.md` (why sequential not async; why agent never resolves own threads).

## Dual-Verify
- **Claude deep review**: 1 HIGH found and fixed pre-commit (`gh --jq --arg` invalid syntax — fixed by piping to standalone jq).
- **Codex audit**: 1 High + 4 Medium + 2 Low found, all addressed pre-commit:
  - H1: `next-task` description claimed P0 + active-phase computation that the query did not implement → rewrote description to match actual behavior.
  - M1: `--limit 50` vs `--limit 100` inconsistency → unified on 100.
  - M2: dev-pipeline retry path did not specify constraint persistence → added explicit "constraint preservation" rule.
  - M3: dev-pipeline detachability claim was inconsistent with GitHub-specific protocol → softened claim, called out the Mercury-specific `/gh-project-flow` line for stripping.
  - M4: `main.md` used unrestricted `Agent` → switched to allowlist `Agent(dev, acceptance, critic, research, design)`.
  - L1: `⚠️` emoji rendered as `??` mojibake → removed.
  - L2: PHILOSOPHY portability claim too strong → softened to match SKILL.md.

## Test plan
- [ ] gh-project-flow `next-task` returns the highest-priority Phase 1 Todo (verified during dogfood: returned PVTI...uig with priority P0)
- [ ] gh-project-flow `start` flips item status Todo → In Progress (verified: #185 itself was moved during dogfood)
- [ ] All six `.claude/agents/*.md` files load without error after session restart (frontmatter YAML valid)
- [ ] dev-pipeline skill SKILL.md description triggers on intended user phrases
- [ ] PHILOSOPHY docs render in markdown without broken tables or fences

## Known follow-ups (NOT in this PR)
- Real-project Phase 1 validation (Issue → Dev → Acceptance → PR → Merge on a non-Mercury repo) requires user to choose target project — deferred to a separate session.
- pr-flow SKILL.md itself unchanged — user-reported "gh project limit bug in pr-flow" was misattribution; pr-flow contains zero `gh project` references. The defensive `--limit 100` rule is enforced in gh-project-flow instead.

Refs #178 #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)