### PR TITLE
feat(handoff): require concrete instructions with Project/Issue query

### DIFF
--- a/.claude/skills/handoff/SKILL.md
+++ b/.claude/skills/handoff/SKILL.md
@@ -43,14 +43,20 @@ Also check:
 Run the following to identify the highest-priority actionable next task:
 ```bash
 # 1. Get P0 and P1 open issues
-gh issue list --label "P0" --state open --json number,title,labels --limit 10
-gh issue list --label "P1" --state open --json number,title,labels --limit 10
+gh issue list --label "P0" --state open --json number,title,labels --limit 50
+gh issue list --label "P1" --state open --json number,title,labels --limit 50
 
 # 2. Get Todo/In-Progress items from GitHub Project #3
-gh project item-list 3 --owner "$(gh repo view --json owner --jq '.owner.login')" --format json --limit 30 | \
-  python -c "import json,sys; data=json.load(sys.stdin); \
-  items=[i for i in data['items'] if i.get('status') in ('Todo','In Progress')]; \
-  [print(i.get('priority','?'), i.get('title','?'), i.get('status','?')) for i in sorted(items, key=lambda x: x.get('priority','P9'))]"
+gh project item-list 3 --owner "$(gh repo view --json owner --jq '.owner.login')" --format json --limit 100 | \
+  python -c "
+import json, sys
+data = json.load(sys.stdin)
+items = [i for i in data.get('items', []) if i.get('status') in ('Todo', 'In Progress')]
+status_order = {'In Progress': 0, 'Todo': 1}
+for i in sorted(items, key=lambda x: (status_order.get(x.get('status', ''), 9), x.get('priority', 'P9'))):
+    num = i.get('content', {}).get('number', '?')
+    print(f'#{num} [{i.get(\"priority\",\"?\")}] {i.get(\"title\",\"?\")} ({i.get(\"status\",\"?\")})')
+"
 ```
 
 Use this data to determine: **what is the single most actionable next task?**
@@ -58,7 +64,7 @@ Selection criteria (in order):
 1. Actively blocked P1 bugs with known root cause
 2. In-Progress items from the Project board
 3. Highest-priority P0 Todo from Project board
-4. Next Phase sub-item per EXECUTION-PLAN.md
+4. Next Phase sub-item per `.mercury/docs/EXECUTION-PLAN.md`
 
 Do NOT produce a menu. Pick one primary task and one secondary task (fallback after primary completes).
 

--- a/.claude/skills/handoff/SKILL.md
+++ b/.claude/skills/handoff/SKILL.md
@@ -42,9 +42,9 @@ Also check:
 
 Run the following to identify the highest-priority actionable next task:
 ```bash
-# 1. Get P0/P1 open issues
+# 1. Get P0 and P1 open issues
+gh issue list --label "P0" --state open --json number,title,labels --limit 10
 gh issue list --label "P1" --state open --json number,title,labels --limit 10
-# Add P0 label check too if applicable
 
 # 2. Get Todo/In-Progress items from GitHub Project #3
 gh project item-list 3 --owner "$(gh repo view --json owner --jq '.owner.login')" --format json --limit 30 | \

--- a/.claude/skills/handoff/SKILL.md
+++ b/.claude/skills/handoff/SKILL.md
@@ -38,6 +38,30 @@ Also check:
 - Recent commits: `git log --oneline -10`
 - Any open tasks in the session
 
+**MANDATORY: Query GitHub Project and Issues for next task determination**
+
+Run the following to identify the highest-priority actionable next task:
+```bash
+# 1. Get P0/P1 open issues
+gh issue list --label "P1" --state open --json number,title,labels --limit 10
+# Add P0 label check too if applicable
+
+# 2. Get Todo/In-Progress items from GitHub Project #3
+gh project item-list 3 --owner <repo-owner> --format json --limit 30 | \
+  python -c "import json,sys; data=json.load(sys.stdin); \
+  items=[i for i in data['items'] if i.get('status') in ('Todo','In Progress')]; \
+  [print(i.get('priority','?'), i.get('title','?'), i.get('status','?')) for i in sorted(items, key=lambda x: x.get('priority','P9'))]"
+```
+
+Use this data to determine: **what is the single most actionable next task?**
+Selection criteria (in order):
+1. Actively blocked P1 bugs with known root cause
+2. In-Progress items from the Project board
+3. Highest-priority P0 Todo from Project board
+4. Next Phase sub-item per EXECUTION-PLAN.md
+
+Do NOT produce a menu. Pick one primary task and one secondary task (fallback after primary completes).
+
 ## Step 2: Generate Handoff Document
 
 Write a structured handoff document to:
@@ -57,11 +81,28 @@ type: project
 
 ## Starting Prompt
 
-<A ready-to-paste prompt for the next session. This is the PRIMARY artifact.
-Include enough context that the next session can immediately resume work.>
+这是 S{N+1}。以下是 S{N} 的完整交接。
+
+### 当前状态
+<repo/branch/commit状态，clean/dirty>
+
+### S{N+1} 主任务：<Issue #N — 具体任务标题>
+
+**背景**：<1-2句说明为什么这是最高优先级，来自Issue/Project数据>
+
+**执行步骤**：
+1. <具体可执行步骤，包含文件路径和命令>
+2. <具体可执行步骤>
+3. <验证方法>
+4. <提交/PR步骤>
+
+**次要任务（主任务完成后）**：<Issue #N 或 Phase X-Y，一句话描述>
+
+### 参考文档
+<仅列出主任务相关的文档>
 
 ## Task State
-- **Issue**: #N [title]
+- **Issue**: #N [title] (status)
 - **Branch**: <branch name>
 - **Completed**: <commit hashes and what they did>
 - **In Progress**: <current step, blockers>
@@ -77,34 +118,23 @@ Include enough context that the next session can immediately resume work.>
 Otherwise write: "No additional instructions.">
 ```
 
+**CRITICAL RULE for Starting Prompt**: The prompt MUST contain a single primary task with numbered execution steps. It MUST NOT be a bulleted list of options. The next session agent should be able to start executing step 1 immediately without asking for direction.
+
 ## Step 3: Update session_chain (if DB exists)
 
 Run this to update the session chain record:
 ```bash
 python -c "
-import os, sqlite3, sys
+import sqlite3, json
 from pathlib import Path
-
-agentkb_dir = os.environ.get('AGENTKB_DIR')
-if not agentkb_dir:
-    print('AGENTKB_DIR is not set — skipping session_chain update')
-    sys.exit(0)
-
-db = Path(agentkb_dir) / 'stats' / 'skill-usage.db'
-if not db.exists():
-    print('skill-usage.db not found, skip session_chain update')
-    sys.exit(0)
-
-try:
+db = Path('$AGENTKB_DIR/stats/skill-usage.db')
+if db.exists():
     with sqlite3.connect(str(db)) as c:
         c.execute('''UPDATE session_chain SET handoff_doc=?, status='handoff'
                      WHERE session_id=? AND status IN ('active','complete')''',
                   ('<path to session-handoff.md>', '<session_id>'))
         c.commit()
         print('session_chain updated')
-except Exception as e:
-    print(f'failed to update session_chain: {e}', file=sys.stderr)
-    sys.exit(1)
 "
 ```
 
@@ -115,7 +145,7 @@ except Exception as e:
 ## Step 5: Offer Continuation (Optional)
 
 Ask the user if they want to automatically start a new session:
-- If yes, run: `uv run --directory "$AGENTKB_DIR" python "$AGENTKB_DIR/scripts/handoff-orchestrator.py" --handoff-doc "<absolute_handoff_path>"`
+- If yes, run: `uv run --directory $AGENTKB_DIR python $AGENTKB_DIR/scripts/handoff-orchestrator.py --handoff-doc <path>`
 - If no, the user will manually paste the starting prompt into a new session
 
 Do NOT auto-launch the orchestrator without user confirmation.

--- a/.claude/skills/handoff/SKILL.md
+++ b/.claude/skills/handoff/SKILL.md
@@ -47,7 +47,7 @@ gh issue list --label "P1" --state open --json number,title,labels --limit 10
 # Add P0 label check too if applicable
 
 # 2. Get Todo/In-Progress items from GitHub Project #3
-gh project item-list 3 --owner <repo-owner> --format json --limit 30 | \
+gh project item-list 3 --owner "$(gh repo view --json owner --jq '.owner.login')" --format json --limit 30 | \
   python -c "import json,sys; data=json.load(sys.stdin); \
   items=[i for i in data['items'] if i.get('status') in ('Todo','In Progress')]; \
   [print(i.get('priority','?'), i.get('title','?'), i.get('status','?')) for i in sorted(items, key=lambda x: x.get('priority','P9'))]"
@@ -125,16 +125,29 @@ Otherwise write: "No additional instructions.">
 Run this to update the session chain record:
 ```bash
 python -c "
-import sqlite3, json
+import os, sqlite3, sys
 from pathlib import Path
-db = Path('$AGENTKB_DIR/stats/skill-usage.db')
-if db.exists():
+
+agentkb_dir = os.environ.get('AGENTKB_DIR')
+if not agentkb_dir:
+    print('AGENTKB_DIR is not set — skipping session_chain update')
+    sys.exit(0)
+
+db = Path(agentkb_dir) / 'stats' / 'skill-usage.db'
+if not db.exists():
+    print('skill-usage.db not found, skip session_chain update')
+    sys.exit(0)
+
+try:
     with sqlite3.connect(str(db)) as c:
         c.execute('''UPDATE session_chain SET handoff_doc=?, status='handoff'
                      WHERE session_id=? AND status IN ('active','complete')''',
                   ('<path to session-handoff.md>', '<session_id>'))
         c.commit()
         print('session_chain updated')
+except Exception as e:
+    print(f'failed to update session_chain: {e}', file=sys.stderr)
+    sys.exit(1)
 "
 ```
 
@@ -145,7 +158,7 @@ if db.exists():
 ## Step 5: Offer Continuation (Optional)
 
 Ask the user if they want to automatically start a new session:
-- If yes, run: `uv run --directory $AGENTKB_DIR python $AGENTKB_DIR/scripts/handoff-orchestrator.py --handoff-doc <path>`
+- If yes, run: `uv run --directory "$AGENTKB_DIR" python "$AGENTKB_DIR/scripts/handoff-orchestrator.py" --handoff-doc "<absolute_handoff_path>"`
 - If no, the user will manually paste the starting prompt into a new session
 
 Do NOT auto-launch the orchestrator without user confirmation.


### PR DESCRIPTION
## Summary
- Step 1 MANDATORY: query GitHub Project #3 + P1 issues to determine the single highest-priority actionable next task before writing handoff
- Selection criteria: P1 bugs (known root cause) > In-Progress > P0 Todo > Next Phase sub-item
- Step 2 Starting Prompt template: numbered execution steps format, no optional-next-steps menu
- CRITICAL RULE added: prompt must be immediately executable without re-selecting direction

## Motivation
Previous `/handoff` outputs produced menus of options instead of concrete session instructions, requiring the user to re-decide direction at the start of each new session.

## Test plan
- [x] Verified on S52→S53 handoff: concrete execution steps generated after querying Project #3 + P1 issues
- [ ] Argus review

Refs: S52 feedback (feedback_handoff_concrete_instructions.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)