### PR TITLE
feat(#218): register AgentKB memory compiler hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -95,6 +95,39 @@
         ]
       }
     ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run --directory D:/Mercury/AgentKB python D:/Mercury/AgentKB/hooks/session-start.py",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run --directory D:/Mercury/AgentKB python D:/Mercury/AgentKB/hooks/session-end.py",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run --directory D:/Mercury/AgentKB python D:/Mercury/AgentKB/hooks/pre-compact.py",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [


### PR DESCRIPTION
## Summary
- Register SessionStart, SessionEnd, and PreCompact hooks in settings.json
- Hooks point at `D:/Mercury/AgentKB` (claude-memory-compiler clone with Mercury customizations)
- SessionStart injects knowledge/index.md + recent daily log into every session
- SessionEnd/PreCompact capture transcripts → spawn background flush → daily log → compile

## Context
- Phase 3 Memory Layer (#182), sub-issue #218
- AgentKB is a separate repo (coleam00/claude-memory-compiler) at `D:/Mercury/AgentKB`
- Autoresearch report: `.research/reports/RESEARCH-Phase3-Memory-Layer-2026-04-10.md`
- Architecture decisions: DIRECTION.md §8 Post-Phase-2, Issue #217 comment

## Dual-verify
- Claude Code: PASS (0 Critical, 0 High, 1 Medium — hardcoded path acceptable for personal project)
- Codex: UNAVAILABLE (stalled on web search — fallback applied per low-risk config change)

## Test plan
- [x] `session-start.py` tested manually — outputs correct JSON with knowledge index
- [ ] SessionEnd hook fires on real session end (requires session termination)
- [ ] Flush→Compile pipeline produces daily log entries (requires real usage)

Closes #218

Generated with Claude Code