### PR TITLE
docs(#238): Phase 4-1 Session Continuity ADR draft

### DIFF
--- a/.mercury/docs/research/phase4-1-design-decisions-2026-04-13.md
+++ b/.mercury/docs/research/phase4-1-design-decisions-2026-04-13.md
@@ -1,0 +1,133 @@
+# Phase 4-1 Session Continuity — 设计决策记录
+> Date: 2026-04-13 | 补充自 S47 ADR draft 讨论
+
+---
+
+## 确认决策
+
+### 触发方式
+
+| 触发源 | 行为 |
+|--------|------|
+| `/handoff [text]` | 用户主动触发；`text` 为追加到下 session 的指令 |
+| Agent 自主调用 | 任务完成时 agent 可以直接调用，不需要特殊符号 |
+| Stop hook（兜底） | 任务未完成时 block stop，提示用户显式 `/handoff` |
+
+不使用特殊符号分隔（减少用户调用阻力）。
+
+### 续接方式
+
+**选定 Option B（Agent SDK 自动启动新 session）**：
+- 生成 handoff doc → 通过 Agent SDK 自动开新 session → 注入 handoff 作为 prompt 前缀
+- 目标：agent 在有足够背景信息的情况下可自主推进任务，减少人类反复干预
+- 这是多 agent team 工作的前置条件
+
+### 两种运行模式（优先级有序）
+
+**Mode 1（Phase 4-1，优先实现）：compact-coexist**
+- 让 session 自由运行，compaction 正常工作
+- 任务完成后 `/handoff` 写最终文档
+- PreCompact checkpoint（Phase 3 flush）作为底稿
+- 好处：自动化潜力高（任务完成 → 队列取下一任务 → 自动续接）
+
+**Mode 2（Phase 4-3，后续优化）：compact-prevention**
+- 接近 context 上限时在任务节点主动 `/handoff`
+- context 始终保持在合理范围
+- 缺点：Phase 3 的 PreCompact/PostCompact hooks 需要重定位用途
+
+### 范围限制
+
+- 仅本地工作环境，不做跨机器/云端对应（依赖底层 Claude Code 自身升级）
+- Sub-agent 不纳入机制（sub-agent 是一次性任务，无需持续 handoff）
+- 多窗口：只在调用 `/handoff` 的 session 生效，其他窗口不受影响
+
+### Handoff 文档格式
+
+```markdown
+# Session Handoff — {date}
+
+## 任务状态
+- Issue: #N [title]
+- Branch: feat/N-xxx  
+- 完成: [commit hash list]
+- 进行中: [当前步骤，卡点]
+- 待处理: [ ] item1 ...
+
+## 关键上下文（compact 丢失防护）
+- 架构决策 / 踩坑 / 约束发现
+
+## 用户追加指令
+{/handoff 后的 text，若有}
+
+## 下一 Session 首要任务
+1. ...
+```
+
+---
+
+## 新增依赖问题（Phase 4-2/4-3 需解决）
+
+### 1. Session 链管理（Phase 4-2）
+
+扩展现有 `skill_stats.db`（SQLite），新增表：
+
+```sql
+CREATE TABLE session_chain (
+    session_id      TEXT PRIMARY KEY,
+    issue_ids       TEXT,          -- JSON: ["#238", "#183"]
+    branch          TEXT,
+    worktree_path   TEXT,          -- NULL if main workspace
+    start_time      DATETIME,
+    end_time        DATETIME,
+    handoff_doc     TEXT,          -- file path
+    next_session_id TEXT,          -- FK self
+    status          TEXT           -- active / handoff / complete
+);
+```
+
+`flush.py` SessionEnd 时顺手写 chain record（已知 session_id + branch）。
+
+### 2. Worktree-per-task（Phase 4-2）
+
+现状：多任务并发时共用主 workspace，分支混乱。
+方向：强制 worktree-per-task，worktree CWD 不同 → handoff 自然隔离。
+已有资源：OMC `project-session-manager` skill（评估可否直接集成，勿重新实现）。
+
+---
+
+## 前置研究任务（实施前必须完成）
+
+### OpenClaw 研究（新 Issue 待创建）
+
+OpenClaw 是本地完全自主运行的 agent（250K GitHub stars，60 天内超越 React）。
+需研究其如何处理：
+1. 长期记忆（long-term memory）管理
+2. 群体记忆（collective memory，多 agent 共享）
+3. Context 窗口管理（如何避免/处理 context overflow）
+
+初步已知：
+- 三层 memory 架构：daily/{date}.md + MEMORY.md（KB）+ session archive（语义搜索）
+- 文件优先（Markdown on disk），vector DB（Milvus）做语义检索层
+- 与 Mercury AgentKB 架构高度相似，但增加了 vector semantic search 层
+- 集成：Mem0、Supermemory、NVIDIA NemoClaw（policy enforcement）
+
+**研究目标**：评估 OpenClaw 的 session continuity 和 group memory 方案，提炼可借鉴的设计模式用于 Mercury Phase 4 实现。
+
+---
+
+## 任务队列自动化潜力（Phase 4-4 展望）
+
+Mode 1 + session chain + Issue backlog → 完整自动化链路：
+
+```
+Issue backlog → 分配 Issue → 创建 worktree → 开 session
+     ↓
+  任务执行（可 compact）
+     ↓
+  /handoff → 写 chain record + handoff doc
+     ↓
+  从 backlog 取下一 Issue → 自动开新 session（注入 handoff）
+```
+
+这是 Mercury DIRECTION.md "autonomous continuation" 的具体实现形态。
+Phase 4-1 不实现到这层，但 session_chain 数据模型必须兼容。

--- a/.mercury/docs/research/phase4-1-design-decisions-2026-04-13.md
+++ b/.mercury/docs/research/phase4-1-design-decisions-2026-04-13.md
@@ -17,7 +17,7 @@
 
 ### 续接方式
 
-**选定 Option B（Agent SDK 自动启动新 session）**：
+**选定 Option D（Hybrid: Stop-hook handoff + Agent SDK resume）**：
 - 生成 handoff doc → 通过 Agent SDK 自动开新 session → 注入 handoff 作为 prompt 前缀
 - 目标：agent 在有足够背景信息的情况下可自主推进任务，减少人类反复干预
 - 这是多 agent team 工作的前置条件

--- a/.mercury/docs/research/phase4-1-session-continuity-adr-draft.md
+++ b/.mercury/docs/research/phase4-1-session-continuity-adr-draft.md
@@ -1,7 +1,7 @@
 # Phase 4-1 ADR — Session Continuity 技术方案选型
 
-**Status**: DRAFT — AWAITING USER DECISION
-**Date**: 2026-04-12
+**Status**: DECIDED — 2026-04-13
+**Date**: 2026-04-12 (updated 2026-04-13)
 **Issue**: #183 (parent: Phase 3 Memory Layer)
 **Decision authority**: User (最终方案选型需用户拍板)
 **Research artifact**: `.research/reports/RESEARCH-Session-Continuity-183-2026-04-11.md` (5 questions, 30+ sources)

--- a/.mercury/docs/research/phase4-1-session-continuity-adr-draft.md
+++ b/.mercury/docs/research/phase4-1-session-continuity-adr-draft.md
@@ -1,0 +1,160 @@
+# Phase 4-1 ADR — Session Continuity 技术方案选型
+
+**Status**: DRAFT — AWAITING USER DECISION
+**Date**: 2026-04-12
+**Issue**: #183 (parent: Phase 3 Memory Layer)
+**Decision authority**: User (最终方案选型需用户拍板)
+**Research artifact**: `.research/reports/RESEARCH-Session-Continuity-183-2026-04-11.md` (5 questions, 30+ sources)
+
+---
+
+## Context
+
+Mercury 的 Phase 4 目标是实现 **Session Continuity**：当一个 Claude Code 会话因 context 压缩、预算耗尽或用户中断而结束时，下一个会话能够无缝恢复任务状态，不依赖人工手动传递背景。
+
+### 现状问题
+
+- 每个 Claude Code 会话是独立的 — 结束即失忆
+- 当前缓解手段：用户手动 handoff（写文档粘贴到下个会话首条消息）
+- Phase 3 Memory Layer 部分解决了 **知识积累**（daily log + compile → AgentKB），但不解决 **任务断点恢复**
+
+### Phase 3 Memory Layer 已提供的基础设施
+
+| 组件 | 状态 |
+|------|------|
+| AgentKB daily log (flush.py) | ✅ 运行中 |
+| SessionEnd hook | ✅ 全局注册 |
+| PreCompact hook | ✅ 已修复 (#232) |
+| NAS rsync 备份 | ✅ 每小时 rc=0 |
+| AgentKB compile pipeline | ✅ 运行中 |
+
+Phase 4 在此基础上增加 **结构化 handoff 生成 + 自动续接** 能力。
+
+---
+
+## 方案对比
+
+研究报告评估了四个方案，以下是完整对比：
+
+### Option A — SDK-Based Orchestrator（最高控制度）
+
+**原理**: 外部 Python 脚本通过 Agent SDK 包装 Claude Code 会话。
+- 设置 `max_turns=30` 或 `max_budget_usd` 作为会话预算
+- 预算耗尽时（`error_max_turns` / `error_max_budget_usd`）：自动从 transcript 生成 handoff doc
+- 立即以 `resume=session_id` 启动新会话，handoff 注入为 prompt 前缀
+- 任务完成时检查是否需要链接下一会话
+
+**优点**: 完全自动续接，无需人工干预；可编程控制会话生命周期
+**缺点**: 需要 Mercury 外部运行一个 orchestrator 进程；改变用户启动 Claude Code 的方式
+**Mercury 适配度**: 高 — DIRECTION.md 描述的 Session Continuity 直接对应此模式
+
+---
+
+### Option B — Hook-Based Passive Continuity（最低复杂度）
+
+**原理**: 4 个 hooks 组合，不改变用户启动方式。
+1. `SessionStart` — 读取并注入 `.claude/handoff.md`
+2. `PostToolUse` — 通过 transcript 长度启发式监控 context 用量
+3. `PreCompact` — 提醒 Claude 在压缩前写 handoff
+4. `Stop` — 拦截停止（exit code 2），强制 Claude 先完成 handoff
+
+**优点**: 最轻量；与现有 hook 架构完全兼容；不改变用户工作流
+**缺点**: 被动续接 — 仍需用户粘贴 handoff 到新会话；无法自动链接
+
+**Mercury 适配度**: 中 — 解决"不丢 context"但不解决"自动续接"
+
+---
+
+### Option C — CLI Wrapper + Session Monitor（中等复杂度）
+
+**原理**: Shell/Python 脚本监控 `claude` 进程。退出后读 transcript，生成 handoff，再以 `claude -c` 重启。
+
+**优点**: 对用户透明（替换 `claude` 命令）；利用 `-c` 续接
+**缺点**: DIRECTION.md 明确 Mercury 不是"CLI wrapper"；`-c` 依赖 session 文件本地存在
+**Mercury 适配度**: 低-中
+
+---
+
+### Option D — Hybrid：Stop-hook handoff + SDK resume（研究报告推荐）
+
+**原理**: 结合 B 和 A：
+1. `Stop` hook（exit code 2）强制 Claude 在停止前写结构化 handoff 到 auto-memory
+2. SDK orchestrator 脚本检测会话结束，立即以 `resume=session_id` + handoff prompt 启动新会话
+3. `CLAUDE.md` 包含 compaction summary 指令，保留 task state 跨越压缩点
+
+**优点**: 同时解决"不丢 context"和"自动续接"；复用 Phase 3 Memory Layer 存储
+**缺点**: 需要实现两个组件（Stop hook + SDK orchestrator）；orchestrator 需持续运行
+**Mercury 适配度**: 最高
+
+---
+
+## 方案对比矩阵
+
+| 维度 | Option A | Option B | Option C | Option D |
+|------|----------|----------|----------|----------|
+| 自动续接（无需人工粘贴） | ✅ | ❌ | ✅ | ✅ |
+| 不改变用户启动方式 | ❌ | ✅ | ❌ | 需讨论 |
+| 实现复杂度 | 高 | 低 | 中 | 中-高 |
+| 复用 Phase 3 infrastructure | 中 | 高 | 低 | 高 |
+| 依赖外部进程 | ✅ orchestrator | ❌ | ✅ wrapper | ✅ orchestrator |
+| 跨机器恢复支持 | 需 .jsonl 同步 | ✅ (handoff file) | 需 .jsonl | 混合 |
+| 研究报告推荐 | — | — | — | ✅ |
+
+---
+
+## 关键技术事实（来自研究报告）
+
+1. **Agent SDK session resume 已确认可用**: `resume=session_id` + `fork_session=True` 是 stable API
+2. **SDK 无"context 快满"预警**: `compact_boundary` 在压缩后才触发，无 pre-compaction 回调；`max_turns` 可作为代理预算
+3. **Stop hook exit code 2 可拦截**: 已被 claude-code-session-kit 在 92 次真实 session 验证
+4. **`PostCompact` 无 `compact_summary` 字段**: DIRECTION.md 中的引用是 UNVERIFIED（研究确认）
+5. **1M context window 已 GA (2026-03)**: 压缩频率大幅降低，session 寿命更长
+6. **社区验证**: claude-code-session-kit、claude-auto-resume 等项目已证明这些模式可行
+
+---
+
+## 研究报告推荐意见
+
+研究报告推荐 **Option D (Hybrid)**，理由：
+- 利用现有 Phase 3 Memory Layer（AgentKB 存储 handoff）
+- Stop hook 是 Mercury 已有的 hook 架构扩展，不引入新范式
+- SDK orchestrator 可用现有 Python stack 实现
+- 同时解决被动保护（Stop hook）和主动续接（SDK resume）
+
+---
+
+## 待决策事项（需用户拍板）
+
+**核心问题**: 选择哪个 Option？
+
+推荐优先级：D > A > B > C
+
+**若选 Option D / A，需确认**：
+1. **Orchestrator 形态**: 独立 Python 脚本（手动运行）vs 后台守护进程 vs Task Scheduler 定时任务？
+2. **启动方式变更**: 用户是否接受改用 `python orchestrator.py` 启动 Claude Code？或保持 `claude` 直接启动，由 Stop hook 处理？
+3. **Handoff 粒度**: 每次 Stop 都写 handoff（高频但轻量）vs 仅在 context 耗尽时写（低频但必要）？
+
+**若选 Option B**：
+- 仅解决"不丢 context"问题，不实现自动续接，接受需要人工粘贴 handoff
+
+---
+
+## 实施计划（草案，待选型确认后细化）
+
+### Phase 4-1 子里程碑
+
+| 里程碑 | 内容 | 依赖 |
+|--------|------|------|
+| M1: Stop hook | 实现强制 handoff 写入的 Stop hook，exit code 2 拦截 | — |
+| M2: Handoff schema | 定义结构化 handoff 格式（兼容 auto-memory + AgentKB） | M1 |
+| M3: SDK orchestrator | Python 脚本包装会话生命周期（如选 A/D） | M1+M2 |
+| M4: E2E 验证 | 跨会话任务恢复 + AgentKB 知识查询完整测试 | M3 |
+
+---
+
+## 关联 Issues
+
+- **父 Issue**: #183 — Cross-Session State & Continuity (OPEN)
+- **Phase 4-1 子 Issue**: 待创建（关联 #183）
+- **Phase 3 已关闭**: #217 (NAS KB 架构) #218 (MCP compile) #219 (kb-lint)
+- **Phase 3 P1 open**: #232 (flush.py PreCompact fix — 已修复，待 PR)

--- a/.mercury/docs/research/phase4-1-session-continuity-adr-draft.md
+++ b/.mercury/docs/research/phase4-1-session-continuity-adr-draft.md
@@ -1,9 +1,9 @@
 # Phase 4-1 ADR — Session Continuity 技术方案选型
 
-**Status**: DECIDED — 2026-04-13
+**Status**: DECIDED — 2026-04-13 (用户已拍板选定 Option D)
 **Date**: 2026-04-12 (updated 2026-04-13)
-**Issue**: #183 (parent: Phase 3 Memory Layer)
-**Decision authority**: User (最终方案选型需用户拍板)
+**Issue**: #238 (Phase 4-1 实现), parent: #183 (Phase 4 Session Continuity)
+**Decision authority**: User (已完成决策)
 **Research artifact**: `.research/reports/RESEARCH-Session-Continuity-183-2026-04-11.md` (5 questions, 30+ sources)
 
 ---
@@ -123,38 +123,31 @@ Phase 4 在此基础上增加 **结构化 handoff 生成 + 自动续接** 能力
 
 ---
 
-## 待决策事项（需用户拍板）
+## 已决策事项（S47 用户拍板完成）
 
-**核心问题**: 选择哪个 Option？
+**选定方案**: Option D (Hybrid: Stop-hook handoff + SDK resume)
 
-推荐优先级：D > A > B > C
-
-**若选 Option D / A，需确认**：
-1. **Orchestrator 形态**: 独立 Python 脚本（手动运行）vs 后台守护进程 vs Task Scheduler 定时任务？
-2. **启动方式变更**: 用户是否接受改用 `python orchestrator.py` 启动 Claude Code？或保持 `claude` 直接启动，由 Stop hook 处理？
-3. **Handoff 粒度**: 每次 Stop 都写 handoff（高频但轻量）vs 仅在 context 耗尽时写（低频但必要）？
-
-**若选 Option B**：
-- 仅解决"不丢 context"问题，不实现自动续接，接受需要人工粘贴 handoff
+**已确认细节**：
+1. **Orchestrator 形态**: 独立 Python 脚本（`handoff-orchestrator.py`），用户通过 `/handoff` skill 触发
+2. **启动方式**: 保持 `claude` 直接启动，`/handoff` 在 session 内调用，orchestrator 负责续接
+3. **Handoff 粒度**: 用户主动 `/handoff` 或 agent 自主调用；PreCompact 自动写 checkpoint 作为底稿
 
 ---
 
-## 实施计划（草案，待选型确认后细化）
+## 实施计划（已执行，S48 完成）
 
 ### Phase 4-1 子里程碑
 
-| 里程碑 | 内容 | 依赖 |
+| 里程碑 | 内容 | 状态 |
 |--------|------|------|
-| M1: Stop hook | 实现强制 handoff 写入的 Stop hook，exit code 2 拦截 | — |
-| M2: Handoff schema | 定义结构化 handoff 格式（兼容 auto-memory + AgentKB） | M1 |
-| M3: SDK orchestrator | Python 脚本包装会话生命周期（如选 A/D） | M1+M2 |
-| M4: E2E 验证 | 跨会话任务恢复 + AgentKB 知识查询完整测试 | M3 |
+| M0: PreCompact checkpoint | flush.py 检测 PreCompact 触发，写 session-checkpoint.md 到 auto-memory | 🔄 AgentKB PR#5 |
+| M2: session_chain 表 | skill_stats.py 新增表 + session-end.py 自动记录 | 🔄 AgentKB PR#5 |
+| M1: /handoff skill | 全局 skill + handoff-orchestrator.py (Agent SDK) | 🔄 AgentKB PR#5 |
 
 ---
 
 ## 关联 Issues
 
 - **父 Issue**: #183 — Cross-Session State & Continuity (OPEN)
-- **Phase 4-1 子 Issue**: 待创建（关联 #183）
-- **Phase 3 已关闭**: #217 (NAS KB 架构) #218 (MCP compile) #219 (kb-lint)
-- **Phase 3 P1 open**: #232 (flush.py PreCompact fix — 已修复，待 PR)
+- **Phase 4-1 实现 Issue**: #238 (OPEN, 关联 #183)
+- **Phase 3 已关闭**: #217 (NAS KB 架构) #232 (flush.py PreCompact fix, merged)


### PR DESCRIPTION
## Summary

Adds ADR draft for Phase 4-1 Session Continuity implementation decision.

## Context

Phase 3 Memory Layer is complete. Phase 4 begins with selecting a technical approach for session continuity — the ability for Claude Code sessions to resume from where they left off without manual handoff.

## What's in the draft

Four options evaluated from `.research/reports/RESEARCH-Session-Continuity-183-2026-04-11.md`:

| Option | Approach | Complexity | Auto-resume |
|--------|----------|-----------|-------------|
| A | SDK-Based Orchestrator | High | ✅ |
| B | Hook-Based Passive | Low | ❌ |
| C | CLI Wrapper | Medium | ✅ |
| **D** | **Hybrid Stop-hook + SDK resume** | Medium-High | ✅ |

Research report recommends **Option D**.

## Decision Required

This PR is a **draft ADR awaiting user decision**. Implementation (#238) does not start until option is selected.

**Questions for user:**
1. Which option? (Recommended: D > A > B > C)
2. Orchestrator form: standalone script / daemon / Task Scheduler?
3. OK to change how Claude Code is launched?

Refs #238 #183

## Test Plan

- [ ] User reviews ADR and selects option
- [ ] ADR updated with final decision
- [ ] Implementation begins in separate PR