### PR TITLE
fix(skill/handoff): remove extra -- sentinel + use /handoff auto syntax (#255)

### DIFF
--- a/.claude/skills/handoff/SKILL.md
+++ b/.claude/skills/handoff/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: handoff
-description: Generate a structured handoff document and ready-to-paste starting prompt for the next session. Use `/handoff` for manual mode (output only). Use `/handoff:auto` to auto-launch the new session via `claude` CLI after the document is written.
-argument-hint: "[:auto] [optional extra instructions for the next session]"
+description: Generate a structured handoff document and ready-to-paste starting prompt for the next session. Use `/handoff` for manual mode (output only). Use `/handoff auto` to auto-launch the new session via `claude` CLI after the document is written.
+argument-hint: "[auto] [optional extra instructions for the next session]"
 user-invocable: true
 allowed-tools:
   - Read
@@ -24,19 +24,24 @@ Parse `$ARGUMENTS`:
 |---|---|---|
 | `/handoff` (no args) | **manual** | Write doc + output starting prompt in chat. Do NOT launch a new session. Old session stays alive by user choice. |
 | `/handoff <instructions>` | **manual + extra** | Same as manual; put `<instructions>` into the "User Instructions" section of the handoff doc. |
-| `/handoff:auto` | **auto** | Write doc + output starting prompt + **auto-launch** new session via `claude` CLI after Pre-Termination Checklist passes. Old session should `/exit` after — auto mode treats the old session as a terminal event. |
-| `/handoff:auto <instructions>` | **auto + extra** | Same as auto, with extra instructions embedded. |
-| `/handoff auto` (legacy) | **auto** | Same as `/handoff:auto`. Accept both syntaxes. |
+| `/handoff auto` | **auto** | Write doc + output starting prompt + **auto-launch** new session via `claude` CLI after Pre-Termination Checklist passes. Old session should `/exit` after — auto mode treats the old session as a terminal event. |
+| `/handoff auto <instructions>` | **auto + extra** | Same as auto, with extra instructions embedded. |
 
-Default (no explicit auto): manual mode. Never auto-launch without an
-explicit `:auto` / `auto` token.
+Default (no explicit `auto`): manual mode. Never auto-launch without an
+explicit `auto` token as the first whitespace-delimited argument.
 
-**Strict parsing**: `:auto` must be either the first argument or part of
-the command syntax (`/handoff:auto`). `/handoff auto` is accepted only
-when `auto` is the **sole** argument or the first whitespace-delimited
-token (i.e., `/handoff auto <extra>` is auto+extra, `/handoff automatic`
-is **manual** with instructions "automatic"). This prevents accidental
-auto-spawn from user instructions that happen to start with "auto".
+**Note on `/handoff:auto`**: Claude Code's colon syntax (`<x>:<y>`) is
+reserved for plugin namespacing (e.g. `/plugin-name:skill-name`). A
+project-level skill registered as `handoff` only resolves via `/handoff`,
+and `/handoff:auto` is NOT a valid slash invocation for this skill — the
+parser will treat it as an unknown command. Always use `/handoff auto`
+(space-delimited).
+
+**Strict parsing**: `auto` must be the **sole** argument or the first
+whitespace-delimited token (i.e., `/handoff auto <extra>` is auto+extra,
+`/handoff automatic` is **manual** with instructions "automatic"). This
+prevents accidental auto-spawn from user instructions that happen to
+start with "auto".
 
 **Terminal-event semantics**: "handoff is a terminal event for the old
 session" only applies to **auto mode** — the old session is expected to
@@ -271,15 +276,20 @@ this one. Do NOT spawn any new process.
 
 Optional: offer to launch if the user later says so (Step 6).
 
-### Auto mode (`/handoff:auto`)
+### Auto mode (`/handoff auto`)
 
 After Step 5.1 + 5.2, and Pre-Termination Checklist passed:
 
-**Required launch pattern — write prompt to a temp file, then pass via
-`claude -- "$(...)"` to defeat option parsing and shell-escape hazards.**
-The inline string forms below are shown only as the final shape of the
-command; do NOT concatenate an unescaped prompt directly into the command
-line.
+**Required launch pattern — write prompt to a locked-down temp file, then
+pass via `claude "$(cat ...)"` as a single positional argument.** This
+matches the canonical `claude-handoff` plugin shape
+(<https://github.com/392fyc/claude-handoff>) which has been validated
+end-to-end on Windows (wt + PowerShell profile). Do NOT insert a `--`
+sentinel between `claude` and the prompt — on Windows, `wt` spawns
+`claude.cmd` (npm shim) directly via CreateProcess; cmd.exe's batch
+re-parser can mis-handle the extra `--`, causing the new tab to open
+with no running process. Handoff prompts always start with literal text
+(e.g. `这是 S{N+1}`), never with `-`, so the `--` sentinel is unnecessary.
 
 **Prerequisites**: auto-mode launch assumes a POSIX-like shell (`mktemp`,
 `chmod`, `cat`, heredoc). On Windows this means **Git Bash / MSYS2 / WSL**
@@ -315,12 +325,12 @@ Set-Content -LiteralPath $TMP -Value @'
 
 **Windows** (Windows Terminal, new tab — `wt` opens a real new tab):
 ```bash
-wt -w 0 nt --title "Handoff" -- claude -- "$(cat "$TMP")"
+wt -w 0 nt --title "Handoff" -- claude "$(cat "$TMP")"
 ```
 
 **macOS / Linux with tmux** (real new window, detached from current TTY):
 ```bash
-tmux new-window -n handoff "claude -- \"\$(cat $TMP)\""
+tmux new-window -n handoff "claude \"\$(cat $TMP)\""
 ```
 
 **macOS / Linux without tmux** — there is no portable "new terminal"
@@ -334,14 +344,12 @@ themselves.
 
 ```bash
 # Detached tmux session (survives current shell exit):
-tmux new-session -d -s handoff "claude -- \"\$(cat $TMP)\""
+tmux new-session -d -s handoff "claude \"\$(cat $TMP)\""
 # Then `tmux attach -t handoff` from the user's preferred terminal.
 ```
 
-The positional argument after `--` is the session's first user message —
-documented at <https://code.claude.com/docs/en/cli-reference>. The `--`
-sentinel ensures a prompt beginning with `-` is not parsed as a CLI option
-(<https://github.com/anthropics/claude-code/issues/3844>). The
+The positional argument to `claude` is the session's first user message —
+documented at <https://code.claude.com/docs/en/cli-reference>. The
 SessionStart hook will inject the full handoff document as
 `additionalContext`, so the new session has everything.
 
@@ -384,8 +392,9 @@ the auto path from Step 5 (auto mode).
   a manual invocation.
 - Before terminating (auto mode) verify all pending work has completed.
   Nothing carries over automatically.
-- Manual mode MUST NOT spawn processes. Only `:auto` (or legacy `auto`) token
-  triggers the `claude` CLI launch.
+- Manual mode MUST NOT spawn processes. Only the `auto` token (as the
+  first whitespace-delimited argument to `/handoff`) triggers the `claude`
+  CLI launch.
 - The legacy `$AGENTKB_DIR/scripts/handoff-orchestrator.py` path is
   DEPRECATED. Do not invoke it. The `claude-handoff` plugin is the
   canonical session-continuity module

--- a/.claude/skills/handoff/SKILL.md
+++ b/.claude/skills/handoff/SKILL.md
@@ -3,12 +3,7 @@ name: handoff
 description: Generate a structured handoff document and ready-to-paste starting prompt for the next session. Use `/handoff` for manual mode (output only). Use `/handoff auto` to auto-launch the new session via `claude` CLI after the document is written.
 argument-hint: "[auto] [optional extra instructions for the next session]"
 user-invocable: true
-allowed-tools:
-  - Read
-  - Write
-  - Bash
-  - Glob
-  - Grep
+allowed-tools: Read, Write, Bash, Glob, Grep
 ---
 
 # /handoff — Session Handoff & Continuation
@@ -345,7 +340,7 @@ wt -w 0 nt --title "Handoff" -- claude "$(cat "$TMP")"
 
 **macOS / Linux with tmux** (real new window, detached from current TTY):
 ```bash
-tmux new-window -n handoff "claude \"\$(cat $TMP)\""
+tmux new-window -n handoff "claude \"\$(cat \"$TMP\")\""
 ```
 
 **macOS / Linux without tmux** — there is no portable "new terminal"
@@ -359,7 +354,7 @@ themselves.
 
 ```bash
 # Detached tmux session (survives current shell exit):
-tmux new-session -d -s handoff "claude \"\$(cat $TMP)\""
+tmux new-session -d -s handoff "claude \"\$(cat \"$TMP\")\""
 # Then `tmux attach -t handoff` from the user's preferred terminal.
 ```
 

--- a/.claude/skills/handoff/SKILL.md
+++ b/.claude/skills/handoff/SKILL.md
@@ -108,7 +108,9 @@ else
   OWNER=$(gh repo view --json owner --jq '.owner.login' 2>/dev/null)
   PROJ_NUM="${HANDOFF_PROJECT_NUM:-}"
 
-  if [ -n "$PROJ_NUM" ]; then
+  if [ -z "$OWNER" ]; then
+    echo "INFO: could not resolve repo owner via gh — skipping Project query"
+  elif [ -n "$PROJ_NUM" ]; then
     gh project item-list "$PROJ_NUM" --owner "$OWNER" --format json --limit 100 2>/dev/null | \
       python -c "
 import json, sys
@@ -308,14 +310,21 @@ version; stdin support is documented at
 
 ```bash
 # Step A (POSIX shells — Git Bash, WSL, macOS, Linux):
-# write the verbatim prompt to a locked-down temp file.
-TMP=$(mktemp) && chmod 600 "$TMP" && cat > "$TMP" <<'PROMPT_EOF'
+# Create temp file, register cleanup BEFORE writing sensitive content, then write.
+# Ordering rationale: if any later step (chmod, heredoc, launch) fails or is
+# interrupted, the EXIT trap still fires and removes the file. Registering the
+# trap after the write would leave a window where a crash leaks handoff content.
+TMP=$(mktemp) || { echo "ERROR: mktemp failed" >&2; exit 1; }
+trap 'rm -f "$TMP"' EXIT
+chmod 600 "$TMP" || { echo "ERROR: chmod failed" >&2; exit 1; }
+cat > "$TMP" <<'PROMPT_EOF'
 <STARTING_PROMPT_VERBATIM>
 PROMPT_EOF
 ```
 
 ```powershell
 # Step A (PowerShell on Windows, if no Git Bash):
+# Register cleanup via try/finally around the launch (see Step B below).
 $TMP = [System.IO.Path]::GetTempFileName()
 Set-Content -LiteralPath $TMP -Value @'
 <STARTING_PROMPT_VERBATIM>
@@ -353,15 +362,18 @@ documented at <https://code.claude.com/docs/en/cli-reference>. The
 SessionStart hook will inject the full handoff document as
 `additionalContext`, so the new session has everything.
 
-**Cleanup (always run, regardless of branch taken)**:
+**Cleanup**:
 
-```bash
-# POSIX: run after launch succeeds; use trap for failure paths.
-trap 'rm -f "$TMP"' EXIT
-```
+On POSIX shells the `trap 'rm -f "$TMP"' EXIT` is already registered in
+Step A above, immediately after `mktemp` — it fires on the shell's EXIT
+regardless of whether the launch command succeeded, failed, or was
+interrupted. No additional cleanup code is needed here.
+
+On PowerShell, wrap the launch in try/finally so the temp file is removed
+even if the launch throws:
 
 ```powershell
-# PowerShell: run after launch; use try/finally for failure paths.
+# PowerShell: register cleanup around the launch.
 try { <launch command> } finally { Remove-Item -LiteralPath $TMP -Force -ErrorAction SilentlyContinue }
 ```
 

--- a/.claude/skills/handoff/SKILL.md
+++ b/.claude/skills/handoff/SKILL.md
@@ -246,8 +246,14 @@ may not yet be wired at session-start.py.
 ## Step 4: Pre-Termination Checklist
 
 Before launching a new session (auto mode) OR outputting the prompt (manual
-mode), verify **all** in-flight work has finished. A handoff is a
-**terminal event** for the old session — nothing carries over automatically.
+mode), verify **all** in-flight work has finished or been explicitly
+deferred. In **auto mode**, the handoff is a **terminal event** for the
+old session — once the new session is spawned, the old session should
+`/exit`. In **manual mode**, producing the handoff prompt is **not**
+itself a terminal event; the output is a stable snapshot that the next
+session (or the current session continuing) can pick up from. In either
+mode, nothing carries over automatically to the next session unless it
+goes through the written handoff document + auto-memory path.
 
 Confirm each:
 


### PR DESCRIPTION
## Summary

Fixes two bugs introduced during Argus iter-4 hardening of #253 that broke `/handoff auto` on Windows:

1. **`wt` new tab opened but `claude` did not start.** Extra `--` inserted between `claude` and the prompt argument — canonical `claude-handoff` plugin v1.0.0-alpha.1 uses `claude "$prompt"` (no `--`). On Windows, `wt` CreateProcesses `claude.cmd` (npm shim) directly; cmd.exe's batch re-parser mis-handled the extra `--`, causing the new tab to open with no running process. Fix: drop the `--`.
2. **`/handoff:auto` not a valid slash invocation.** Claude Code `<x>:<y>` colon syntax is reserved for plugin namespacing — project-level skills only resolve via `/handoff`. Fix: all `/handoff:auto` → `/handoff auto` (space-delimited argument). Strict parsing preserves `/handoff automatic` → manual mode.

Docs-only change to `.claude/skills/handoff/SKILL.md` (37 insertions / 28 deletions). No behavior change to the `$ARGUMENTS` parser — `auto` as the first whitespace-delimited token was already supported.

## Test plan

- [ ] `/handoff` (no args) → manual mode, outputs prompt only, no process spawn
- [ ] `/handoff auto` → writes doc, writes temp file, runs `wt ... -- claude "$(cat "$TMP")"`, new tab opens **and claude starts** with handoff prompt
- [ ] `/handoff automatic` → manual mode with instructions="automatic" (NOT auto mode)
- [ ] `/handoff:auto` (colon form) → unknown command (documented as not supported)
- [ ] Temp file cleanup via `trap 'rm -f "$TMP"' EXIT` still fires

## Sources

- https://github.com/anthropics/claude-code/issues/41842
- https://code.claude.com/docs/en/slash-commands
- https://github.com/392fyc/claude-handoff (v1.0.0-alpha.1 canonical pattern)

Closes #255.
Refs #253.

Generated with Claude Code