### PR TITLE
fix(skills): use reviewDecision/latestReviews in pr-flow polling (#190)

### DIFF
--- a/.claude/skills/pr-flow/SKILL.md
+++ b/.claude/skills/pr-flow/SKILL.md
@@ -122,10 +122,13 @@ CronCreate:
     2. If state is MERGED or CLOSED → PR is terminal, report to user, delete this cron
     3. If isDraft is true → PR moved back to DRAFT, stop polling and report to user, delete this cron
     4. If state is OPEN and reviewDecision is APPROVED → report to user, delete this cron
-    5. For new-finding detection use:
-       gh api "repos/<OWNER>/<REPO>/pulls/<PR_NUMBER>/comments?since=<last_checked_iso>" --paginate
-       and filter to user.login == "argus-review[bot]"
-       Track last_checked in .pr-flow-last-checked-<PR_NUMBER>.
+    5. For new-finding detection:
+       a. Read last_checked_iso from .pr-flow-last-checked-<PR_NUMBER> (or use the PR creation time on first run).
+       b. Capture the current time as new_checked_iso = now() BEFORE making the API call.
+       c. Run: gh api "repos/<OWNER>/<REPO>/pulls/<PR_NUMBER>/comments?since=<last_checked_iso>" --paginate \
+                --jq '.[] | select(.user.login == "argus-review[bot]")'
+       d. Process any returned comments as new findings.
+       e. Atomically overwrite .pr-flow-last-checked-<PR_NUMBER> with new_checked_iso (do NOT set it to the last comment's timestamp — use the pre-API wall clock so comments arriving during the API call are not missed on the next poll).
     6. If new inline comments from argus-review[bot] exist → report to user for Phase 3
     7. Track no-activity count in .pr-flow-check-count-<PR_NUMBER>
     8. After 3 quiet checks, post "@argus-review review" (max 3 total triggers per cron_safety rule)
@@ -265,7 +268,7 @@ CronCreate:
     Concrete jq filter pattern to use in step 1 below (substitute FIX_COMMIT_TIME at cron-creation time, not at cron-runtime).
     The `latestArgus` extraction wraps the `select` in `map(...) | .[0] // {state: null, submittedAt: null}` so a missing reviewer yields a known-shape default object instead of an empty stream that would crash downstream `.submittedAt` dereferences.
       gh pr view <PR_NUMBER> --json state,isDraft,reviewDecision,latestReviews \
-        --jq '{decision: .reviewDecision, state, draft: .isDraft, latestArgus: ((.latestReviews // []) | map(select(.author.login == "argus-review")) | .[0] // {state: null, submittedAt: null})}'
+        --jq '{decision: .reviewDecision, state, isDraft, latestArgus: ((.latestReviews // []) | map(select(.author.login == "argus-review")) | .[0] // {state: null, submittedAt: null})}'
     1. Run the gh pr view query above.
     2. If state is MERGED or CLOSED → PR is terminal, report to user, delete this cron
     3. If isDraft is true → PR moved to DRAFT, stop polling and report to user, delete this cron

--- a/.claude/skills/pr-flow/SKILL.md
+++ b/.claude/skills/pr-flow/SKILL.md
@@ -109,19 +109,25 @@ gh pr create "${PR_ARGS[@]}"
 
 > **Review polling field selection (see #190)**
 > Use `reviewDecision` as the authoritative approval gate — it reflects GitHub's own per-reviewer-latest aggregation and flips to `APPROVED` only when all requested reviews are satisfied.
+> Always include `state` in the JSON query so polling can stop cleanly on MERGED / CLOSED / DRAFT transitions. A cron that ignores `state` will keep polling a closed PR until it hits the quiet-check timeout, producing false alarms.
 > Prefer `latestReviews` over `reviews` when you need "the most recent review per reviewer": `reviews` is the full chronological array and its last element can be an older COMMENTED review that predates a newer APPROVED review from the same reviewer. `latestReviews` is deduplicated per-user.
-> For "are there new inline findings" detection, use `gh api repos/<owner>/<repo>/pulls/<N>/comments` (review comments endpoint), NOT the review list.
+> For "is there any new inline finding" detection, query `gh api repos/<owner>/<repo>/pulls/<N>/comments --paginate` (review comments endpoint). Always pass `--paginate` — the default page size is 30 and large PRs can exceed it, silently hiding new findings. Track a "last processed comment id or timestamp" per PR so each poll is incremental rather than re-scanning.
 
 ```
 CronCreate:
   cron: "*/10 * * * *"
   prompt: |
     Check PR #<PR_NUMBER> review status.
-    1. Run: gh pr view <PR_NUMBER> --json reviewDecision,latestReviews
-    2. If reviewDecision is APPROVED → report to user, delete this cron
-    3. If new inline comments from argus-review[bot] exist → report to user for Phase 3
-    4. Track no-activity count in .pr-flow-check-count-<PR_NUMBER>
-    5. After 3 quiet checks, post "@argus-review review" (max 3 total triggers per cron_safety rule)
+    1. Run: gh pr view <PR_NUMBER> --json state,reviewDecision,latestReviews
+    2. If state is MERGED or CLOSED → PR is terminal, report to user, delete this cron
+    3. If state is OPEN and reviewDecision is APPROVED → report to user, delete this cron
+    4. For new-finding detection use:
+       gh api "repos/<OWNER>/<REPO>/pulls/<PR_NUMBER>/comments?since=<last_checked_iso>" --paginate
+       and filter to user.login == "argus-review[bot]"
+       Track last_checked in .pr-flow-last-checked-<PR_NUMBER>.
+    5. If new inline comments from argus-review[bot] exist → report to user for Phase 3
+    6. Track no-activity count in .pr-flow-check-count-<PR_NUMBER>
+    7. After 3 quiet checks, post "@argus-review review" (max 3 total triggers per cron_safety rule)
   recurring: true
 ```
 
@@ -241,16 +247,22 @@ git push
 
 Argus receives the push event and will automatically run incremental review. Create a CronCreate job to poll for the response:
 
+> **Incremental detection semantics (see #190)**
+> `latestReviews` is deduplicated per reviewer, so `latestReviews[argus]` gives Argus's single newest review regardless of how many COMMENTED rounds preceded it. That is the right field to answer "is Argus's current verdict APPROVED?" but it is NOT sufficient to answer "did any new Argus activity happen after the fix commit" — for that, compare `latestReviews[argus].submittedAt` against the fix commit timestamp, or iterate the full `reviews` array filtered by `submittedAt > fix_commit_time`. The cron below uses the timestamp-comparison approach.
+
 ```
 CronCreate:
   cron: "*/10 * * * *"
   prompt: |
     Check PR #<PR_NUMBER> for Argus incremental review after fix push.
-    1. Run: gh pr view <PR_NUMBER> --json reviewDecision,latestReviews
-    2. Check for new reviews from argus-review[bot] after the fix commit (latestReviews gives per-reviewer most-recent state)
-    3. If reviewDecision is APPROVED → report to user, delete this cron
-    4. If new COMMENT review with findings → report findings to user
-    5. After 6 quiet checks (1 hour), report timeout to user for manual intervention
+    1. Run: gh pr view <PR_NUMBER> --json state,reviewDecision,latestReviews,headRefOid
+    2. If state is MERGED or CLOSED → PR is terminal, report to user, delete this cron
+    3. If reviewDecision is APPROVED AND latestReviews[argus-review].submittedAt > <FIX_COMMIT_TIME> → report APPROVED to user, delete this cron
+    4. For new-finding detection, run:
+       gh api "repos/<OWNER>/<REPO>/pulls/<PR_NUMBER>/comments?since=<FIX_COMMIT_TIME>" --paginate
+       Filter to user.login == "argus-review[bot]" and report any hits as new findings
+    5. If new COMMENT review with findings → report findings to user
+    6. After 6 quiet checks (1 hour), report timeout to user for manual intervention
   recurring: true
 ```
 

--- a/.claude/skills/pr-flow/SKILL.md
+++ b/.claude/skills/pr-flow/SKILL.md
@@ -118,16 +118,17 @@ CronCreate:
   cron: "*/10 * * * *"
   prompt: |
     Check PR #<PR_NUMBER> review status.
-    1. Run: gh pr view <PR_NUMBER> --json state,reviewDecision,latestReviews
+    1. Run: gh pr view <PR_NUMBER> --json state,isDraft,reviewDecision,latestReviews
     2. If state is MERGED or CLOSED → PR is terminal, report to user, delete this cron
-    3. If state is OPEN and reviewDecision is APPROVED → report to user, delete this cron
-    4. For new-finding detection use:
+    3. If isDraft is true → PR moved back to DRAFT, stop polling and report to user, delete this cron
+    4. If state is OPEN and reviewDecision is APPROVED → report to user, delete this cron
+    5. For new-finding detection use:
        gh api "repos/<OWNER>/<REPO>/pulls/<PR_NUMBER>/comments?since=<last_checked_iso>" --paginate
        and filter to user.login == "argus-review[bot]"
        Track last_checked in .pr-flow-last-checked-<PR_NUMBER>.
-    5. If new inline comments from argus-review[bot] exist → report to user for Phase 3
-    6. Track no-activity count in .pr-flow-check-count-<PR_NUMBER>
-    7. After 3 quiet checks, post "@argus-review review" (max 3 total triggers per cron_safety rule)
+    6. If new inline comments from argus-review[bot] exist → report to user for Phase 3
+    7. Track no-activity count in .pr-flow-check-count-<PR_NUMBER>
+    8. After 3 quiet checks, post "@argus-review review" (max 3 total triggers per cron_safety rule)
   recurring: true
 ```
 
@@ -255,14 +256,19 @@ CronCreate:
   cron: "*/10 * * * *"
   prompt: |
     Check PR #<PR_NUMBER> for Argus incremental review after fix push.
-    1. Run: gh pr view <PR_NUMBER> --json state,reviewDecision,latestReviews,headRefOid
+    Concrete jq filter pattern to use in step 3 below (substitute FIX_COMMIT_TIME at cron-creation time, not at cron-runtime):
+      gh pr view <PR_NUMBER> --json state,isDraft,reviewDecision,latestReviews \
+        --jq '{decision: .reviewDecision, state, draft: .isDraft, latestArgus: (.latestReviews[] | select(.author.login == "argus-review") | {state, submittedAt})}'
+    1. Run the gh pr view query above.
     2. If state is MERGED or CLOSED → PR is terminal, report to user, delete this cron
-    3. If reviewDecision is APPROVED AND latestReviews[argus-review].submittedAt > <FIX_COMMIT_TIME> → report APPROVED to user, delete this cron
-    4. For new-finding detection, run:
-       gh api "repos/<OWNER>/<REPO>/pulls/<PR_NUMBER>/comments?since=<FIX_COMMIT_TIME>" --paginate
-       Filter to user.login == "argus-review[bot]" and report any hits as new findings
-    5. If new COMMENT review with findings → report findings to user
-    6. After 6 quiet checks (1 hour), report timeout to user for manual intervention
+    3. If isDraft is true → PR moved to DRAFT, stop polling and report to user, delete this cron
+    4. If decision is APPROVED AND latestArgus.submittedAt > "<FIX_COMMIT_TIME>" (ISO string comparison, both in UTC Zulu) → report APPROVED to user, delete this cron
+    5. For new-finding detection, run:
+       gh api "repos/<OWNER>/<REPO>/pulls/<PR_NUMBER>/comments?since=<FIX_COMMIT_TIME>" --paginate \
+         --jq '.[] | select(.user.login == "argus-review[bot]") | {id, path, line, body}'
+       Report any hits as new findings.
+    6. If new COMMENT review with findings → report findings to user
+    7. After 6 quiet checks (1 hour), report timeout to user for manual intervention
   recurring: true
 ```
 

--- a/.claude/skills/pr-flow/SKILL.md
+++ b/.claude/skills/pr-flow/SKILL.md
@@ -250,20 +250,27 @@ Argus receives the push event and will automatically run incremental review. Cre
 
 > **Incremental detection semantics (see #190)**
 > `latestReviews` is deduplicated per reviewer, so `latestReviews[argus]` gives Argus's single newest review regardless of how many COMMENTED rounds preceded it. That is the right field to answer "is Argus's current verdict APPROVED?" but it is NOT sufficient to answer "did any new Argus activity happen after the fix commit" — for that, compare `latestReviews[argus].submittedAt` against the fix commit timestamp, or iterate the full `reviews` array filtered by `submittedAt > fix_commit_time`. The cron below uses the timestamp-comparison approach.
+>
+> **Reviewer login form — GraphQL vs REST (must match the API)**
+> The two GitHub surfaces return different login strings for the same bot account, and mixing them silently drops matches:
+> - `gh pr view --json latestReviews` (GraphQL) → `.author.login == "argus-review"` (no `[bot]` suffix)
+> - `gh api repos/.../pulls/<N>/reviews` and `.../comments` (REST) → `.user.login == "argus-review[bot]"` (with suffix)
+> Use the matching form for each API. The same-PR cron uses both forms intentionally because it calls both surfaces.
 
 ```
 CronCreate:
   cron: "*/10 * * * *"
   prompt: |
     Check PR #<PR_NUMBER> for Argus incremental review after fix push.
-    Concrete jq filter pattern to use in step 3 below (substitute FIX_COMMIT_TIME at cron-creation time, not at cron-runtime):
+    Concrete jq filter pattern to use in step 1 below (substitute FIX_COMMIT_TIME at cron-creation time, not at cron-runtime).
+    The `latestArgus` extraction wraps the `select` in `map(...) | .[0] // {state: null, submittedAt: null}` so a missing reviewer yields a known-shape default object instead of an empty stream that would crash downstream `.submittedAt` dereferences.
       gh pr view <PR_NUMBER> --json state,isDraft,reviewDecision,latestReviews \
-        --jq '{decision: .reviewDecision, state, draft: .isDraft, latestArgus: (.latestReviews[] | select(.author.login == "argus-review") | {state, submittedAt})}'
+        --jq '{decision: .reviewDecision, state, draft: .isDraft, latestArgus: ((.latestReviews // []) | map(select(.author.login == "argus-review")) | .[0] // {state: null, submittedAt: null})}'
     1. Run the gh pr view query above.
     2. If state is MERGED or CLOSED → PR is terminal, report to user, delete this cron
     3. If isDraft is true → PR moved to DRAFT, stop polling and report to user, delete this cron
-    4. If decision is APPROVED AND latestArgus.submittedAt > "<FIX_COMMIT_TIME>" (ISO string comparison, both in UTC Zulu) → report APPROVED to user, delete this cron
-    5. For new-finding detection, run:
+    4. If decision is APPROVED AND latestArgus.submittedAt is non-null AND latestArgus.submittedAt > "<FIX_COMMIT_TIME>" (ISO string comparison, both in UTC Zulu) → report APPROVED to user, delete this cron
+    5. For new-finding detection, run (note the REST-side `argus-review[bot]` login form with the `[bot]` suffix — this is NOT the same as the GraphQL `argus-review` form used in step 1):
        gh api "repos/<OWNER>/<REPO>/pulls/<PR_NUMBER>/comments?since=<FIX_COMMIT_TIME>" --paginate \
          --jq '.[] | select(.user.login == "argus-review[bot]") | {id, path, line, body}'
        Report any hits as new findings.

--- a/.claude/skills/pr-flow/SKILL.md
+++ b/.claude/skills/pr-flow/SKILL.md
@@ -107,12 +107,17 @@ gh pr create "${PR_ARGS[@]}"
 
 **MANDATORY**: Create a CronCreate job to poll. Do NOT use sleep loops.
 
+> **Review polling field selection (see #190)**
+> Use `reviewDecision` as the authoritative approval gate — it reflects GitHub's own per-reviewer-latest aggregation and flips to `APPROVED` only when all requested reviews are satisfied.
+> Prefer `latestReviews` over `reviews` when you need "the most recent review per reviewer": `reviews` is the full chronological array and its last element can be an older COMMENTED review that predates a newer APPROVED review from the same reviewer. `latestReviews` is deduplicated per-user.
+> For "are there new inline findings" detection, use `gh api repos/<owner>/<repo>/pulls/<N>/comments` (review comments endpoint), NOT the review list.
+
 ```
 CronCreate:
   cron: "*/10 * * * *"
   prompt: |
     Check PR #<PR_NUMBER> review status.
-    1. Run: gh pr view <PR_NUMBER> --json reviews,reviewDecision
+    1. Run: gh pr view <PR_NUMBER> --json reviewDecision,latestReviews
     2. If reviewDecision is APPROVED → report to user, delete this cron
     3. If new inline comments from argus-review[bot] exist → report to user for Phase 3
     4. Track no-activity count in .pr-flow-check-count-<PR_NUMBER>
@@ -241,9 +246,9 @@ CronCreate:
   cron: "*/10 * * * *"
   prompt: |
     Check PR #<PR_NUMBER> for Argus incremental review after fix push.
-    1. Run: gh pr view <PR_NUMBER> --json reviews,reviewDecision
-    2. Check for new reviews from argus-review[bot] after the fix commit
-    3. If APPROVED → report to user, delete this cron
+    1. Run: gh pr view <PR_NUMBER> --json reviewDecision,latestReviews
+    2. Check for new reviews from argus-review[bot] after the fix commit (latestReviews gives per-reviewer most-recent state)
+    3. If reviewDecision is APPROVED → report to user, delete this cron
     4. If new COMMENT review with findings → report findings to user
     5. After 6 quiet checks (1 hour), report timeout to user for manual intervention
   recurring: true


### PR DESCRIPTION
## Summary

Two cron-prompt snippets in `.claude/skills/pr-flow/SKILL.md` fetched the full chronological `reviews` array from `gh pr view`. When a reviewer posts COMMENTED-then-APPROVED on iterative PRs (standard Argus pattern), array-last polling can see the older COMMENTED entry and miss the newer APPROVED state from the same reviewer.

### Fix

Switch both snippets to fetch `reviewDecision,latestReviews`:

- **`reviewDecision`** is GitHub's authoritative per-reviewer-latest aggregation → use as the APPROVE gate
- **`latestReviews`** is the per-reviewer deduplicated most-recent list → safe for "newest per reviewer" lookups
- The full `reviews` array is reserved for chronological activity detection, not approval gating
- Inline-finding detection should hit the review-comments endpoint (`gh api repos/<owner>/<repo>/pulls/<N>/comments`) rather than the review list

Also adds a callout block near the Phase 2 snippet documenting the field distinction so future editors do not regress.

### Origin

Surfaced on Argus PR #7 during Mercury Phase 1 validation: `reviewDecision` had already flipped to `APPROVED` but array-last polling was still returning the older COMMENTED entry from the same reviewer.

## Test plan

- [x] Grep `.claude/` for `\.reviews\[-1\]` and `--json reviews,` — zero remaining hits
- [x] Both Phase 2 and Phase 5 cron snippets updated
- [x] Callout block added with the field-distinction explanation
- [x] `dual-verify/SKILL.md` audited — no `.reviews[-1]` / `reviews,` patterns present, no changes needed

## Checklist

- [x] All pr-flow polling snippets use `reviewDecision` / `latestReviews`
- [x] Comment block added explaining the distinction
- [x] No regressions in polling timing, thresholds, or retry caps
- [x] Scope limited to `.claude/skills/pr-flow/SKILL.md`

Closes #190