### PR TITLE
docs: add MIT License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 392fyc
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "mercury",
   "version": "0.0.1",
   "private": true,
+  "license": "MIT",
   "description": "AI Agent harness framework — session continuity, memory, quality gates",
   "type": "module",
   "scripts": {},


### PR DESCRIPTION
## Summary

- Adds `LICENSE` file (MIT) to Mercury repo root
- Resolves the gap flagged in #233 (OpenViking AGPL evaluation) where outgoing license was undeclared

## Decision rationale

- All 13 entries in `.mercury/state/upstream-manifest.json` are MIT-licensed → direct compatibility, no NOTICE file needed
- MIT is simpler than Apache-2.0 for a personal/small-team framework; patent grant clause (Apache-2.0 advantage) is not a current concern
- Ideas and design patterns from other projects are not copyrightable; only cherry-picked code (tracked in manifest) requires compliance

## Test plan

- [ ] Verify `LICENSE` file is present in repo root
- [ ] Verify content matches standard MIT template with correct year (2026) and author (392fyc)
- [ ] Confirm GitHub auto-detects license as MIT

Closes #234
Refs #233

🤖 Generated with [Claude Code](https://claude.ai/claude-code)