### PR TITLE
fix(hooks): propagate -R flag and anchor merge detection in pr-merge-guard (#189)

### DIFF
--- a/.claude/hooks/pr-merge-guard.sh
+++ b/.claude/hooks/pr-merge-guard.sh
@@ -10,15 +10,25 @@
 #     The hook parsed PR number from `gh pr merge N -R owner/repo` but then called
 #     `gh pr view "$PR_NUMBER"` without --repo, so it queried Mercury's PR #N instead
 #     of the target repo's PR #N and incorrectly blocked an APPROVED merge.
-#     Fix: parse -R / --repo / --repo=VALUE from the command; propagate to every gh call.
+#     Fix: parse -R / --repo / --repo=VALUE and propagate to every gh call.
 #
 #   Session 27 / Issue #189 — Bug 2: grep pattern matched command text inside Write/Edit
 #     content. Creating Issue #189 itself triggered the hook because the body text
-#     contained the substring "gh pr merge". The old pattern fired on any Bash command
-#     whose text contained that substring.
-#     Fix: anchor the match to command structure — only fire when a token sequence
-#     "gh pr merge" appears at the start of a logical command segment (after optional
-#     env-var prefixes, and across &&, ||, ;, | separators).
+#     contained the substring "gh pr merge". First attempt used an inverse whitelist
+#     (first token must be `gh`) + naive sed-based segment splitting; Argus flagged
+#     the whitelist as a bypass vector (`echo ok && gh pr merge N` would skip) and
+#     the repo parsing as cross-segment bleed.
+#
+#   Session 27 / PR #210 iteration 2 — proper fix:
+#     - Quote-aware awk segment splitter: respects single/double quote state, so
+#       `git commit -m "...gh pr merge..."` and `echo '...;gh pr merge...'` both
+#       produce a single segment whose first token is git/echo, which does not
+#       match `^gh pr merge` → no false positive.
+#     - Inverse whitelist removed: `echo ok && gh pr merge N` now correctly splits
+#       into two segments, the second begins with `gh pr merge`, intercept fires.
+#     - -R/--repo parsing is scoped to the matched merge segment only, not the
+#       whole command — prevents `gh pr view -R A && gh pr merge 5 -R B` from
+#       picking up repo A when validating the B merge.
 
 INPUT=$(cat)
 # Extract command (jq preferred, sed fallback)
@@ -28,39 +38,71 @@ else
   COMMAND=$(echo "$INPUT" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
 fi
 
-# ── Bug 2 fix (part 1): inverse whitelist — first token must be gh ──
-# If the outer command's first real token is anything other than `gh`,
-# skip entirely. This handles the common false-positive of
-# `git commit -m "body gh pr merge"`, `cat <<EOF ... gh pr merge ... EOF`,
-# `for k in ...; do ... gh pr merge ...`, etc. where the literal text
-# appears inside a quoted/heredoc body, not as a real command.
-# Strips leading whitespace + VAR=value env prefixes before checking.
-# Realistic chained merges always begin with `gh` (e.g.
-# `gh pr checks N && gh pr merge N`), so this is both simpler and
-# more accurate than an explicit per-program whitelist.
-_stripped=$(printf '%s' "$COMMAND" | sed 's/^[[:space:]]*//; s/^\([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]*\)*//')
-_first_prog=$(printf '%s' "$_stripped" | awk '{print $1}')
-if [ "$_first_prog" != "gh" ]; then
-  exit 0
-fi
+# ── Quote-aware segment splitter ─────────────────────────────────
+# Splits $COMMAND on shell separators (;, |, ||, &&) while respecting
+# single-quoted and double-quoted regions. Inside single quotes no
+# interpretation occurs until the closing '. Inside double quotes,
+# `\"` is an escaped quote and does NOT close the string; any other
+# character passes through. Separators inside either quote type are
+# emitted into the buffer verbatim. This is a minimal shell parser —
+# it does not handle here-docs or backtick subshells, but those are
+# irrelevant for the merge-detection use case.
+#
+# SQ is passed in as a variable because awk scripts are wrapped in
+# bash single quotes, so a literal single quote character is not
+# representable inline.
+_SEGMENTS=$(printf '%s\n' "$COMMAND" | awk -v SQ="'" '
+BEGIN { in_sq=0; in_dq=0; buf=""; esc=0 }
+{
+  line = $0
+  n = length(line)
+  for (i = 1; i <= n; i++) {
+    c = substr(line, i, 1)
+    if (esc) { buf = buf c; esc = 0; continue }
+    if (in_sq) {
+      if (c == SQ) in_sq = 0
+      buf = buf c
+      continue
+    }
+    if (in_dq) {
+      if (c == "\\") { buf = buf c; esc = 1; continue }
+      if (c == "\"") in_dq = 0
+      buf = buf c
+      continue
+    }
+    if (c == SQ) { in_sq = 1; buf = buf c; continue }
+    if (c == "\"") { in_dq = 1; buf = buf c; continue }
+    if (c == ";") { print buf; buf = ""; continue }
+    if (c == "|") {
+      nc = (i < n) ? substr(line, i+1, 1) : ""
+      if (nc == "|") { print buf; buf = ""; i++ }
+      else { print buf; buf = "" }
+      continue
+    }
+    if (c == "&") {
+      nc = (i < n) ? substr(line, i+1, 1) : ""
+      if (nc == "&") { print buf; buf = ""; i++; continue }
+      print buf; buf = ""; continue
+    }
+    buf = buf c
+  }
+  # preserve line breaks inside quoted regions, separate lines outside
+  buf = buf " "
+}
+END { if (buf != "") print buf }
+')
 
-# ── Bug 2 fix (part 2): anchor match to command structure ────────
-# Split the command on shell separators (&&, ||, ;, |) so each logical
-# segment is checked independently. Only intercept when a segment's
-# first meaningful token sequence is literally: gh  pr  merge.
-# Note: text-based splitting does NOT respect quote boundaries, so a
-# literal `; gh pr merge` inside a quoted body of a non-whitelisted
-# first program would still false-positive. The whitelist above
-# covers the realistic cases.
+# ── Walk segments and find a real `gh pr merge` invocation ──────
 _INTERCEPT=0
-_SEGMENTS=$(printf '%s' "$COMMAND" | sed 's/&&/\n/g; s/||/\n/g; s/;/\n/g; s/|/\n/g')
+MATCHED_SEG=""
 while IFS= read -r _seg; do
-  _seg=$(printf '%s' "$_seg" | sed 's/^[[:space:]]*//')
+  _seg=$(printf '%s' "$_seg" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')
   [ -z "$_seg" ] && continue
   # Strip leading VAR=value env-var prefixes (e.g. GH_TOKEN=x gh pr merge ...)
   _first_cmd=$(printf '%s' "$_seg" | sed 's/^\([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]*\)*//')
   if printf '%s' "$_first_cmd" | grep -qE '^gh[[:space:]]+pr[[:space:]]+merge([[:space:]]|$)'; then
     _INTERCEPT=1
+    MATCHED_SEG="$_first_cmd"
     break
   fi
 done <<EOF
@@ -69,10 +111,13 @@ EOF
 
 [ "$_INTERCEPT" -eq 1 ] || exit 0
 
-# ── Bug 1 fix: parse -R / --repo and propagate to all gh calls ───
+# ── Parse -R / --repo from the MATCHED segment only ─────────────
+# Scoping to the matched merge segment prevents a prior `gh pr view -R A`
+# in the same chained command from polluting the repo flag when the
+# actual merge targets repo B.
 REPO_FLAG=""
 _prev=""
-for _tok in $COMMAND; do
+for _tok in $MATCHED_SEG; do
   case "$_prev" in
     -R|--repo)
       REPO_FLAG="$_tok"
@@ -93,9 +138,9 @@ else
   _REPO_ARG=""
 fi
 
-# Extract PR selector — first non-flag token after `gh pr merge`
-# Strip `gh pr merge` prefix, then find first token not starting with -
-MERGE_ARGS=$(echo "$COMMAND" | sed -n 's/.*gh[[:space:]][[:space:]]*pr[[:space:]][[:space:]]*merge[[:space:]][[:space:]]*//p')
+# ── Extract PR selector from the matched segment ────────────────
+# Strip `gh pr merge` prefix, then walk tokens skipping flags.
+MERGE_ARGS=$(printf '%s' "$MATCHED_SEG" | sed 's/^gh[[:space:]][[:space:]]*pr[[:space:]][[:space:]]*merge[[:space:]]*//')
 PR_SELECTOR=""
 _skip_next=0
 for token in $MERGE_ARGS; do

--- a/.claude/hooks/pr-merge-guard.sh
+++ b/.claude/hooks/pr-merge-guard.sh
@@ -115,9 +115,79 @@ while IFS= read -r _seg; do
     _first_cmd=$(printf '%s' "$_first_cmd" | sed -E 's/^(--|-[A-Za-z][A-Za-z0-9-]*)([[:space:]]+|$)//')
     [ "$_first_cmd" = "$_prev_cmd" ] && break
   done
-  if printf '%s' "$_first_cmd" | grep -qE '^gh[[:space:]]+pr[[:space:]]+merge([[:space:]]|$)'; then
+  # Token-walker state machine: match `gh [global-opts] pr [sub-opts] merge [merge-args]`.
+  # This allows global gh options like `-R owner/name` to appear between `gh`
+  # and the `pr` subcommand (addresses PR #210 Argus finding `gh -R X pr merge` bypass).
+  # Uses bash array word-splitting on $_first_cmd — adequate for the command prefix
+  # since global options and subcommand names are never quoted in realistic usage.
+  # Quoted values in the MERGE tail (e.g. `-t "my title"`) are handled separately by
+  # merge-arg extraction below.
+  set -f  # disable glob expansion during the split
+  # shellcheck disable=SC2206
+  _tokens=( $_first_cmd )
+  set +f
+  _global_repo=""
+  _pr_idx=-1
+  _merge_idx=-1
+  if [ "${_tokens[0]:-}" = "gh" ]; then
+    _i=1
+    _ntok=${#_tokens[@]}
+    # Scan gh-global options until we hit `pr` or a non-option non-subcommand token
+    while [ "$_i" -lt "$_ntok" ]; do
+      _tok="${_tokens[$_i]}"
+      case "$_tok" in
+        -R|--repo)
+          _i=$((_i + 1))
+          _global_repo="${_tokens[$_i]:-}"
+          ;;
+        --repo=*)
+          _global_repo="${_tok#--repo=}"
+          ;;
+        --help|--version|-h)
+          ;;
+        -*)
+          # Unknown global option — assume no value (best-effort).
+          ;;
+        pr)
+          _pr_idx=$_i
+          _i=$((_i + 1))
+          break
+          ;;
+        *)
+          _i=$_ntok  # non-pr subcommand — not a merge
+          break
+          ;;
+      esac
+      _i=$((_i + 1))
+    done
+    # If we found `pr`, scan for `merge` (skipping any sub-opts)
+    if [ "$_pr_idx" -ge 0 ]; then
+      while [ "$_i" -lt "$_ntok" ]; do
+        _tok="${_tokens[$_i]}"
+        case "$_tok" in
+          merge)
+            _merge_idx=$_i
+            break
+            ;;
+          -*)
+            ;;  # sub-subcommand-level option, skip
+          *)
+            _i=$_ntok  # non-merge, abort
+            break
+            ;;
+        esac
+        _i=$((_i + 1))
+      done
+    fi
+  fi
+  if [ "$_merge_idx" -ge 0 ]; then
     _INTERCEPT=1
     MATCHED_SEG="$_first_cmd"
+    GLOBAL_REPO_FLAG="$_global_repo"
+    # Capture the merge-tail: everything after the `merge` token, as a string.
+    # This is a raw slice from the original _first_cmd string, NOT the tokens
+    # array, so quoted values inside the tail are preserved verbatim.
+    MERGE_TAIL=$(printf '%s' "$_first_cmd" | sed -E 's/^.*[[:space:]]merge([[:space:]]+|$)//')
     break
   fi
 done <<EOF
@@ -126,13 +196,13 @@ EOF
 
 [ "$_INTERCEPT" -eq 1 ] || exit 0
 
-# ── Parse -R / --repo from the MATCHED segment only ─────────────
-# Scoping to the matched merge segment prevents a prior `gh pr view -R A`
-# in the same chained command from polluting the repo flag when the
-# actual merge targets repo B.
+# ── Parse -R / --repo from the MERGE tail only, fall back to global ──
+# Merge-local -R takes precedence over any global -R captured before the
+# `pr` subcommand. This handles `gh -R A pr merge 5 -R B` → repo = B.
 REPO_FLAG=""
 _prev=""
-for _tok in $MATCHED_SEG; do
+# shellcheck disable=SC2086
+for _tok in $MERGE_TAIL; do
   case "$_prev" in
     -R|--repo)
       REPO_FLAG="$_tok"
@@ -147,51 +217,65 @@ for _tok in $MATCHED_SEG; do
   esac
   _prev="$_tok"
 done
+# Fall back to the global -R parsed during segment detection
+[ -z "$REPO_FLAG" ] && REPO_FLAG="${GLOBAL_REPO_FLAG:-}"
+# Strip surrounding quotes defensively (real repo names never need them).
+REPO_FLAG="${REPO_FLAG%\"}"; REPO_FLAG="${REPO_FLAG#\"}"
+REPO_FLAG="${REPO_FLAG%\'}"; REPO_FLAG="${REPO_FLAG#\'}"
+# Build _REPO_ARG as a bash array for safe expansion at call sites.
+# Replaces the previous `--repo $REPO_FLAG` string concat which word-split
+# unsafely if the value ever contained whitespace or metacharacters.
 if [ -n "$REPO_FLAG" ]; then
-  # Strip surrounding quotes if the token carried them through
-  # (e.g. `-R "owner/name"` or `-R 'owner/name'`). Real GitHub repo
-  # identifiers match [A-Za-z0-9._-]+/[A-Za-z0-9._-]+ and never need
-  # quoting, but be defensive in case the source command quoted the
-  # value anyway.
-  REPO_FLAG="${REPO_FLAG%\"}"; REPO_FLAG="${REPO_FLAG#\"}"
-  REPO_FLAG="${REPO_FLAG%\'}"; REPO_FLAG="${REPO_FLAG#\'}"
-  _REPO_ARG="--repo $REPO_FLAG"
+  _REPO_ARG=(--repo "$REPO_FLAG")
 else
-  _REPO_ARG=""
+  _REPO_ARG=()
 fi
 
-# ── Extract PR selector from the matched segment ────────────────
-# Strip `gh pr merge` prefix, then walk tokens skipping flags.
-MERGE_ARGS=$(printf '%s' "$MATCHED_SEG" | sed 's/^gh[[:space:]][[:space:]]*pr[[:space:]][[:space:]]*merge[[:space:]]*//')
+# ── Extract PR selector from the MERGE tail ─────────────────────
+# MERGE_TAIL contains just the tokens after `merge`. Walk them with a
+# value-taking-flag skip list so the parser does not misidentify an option
+# value (e.g. `-t "my title"`) as the PR selector.
+# Value-taking options for `gh pr merge`:
+#   -R / --repo           (also global — already handled above, but keep here for local scope)
+#   -b / --body STRING
+#   -B / --body-file FILE
+#   -t / --subject STRING
+#   -A / --author-email STRING
+#   --match-head-commit SHA
 PR_SELECTOR=""
 _skip_next=0
-for token in $MERGE_ARGS; do
+# shellcheck disable=SC2086
+for token in $MERGE_TAIL; do
   if [ "$_skip_next" -eq 1 ]; then
     _skip_next=0
     continue
   fi
   case "$token" in
-    -R|--repo)
-      # Next token is the repo value, skip it
+    -R|--repo|-b|--body|-B|--body-file|-t|--subject|-A|--author-email|--match-head-commit)
       _skip_next=1
+      continue
+      ;;
+    --repo=*|--body=*|--body-file=*|--subject=*|--author-email=*|--match-head-commit=*)
       continue
       ;;
     -*) continue ;;
     *) PR_SELECTOR="$token"; break ;;
   esac
 done
+# Defensive quote strip on the selector itself (real PR numbers are plain
+# integers or URLs, but a `gh pr merge "5"` form could carry quotes).
+PR_SELECTOR="${PR_SELECTOR%\"}"; PR_SELECTOR="${PR_SELECTOR#\"}"
+PR_SELECTOR="${PR_SELECTOR%\'}"; PR_SELECTOR="${PR_SELECTOR#\'}"
 PR_NUMBER=""
 
 case "$PR_SELECTOR" in
   ''|--*)
     # No selector or flag-only; fallback to current branch PR
-    # shellcheck disable=SC2086
-    PR_NUMBER=$(gh pr view $_REPO_ARG --json number -q '.number' 2>/dev/null)
+    PR_NUMBER=$(gh pr view "${_REPO_ARG[@]}" --json number -q '.number' 2>/dev/null)
     ;;
   *[!0-9]*)
     # URL or branch name selector — resolve via gh
-    # shellcheck disable=SC2086
-    PR_NUMBER=$(gh pr view "$PR_SELECTOR" $_REPO_ARG --json number -q '.number' 2>/dev/null)
+    PR_NUMBER=$(gh pr view "$PR_SELECTOR" "${_REPO_ARG[@]}" --json number -q '.number' 2>/dev/null)
     ;;
   *)
     # Pure numeric
@@ -219,8 +303,7 @@ fi
 
 # ── Primary gate: reviewDecision ──────────────────────────────────
 # This covers approvals from any source: Argus, CodeRabbit, or human.
-# shellcheck disable=SC2086
-REVIEW_DECISION=$(gh pr view "$PR_NUMBER" $_REPO_ARG --json reviewDecision --jq '.reviewDecision // "REVIEW_REQUIRED"' 2>/dev/null | tr '[:lower:]' '[:upper:]')
+REVIEW_DECISION=$(gh pr view "$PR_NUMBER" "${_REPO_ARG[@]}" --json reviewDecision --jq '.reviewDecision // "REVIEW_REQUIRED"' 2>/dev/null | tr '[:lower:]' '[:upper:]')
 
 if [ "$REVIEW_DECISION" = "APPROVED" ]; then
   exit 0
@@ -232,8 +315,7 @@ fi
 if [ -n "$REPO_FLAG" ]; then
   REPO="$REPO_FLAG"
 else
-  # shellcheck disable=SC2086
-  REPO=$(gh pr view "$PR_NUMBER" $_REPO_ARG --json baseRepository --jq '.baseRepository.nameWithOwner' 2>/dev/null)
+  REPO=$(gh pr view "$PR_NUMBER" "${_REPO_ARG[@]}" --json baseRepository --jq '.baseRepository.nameWithOwner' 2>/dev/null)
   if [ -z "$REPO" ]; then
     REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null)
   fi
@@ -247,8 +329,7 @@ BOT_REVIEW_STATE=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
   )] | last | .state // empty' 2>/dev/null)
 
 # Also check legacy CodeRabbit CI check (transition period)
-# shellcheck disable=SC2086
-CR_CI_STATUS=$(gh pr checks "$PR_NUMBER" $_REPO_ARG --json name,state -q '.[] | select(.name | test("CodeRabbit";"i")) | .state' 2>/dev/null | head -n1 | tr '[:upper:]' '[:lower:]')
+CR_CI_STATUS=$(gh pr checks "$PR_NUMBER" "${_REPO_ARG[@]}" --json name,state -q '.[] | select(.name | test("CodeRabbit";"i")) | .state' 2>/dev/null | head -n1 | tr '[:upper:]' '[:lower:]')
 
 # ── Block CHANGES_REQUESTED before any bot/CI allow gates ─────────
 # This prevents stale bot approvals or legacy CI success from bypassing

--- a/.claude/hooks/pr-merge-guard.sh
+++ b/.claude/hooks/pr-merge-guard.sh
@@ -98,8 +98,23 @@ MATCHED_SEG=""
 while IFS= read -r _seg; do
   _seg=$(printf '%s' "$_seg" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')
   [ -z "$_seg" ] && continue
-  # Strip leading VAR=value env-var prefixes (e.g. GH_TOKEN=x gh pr merge ...)
-  _first_cmd=$(printf '%s' "$_seg" | sed 's/^\([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]*\)*//')
+  # Iteratively normalize the leading portion of the segment, stripping
+  # any combination of:
+  #   - VAR=value env-var prefixes (e.g. GH_TOKEN=x gh ...)
+  #   - command wrappers (env, command, exec, builtin, nohup, time)
+  #   - short/long flags that those wrappers may accept (-i, -u, -p, --)
+  # The loop runs until the string stops changing (bounded to 5 passes).
+  # This closes the `env ... gh pr merge` and `command gh pr merge`
+  # bypass vectors flagged on PR #210.
+  _first_cmd="$_seg"
+  for _i in 1 2 3 4 5; do
+    _prev_cmd="$_first_cmd"
+    _first_cmd=$(printf '%s' "$_first_cmd" | sed 's/^[[:space:]]*//')
+    _first_cmd=$(printf '%s' "$_first_cmd" | sed 's/^\([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]*\)*//')
+    _first_cmd=$(printf '%s' "$_first_cmd" | sed -E 's/^(env|command|exec|builtin|nohup|time)[[:space:]]+//')
+    _first_cmd=$(printf '%s' "$_first_cmd" | sed -E 's/^(--|-[A-Za-z][A-Za-z0-9-]*)([[:space:]]+|$)//')
+    [ "$_first_cmd" = "$_prev_cmd" ] && break
+  done
   if printf '%s' "$_first_cmd" | grep -qE '^gh[[:space:]]+pr[[:space:]]+merge([[:space:]]|$)'; then
     _INTERCEPT=1
     MATCHED_SEG="$_first_cmd"
@@ -133,6 +148,13 @@ for _tok in $MATCHED_SEG; do
   _prev="$_tok"
 done
 if [ -n "$REPO_FLAG" ]; then
+  # Strip surrounding quotes if the token carried them through
+  # (e.g. `-R "owner/name"` or `-R 'owner/name'`). Real GitHub repo
+  # identifiers match [A-Za-z0-9._-]+/[A-Za-z0-9._-]+ and never need
+  # quoting, but be defensive in case the source command quoted the
+  # value anyway.
+  REPO_FLAG="${REPO_FLAG%\"}"; REPO_FLAG="${REPO_FLAG#\"}"
+  REPO_FLAG="${REPO_FLAG%\'}"; REPO_FLAG="${REPO_FLAG#\'}"
   _REPO_ARG="--repo $REPO_FLAG"
 else
   _REPO_ARG=""

--- a/.claude/hooks/pr-merge-guard.sh
+++ b/.claude/hooks/pr-merge-guard.sh
@@ -112,6 +112,11 @@ while IFS= read -r _seg; do
     _first_cmd=$(printf '%s' "$_first_cmd" | sed 's/^[[:space:]]*//')
     _first_cmd=$(printf '%s' "$_first_cmd" | sed 's/^\([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]*\)*//')
     _first_cmd=$(printf '%s' "$_first_cmd" | sed -E 's/^(env|command|exec|builtin|nohup|time)[[:space:]]+//')
+    # env-specific value-taking flags (-u NAME, -S STR, -C DIR) must be
+    # consumed WITH their value so the value is not mistaken for the command
+    # name on the next strip pass. This closes the `env -u VAR gh pr merge`
+    # bypass flagged on PR #210 iteration 4.
+    _first_cmd=$(printf '%s' "$_first_cmd" | sed -E 's/^-(u|S|C)[[:space:]]+[^[:space:]]+[[:space:]]+//')
     _first_cmd=$(printf '%s' "$_first_cmd" | sed -E 's/^(--|-[A-Za-z][A-Za-z0-9-]*)([[:space:]]+|$)//')
     [ "$_first_cmd" = "$_prev_cmd" ] && break
   done
@@ -273,8 +278,20 @@ case "$PR_SELECTOR" in
     # No selector or flag-only; fallback to current branch PR
     PR_NUMBER=$(gh pr view "${_REPO_ARG[@]}" --json number -q '.number' 2>/dev/null)
     ;;
+  http://*|https://*)
+    # PR URL selector — parse owner/repo from the URL path so the
+    # subsequent gh calls target the correct repo even when the user
+    # did not pass -R/--repo explicitly. Closes PR #210 iteration-4
+    # cross-repo-URL misfire flagged by Argus (lines 278-320).
+    _url_repo=$(printf '%s' "$PR_SELECTOR" | sed -E 's|^https?://[^/]+/([^/[:space:]]+)/([^/[:space:]]+)/pull/[0-9]+.*|\1/\2|')
+    if [ -n "$_url_repo" ] && [ "$_url_repo" != "$PR_SELECTOR" ] && [ -z "$REPO_FLAG" ]; then
+      REPO_FLAG="$_url_repo"
+      _REPO_ARG=(--repo "$REPO_FLAG")
+    fi
+    PR_NUMBER=$(gh pr view "$PR_SELECTOR" "${_REPO_ARG[@]}" --json number -q '.number' 2>/dev/null)
+    ;;
   *[!0-9]*)
-    # URL or branch name selector — resolve via gh
+    # Non-numeric non-URL (branch name) — resolve via gh
     PR_NUMBER=$(gh pr view "$PR_SELECTOR" "${_REPO_ARG[@]}" --json number -q '.number' 2>/dev/null)
     ;;
   *)

--- a/.claude/hooks/pr-merge-guard.sh
+++ b/.claude/hooks/pr-merge-guard.sh
@@ -4,6 +4,21 @@
 #
 # Pattern: same as pre-commit-guard.sh
 #   PreToolUse(Bash) → detect "gh pr merge" → check review status → block/allow
+#
+# Fix history:
+#   Session 22 / Argus PR #7 — Bug 1: -R/--repo flag not propagated.
+#     The hook parsed PR number from `gh pr merge N -R owner/repo` but then called
+#     `gh pr view "$PR_NUMBER"` without --repo, so it queried Mercury's PR #N instead
+#     of the target repo's PR #N and incorrectly blocked an APPROVED merge.
+#     Fix: parse -R / --repo / --repo=VALUE from the command; propagate to every gh call.
+#
+#   Session 27 / Issue #189 — Bug 2: grep pattern matched command text inside Write/Edit
+#     content. Creating Issue #189 itself triggered the hook because the body text
+#     contained the substring "gh pr merge". The old pattern fired on any Bash command
+#     whose text contained that substring.
+#     Fix: anchor the match to command structure — only fire when a token sequence
+#     "gh pr merge" appears at the start of a logical command segment (after optional
+#     env-var prefixes, and across &&, ||, ;, | separators).
 
 INPUT=$(cat)
 # Extract command (jq preferred, sed fallback)
@@ -13,15 +28,87 @@ else
   COMMAND=$(echo "$INPUT" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
 fi
 
-# Only intercept gh pr merge commands
-echo "$COMMAND" | grep -qE 'gh[[:space:]]+pr[[:space:]]+merge' || exit 0
+# ── Bug 2 fix (part 1): inverse whitelist — first token must be gh ──
+# If the outer command's first real token is anything other than `gh`,
+# skip entirely. This handles the common false-positive of
+# `git commit -m "body gh pr merge"`, `cat <<EOF ... gh pr merge ... EOF`,
+# `for k in ...; do ... gh pr merge ...`, etc. where the literal text
+# appears inside a quoted/heredoc body, not as a real command.
+# Strips leading whitespace + VAR=value env prefixes before checking.
+# Realistic chained merges always begin with `gh` (e.g.
+# `gh pr checks N && gh pr merge N`), so this is both simpler and
+# more accurate than an explicit per-program whitelist.
+_stripped=$(printf '%s' "$COMMAND" | sed 's/^[[:space:]]*//; s/^\([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]*\)*//')
+_first_prog=$(printf '%s' "$_stripped" | awk '{print $1}')
+if [ "$_first_prog" != "gh" ]; then
+  exit 0
+fi
+
+# ── Bug 2 fix (part 2): anchor match to command structure ────────
+# Split the command on shell separators (&&, ||, ;, |) so each logical
+# segment is checked independently. Only intercept when a segment's
+# first meaningful token sequence is literally: gh  pr  merge.
+# Note: text-based splitting does NOT respect quote boundaries, so a
+# literal `; gh pr merge` inside a quoted body of a non-whitelisted
+# first program would still false-positive. The whitelist above
+# covers the realistic cases.
+_INTERCEPT=0
+_SEGMENTS=$(printf '%s' "$COMMAND" | sed 's/&&/\n/g; s/||/\n/g; s/;/\n/g; s/|/\n/g')
+while IFS= read -r _seg; do
+  _seg=$(printf '%s' "$_seg" | sed 's/^[[:space:]]*//')
+  [ -z "$_seg" ] && continue
+  # Strip leading VAR=value env-var prefixes (e.g. GH_TOKEN=x gh pr merge ...)
+  _first_cmd=$(printf '%s' "$_seg" | sed 's/^\([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]*\)*//')
+  if printf '%s' "$_first_cmd" | grep -qE '^gh[[:space:]]+pr[[:space:]]+merge([[:space:]]|$)'; then
+    _INTERCEPT=1
+    break
+  fi
+done <<EOF
+$_SEGMENTS
+EOF
+
+[ "$_INTERCEPT" -eq 1 ] || exit 0
+
+# ── Bug 1 fix: parse -R / --repo and propagate to all gh calls ───
+REPO_FLAG=""
+_prev=""
+for _tok in $COMMAND; do
+  case "$_prev" in
+    -R|--repo)
+      REPO_FLAG="$_tok"
+      break
+      ;;
+  esac
+  case "$_tok" in
+    --repo=*)
+      REPO_FLAG="${_tok#--repo=}"
+      break
+      ;;
+  esac
+  _prev="$_tok"
+done
+if [ -n "$REPO_FLAG" ]; then
+  _REPO_ARG="--repo $REPO_FLAG"
+else
+  _REPO_ARG=""
+fi
 
 # Extract PR selector — first non-flag token after `gh pr merge`
 # Strip `gh pr merge` prefix, then find first token not starting with -
 MERGE_ARGS=$(echo "$COMMAND" | sed -n 's/.*gh[[:space:]][[:space:]]*pr[[:space:]][[:space:]]*merge[[:space:]][[:space:]]*//p')
 PR_SELECTOR=""
+_skip_next=0
 for token in $MERGE_ARGS; do
+  if [ "$_skip_next" -eq 1 ]; then
+    _skip_next=0
+    continue
+  fi
   case "$token" in
+    -R|--repo)
+      # Next token is the repo value, skip it
+      _skip_next=1
+      continue
+      ;;
     -*) continue ;;
     *) PR_SELECTOR="$token"; break ;;
   esac
@@ -31,11 +118,13 @@ PR_NUMBER=""
 case "$PR_SELECTOR" in
   ''|--*)
     # No selector or flag-only; fallback to current branch PR
-    PR_NUMBER=$(gh pr view --json number -q '.number' 2>/dev/null)
+    # shellcheck disable=SC2086
+    PR_NUMBER=$(gh pr view $_REPO_ARG --json number -q '.number' 2>/dev/null)
     ;;
   *[!0-9]*)
     # URL or branch name selector — resolve via gh
-    PR_NUMBER=$(gh pr view "$PR_SELECTOR" --json number -q '.number' 2>/dev/null)
+    # shellcheck disable=SC2086
+    PR_NUMBER=$(gh pr view "$PR_SELECTOR" $_REPO_ARG --json number -q '.number' 2>/dev/null)
     ;;
   *)
     # Pure numeric
@@ -63,7 +152,8 @@ fi
 
 # ── Primary gate: reviewDecision ──────────────────────────────────
 # This covers approvals from any source: Argus, CodeRabbit, or human.
-REVIEW_DECISION=$(gh pr view "$PR_NUMBER" --json reviewDecision --jq '.reviewDecision // "REVIEW_REQUIRED"' 2>/dev/null | tr '[:lower:]' '[:upper:]')
+# shellcheck disable=SC2086
+REVIEW_DECISION=$(gh pr view "$PR_NUMBER" $_REPO_ARG --json reviewDecision --jq '.reviewDecision // "REVIEW_REQUIRED"' 2>/dev/null | tr '[:lower:]' '[:upper:]')
 
 if [ "$REVIEW_DECISION" = "APPROVED" ]; then
   exit 0
@@ -72,9 +162,14 @@ fi
 # ── Secondary gate: has any review bot posted a review? ──────────
 # Check for reviews from argus-review[bot] or coderabbitai[bot].
 # Argus posts GitHub Review objects (not CI checks).
-REPO=$(gh pr view "$PR_NUMBER" --json baseRepository --jq '.baseRepository.nameWithOwner' 2>/dev/null)
-if [ -z "$REPO" ]; then
-  REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null)
+if [ -n "$REPO_FLAG" ]; then
+  REPO="$REPO_FLAG"
+else
+  # shellcheck disable=SC2086
+  REPO=$(gh pr view "$PR_NUMBER" $_REPO_ARG --json baseRepository --jq '.baseRepository.nameWithOwner' 2>/dev/null)
+  if [ -z "$REPO" ]; then
+    REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null)
+  fi
 fi
 
 BOT_REVIEW_STATE=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
@@ -85,7 +180,8 @@ BOT_REVIEW_STATE=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
   )] | last | .state // empty' 2>/dev/null)
 
 # Also check legacy CodeRabbit CI check (transition period)
-CR_CI_STATUS=$(gh pr checks "$PR_NUMBER" --json name,state -q '.[] | select(.name | test("CodeRabbit";"i")) | .state' 2>/dev/null | head -n1 | tr '[:upper:]' '[:lower:]')
+# shellcheck disable=SC2086
+CR_CI_STATUS=$(gh pr checks "$PR_NUMBER" $_REPO_ARG --json name,state -q '.[] | select(.name | test("CodeRabbit";"i")) | .state' 2>/dev/null | head -n1 | tr '[:upper:]' '[:lower:]')
 
 # ── Block CHANGES_REQUESTED before any bot/CI allow gates ─────────
 # This prevents stale bot approvals or legacy CI success from bypassing


### PR DESCRIPTION
## Summary

Fixes two bugs in `.claude/hooks/pr-merge-guard.sh` that surfaced during Mercury Phase 1/2 operation.

### Bug 1 — `-R`/`--repo` flag not propagated
Hook parsed the PR number from a merge command but called subsequent `gh` subcommands without `--repo`, so they queried the cwd repo instead of the merge target. Hit on Argus PR #7 during Phase 1 — the guard blocked a legitimately APPROVED merge because it was querying Mercury's PR #7 instead of Argus's.

**Fix**: Parse `-R` / `--repo` / `--repo=VALUE` from the intercepted command, build `_REPO_ARG`, and propagate it to every `gh pr view` / `gh pr checks` / `gh api repos/...` call. Falls back to the current repo when no flag is present. Also skip `-R`/`--repo` and its value when extracting the PR selector.

### Bug 2 — hook fired on command text inside quoted bodies
Any Bash command whose raw text contained the substring `gh pr merge` was intercepted, including `git commit -m "...gh pr merge..."`. Hit while filing Issue #189 itself.

**Fix applied in two parts**:

1. **Inverse whitelist**: only proceed when the outer command's first real token (after stripping whitespace and `VAR=value` env prefixes) is literally `gh`. Covers `git`, `echo`, `cat`, `printf`, `for`, `awk`, `python`, and every other program whose body may embed literal `gh pr merge` text inside a quoted string or heredoc. Realistic chained merges always begin with `gh`, so this is both simpler and more accurate than an explicit per-program whitelist.

2. **Structural anchor**: after the whitelist passes, split the command on shell separators and only intercept when a segment's first meaningful token sequence is literally `gh pr merge`. This catches the legitimate chained form (`gh pr checks N && gh pr merge N`) while still rejecting a `gh`-prefixed non-merge like `gh issue create --body '...gh pr merge...'`.

### Known trade-off
A chained merge whose outer command starts with a non-`gh` program (e.g. `printf x ; gh pr merge 5`) will NOT be intercepted. That pattern is not used in practice in Mercury.

## Test plan

Verified manually with 5 scenarios (`CLAUDE_PROJECT_DIR=/tmp/fake bash .claude/hooks/pr-merge-guard.sh`):

| # | Payload | Expected | Actual |
|---|---|---|---|
| A | `gh issue create --body foo` | skip (no merge) | exit 0 ✓ |
| B | `gh pr merge 208 --squash` | intercept → APPROVED → allow | exit 0 ✓ |
| C | `gh pr checks 5 && gh pr merge 5` | intercept (chained form) | exit 2 ✓ |
| D | `git commit -m "...gh pr merge..."` | skip (first token `git`) | exit 0 ✓ |
| E | `printf foo ; gh pr merge 5` | skip (accepted trade-off) | exit 0 ✓ |

Also verified `-R 392fyc/Argus` parses into `_REPO_ARG='--repo 392fyc/Argus'` via `bash -x` trace (Bug 1 fix).

## Checklist

- [x] Merging with `-R owner/repo` correctly queries the target repo
- [x] Merging without `-R` still works against the current repo (backward compat)
- [x] Bypass flag path (`.mercury/state/pr-merge-approved-N`) unchanged
- [x] Hook does NOT fire on non-merge commands that embed merge-command text
- [x] Fix history comment block added to hook header
- [x] No other files touched

Closes #189