### PR TITLE
fix(loop-detector): scanStr window + no_progress threshold 3→5 (#230)

### DIFF
--- a/.mercury/config/loop-detector.json
+++ b/.mercury/config/loop-detector.json
@@ -1,6 +1,6 @@
 {
   "enabled": true,
-  "no_progress_threshold": 3,
+  "no_progress_threshold": 5,
   "same_error_threshold": 5,
   "duplicate_call_threshold": 3,
   "read_write_ratio_threshold": 8

--- a/adapters/mercury-loop-detector/hook.cjs
+++ b/adapters/mercury-loop-detector/hook.cjs
@@ -98,8 +98,8 @@ function hashInput(input) {
 
 function toStr(v) { return typeof v === 'string' ? v : JSON.stringify(v ?? ''); }
 
-// Scan first+last 1500 chars only; skips incidental keyword matches in large JSON blobs.
-function scanStr(r) { const s = toStr(r); return s.length <= 3000 ? s : s.slice(0, 1500) + '\n' + s.slice(-1500); }
+// Scan first+mid+last 1000 chars each; avoids false positives from middle JSON blobs, retains middle error coverage.
+function scanStr(r) { const s = toStr(r); if (s.length <= 3000) return s; const m = Math.floor(s.length / 2); return s.slice(0, 1000) + '\n' + s.slice(m - 500, m + 500) + '\n' + s.slice(-1000); }
 
 function hasError(response) {
   return /\b(?:error|failed|exception)\b|exit code [1-9]/i.test(scanStr(response));

--- a/adapters/mercury-loop-detector/hook.cjs
+++ b/adapters/mercury-loop-detector/hook.cjs
@@ -98,8 +98,8 @@ function hashInput(input) {
 
 function toStr(v) { return typeof v === 'string' ? v : JSON.stringify(v ?? ''); }
 
-// Scan first+mid+last 1000 chars each; avoids false positives from middle JSON blobs, retains middle error coverage.
-function scanStr(r) { const s = toStr(r); if (s.length <= 3000) return s; const m = Math.floor(s.length / 2); return s.slice(0, 1000) + '\n' + s.slice(m - 500, m + 500) + '\n' + s.slice(-1000); }
+// Scan first+last 1500 chars; skips large-JSON middle (false-positive risk). Trade-off: mid-only errors missed (real tool errors appear at start/end).
+function scanStr(r) { const s = toStr(r); return s.length <= 3000 ? s : s.slice(0, 1500) + '\n' + s.slice(-1500); }
 
 function hasError(response) {
   return /\b(?:error|failed|exception)\b|exit code [1-9]/i.test(scanStr(response));

--- a/adapters/mercury-loop-detector/hook.cjs
+++ b/adapters/mercury-loop-detector/hook.cjs
@@ -24,7 +24,7 @@ const pass  = () => process.exit(0);
 
 const DEFAULTS = {
   enabled: true,
-  no_progress_threshold: 3,       // consecutive action calls (non-read/write/error) with no write
+  no_progress_threshold: 5,       // consecutive action calls (non-read/write/error) with no write
   same_error_threshold: 5,        // consecutive calls sharing the same error signature
   duplicate_call_threshold: 3,    // consecutive identical tool+input hash calls (success only)
   read_write_ratio_threshold: 8   // consecutive read-only calls with no writes
@@ -51,13 +51,9 @@ function loadConfig(cwd) {
 
 // ── State (independent counters per session) ─────────────────────────────────
 
-const EMPTY_STATE = () => ({
-  session_id: null,
-  dup_count: 0, dup_tool: null, dup_hash: null,
-  err_count: 0, err_last: null,
-  read_count: 0,
-  np_count: 0
-});
+const EMPTY_STATE = () => ({ session_id: null,
+  dup_count: 0, dup_tool: null, dup_hash: null, err_count: 0, err_last: null,
+  read_count: 0, np_count: 0 });
 
 function safeInt(v) { return Number.isFinite(v) && v >= 0 ? Math.round(v) : 0; }
 
@@ -95,7 +91,6 @@ const WRITE_TOOLS = new Set(['Edit', 'Write', 'NotebookEdit', 'MultiEdit']);
 const READ_TOOLS  = new Set(['Read', 'Glob', 'Grep']);
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
-
 function hashInput(input) {
   const s = typeof input === 'string' ? input : JSON.stringify(input ?? '');
   return crypto.createHash('sha256').update(s).digest('hex').slice(0, 8); // sha256: FIPS-safe
@@ -103,19 +98,20 @@ function hashInput(input) {
 
 function toStr(v) { return typeof v === 'string' ? v : JSON.stringify(v ?? ''); }
 
+// Scan first+last 1500 chars only; skips incidental keyword matches in large JSON blobs.
+function scanStr(r) { const s = toStr(r); return s.length <= 3000 ? s : s.slice(0, 1500) + '\n' + s.slice(-1500); }
+
 function hasError(response) {
-  return /\b(?:error|failed|exception)\b|exit code [1-9]/i.test(toStr(response));
+  return /\b(?:error|failed|exception)\b|exit code [1-9]/i.test(scanStr(response));
 }
 
 function errorSig(response) {
-  const m = toStr(response).match(/(?:error|failed|exception|exit code \d+)[^.\n]{0,80}/i);
+  const m = scanStr(response).match(/(?:error|failed|exception|exit code \d+)[^.\n]{0,80}/i);
   return m ? m[0].trim().slice(0, 80) : null;
 }
-
 // ── Update independent counters ──────────────────────────────────────────────
 
 function update(state, tool, hash, is_write, is_read, errored, err_sig) {
-  // duplicate_call: repeated identical SUCCESSFUL calls (errors tracked by same_error)
   if (!errored) {
     if (tool === state.dup_tool && hash === state.dup_hash) { state.dup_count++; }
     else { state.dup_count = 1; state.dup_tool = tool; state.dup_hash = hash; }
@@ -123,7 +119,6 @@ function update(state, tool, hash, is_write, is_read, errored, err_sig) {
     state.dup_count = 0; state.dup_tool = null; state.dup_hash = null;
   }
 
-  // same_error: consecutive calls with an identical error signature
   if (errored && err_sig) {
     if (err_sig === state.err_last) { state.err_count++; }
     else { state.err_count = 1; state.err_last = err_sig; }
@@ -131,12 +126,10 @@ function update(state, tool, hash, is_write, is_read, errored, err_sig) {
     state.err_count = 0; state.err_last = null;
   }
 
-  // read_write_ratio: consecutive read-tool calls; resets on write or non-read
   if (is_write)     { state.read_count = 0; }
   else if (is_read) { state.read_count++; }
-  else              { state.read_count = 0; } // Bash/Agent/etc. breaks read streak
+  else              { state.read_count = 0; }
 
-  // no_progress: action calls (non-read, non-write, non-error) without any file write
   if (is_write || is_read || errored) { state.np_count = 0; }
   else                                { state.np_count++; }
 }


### PR DESCRIPTION
## Summary
- `hasError()`/`errorSig()`: scan first+last 1500 chars of long responses only (skip middle of large JSON blobs). Seam separator `\n` prevents cross-boundary synthetic keyword creation.
- `no_progress_threshold`: 3 → 5 in both `DEFAULTS` and `.mercury/config/loop-detector.json`. Main agent legitimately runs 3–4 Bash/CronList/ToolSearch calls between writes during PR review workflows.

Observed in S37 (PR #229 merge): `gh api` diff_hunks contained hook comment text → `same_error` false positive (5 identical "Error detection reads..." signatures). `no_progress` fired on 3-call verify sequences.

Closes #230

## Test plan
- [ ] `same_error` does not fire on successful `gh api` calls returning large JSON
- [ ] `no_progress` does not fire during a 4-call Bash verify sequence
- [ ] All 4 detection signals (no_progress, same_error, duplicate_call, read_write_ratio) still fire at their thresholds
- [ ] `wc -l hook.cjs` = 200 (adapter LoC constraint)

dual-verify: PASS (Claude: PASS, Codex: PASS, seam separator Low fixed)

Generated with Claude Code