### PR TITLE
fix(skills): port 7 portability fixes from Argus review back to Mercury copies

### DIFF
--- a/.claude/agents/acceptance.md
+++ b/.claude/agents/acceptance.md
@@ -34,10 +34,15 @@ Evaluate only from code, tests, and runtime output. Do not rely on the developer
 
 ## Output Format
 
+The verdict schema matches what `dev-pipeline` SKILL.md Phase 4 parses. Both `criteriaResults` (per-criterion breakdown) and `findings` / `recommendations` (free-form lists) are required fields. Do NOT omit `criteriaResults` — the pipeline keys off it for retry decisions.
+
 ```json
 {
   "verdict": "pass|partial|fail|blocked",
-  "findings": ["..."],
-  "recommendations": ["..."]
+  "criteriaResults": [
+    {"criterion": "text of the criterion", "verdict": "pass|fail|partial", "evidence": "file:line or test output"}
+  ],
+  "findings": ["problem 1", "problem 2"],
+  "recommendations": ["actionable fix 1"]
 }
 ```

--- a/.claude/skills/dev-pipeline/SKILL.md
+++ b/.claude/skills/dev-pipeline/SKILL.md
@@ -75,12 +75,16 @@ Before invoking this skill, the following must be true:
 
 ```bash
 TASK_START_SHA=$(git rev-parse HEAD)
-SHA_FILE="${TMPDIR:-/tmp}/dev-pipeline-task-start-sha-$$"
+# Use the branch name (sanitized) as a STABLE key so Phase 3 can re-read it
+# from a different shell process. $$ does NOT work here: Main/Phase 2 run in
+# one Bash shell, Phase 3 runs in a later Bash shell with a different PID.
+BRANCH_KEY=$(git rev-parse --abbrev-ref HEAD | tr '/' '_' | tr -cd '[:alnum:]_-')
+SHA_FILE="${TMPDIR:-/tmp}/dev-pipeline-task-start-sha-${BRANCH_KEY}"
 echo "$TASK_START_SHA" > "$SHA_FILE"
 # Phase 6 cleanup: rm -f "$SHA_FILE"
 ```
 
-The file is named with `$$` (current shell PID) so concurrent pipelines do not collide. Phase 6 hand-off must remove it.
+The file is keyed by the current branch name (slash-sanitized). This is stable across Bash invocations within the same pipeline run, and concurrent pipelines collide only if they are on the same branch — which would be a pre-existing git conflict anyway. Phase 6 hand-off must remove it.
 
 Use the Agent tool with subagent_type set to dev. The prompt template:
 
@@ -217,7 +221,7 @@ Based on the acceptance verdict:
 rm -f "$SHA_FILE"
 ```
 
-This runs on `pass`, `blocked`, escalation after `partial`/`fail`, and on iteration-cap escalation. The ONLY paths that skip cleanup are intra-iteration dev re-dispatches (because Phase 3 still needs the SHA). If the loop terminates without reaching one of these branches (e.g. host crash), the file at `${TMPDIR:-/tmp}/dev-pipeline-task-start-sha-$$` will be cleaned up by OS tmp eviction; PID-suffix prevents collision.
+This runs on `pass`, `blocked`, escalation after `partial`/`fail`, and on iteration-cap escalation. The ONLY paths that skip cleanup are intra-iteration dev re-dispatches (because Phase 3 still needs the SHA). If the loop terminates without reaching one of these branches (e.g. host crash), the file at `${TMPDIR:-/tmp}/dev-pipeline-task-start-sha-${BRANCH_KEY}` will be cleaned up on the next pipeline run against the same branch (the new invocation overwrites it) or by OS tmp eviction; the branch-key naming prevents cross-branch collision.
 
 ## Phase 6: Hand-off
 

--- a/.claude/skills/dual-verify/SKILL.md
+++ b/.claude/skills/dual-verify/SKILL.md
@@ -36,25 +36,29 @@ Codex is invoked via `Agent` tool (rescue subagent) — no manual terminal step 
 ```bash
 # Detect the base branch the current branch was cut from.
 # Prefer develop if it exists (Mercury convention), else the repo default branch.
-# If gh repo view fails entirely (no auth, offline), try common names in order.
-BASE=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || true)
-if [ -z "$BASE" ]; then
-  for candidate in develop main master; do
-    if git rev-parse --verify "origin/$candidate" >/dev/null 2>&1; then
-      BASE="$candidate"; break
-    fi
-  done
+# Strategy: query the REMOTE (ls-remote + gh) instead of local refs, so shallow
+# clones and minimal checkouts still work without a prior fetch.
+BASE=""
+# Ask the remote directly — ls-remote does not require any local refs to exist.
+REMOTE_REFS=$(git ls-remote --heads origin 2>/dev/null || true)
+if [ -n "$REMOTE_REFS" ]; then
+  if echo "$REMOTE_REFS" | grep -q 'refs/heads/develop$'; then
+    BASE=develop
+  elif BASE=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null) && [ -n "$BASE" ]; then
+    : # gh succeeded
+  else
+    for candidate in main master; do
+      if echo "$REMOTE_REFS" | grep -q "refs/heads/${candidate}\$"; then
+        BASE="$candidate"; break
+      fi
+    done
+  fi
 fi
 if [ -z "$BASE" ]; then
   echo "ERROR: dual-verify could not detect a base branch. Set BASE manually and retry." >&2
   exit 1
 fi
-# Override to develop if it exists on origin (Mercury convention).
-if git rev-parse --verify "origin/develop" >/dev/null 2>&1; then
-  BASE=develop
-fi
-# Ensure the base branch is fetched. Shallow clones and CI checkouts often lack origin/$BASE,
-# which would make `git diff origin/${BASE}...HEAD` fail silently with a confusing error.
+# Fetch the base branch so origin/$BASE is populated even on shallow clones / minimal checkouts.
 git fetch origin "$BASE" --quiet || {
   echo "ERROR: dual-verify failed to fetch origin/$BASE — check network or branch name" >&2
   exit 1

--- a/.claude/skills/dual-verify/SKILL.md
+++ b/.claude/skills/dual-verify/SKILL.md
@@ -34,13 +34,26 @@ Codex is invoked via `Agent` tool (rescue subagent) — no manual terminal step 
 **Claude Code deep review** (this session):
 
 ```bash
+# Detect remote name. Most repos use `origin` but some use `upstream` or a custom name.
+# Strategy: prefer `origin` if present (convention), else use the first configured remote.
+REMOTE=""
+if git remote get-url origin >/dev/null 2>&1; then
+  REMOTE=origin
+else
+  REMOTE=$(git remote | head -n 1)
+fi
+if [ -z "$REMOTE" ]; then
+  echo "ERROR: dual-verify could not detect a git remote. Configure one with 'git remote add origin <url>' and retry." >&2
+  exit 1
+fi
+
 # Detect the base branch the current branch was cut from.
 # Prefer develop if it exists (Mercury convention), else the repo default branch.
 # Strategy: query the REMOTE (ls-remote + gh) instead of local refs, so shallow
 # clones and minimal checkouts still work without a prior fetch.
 BASE=""
 # Ask the remote directly — ls-remote does not require any local refs to exist.
-REMOTE_REFS=$(git ls-remote --heads origin 2>/dev/null || true)
+REMOTE_REFS=$(git ls-remote --heads "$REMOTE" 2>/dev/null || true)
 if [ -n "$REMOTE_REFS" ]; then
   if echo "$REMOTE_REFS" | grep -q 'refs/heads/develop$'; then
     BASE=develop
@@ -58,13 +71,13 @@ if [ -z "$BASE" ]; then
   echo "ERROR: dual-verify could not detect a base branch. Set BASE manually and retry." >&2
   exit 1
 fi
-# Fetch the base branch so origin/$BASE is populated even on shallow clones / minimal checkouts.
-git fetch origin "$BASE" --quiet || {
-  echo "ERROR: dual-verify failed to fetch origin/$BASE — check network or branch name" >&2
+# Fetch the base branch so $REMOTE/$BASE is populated even on shallow clones / minimal checkouts.
+git fetch "$REMOTE" "$BASE" --quiet || {
+  echo "ERROR: dual-verify failed to fetch ${REMOTE}/${BASE} — check network or branch name" >&2
   exit 1
 }
-git diff "origin/${BASE}...HEAD" --stat
-git diff "origin/${BASE}...HEAD"
+git diff "${REMOTE}/${BASE}...HEAD" --stat
+git diff "${REMOTE}/${BASE}...HEAD"
 ```
 
 Check: language-appropriate correctness gates (e.g. `tsc --noEmit` for TypeScript, `pnpm lint`, `pytest --collect-only` for Python), logic correctness, integration points, schema compliance, missing branches in switch/if chains, resource leaks.

--- a/.claude/skills/dual-verify/SKILL.md
+++ b/.claude/skills/dual-verify/SKILL.md
@@ -48,27 +48,24 @@ if [ -z "$REMOTE" ]; then
 fi
 
 # Detect the base branch the current branch was cut from.
-# Prefer develop if it exists (Mercury convention), else the repo default branch.
-# Strategy: query the REMOTE (ls-remote + gh) instead of local refs, so shallow
-# clones and minimal checkouts still work without a prior fetch.
+# Strategy: query the REMOTE (ls-remote) directly — no local refs, no gh context.
+# Rationale for not using `gh repo view`: in fork / multi-remote setups, gh's current
+# context may point at a different repo than $REMOTE, leading to a mismatched base
+# branch. ls-remote is bound to the exact git remote we'll diff against, so there is
+# no drift. The develop → main → master cascade covers effectively all real repos.
 BASE=""
-# Ask the remote directly — ls-remote does not require any local refs to exist.
 REMOTE_REFS=$(git ls-remote --heads "$REMOTE" 2>/dev/null || true)
-if [ -n "$REMOTE_REFS" ]; then
-  if echo "$REMOTE_REFS" | grep -q 'refs/heads/develop$'; then
-    BASE=develop
-  elif BASE=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null) && [ -n "$BASE" ]; then
-    : # gh succeeded
-  else
-    for candidate in main master; do
-      if echo "$REMOTE_REFS" | grep -q "refs/heads/${candidate}\$"; then
-        BASE="$candidate"; break
-      fi
-    done
-  fi
+if [ -z "$REMOTE_REFS" ]; then
+  echo "ERROR: dual-verify failed to enumerate branches on remote '$REMOTE' — check network or credentials" >&2
+  exit 1
 fi
+for candidate in develop main master; do
+  if echo "$REMOTE_REFS" | grep -q "refs/heads/${candidate}\$"; then
+    BASE="$candidate"; break
+  fi
+done
 if [ -z "$BASE" ]; then
-  echo "ERROR: dual-verify could not detect a base branch. Set BASE manually and retry." >&2
+  echo "ERROR: dual-verify could not detect a base branch (tried develop/main/master on $REMOTE). Set BASE manually and retry." >&2
   exit 1
 fi
 # Fetch the base branch so $REMOTE/$BASE is populated even on shallow clones / minimal checkouts.

--- a/.claude/skills/dual-verify/SKILL.md
+++ b/.claude/skills/dual-verify/SKILL.md
@@ -36,10 +36,29 @@ Codex is invoked via `Agent` tool (rescue subagent) — no manual terminal step 
 ```bash
 # Detect the base branch the current branch was cut from.
 # Prefer develop if it exists (Mercury convention), else the repo default branch.
-BASE=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo "master")
-if gh api "repos/$(gh repo view --json owner --jq '.owner.login')/$(gh repo view --json name --jq '.name')/branches/develop" --silent 2>/dev/null; then
+# If gh repo view fails entirely (no auth, offline), try common names in order.
+BASE=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || true)
+if [ -z "$BASE" ]; then
+  for candidate in develop main master; do
+    if git rev-parse --verify "origin/$candidate" >/dev/null 2>&1; then
+      BASE="$candidate"; break
+    fi
+  done
+fi
+if [ -z "$BASE" ]; then
+  echo "ERROR: dual-verify could not detect a base branch. Set BASE manually and retry." >&2
+  exit 1
+fi
+# Override to develop if it exists on origin (Mercury convention).
+if git rev-parse --verify "origin/develop" >/dev/null 2>&1; then
   BASE=develop
 fi
+# Ensure the base branch is fetched. Shallow clones and CI checkouts often lack origin/$BASE,
+# which would make `git diff origin/${BASE}...HEAD` fail silently with a confusing error.
+git fetch origin "$BASE" --quiet || {
+  echo "ERROR: dual-verify failed to fetch origin/$BASE — check network or branch name" >&2
+  exit 1
+}
 git diff "origin/${BASE}...HEAD" --stat
 git diff "origin/${BASE}...HEAD"
 ```

--- a/.claude/skills/dual-verify/SKILL.md
+++ b/.claude/skills/dual-verify/SKILL.md
@@ -34,11 +34,17 @@ Codex is invoked via `Agent` tool (rescue subagent) — no manual terminal step 
 **Claude Code deep review** (this session):
 
 ```bash
-git diff develop...HEAD --stat
-git diff develop...HEAD
+# Detect the base branch the current branch was cut from.
+# Prefer develop if it exists (Mercury convention), else the repo default branch.
+BASE=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo "master")
+if gh api "repos/$(gh repo view --json owner --jq '.owner.login')/$(gh repo view --json name --jq '.name')/branches/develop" --silent 2>/dev/null; then
+  BASE=develop
+fi
+git diff "origin/${BASE}...HEAD" --stat
+git diff "origin/${BASE}...HEAD"
 ```
 
-Check: TypeScript correctness (run `npx tsc --noEmit`), logic correctness, integration points, OpenSpace schema compliance, missing metric paths, memory leaks.
+Check: language-appropriate correctness gates (e.g. `tsc --noEmit` for TypeScript, `pnpm lint`, `pytest --collect-only` for Python), logic correctness, integration points, schema compliance, missing branches in switch/if chains, resource leaks.
 
 **Codex audit** (rescue subagent — launch via Agent tool with `subagent_type: codex:codex-rescue`):
 

--- a/.claude/skills/dual-verify/SKILL.md
+++ b/.claude/skills/dual-verify/SKILL.md
@@ -53,19 +53,27 @@ fi
 # context may point at a different repo than $REMOTE, leading to a mismatched base
 # branch. ls-remote is bound to the exact git remote we'll diff against, so there is
 # no drift. The develop → main → master cascade covers effectively all real repos.
-BASE=""
-REMOTE_REFS=$(git ls-remote --heads "$REMOTE" 2>/dev/null || true)
-if [ -z "$REMOTE_REFS" ]; then
-  echo "ERROR: dual-verify failed to enumerate branches on remote '$REMOTE' — check network or credentials" >&2
-  exit 1
-fi
-for candidate in develop main master; do
-  if echo "$REMOTE_REFS" | grep -q "refs/heads/${candidate}\$"; then
-    BASE="$candidate"; break
-  fi
-done
+#
+# Escape hatch: if you are in one of the rare repos with a custom default branch name
+# (e.g. `trunk`, `stable`, `release`), set BASE_BRANCH_OVERRIDE in the env to skip the
+# cascade entirely. This is the supported way to handle custom default branches
+# without reintroducing the gh-vs-git-remote drift that iteration 4 removed.
+BASE="${BASE_BRANCH_OVERRIDE:-}"
 if [ -z "$BASE" ]; then
-  echo "ERROR: dual-verify could not detect a base branch (tried develop/main/master on $REMOTE). Set BASE manually and retry." >&2
+  REMOTE_REFS=$(git ls-remote --heads "$REMOTE" 2>/dev/null || true)
+  if [ -z "$REMOTE_REFS" ]; then
+    echo "ERROR: dual-verify failed to enumerate branches on remote '$REMOTE' — check network or credentials" >&2
+    exit 1
+  fi
+  for candidate in develop main master; do
+    if echo "$REMOTE_REFS" | grep -q "refs/heads/${candidate}\$"; then
+      BASE="$candidate"; break
+    fi
+  done
+fi
+if [ -z "$BASE" ]; then
+  echo "ERROR: dual-verify could not detect a base branch (tried develop/main/master on $REMOTE)." >&2
+  echo "Set BASE_BRANCH_OVERRIDE=<your-base-branch> and retry." >&2
   exit 1
 fi
 # Fetch the base branch so $REMOTE/$BASE is populated even on shallow clones / minimal checkouts.

--- a/.claude/skills/pr-flow/SKILL.md
+++ b/.claude/skills/pr-flow/SKILL.md
@@ -30,11 +30,18 @@ Understand these Argus capabilities before executing:
 
 ## Variables
 
-```
+```bash
 PR_NUMBER=<number>
 PR_URL=<url>
-OWNER=392fyc
-REPO_NAME=Mercury
+# Auto-detect repo + base branch — works in any GitHub repo, not just Mercury.
+OWNER=$(gh repo view --json owner --jq '.owner.login')
+REPO_NAME=$(gh repo view --json name --jq '.name')
+BASE_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')
+# Mercury convention override: if a "develop" branch exists, prefer it over the default branch
+# so feature PRs land on develop first and the default branch stays deploy-clean.
+if gh api "repos/${OWNER}/${REPO_NAME}/branches/develop" --silent 2>/dev/null; then
+  BASE_BRANCH=develop
+fi
 ITERATION=0
 MAX_ITERATIONS=5
 ```
@@ -46,7 +53,21 @@ MAX_ITERATIONS=5
 ```bash
 BRANCH=$(git branch --show-current)
 git push -u origin "$BRANCH"
-gh pr create --base develop \
+
+# Assignee: prefer the authenticated user so this works in any repo, not just 392fyc's.
+# Fall back to @me if the API call fails.
+ASSIGNEE=$(gh api user --jq '.login' 2>/dev/null || echo "@me")
+
+# Labels: only apply labels that actually exist in the target repo. Unknown labels fail the PR create.
+# To add labels, extend this array and ensure each exists in the target repo first.
+LABEL_ARG=""
+for L in "enhancement"; do
+  if MSYS_NO_PATHCONV=1 gh api "repos/${OWNER}/${REPO_NAME}/labels/${L}" --silent 2>/dev/null; then
+    LABEL_ARG="${LABEL_ARG}${LABEL_ARG:+,}${L}"
+  fi
+done
+
+gh pr create --base "$BASE_BRANCH" \
   --title "<type>(<scope>): description (#issue)" \
   --body "$(cat <<'BODY'
 ## Summary
@@ -58,8 +79,8 @@ gh pr create --base develop \
 Generated with Claude Code
 BODY
 )" \
-  --assignee 392fyc \
-  --label "<bug|enhancement|refactor>"
+  --assignee "$ASSIGNEE" \
+  ${LABEL_ARG:+--label "$LABEL_ARG"}
 ```
 
 **GATE 1**: PR created. Extract and store `PR_NUMBER` and `PR_URL`.
@@ -296,10 +317,12 @@ if [ "$WT_FAIL" -eq 0 ]; then
   ')
 fi
 
-# Switch off branch (must happen before branch deletion)
+# Switch off branch (must happen before branch deletion).
+# Reuse BASE_BRANCH computed at the start of the skill — do NOT hardcode "develop",
+# because repos without a develop branch (master-only) would fail here.
 if [ "$(git rev-parse --abbrev-ref HEAD)" = "$BRANCH" ]; then
-  if ! git switch develop 2>/dev/null && ! git checkout develop 2>/dev/null; then
-    echo "WARNING: failed to switch off branch $BRANCH — skipping cleanup"
+  if ! git switch "$BASE_BRANCH" 2>/dev/null && ! git checkout "$BASE_BRANCH" 2>/dev/null; then
+    echo "WARNING: failed to switch off branch $BRANCH to $BASE_BRANCH — skipping cleanup"
     WT_FAIL=1
   fi
 fi

--- a/.claude/skills/pr-flow/SKILL.md
+++ b/.claude/skills/pr-flow/SKILL.md
@@ -59,16 +59,29 @@ git push -u origin "$BRANCH"
 ASSIGNEE=$(gh api user --jq '.login' 2>/dev/null || echo "@me")
 
 # Labels: only apply labels that actually exist in the target repo. Unknown labels fail the PR create.
-# To add labels, extend this array and ensure each exists in the target repo first.
+# To add labels, extend this array. Label names MUST match [A-Za-z0-9:_./-]+ — if you need labels
+# with spaces or other special characters, URL-encode them via jq before passing to gh api.
 LABEL_ARG=""
 for L in "enhancement"; do
+  # Validate label name shape before passing to the API path (defense-in-depth against injection
+  # and silent probe failures when the label contains characters that need URL encoding).
+  case "$L" in
+    *[!A-Za-z0-9:_./-]*)
+      echo "WARNING: label '$L' contains non-simple characters — skipping; use URL-encoded form or rename the label" >&2
+      continue
+      ;;
+  esac
   if MSYS_NO_PATHCONV=1 gh api "repos/${OWNER}/${REPO_NAME}/labels/${L}" --silent 2>/dev/null; then
     LABEL_ARG="${LABEL_ARG}${LABEL_ARG:+,}${L}"
   fi
 done
 
-gh pr create --base "$BASE_BRANCH" \
-  --title "<type>(<scope>): description (#issue)" \
+# Build gh pr create argv explicitly. The ${X:+word} conditional expansion does NOT work here
+# because the quotes inside "word" become literal characters after expansion, so gh would receive
+# '--label "enhancement"' as a single token. Use an array for safe argument splitting.
+PR_ARGS=(
+  --base "$BASE_BRANCH"
+  --title "<type>(<scope>): description (#issue)"
   --body "$(cat <<'BODY'
 ## Summary
 - bullet points
@@ -78,9 +91,14 @@ gh pr create --base "$BASE_BRANCH" \
 
 Generated with Claude Code
 BODY
-)" \
-  --assignee "$ASSIGNEE" \
-  ${LABEL_ARG:+--label "$LABEL_ARG"}
+)"
+  --assignee "$ASSIGNEE"
+)
+if [ -n "$LABEL_ARG" ]; then
+  PR_ARGS+=(--label "$LABEL_ARG")
+fi
+
+gh pr create "${PR_ARGS[@]}"
 ```
 
 **GATE 1**: PR created. Extract and store `PR_NUMBER` and `PR_URL`.


### PR DESCRIPTION
## Summary

Ports the 7 portability bugs fixed in [392fyc/Argus#3](https://github.com/392fyc/Argus/pull/3) (commit `911ec9e` on Argus develop) back to Mercury's own `.claude/` copies. Resolves [#187](https://github.com/392fyc/Mercury/issues/187).

Mercury's own dual-verify never caught any of these during Phase 1 / PR #186 because every bug is a cross-repo assumption that accidentally happens to be correct **for the Mercury repo** (owner `392fyc`, branch `develop`, etc). This is the exact "single-repo review blind spot" signal that Phase 1's cross-project validation was designed to surface. The Argus review bot (which reviewed its own copy of Mercury's skills) caught all 7 in one iteration.

## 9 fixes (7 semantic + 1 doc drift + 1 case rename)

1. **`acceptance.md`**: add `criteriaResults` to the JSON output example so it matches what `dev-pipeline` Phase 4 parses (silently-broken retry logic)
2. **`dev-pipeline` Phase 2**: replace `$$` PID suffix on `SHA_FILE` with sanitized branch name — Phase 3 runs in a later Bash shell with a different PID, so the `$$` version was unreachable
3. **`dev-pipeline` Phase 5 Cleanup note**: fix in-prose reference to match the new branch-keyed naming (doc drift caught by Codex audit)
4. **`dual-verify` Step 1**: replace hardcoded `git diff develop...HEAD` with auto-detected base via `gh repo view` + develop override
5. **`dual-verify` case rename**: `skill.md` → `SKILL.md` (git case-rename). Linux is case-sensitive and Claude Code's skill loader expects `SKILL.md` — this skill was silently unusable on Linux before this commit. Mercury only worked by accident because Windows is case-insensitive.
6. **`pr-flow` Variables**: auto-detect `OWNER` / `REPO_NAME` / `BASE_BRANCH` via `gh repo view`; preserve Mercury's develop-first preference via a branch-exists probe
7. **`pr-flow` Phase 1 assignee**: use `gh api user --jq .login` to get the authenticated login instead of hardcoding `392fyc`; falls back to `@me`
8. **`pr-flow` Phase 1 labels**: probe each label's existence via `gh api repos/.../labels/NAME --silent` before adding; unknown labels no longer break PR create in repos that don't have the label pre-created
9. **`pr-flow` Phase 7 cleanup**: reuse `$BASE_BRANCH` in the `git switch` fallback instead of hardcoding `develop`

## Mercury-specific things NOT changed

- `dev-pipeline` Phase 6 still references `/gh-project-flow` — correct, that skill is BOOTSTRAP-ONLY for Mercury self-dev and stays Mercury-local
- Nothing else in the diff is Mercury-specific

## Dual-verify

- **Claude deep review**: PASS
- **Codex audit**: PASS with one MINOR doc drift fix applied before commit (the `$$` wording in the Phase 5 Cleanup explanation). Verified all 7 fixes match Argus `911ec9e` semantically, and the `gh api ... --silent` exit-code gate behavior is correct per [GitHub CLI manual](https://cli.github.com/manual/gh_api)

## Test plan

- [ ] On Mercury (where `develop` exists), `gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'` returns `master` and the develop-override kicks in → `BASE_BRANCH=develop` ✓ (verified locally before commit)
- [ ] The renamed `.claude/skills/dual-verify/SKILL.md` is discovered by Claude Code after session restart
- [ ] Mercury's own subsequent PR (next Mercury feature work) uses the new pr-flow Variables block without regression
- [ ] Argus-style portability bugs do NOT resurface the next time we copy skills to another repo

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)