### PR TITLE
fix(flush): close #232 — PreCompact flush bypass Agent SDK

### DIFF
--- a/.mercury/docs/research/phase4-1-session-continuity-adr-draft.md
+++ b/.mercury/docs/research/phase4-1-session-continuity-adr-draft.md
@@ -24,7 +24,7 @@ Mercury 的 Phase 4 目标是实现 **Session Continuity**：当一个 Claude Co
 |------|------|
 | AgentKB daily log (flush.py) | ✅ 运行中 |
 | SessionEnd hook | ✅ 全局注册 |
-| PreCompact hook | ✅ 已修复 (#232, AgentKB PR#9: bypass SDK → `claude -p`) |
+| PreCompact hook | ✅ 已修复 (#232, AgentKB [PR#9](https://github.com/392fyc/claude-memory-compiler/pull/9) `9c5adde`: bypass SDK → `claude -p`) |
 | NAS rsync 备份 | ✅ 每小时 rc=0 |
 | AgentKB compile pipeline | ✅ 运行中 |
 
@@ -150,4 +150,4 @@ Phase 4 在此基础上增加 **结构化 handoff 生成 + 自动续接** 能力
 
 - **父 Issue**: #183 — Cross-Session State & Continuity (OPEN)
 - **Phase 4-1 实现 Issue**: #238 (OPEN, 关联 #183)
-- **Phase 3 已关闭**: #217 (NAS KB 架构) #232 (flush.py PreCompact fix — bypass Agent SDK with `claude -p` subprocess, AgentKB PR#9)
+- **Phase 3 已关闭**: #217 (NAS KB 架构) #232 (flush.py PreCompact fix — bypass Agent SDK with `claude -p` subprocess, AgentKB [PR#9](https://github.com/392fyc/claude-memory-compiler/pull/9) `9c5adde`; 验证: SessionEnd FLUSH_OK 6s, PreCompact saved 1298 chars 14s)

--- a/.mercury/docs/research/phase4-1-session-continuity-adr-draft.md
+++ b/.mercury/docs/research/phase4-1-session-continuity-adr-draft.md
@@ -24,7 +24,7 @@ Mercury 的 Phase 4 目标是实现 **Session Continuity**：当一个 Claude Co
 |------|------|
 | AgentKB daily log (flush.py) | ✅ 运行中 |
 | SessionEnd hook | ✅ 全局注册 |
-| PreCompact hook | ✅ 已修复 (#232) |
+| PreCompact hook | ✅ 已修复 (#232, AgentKB PR#9: bypass SDK → `claude -p`) |
 | NAS rsync 备份 | ✅ 每小时 rc=0 |
 | AgentKB compile pipeline | ✅ 运行中 |
 
@@ -150,4 +150,4 @@ Phase 4 在此基础上增加 **结构化 handoff 生成 + 自动续接** 能力
 
 - **父 Issue**: #183 — Cross-Session State & Continuity (OPEN)
 - **Phase 4-1 实现 Issue**: #238 (OPEN, 关联 #183)
-- **Phase 3 已关闭**: #217 (NAS KB 架构) #232 (flush.py PreCompact fix, merged)
+- **Phase 3 已关闭**: #217 (NAS KB 架构) #232 (flush.py PreCompact fix — bypass Agent SDK with `claude -p` subprocess, AgentKB PR#9)


### PR DESCRIPTION
## Summary

- Closes #232 — AgentKB `flush.py` PreCompact intermittent exit code 1
- Actual code fix is in AgentKB [PR#9](https://github.com/392fyc/claude-memory-compiler/pull/9): replaced Agent SDK `query()` with direct `claude -p` subprocess call
- This PR updates Mercury Phase 4-1 ADR to reflect the final fix approach

## Root cause

Agent SDK's bundled CLI intermittently exits with code 1 during PreCompact hooks. The SDK's `_handle_stderr()` silently swallows errors (`except Exception: pass`), and `subprocess_cli.py:616` hardcodes `"Check stderr output for details"` — real stderr is never surfaced.

## Fix

Bypass Agent SDK entirely: call `claude -p` via `subprocess.run(capture_output=True)` for real stderr capture and reliable execution in both SessionEnd and PreCompact trigger paths.

## Test plan

- [x] SessionEnd trigger: FLUSH_OK (6s)
- [x] PreCompact trigger: saved 1298 chars to daily log (14s)
- [ ] Monitor next real PreCompact event in flush.log

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)