### PR TITLE
feat(#213): caveman-toggle skill — persistent concise mode via CLAUDE.local.md

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -119,6 +119,7 @@
       }
     ]
   },
+  "language": "zh-CN",
   "enabledPlugins": {
     "codex@openai-codex": true,
     "claude-hud@claude-hud": true,

--- a/.claude/skills/caveman-toggle/SKILL.md
+++ b/.claude/skills/caveman-toggle/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: caveman-toggle
+description: |
+  Toggle persistent caveman concise mode for Mercury. Manages CLAUDE.local.md to enable/disable
+  terse output style across sessions. Use when the user says "/caveman-on", "/caveman-off",
+  "/caveman-status", "开启caveman", "关闭caveman", "简洁模式", "caveman mode".
+user-invocable: true
+allowed-tools: Read, Write, Bash
+---
+
+# Caveman Toggle Skill
+
+Manages `CLAUDE.local.md` at the project root to enable or disable caveman concise mode.
+Based on [JuliusBrussee/caveman](https://github.com/JuliusBrussee/caveman) (MIT).
+
+**Important**: CLAUDE.local.md is loaded at session start only. Changes take effect on the **next session restart**.
+
+## Commands
+
+### `/caveman-on [lite|full|ultra]`
+
+Default intensity: `lite`.
+
+1. Read `CLAUDE.local.md.example` from the project root
+2. If intensity is `full` or `ultra`, replace the `<!-- caveman-mode: lite -->` ... `<!-- end-intensity -->` block with the appropriate variant (see intensity variants below)
+3. Write the result to `CLAUDE.local.md` (overwrite if exists)
+4. Print: "Caveman [intensity] mode enabled. **Restart session to activate.**"
+
+### `/caveman-off`
+
+1. Check if `CLAUDE.local.md` exists
+2. If yes: delete it with `Bash: rm "$CLAUDE_PROJECT_DIR/CLAUDE.local.md"`
+3. Print: "Caveman mode disabled. **Restart session to deactivate.**"
+4. If no: print "Caveman mode is already off."
+
+### `/caveman-status`
+
+1. Check if `CLAUDE.local.md` exists (use Bash: `test -f "$CLAUDE_PROJECT_DIR/CLAUDE.local.md" && echo exists || echo missing`)
+2. If exists: grep `<!-- caveman-mode:` in `"$CLAUDE_PROJECT_DIR/CLAUDE.local.md"` to read current intensity
+3. Print current state: "Caveman [intensity] — active (restart already done if instructions visible)" or "Caveman OFF"
+
+## Intensity Variants
+
+When the user requests `full` or `ultra`, replace the intensity block in the example:
+
+**lite** (default — grammar preserved, filler removed):
+```
+<!-- caveman-mode: lite -->
+Respond terse like smart caveman. Drop filler words, hedging, pleasantries.
+Keep articles and full sentences. No "sure/certainly/happy to/I think/perhaps/basically".
+<!-- end-intensity -->
+```
+
+**full** (drop articles, allow fragments):
+```
+<!-- caveman-mode: full -->
+Respond terse like smart caveman. Drop filler, articles, hedging, pleasantries.
+Fragments ok. Short synonyms. Pattern: [thing] [action] [reason].
+<!-- end-intensity -->
+```
+
+**ultra** (maximum compression):
+```
+<!-- caveman-mode: ultra -->
+Respond terse like smart caveman. Drop filler, articles, conjunctions.
+Abbreviate: DB/auth/config/req/res/fn/impl. Use X→Y for causality. Max brevity.
+<!-- end-intensity -->
+```

--- a/.claude/skills/caveman-toggle/SKILL.md
+++ b/.claude/skills/caveman-toggle/SKILL.md
@@ -22,14 +22,15 @@ Based on [JuliusBrussee/caveman](https://github.com/JuliusBrussee/caveman) (MIT)
 Default intensity: `lite`.
 
 1. Read `CLAUDE.local.md.example` from the project root
-2. If intensity is `full` or `ultra`, replace the `<!-- caveman-mode: lite -->` ... `<!-- end-intensity -->` block with the appropriate variant (see intensity variants below)
-3. Write the result to `CLAUDE.local.md` (overwrite if exists)
+2. Validate the template contains exactly one `<!-- caveman-mode: ... -->` to `<!-- end-intensity -->` block; if not, abort with error: "Template block missing or duplicated — check CLAUDE.local.md.example"
+3. If intensity is `full` or `ultra`, replace that single block with the appropriate variant (see intensity variants below)
+4. Write the result to `CLAUDE.local.md` (overwrite if exists) only after successful validation/replacement
 4. Print: "Caveman [intensity] mode enabled. **Restart session to activate.**"
 
 ### `/caveman-off`
 
 1. Check if `CLAUDE.local.md` exists
-2. If yes: delete it with `Bash: rm "$CLAUDE_PROJECT_DIR/CLAUDE.local.md"`
+2. If yes: delete it with `Bash: [ -n "$CLAUDE_PROJECT_DIR" ] && [ -f "$CLAUDE_PROJECT_DIR/CLAUDE.local.md" ] && rm -- "$CLAUDE_PROJECT_DIR/CLAUDE.local.md"`
 3. Print: "Caveman mode disabled. **Restart session to deactivate.**"
 4. If no: print "Caveman mode is already off."
 

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ desktop.ini
 $RECYCLE.BIN/
 
 # Claude Code
+CLAUDE.local.md
 .claude/plans/
 .claude/hooks/state/
 .claude/scheduled_tasks.lock

--- a/CLAUDE.local.md.example
+++ b/CLAUDE.local.md.example
@@ -1,0 +1,24 @@
+# Mercury — Local Instructions (Caveman Mode)
+#
+# This file is a template for CLAUDE.local.md.
+# CLAUDE.local.md is loaded by Claude Code at session start alongside CLAUDE.md.
+# It is gitignored — changes here are personal and do not affect others.
+#
+# Usage:
+#   /caveman-on        — activate with default intensity (lite)
+#   /caveman-on full   — activate with full intensity
+#   /caveman-off       — deactivate (deletes CLAUDE.local.md)
+#
+# Or copy manually: cp CLAUDE.local.md.example CLAUDE.local.md
+
+<!-- caveman-mode: lite -->
+Respond terse like smart caveman. Drop filler words, hedging, pleasantries.
+Keep articles and full sentences. No "sure/certainly/happy to/I think/perhaps/basically".
+All technical substance preserved. Code blocks unchanged. Errors quoted exact.
+<!-- end-intensity -->
+
+<!-- caveman-exemptions -->
+Exception: milestone completion messages remain in Chinese per project CLAUDE.md.
+Exception: code blocks, git commits, PR bodies — write normal always.
+Exception: security warnings and irreversible action confirmations — write normal always.
+<!-- end-exemptions -->

--- a/README.md
+++ b/README.md
@@ -124,6 +124,39 @@ Define your agents in `mercury.config.json` at the project root. See `mercury.co
 
 **Validation:** If the config file is missing or contains invalid JSON, Mercury falls back to built-in defaults and logs a warning in the GUI console. Required fields (`id`, `displayName`, `cli`, `roles`, `integration`, `capabilities`, `restrictions`, `maxConcurrentSessions`) are validated at load time — agents with missing fields are skipped with a warning. Config changes require an app restart; hot-reload is not currently supported.
 
+## Example Files
+
+Several configuration files are shipped as `.example` templates. Copy and customize before use:
+
+| Template | Target | Purpose |
+|---|---|---|
+| `mercury.config.example.json` | `mercury.config.json` | Agent definitions (see [Configuration](#configuration)) |
+| `.pr_agent.toml.example` | `.pr_agent.toml` | PR review bot configuration (Argus / Qodo Merge) |
+| `CLAUDE.local.md.example` | `CLAUDE.local.md` | Claude Code local instructions (caveman concise mode) |
+
+`mercury.config.json`, `.pr_agent.toml`, and `CLAUDE.local.md` are gitignored — changes stay local.
+
+### Caveman Mode (CLAUDE.local.md)
+
+Enables persistent concise output style via [caveman](https://github.com/JuliusBrussee/caveman) — drops filler ~30-40%, preserves all technical content.
+
+```bash
+# Via skill (recommended) — takes effect on next session restart
+/caveman-on          # enable lite mode (default)
+/caveman-on full     # enable full mode
+/caveman-off         # disable
+
+# Or manually
+cp CLAUDE.local.md.example CLAUDE.local.md
+```
+
+### PR Review Bot (.pr_agent.toml)
+
+```bash
+cp .pr_agent.toml.example .pr_agent.toml
+# Edit .pr_agent.toml with your review bot instructions
+```
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary
- Add `.claude/skills/caveman-toggle/SKILL.md`: `/caveman-on [lite|full|ultra]`, `/caveman-off`, `/caveman-status` commands
- Add `CLAUDE.local.md.example`: committed template with lite mode + Chinese milestone + code exemptions
- Gitignore `CLAUDE.local.md` (runtime toggle, personal local, zero git noise)
- Add `"language": "zh-CN"` to `.claude/settings.json` (project-scoped; sub-agents naturally isolated)
- README: new "Example Files" section documenting all three `.example` templates including `.pr_agent.toml.example`

## Test plan
- [ ] `/caveman-on` creates `CLAUDE.local.md` from example template
- [ ] `/caveman-on full` creates `CLAUDE.local.md` with full-mode intensity block
- [ ] `/caveman-off` deletes `CLAUDE.local.md`; reports "already off" if missing
- [ ] `/caveman-status` correctly reads mode from `$CLAUDE_PROJECT_DIR/CLAUDE.local.md`
- [ ] `CLAUDE.local.md` does not appear in `git status` (gitignored)
- [ ] Session restart with `CLAUDE.local.md` present activates concise mode
- [ ] Milestone messages remain in Chinese (exemption clause honored)
- [ ] pr-flow / pr-merge-guard behavior unchanged

## References
- Closes #213
- Research report: `.research/reports/RESEARCH-Caveman-skill-toggle-213.md`
- Based on [JuliusBrussee/caveman](https://github.com/JuliusBrussee/caveman) v1.3.0 (MIT)
- dual-verify: PASS (Claude: PASS, Codex: NEEDS-CHANGES → 3 issues fixed: marker ref, `$CLAUDE_PROJECT_DIR` path anchoring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)