### PR TITLE
feat(memory/phase-a): mem0 adapter prototype with four P1-bug guards (#252)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,9 @@ mercury.config.json
 # Autoresearch state (standalone mode, transient)
 .research/
 
+# mem0 test venv (Phase A)
+.venv-mem0/
+
 # PR review agent guide (deployment-specific doc, not committed)
 .mercury/docs/guides/argus-review-guide.md
 # .pr_agent.toml is committed (project-scope config for Argus use_repo_settings_file)

--- a/.mercury/docs/guides/mem0-setup.md
+++ b/.mercury/docs/guides/mem0-setup.md
@@ -1,0 +1,92 @@
+# mem0 Memory Layer — Setup (Phase A)
+
+Phase A deliverable for [#252](https://github.com/392fyc/Mercury/issues/252).
+Research basis: `.mercury/docs/research/memory-layer-rebuild-2026-04-16.md`.
+
+## Scope
+
+Phase A ships only the adapter, migration, and smoke-test.
+**Hooks are NOT wired yet** — that is Phase B (#252).
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `scripts/mem0_hooks.py` | Adapter with 4 mandatory P1-bug guards |
+| `scripts/mem0_migrate.py` | One-shot AgentKB Markdown -> mem0 importer |
+| `scripts/mem0_smoke_test.py` | Regression test for every guard |
+| `requirements-mem0.txt` | Pinned deps (mem0ai 1.0.11+, qdrant-client 1.9+) |
+
+## One-time install
+
+Bash (Git Bash / MSYS2):
+
+```bash
+python -m venv .venv-mem0
+. .venv-mem0/Scripts/activate
+pip install -r requirements-mem0.txt
+```
+
+PowerShell:
+
+```powershell
+python -m venv .venv-mem0
+. .\.venv-mem0\Scripts\Activate.ps1
+pip install -r requirements-mem0.txt
+```
+
+Required env vars (register in global `settings.json` once Phase B wires live hooks).
+
+Bash:
+
+```bash
+export MEM0_TELEMETRY=false
+export ANONYMIZED_TELEMETRY=false
+export OPENAI_API_KEY=sk-...
+```
+
+PowerShell:
+
+```powershell
+$env:MEM0_TELEMETRY         = 'false'
+$env:ANONYMIZED_TELEMETRY   = 'false'
+$env:OPENAI_API_KEY         = 'sk-...'
+```
+
+Optional overrides:
+
+- `MERCURY_MEM0_QDRANT_PATH` — Qdrant on-disk storage (default `.mercury/state/mem0/qdrant`)
+- `MERCURY_MEM0_HISTORY_PATH` — SQLite history DB (default `.mercury/state/mem0/history.db`)
+- `MERCURY_MEM0_CONFIG` — JSON path overriding the full `Memory.from_config` dict
+
+Default paths live under `.mercury/state/` (git-ignored; chosen over `/tmp/qdrant` because that path is broken on Windows).
+
+## Smoke test
+
+```bash
+python scripts/mem0_smoke_test.py
+```
+
+Exit 0 = all four P1-bug guards hold (#4099 empty-payload, #4453 threshold absent, #4536 dedup, #4799 list-coerce).
+Non-zero = regression — do NOT proceed to Phase B.
+
+## AgentKB migration (dry-run first)
+
+```bash
+python scripts/mem0_migrate.py --source "$AGENTKB_DIR" --dry-run
+python scripts/mem0_migrate.py --source "$AGENTKB_DIR"
+```
+
+Source Markdown is never modified (additive migration; rollback = ignore mem0 store).
+
+## Adoption preconditions (MUST remain true)
+
+From research doc §Q2:
+
+1. Single-user runtime only.
+2. Never pass `threshold=` to `Memory.search()` — `search_safe` enforces.
+3. Content must be a plain string; list-shaped input is coerced by `add_safe`.
+4. LLM is not Gemini-3 (Claude / GPT only).
+5. Telemetry opt-out enforced via env vars above.
+
+If any precondition is violated in future work, re-derive the choice before continuing.

--- a/.mercury/docs/guides/mem0-setup.md
+++ b/.mercury/docs/guides/mem0-setup.md
@@ -57,7 +57,7 @@ Optional overrides:
 
 - `MERCURY_MEM0_QDRANT_PATH` — Qdrant on-disk storage (default `.mercury/state/mem0/qdrant`)
 - `MERCURY_MEM0_HISTORY_PATH` — SQLite history DB (default `.mercury/state/mem0/history.db`)
-- `MERCURY_MEM0_CONFIG` — JSON path overriding the full `Memory.from_config` dict
+- `MERCURY_MEM0_CONFIG` — JSON path overriding the full `Memory.from_config` dict. **The path must live inside the repo directory** (enforced via `Path.relative_to(repo_root)`); paths outside the repo are ignored with a `stderr` warning and defaults are used. This is a deliberate security clamp — see commit `56d28b3` — so untrusted env vars cannot redirect reads to arbitrary filesystem locations.
 
 Default paths live under `.mercury/state/` (git-ignored; chosen over `/tmp/qdrant` because that path is broken on Windows).
 

--- a/requirements-mem0.txt
+++ b/requirements-mem0.txt
@@ -1,5 +1,8 @@
 # Mercury memory layer — mem0 self-hosted stack.
-# Pinned against research doc memory-layer-rebuild-2026-04-16.md (v1.0.11 stable; v2.0.0b still beta).
+# Constrained version ranges (not exact pins) — research doc
+# memory-layer-rebuild-2026-04-16.md picked v1.0.11 as the stable floor and
+# excluded v2.0.0b1 (still beta). Upgrades across the floor are validated by
+# running scripts/mem0_unit_test.py + scripts/mem0_smoke_test.py before pin-bump.
 # Verified 2026-04-17: pypi.org/project/mem0ai/, docs.mem0.ai/open-source/overview
 mem0ai>=1.0.11,<2.0.0
 qdrant-client>=1.9.0

--- a/requirements-mem0.txt
+++ b/requirements-mem0.txt
@@ -1,0 +1,5 @@
+# Mercury memory layer — mem0 self-hosted stack.
+# Pinned against research doc memory-layer-rebuild-2026-04-16.md (v1.0.11 stable; v2.0.0b still beta).
+# Verified 2026-04-17: pypi.org/project/mem0ai/, docs.mem0.ai/open-source/overview
+mem0ai>=1.0.11,<2.0.0
+qdrant-client>=1.9.0

--- a/scripts/mem0_hooks.py
+++ b/scripts/mem0_hooks.py
@@ -1,0 +1,159 @@
+"""Mercury adapter for mem0 self-hosted memory layer.
+
+Wraps mem0ai.Memory with four mandatory guards against known P1 bugs:
+- #4099 empty-payload hallucination -> add_safe refuses empty content
+- #4799 list-content AttributeError -> add_safe coerces list -> str
+- #4453 threshold filtering broken  -> search_safe never forwards threshold
+- #4536 contradicting-facts silent corruption -> dedup_guard cosine reject
+
+Preconditions (see research doc memory-layer-rebuild-2026-04-16.md):
+single-user runtime, string content only, non-Gemini-3 models, telemetry off.
+"""
+
+from __future__ import annotations
+
+import os
+
+# Must run before anything that could trigger a `mem0` import anywhere in the
+# process; mem0's PostHog telemetry reads these at module-load time.
+os.environ.setdefault("MEM0_TELEMETRY", "false")
+os.environ.setdefault("ANONYMIZED_TELEMETRY", "false")
+
+import json  # noqa: E402
+import threading  # noqa: E402
+from pathlib import Path  # noqa: E402
+from typing import Any, Iterable  # noqa: E402
+
+_DEFAULT_USER = "mercury"
+_DEDUP_THRESHOLD = 0.92
+
+_memory_singleton: Any = None
+_lock = threading.Lock()
+
+
+def _default_qdrant_path() -> str:
+    root = os.environ.get("MERCURY_MEM0_QDRANT_PATH")
+    if root:
+        return root
+    base = Path(__file__).resolve().parents[1] / ".mercury" / "state" / "mem0" / "qdrant"
+    base.mkdir(parents=True, exist_ok=True)
+    return str(base)
+
+
+def _default_history_path() -> str:
+    root = os.environ.get("MERCURY_MEM0_HISTORY_PATH")
+    if root:
+        return root
+    base = Path(__file__).resolve().parents[1] / ".mercury" / "state" / "mem0"
+    base.mkdir(parents=True, exist_ok=True)
+    return str(base / "history.db")
+
+
+def _build_config() -> dict[str, Any]:
+    override = os.environ.get("MERCURY_MEM0_CONFIG")
+    if override and Path(override).exists():
+        return json.loads(Path(override).read_text(encoding="utf-8"))
+    return {
+        "vector_store": {
+            "provider": "qdrant",
+            "config": {
+                "collection_name": "mercury",
+                "path": _default_qdrant_path(),
+                "on_disk": True,
+            },
+        },
+        "history_db_path": _default_history_path(),
+    }
+
+
+def get_memory() -> Any:
+    global _memory_singleton
+    if _memory_singleton is not None:
+        return _memory_singleton
+    with _lock:
+        if _memory_singleton is None:
+            from mem0 import Memory  # type: ignore
+
+            _memory_singleton = Memory.from_config(_build_config())
+    return _memory_singleton
+
+
+def _coerce_str(content: Any) -> str | None:
+    """Return a safe string for mem0, or None if the input should be rejected.
+
+    Rejects None and bytes outright (would otherwise store junk like 'None' or
+    "b'...'"); everything else is rendered via str(). Lists are joined on '\\n'.
+    """
+    if content is None:
+        return None
+    if isinstance(content, (bytes, bytearray)):
+        return None
+    if isinstance(content, str):
+        return content
+    if isinstance(content, Iterable):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, dict) and "content" in item:
+                parts.append(str(item["content"]))
+            else:
+                parts.append(str(item))
+        return "\n".join(p for p in parts if p)
+    return str(content)
+
+
+def dedup_guard(content: str, user_id: str) -> bool:
+    """Return True if content is novel enough to add, False otherwise.
+
+    Fails CLOSED: if the dedup search itself errors, we skip the add so a
+    broken search layer cannot silently re-enable #4536 corruption.
+    """
+    try:
+        existing = search_safe(content, user_id=user_id, limit=3)
+    except Exception as exc:
+        print(f"[mem0_hooks] dedup_guard search failed, skipping add: {exc}")
+        return False
+    for hit in existing or []:
+        score = hit.get("score") if isinstance(hit, dict) else None
+        if isinstance(score, (int, float)) and score >= _DEDUP_THRESHOLD:
+            return False
+    return True
+
+
+def add_safe(
+    content: Any,
+    user_id: str = _DEFAULT_USER,
+    metadata: dict[str, Any] | None = None,
+    skip_dedup: bool = False,
+) -> Any:
+    """Safe wrapper around Memory.add(). Returns result dict, or None if skipped."""
+    coerced = _coerce_str(content)
+    if coerced is None:
+        return None
+    text = coerced.strip()
+    if not text:
+        return None
+    if not skip_dedup and not dedup_guard(text, user_id=user_id):
+        return None
+    mem = get_memory()
+    return mem.add(text, user_id=user_id, metadata=metadata or {})
+
+
+def search_safe(
+    query: str,
+    user_id: str = _DEFAULT_USER,
+    limit: int = 5,
+) -> list[dict[str, Any]]:
+    """Safe wrapper around Memory.search(). Never passes threshold (bug #4453)."""
+    if not query or not query.strip():
+        return []
+    mem = get_memory()
+    result = mem.search(query=query, user_id=user_id, limit=limit)
+    if isinstance(result, dict):
+        return result.get("results", []) or []
+    return list(result or [])
+
+
+def reset_for_tests() -> None:
+    global _memory_singleton
+    with _lock:
+        _memory_singleton = None

--- a/scripts/mem0_hooks.py
+++ b/scripts/mem0_hooks.py
@@ -20,6 +20,7 @@ os.environ.setdefault("MEM0_TELEMETRY", "false")
 os.environ.setdefault("ANONYMIZED_TELEMETRY", "false")
 
 import json  # noqa: E402
+import sys  # noqa: E402
 import threading  # noqa: E402
 from pathlib import Path  # noqa: E402
 from typing import Any  # noqa: E402
@@ -53,13 +54,25 @@ def _build_config() -> dict[str, Any]:
     override = os.environ.get("MERCURY_MEM0_CONFIG")
     if override:
         base_dir = Path(__file__).resolve().parents[1]
+        cfg_path = Path(override).expanduser().resolve()
+        # Bad JSON is a caller mistake — raise loudly rather than mask with
+        # defaults; path / missing-file issues warn and fall through.
         try:
-            cfg_path = Path(override).expanduser().resolve()
-            cfg_path.relative_to(base_dir)  # must live inside the repo
+            cfg_path.relative_to(base_dir)
+        except ValueError:
+            print(
+                f"[mem0_hooks] WARNING: MERCURY_MEM0_CONFIG={override} is outside"
+                f" the repo ({base_dir}); using defaults.",
+                file=sys.stderr,
+            )
+        else:
             if cfg_path.is_file():
                 return json.loads(cfg_path.read_text(encoding="utf-8"))
-        except Exception as exc:
-            print(f"[mem0_hooks] MERCURY_MEM0_CONFIG unusable, falling back to defaults: {exc}")
+            print(
+                f"[mem0_hooks] WARNING: MERCURY_MEM0_CONFIG={override} not found;"
+                " using defaults.",
+                file=sys.stderr,
+            )
     return {
         "vector_store": {
             "provider": "qdrant",

--- a/scripts/mem0_hooks.py
+++ b/scripts/mem0_hooks.py
@@ -103,10 +103,11 @@ def get_memory() -> Any:
 def _coerce_str(content: Any) -> str | None:
     """Return a safe string for mem0, or None if the input should be rejected.
 
-    Accepted: str, dict (pulls "content" key), list/tuple/set of the above.
-    Rejected (returns None): None, bytes, bytearray, and any other shape —
-    generators / arbitrary Iterables are refused so we never silently consume
-    a large stream or mis-concatenate unexpected objects.
+    Accepted: str, dict (pulls "content" key), list/tuple of the above.
+    Rejected (returns None): None, bytes, bytearray, set (iteration order is
+    non-deterministic → memory contents would drift across runs), and any
+    other shape — generators / arbitrary Iterables are refused so we never
+    silently consume a large stream or mis-concatenate unexpected objects.
     """
     if content is None:
         return None
@@ -118,7 +119,7 @@ def _coerce_str(content: Any) -> str | None:
         if "content" in content:
             return str(content["content"])
         return None
-    if isinstance(content, (list, tuple, set)):
+    if isinstance(content, (list, tuple)):
         parts: list[str] = []
         for item in content:
             if isinstance(item, str):

--- a/scripts/mem0_hooks.py
+++ b/scripts/mem0_hooks.py
@@ -22,7 +22,7 @@ os.environ.setdefault("ANONYMIZED_TELEMETRY", "false")
 import json  # noqa: E402
 import threading  # noqa: E402
 from pathlib import Path  # noqa: E402
-from typing import Any, Iterable  # noqa: E402
+from typing import Any  # noqa: E402
 
 _DEFAULT_USER = "mercury"
 _DEDUP_THRESHOLD = 0.92
@@ -51,8 +51,15 @@ def _default_history_path() -> str:
 
 def _build_config() -> dict[str, Any]:
     override = os.environ.get("MERCURY_MEM0_CONFIG")
-    if override and Path(override).exists():
-        return json.loads(Path(override).read_text(encoding="utf-8"))
+    if override:
+        base_dir = Path(__file__).resolve().parents[1]
+        try:
+            cfg_path = Path(override).expanduser().resolve()
+            cfg_path.relative_to(base_dir)  # must live inside the repo
+            if cfg_path.is_file():
+                return json.loads(cfg_path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            print(f"[mem0_hooks] MERCURY_MEM0_CONFIG unusable, falling back to defaults: {exc}")
     return {
         "vector_store": {
             "provider": "qdrant",
@@ -81,8 +88,10 @@ def get_memory() -> Any:
 def _coerce_str(content: Any) -> str | None:
     """Return a safe string for mem0, or None if the input should be rejected.
 
-    Rejects None and bytes outright (would otherwise store junk like 'None' or
-    "b'...'"); everything else is rendered via str(). Lists are joined on '\\n'.
+    Accepted: str, dict (pulls "content" key), list/tuple/set of the above.
+    Rejected (returns None): None, bytes, bytearray, and any other shape —
+    generators / arbitrary Iterables are refused so we never silently consume
+    a large stream or mis-concatenate unexpected objects.
     """
     if content is None:
         return None
@@ -90,15 +99,21 @@ def _coerce_str(content: Any) -> str | None:
         return None
     if isinstance(content, str):
         return content
-    if isinstance(content, Iterable):
+    if isinstance(content, dict):
+        if "content" in content:
+            return str(content["content"])
+        return None
+    if isinstance(content, (list, tuple, set)):
         parts: list[str] = []
         for item in content:
             if isinstance(item, dict) and "content" in item:
                 parts.append(str(item["content"]))
+            elif isinstance(item, str):
+                parts.append(item)
             else:
                 parts.append(str(item))
         return "\n".join(p for p in parts if p)
-    return str(content)
+    return None
 
 
 def dedup_guard(content: str, user_id: str) -> bool:
@@ -149,8 +164,12 @@ def search_safe(
     mem = get_memory()
     result = mem.search(query=query, user_id=user_id, limit=limit)
     if isinstance(result, dict):
-        return result.get("results", []) or []
-    return list(result or [])
+        rows = result.get("results", [])
+        return rows if isinstance(rows, list) else []
+    if isinstance(result, list):
+        return result
+    print(f"[mem0_hooks] unexpected search() return type: {type(result).__name__}")
+    return []
 
 
 def reset_for_tests() -> None:

--- a/scripts/mem0_hooks.py
+++ b/scripts/mem0_hooks.py
@@ -15,9 +15,11 @@ from __future__ import annotations
 import os
 
 # Must run before anything that could trigger a `mem0` import anywhere in the
-# process; mem0's PostHog telemetry reads these at module-load time.
-os.environ.setdefault("MEM0_TELEMETRY", "false")
-os.environ.setdefault("ANONYMIZED_TELEMETRY", "false")
+# process; mem0's PostHog telemetry reads these at module-load time. Force
+# (not setdefault) so a parent process that exported MEM0_TELEMETRY=true
+# cannot re-enable PostHog reporting behind our back.
+os.environ["MEM0_TELEMETRY"] = "false"
+os.environ["ANONYMIZED_TELEMETRY"] = "false"
 
 import json  # noqa: E402
 import sys  # noqa: E402
@@ -119,12 +121,18 @@ def _coerce_str(content: Any) -> str | None:
     if isinstance(content, (list, tuple, set)):
         parts: list[str] = []
         for item in content:
-            if isinstance(item, dict) and "content" in item:
-                parts.append(str(item["content"]))
-            elif isinstance(item, str):
+            if isinstance(item, str):
                 parts.append(item)
+            elif isinstance(item, dict) and "content" in item:
+                piece = item["content"]
+                if isinstance(piece, str):
+                    parts.append(piece)
+                else:
+                    # nested non-string content — reject whole container rather
+                    # than silently stringify None/bytes/objects into the memory
+                    return None
             else:
-                parts.append(str(item))
+                return None
         return "\n".join(p for p in parts if p)
     return None
 

--- a/scripts/mem0_migrate.py
+++ b/scripts/mem0_migrate.py
@@ -43,10 +43,15 @@ def _parse_frontmatter(text: str, dropped: dict[str, int] | None = None) -> tupl
     # opening and closing fences counts for both, making empty frontmatter
     # ('---\n---\nbody') parse correctly.
     end = text.find("\n---\n", 3)
-    if end == -1:
+    if end != -1:
+        header = text[4:end]
+        body = text[end + 5 :]
+    elif text.endswith("\n---"):
+        # Document ending with a bare '---' fence (no trailing newline).
+        header = text[4:-4]
+        body = ""
+    else:
         return {}, text
-    header = text[4:end]
-    body = text[end + 5 :]
     meta: dict[str, Any] = {}
     if not header.strip():
         return meta, body

--- a/scripts/mem0_migrate.py
+++ b/scripts/mem0_migrate.py
@@ -28,6 +28,11 @@ def _parse_frontmatter(text: str) -> tuple[dict[str, Any], str]:
     recognised and stripped. Anything that does not look like frontmatter is
     returned untouched so the body survives intact.
     """
+    # Normalize line endings — Path.read_text uses universal newlines on POSIX
+    # but callers may hand us raw bytes.decode() with CRLF preserved; belt +
+    # suspenders so Windows files still parse correctly.
+    if "\r\n" in text:
+        text = text.replace("\r\n", "\n")
     if not text.startswith("---\n"):
         return {}, text
     # Start the close-marker search at index 3 so the shared '\n' between

--- a/scripts/mem0_migrate.py
+++ b/scripts/mem0_migrate.py
@@ -86,17 +86,19 @@ def _parse_frontmatter(text: str, dropped: dict[str, int] | None = None) -> tupl
     return meta, body
 
 
-def migrate(source: Path, user_id: str, dry_run: bool) -> tuple[int, int]:
+def migrate(source: Path, user_id: str, dry_run: bool) -> tuple[int, int, int]:
+    """Return (added, skipped, errors). errors > 0 means non-zero exit."""
     added = 0
     skipped = 0
+    errors = 0
     dropped: dict[str, int] = {}
     for path in sorted(source.rglob("*.md")):
         rel = path.relative_to(source).as_posix()
         try:
             raw = path.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError) as exc:
-            print(f"SKIP {rel}: {exc}")
-            skipped += 1
+            print(f"ERR  {rel}: {exc}")
+            errors += 1
             continue
         meta, body = _parse_frontmatter(raw, dropped=dropped)
         body = body.strip()
@@ -112,7 +114,7 @@ def migrate(source: Path, user_id: str, dry_run: bool) -> tuple[int, int]:
             result = add_safe(body, user_id=user_id, metadata=meta)
         except Exception as exc:
             print(f"ERR  {rel}: {exc}")
-            skipped += 1
+            errors += 1
             continue
         if result is None:
             print(f"SKIP {rel}: empty or dedup")
@@ -123,7 +125,7 @@ def migrate(source: Path, user_id: str, dry_run: bool) -> tuple[int, int]:
     if dropped:
         summary = ", ".join(f"{k}={v}" for k, v in sorted(dropped.items()))
         print(f"\nfrontmatter keys dropped (by reason): {summary}")
-    return added, skipped
+    return added, skipped, errors
 
 
 def main() -> int:
@@ -141,9 +143,10 @@ def main() -> int:
     source = Path(args.source).resolve()
     if not source.is_dir():
         parser.error(f"source not a directory: {source}")
-    added, skipped = migrate(source, args.user_id, args.dry_run)
-    print(f"\nDone. added={added} skipped={skipped} mode={'dry-run' if args.dry_run else 'live'}")
-    return 0
+    added, skipped, errors = migrate(source, args.user_id, args.dry_run)
+    mode = "dry-run" if args.dry_run else "live"
+    print(f"\nDone. added={added} skipped={skipped} errors={errors} mode={mode}")
+    return 1 if errors else 0
 
 
 if __name__ == "__main__":

--- a/scripts/mem0_migrate.py
+++ b/scripts/mem0_migrate.py
@@ -1,0 +1,119 @@
+"""One-shot AgentKB Markdown -> mem0 migration.
+
+Iterates Markdown under $AGENTKB_DIR (or --source), strips YAML frontmatter,
+and calls add_safe() with parsed metadata. Read-only on source files.
+
+Usage:
+    python scripts/mem0_migrate.py [--source PATH] [--user-id ID] [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from mem0_hooks import add_safe  # noqa: E402
+
+
+def _parse_frontmatter(text: str) -> tuple[dict[str, Any], str]:
+    """Minimal YAML frontmatter extractor.
+
+    Accepts only root-level ``key: value`` lines. Indented continuation lines,
+    list items (``- ...``), and nested mappings are silently dropped rather
+    than promoted to new keys. Empty frontmatter (``---\\n---\\n``) is
+    recognised and stripped. Anything that does not look like frontmatter is
+    returned untouched so the body survives intact.
+    """
+    if not text.startswith("---\n"):
+        return {}, text
+    # Start the close-marker search at index 3 so the shared '\n' between
+    # opening and closing fences counts for both, making empty frontmatter
+    # ('---\n---\nbody') parse correctly.
+    end = text.find("\n---\n", 3)
+    if end == -1:
+        return {}, text
+    header = text[4:end]
+    body = text[end + 5 :]
+    meta: dict[str, Any] = {}
+    if not header.strip():
+        return meta, body
+    for raw in header.splitlines():
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        # drop indented / list-item / non-key lines — keep strict root-level only
+        if raw != stripped or stripped.startswith("- ") or ":" not in stripped:
+            continue
+        key, _, value = stripped.partition(":")
+        key = key.strip()
+        value = value.strip().strip("'\"")
+        # empty scalar = YAML mapping container; drop rather than store a
+        # misleading empty string keyed by a parent node name.
+        if not key or not value:
+            continue
+        meta[key] = value
+    return meta, body
+
+
+def migrate(source: Path, user_id: str, dry_run: bool) -> tuple[int, int]:
+    added = 0
+    skipped = 0
+    for path in sorted(source.rglob("*.md")):
+        rel = path.relative_to(source).as_posix()
+        try:
+            raw = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            print(f"SKIP {rel}: {exc}")
+            skipped += 1
+            continue
+        meta, body = _parse_frontmatter(raw)
+        body = body.strip()
+        if not body:
+            skipped += 1
+            continue
+        meta["source_path"] = rel
+        if dry_run:
+            print(f"DRY  {rel} ({len(body)} chars, meta={list(meta)})")
+            added += 1
+            continue
+        try:
+            result = add_safe(body, user_id=user_id, metadata=meta)
+        except Exception as exc:
+            print(f"ERR  {rel}: {exc}")
+            skipped += 1
+            continue
+        if result is None:
+            print(f"SKIP {rel}: empty or dedup")
+            skipped += 1
+        else:
+            print(f"ADD  {rel}")
+            added += 1
+    return added, skipped
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--source",
+        default=os.environ.get("AGENTKB_DIR"),
+        help="Directory containing AgentKB Markdown (default: $AGENTKB_DIR)",
+    )
+    parser.add_argument("--user-id", default="mercury")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+    if not args.source:
+        parser.error("--source or $AGENTKB_DIR required")
+    source = Path(args.source).resolve()
+    if not source.is_dir():
+        parser.error(f"source not a directory: {source}")
+    added, skipped = migrate(source, args.user_id, args.dry_run)
+    print(f"\nDone. added={added} skipped={skipped} mode={'dry-run' if args.dry_run else 'live'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/mem0_migrate.py
+++ b/scripts/mem0_migrate.py
@@ -19,7 +19,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from mem0_hooks import add_safe  # noqa: E402
 
 
-def _parse_frontmatter(text: str) -> tuple[dict[str, Any], str]:
+def _parse_frontmatter(text: str, dropped: dict[str, int] | None = None) -> tuple[dict[str, Any], str]:
     """Minimal YAML frontmatter extractor.
 
     Accepts only root-level ``key: value`` lines. Indented continuation lines,
@@ -27,6 +27,10 @@ def _parse_frontmatter(text: str) -> tuple[dict[str, Any], str]:
     than promoted to new keys. Empty frontmatter (``---\\n---\\n``) is
     recognised and stripped. Anything that does not look like frontmatter is
     returned untouched so the body survives intact.
+
+    ``dropped`` (if provided) is a counter dict updated in-place with keys
+    ``indented`` / ``list`` / ``empty_value`` / ``comment`` so migration can
+    report aggregate data-loss at end-of-run.
     """
     # Normalize line endings — Path.read_text uses universal newlines on POSIX
     # but callers may hand us raw bytes.decode() with CRLF preserved; belt +
@@ -48,10 +52,21 @@ def _parse_frontmatter(text: str) -> tuple[dict[str, Any], str]:
         return meta, body
     for raw in header.splitlines():
         stripped = raw.strip()
-        if not stripped or stripped.startswith("#"):
+        if not stripped:
             continue
-        # drop indented / list-item / non-key lines — keep strict root-level only
-        if raw != stripped or stripped.startswith("- ") or ":" not in stripped:
+        if stripped.startswith("#"):
+            if dropped is not None:
+                dropped["comment"] = dropped.get("comment", 0) + 1
+            continue
+        if raw != stripped:
+            if dropped is not None:
+                dropped["indented"] = dropped.get("indented", 0) + 1
+            continue
+        if stripped.startswith("- "):
+            if dropped is not None:
+                dropped["list"] = dropped.get("list", 0) + 1
+            continue
+        if ":" not in stripped:
             continue
         key, _, value = stripped.partition(":")
         key = key.strip()
@@ -59,6 +74,8 @@ def _parse_frontmatter(text: str) -> tuple[dict[str, Any], str]:
         # empty scalar = YAML mapping container; drop rather than store a
         # misleading empty string keyed by a parent node name.
         if not key or not value:
+            if dropped is not None and key:
+                dropped["empty_value"] = dropped.get("empty_value", 0) + 1
             continue
         meta[key] = value
     return meta, body
@@ -67,6 +84,7 @@ def _parse_frontmatter(text: str) -> tuple[dict[str, Any], str]:
 def migrate(source: Path, user_id: str, dry_run: bool) -> tuple[int, int]:
     added = 0
     skipped = 0
+    dropped: dict[str, int] = {}
     for path in sorted(source.rglob("*.md")):
         rel = path.relative_to(source).as_posix()
         try:
@@ -75,7 +93,7 @@ def migrate(source: Path, user_id: str, dry_run: bool) -> tuple[int, int]:
             print(f"SKIP {rel}: {exc}")
             skipped += 1
             continue
-        meta, body = _parse_frontmatter(raw)
+        meta, body = _parse_frontmatter(raw, dropped=dropped)
         body = body.strip()
         if not body:
             skipped += 1
@@ -97,6 +115,9 @@ def migrate(source: Path, user_id: str, dry_run: bool) -> tuple[int, int]:
         else:
             print(f"ADD  {rel}")
             added += 1
+    if dropped:
+        summary = ", ".join(f"{k}={v}" for k, v in sorted(dropped.items()))
+        print(f"\nfrontmatter keys dropped (by reason): {summary}")
     return added, skipped
 
 

--- a/scripts/mem0_smoke_test.py
+++ b/scripts/mem0_smoke_test.py
@@ -50,7 +50,8 @@ def main() -> int:
     seed = "Mercury branch model is develop->master"
     add_safe(seed, user_id=USER, skip_dedup=True)
     hits = search_safe(seed, user_id=USER, limit=3)
-    top = max((h.get("score", 0) for h in hits), default=0)
+    scores = [h.get("score", 0) for h in hits if isinstance(h, dict)]
+    top = max(scores, default=0)
     print(f"     dedup probe: top score for identical text = {top:.4f}")
     again = add_safe(seed, user_id=USER)
     check(again is None, f"#4536 dedup_guard rejected near-duplicate (again={again!r})")

--- a/scripts/mem0_smoke_test.py
+++ b/scripts/mem0_smoke_test.py
@@ -1,0 +1,63 @@
+"""Phase A smoke test for mem0 adapter. Verifies all four P1-bug guards.
+
+Run after `pip install -r requirements-mem0.txt` and setting $OPENAI_API_KEY.
+Exit code 0 = all guards pass, non-zero = regression.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from mem0_hooks import add_safe, reset_for_tests, search_safe  # noqa: E402
+
+USER = "mercury-smoke"
+FAILURES: list[str] = []
+
+
+def check(cond: bool, label: str) -> None:
+    mark = "OK  " if cond else "FAIL"
+    print(f"{mark} {label}")
+    if not cond:
+        FAILURES.append(label)
+
+
+def main() -> int:
+    if not os.environ.get("OPENAI_API_KEY"):
+        print("OPENAI_API_KEY not set — abort")
+        return 2
+    reset_for_tests()
+
+    # guard #4099: empty payload must not hallucinate
+    check(add_safe("", user_id=USER) is None, "#4099 empty string rejected")
+    check(add_safe("   \n  ", user_id=USER) is None, "#4099 whitespace rejected")
+
+    # guard #4799: list content coerced, no AttributeError
+    list_input = [{"content": "Mercury runs on Windows 11"}, {"content": "uses pnpm"}]
+    try:
+        r = add_safe(list_input, user_id=USER, skip_dedup=True)
+        check(r is not None, "#4799 list coerced -> str and stored")
+    except AttributeError as exc:
+        check(False, f"#4799 list raised AttributeError: {exc}")
+
+    # guard #4453: search_safe never forwards threshold kwarg
+    results = search_safe("Mercury Windows", user_id=USER, limit=3)
+    check(isinstance(results, list), "#4453 search returns list without threshold")
+
+    # guard #4536: dedup reject near-duplicate
+    seed = "Mercury branch model is develop->master"
+    add_safe(seed, user_id=USER, skip_dedup=True)
+    hits = search_safe(seed, user_id=USER, limit=3)
+    top = max((h.get("score", 0) for h in hits), default=0)
+    print(f"     dedup probe: top score for identical text = {top:.4f}")
+    again = add_safe(seed, user_id=USER)
+    check(again is None, f"#4536 dedup_guard rejected near-duplicate (again={again!r})")
+
+    print(f"\nresult: {len(FAILURES)} failure(s)")
+    return 0 if not FAILURES else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/mem0_unit_test.py
+++ b/scripts/mem0_unit_test.py
@@ -80,6 +80,11 @@ def main() -> int:
         meta == {"title": "real"} and body == "x",
         "frontmatter: container keys dropped, scalar kept",
     )
+    meta, body = mem0_migrate._parse_frontmatter("---\ntitle: t\n---")
+    check(
+        meta == {"title": "t"} and body == "",
+        "frontmatter: tail-less (no trailing newline) handled",
+    )
 
     print(f"\nresult: {len(FAILURES)} failure(s)")
     return 0 if not FAILURES else 1

--- a/scripts/mem0_unit_test.py
+++ b/scripts/mem0_unit_test.py
@@ -39,6 +39,16 @@ def main() -> int:
     check(mem0_hooks._coerce_str(None) is None, "coerce: None rejected")
     check(mem0_hooks._coerce_str(b"bytes") is None, "coerce: bytes rejected")
     check(mem0_hooks._coerce_str(bytearray(b"x")) is None, "coerce: bytearray rejected")
+    check(mem0_hooks._coerce_str((x for x in ["a"])) is None, "coerce: generator rejected")
+    check(mem0_hooks._coerce_str(42) is None, "coerce: int rejected")
+
+    # _coerce_str: accepted container shapes
+    check(
+        mem0_hooks._coerce_str({"content": "x"}) == "x",
+        "coerce: dict with content key",
+    )
+    check(mem0_hooks._coerce_str({"other": 1}) is None, "coerce: dict without content rejected")
+    check(mem0_hooks._coerce_str(("a", "b")) == "a\nb", "coerce: tuple of str")
 
     # _build_config shape + paths resolve
     cfg = mem0_hooks._build_config()

--- a/scripts/mem0_unit_test.py
+++ b/scripts/mem0_unit_test.py
@@ -1,0 +1,79 @@
+"""Offline unit tests for mem0 adapter helpers.
+
+Exercises pure functions that do NOT require OpenAI or Qdrant. Run this as
+the first gate after install; full smoke test (mem0_smoke_test.py) runs
+afterwards with OPENAI_API_KEY set.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import mem0_hooks  # noqa: E402
+import mem0_migrate  # noqa: E402
+
+FAILURES: list[str] = []
+
+
+def check(cond: bool, label: str) -> None:
+    mark = "OK  " if cond else "FAIL"
+    print(f"{mark} {label}")
+    if not cond:
+        FAILURES.append(label)
+
+
+def main() -> int:
+    # _coerce_str: accepted shapes
+    check(mem0_hooks._coerce_str("plain") == "plain", "coerce: str passthrough")
+    check(mem0_hooks._coerce_str(["a", "b"]) == "a\nb", "coerce: list of str")
+    check(
+        mem0_hooks._coerce_str([{"content": "x"}, {"content": "y"}]) == "x\ny",
+        "coerce: list of dicts with content key",
+    )
+    check(mem0_hooks._coerce_str([]) == "", "coerce: empty list")
+
+    # _coerce_str: rejected shapes return None (never stringify junk)
+    check(mem0_hooks._coerce_str(None) is None, "coerce: None rejected")
+    check(mem0_hooks._coerce_str(b"bytes") is None, "coerce: bytes rejected")
+    check(mem0_hooks._coerce_str(bytearray(b"x")) is None, "coerce: bytearray rejected")
+
+    # _build_config shape + paths resolve
+    cfg = mem0_hooks._build_config()
+    check("vector_store" in cfg, "config: has vector_store")
+    check(cfg["vector_store"]["provider"] == "qdrant", "config: qdrant provider")
+    check("path" in cfg["vector_store"]["config"], "config: qdrant path set")
+    check(Path(cfg["history_db_path"]).parent.exists(), "config: history dir exists")
+
+    # telemetry env bootstrapped at module import time
+    check(os.environ.get("MEM0_TELEMETRY") == "false", "env: MEM0_TELEMETRY set")
+    check(
+        os.environ.get("ANONYMIZED_TELEMETRY") == "false",
+        "env: ANONYMIZED_TELEMETRY set",
+    )
+
+    # _parse_frontmatter
+    meta, body = mem0_migrate._parse_frontmatter("no frontmatter here")
+    check(meta == {} and body == "no frontmatter here", "frontmatter: absent ignored")
+    meta, body = mem0_migrate._parse_frontmatter("---\ntitle: t\ntags: a\n---\nbody")
+    check(meta == {"title": "t", "tags": "a"} and body == "body", "frontmatter: parsed")
+    meta, body = mem0_migrate._parse_frontmatter("---\nbroken")
+    check(meta == {} and "broken" in body, "frontmatter: malformed falls through")
+    meta, body = mem0_migrate._parse_frontmatter("---\n---\nbody")
+    check(meta == {} and body == "body", "frontmatter: empty block stripped")
+    meta, body = mem0_migrate._parse_frontmatter(
+        "---\nparent:\n  child: value\ntags:\n- a\ntitle: real\n---\nx"
+    )
+    check(
+        meta == {"title": "real"} and body == "x",
+        "frontmatter: container keys dropped, scalar kept",
+    )
+
+    print(f"\nresult: {len(FAILURES)} failure(s)")
+    return 0 if not FAILURES else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/mem0_unit_test.py
+++ b/scripts/mem0_unit_test.py
@@ -61,6 +61,7 @@ def main() -> int:
         mem0_hooks._coerce_str([{"content": b"x"}]) is None,
         "coerce: list with dict{'content': bytes} rejects whole container",
     )
+    check(mem0_hooks._coerce_str({"a", "b"}) is None, "coerce: set rejected (non-deterministic order)")
 
     # _build_config shape + paths resolve
     cfg = mem0_hooks._build_config()

--- a/scripts/mem0_unit_test.py
+++ b/scripts/mem0_unit_test.py
@@ -49,6 +49,18 @@ def main() -> int:
     )
     check(mem0_hooks._coerce_str({"other": 1}) is None, "coerce: dict without content rejected")
     check(mem0_hooks._coerce_str(("a", "b")) == "a\nb", "coerce: tuple of str")
+    check(
+        mem0_hooks._coerce_str(["ok", None]) is None,
+        "coerce: list with None element rejects whole container",
+    )
+    check(
+        mem0_hooks._coerce_str([{"content": None}]) is None,
+        "coerce: list with dict{'content': None} rejects whole container",
+    )
+    check(
+        mem0_hooks._coerce_str([{"content": b"x"}]) is None,
+        "coerce: list with dict{'content': bytes} rejects whole container",
+    )
 
     # _build_config shape + paths resolve
     cfg = mem0_hooks._build_config()


### PR DESCRIPTION
## Summary

Phase A of Issue #252 — Mercury memory-layer rebuild on **mem0** per research #250 conclusion.

- Ships the self-hosted mem0 scaffolding (adapter + importer + tests + setup doc). **No runtime hooks wired yet** — Phase B covers `pre-compact`, `session-end`, `flush`.
- Adapter is 121 LOC, well under Mercury's 200-LOC adapter rule.
- All four upstream P1 bugs (#4099 / #4453 / #4536 / #4799) have dedicated guards + regression tests.

## Files

| Path | Purpose |
|---|---|
| `scripts/mem0_hooks.py` | Adapter with four mandatory guards + telemetry env bootstrap |
| `scripts/mem0_migrate.py` | One-shot AgentKB Markdown -> mem0 importer (strict-root frontmatter, per-file error isolation) |
| `scripts/mem0_unit_test.py` | 18 offline checks (no network) |
| `scripts/mem0_smoke_test.py` | 5 live checks against OpenAI + Qdrant |
| `requirements-mem0.txt` | Pinned `mem0ai>=1.0.11,<2.0.0` + `qdrant-client>=1.9.0` |
| `.mercury/docs/guides/mem0-setup.md` | Install (Bash + PowerShell), env vars, smoke workflow, adoption preconditions |
| `.gitignore` | +`.venv-mem0/` |

## Guards wired against upstream P1 bugs

| mem0 issue | Guard | Test |
|---|---|---|
| [#4099](https://github.com/mem0ai/mem0/issues/4099) empty-payload hallucination | `add_safe` rejects empty / whitespace-only content | smoke test 1-2 |
| [#4453](https://github.com/mem0ai/mem0/issues/4453) broken threshold filter | `search_safe` never forwards `threshold=` | smoke test 4 |
| [#4536](https://github.com/mem0ai/mem0/issues/4536) contradicting-fact corruption | `dedup_guard` rejects cosine >= 0.92; **fails closed** on search error | smoke test 5 |
| [#4799](https://github.com/mem0ai/mem0/issues/4799) list-content AttributeError | `_coerce_str` joins list content to string before `add` | smoke test 3 |

All four issues verified still OPEN on 2026-04-17 via `gh api repos/mem0ai/mem0/issues/...`.

## Dual-verify

Claude Code deep review + Codex rescue-subagent audit run in parallel per `/dual-verify` skill.

Codex returned REQUEST-CHANGES with **five major findings** — every one addressed before push:

1. `dedup_guard` failed open on search exceptions -> now fails closed with a log line.
2. `_parse_frontmatter` mis-promoted indented / list-item lines to top-level keys and mishandled `---\n---\n` -> strict root-only key parser; empty-block offset fix; container keys with empty scalar values are dropped.
3. `migrate()` aborted on the first `add_safe` failure -> per-file try/except; continues and counts.
4. Telemetry env vars were set inside `get_memory()` -> moved to module import top so they run before any `mem0` import anywhere in the process.
5. `add_safe(None)` / `add_safe(b"...")` stored junk strings -> `_coerce_str` returns `None` for those shapes and `add_safe` short-circuits.

Minor findings: PowerShell examples added to setup doc. (Mojibake flags were valid UTF-8 em-dashes rendered as `??` in Codex's terminal — no action.)

Unit tests: 18/18 pass offline. Smoke tests: 5/5 pass against OpenAI + embedded Qdrant on a clean state.

## Adoption preconditions (must remain true)

Per research doc §Q2:

1. Single-user runtime only.
2. Never pass `threshold=` to `Memory.search()` — `search_safe` enforces.
3. Content must be a plain string; list-shaped input is coerced by `add_safe`.
4. LLM is not Gemini-3 (Claude / GPT only).
5. Telemetry opt-out enforced via `MEM0_TELEMETRY=false` + `ANONYMIZED_TELEMETRY=false`.

## Test plan

- [x] `pip install -r requirements-mem0.txt` in a fresh venv
- [x] `python scripts/mem0_unit_test.py` -> 18/18 pass
- [x] `export OPENAI_API_KEY=...` + `python scripts/mem0_smoke_test.py` -> 5/5 pass
- [x] `python scripts/mem0_migrate.py --source "$AGENTKB_DIR" --dry-run` (live migration is Phase B)

## Follow-ups

- Phase B (`#252`): wire `pre-compact`, `session-end`, `flush` hooks via `add_safe` / `search_safe`.
- Phase C (`#252`): cross-session recall test + telemetry audit.
- AgentKB fork: queue for standby once Phase C lands.

## Refs

- Research: `.mercury/docs/research/memory-layer-rebuild-2026-04-16.md`
- Issue: #252
- Upstream: https://github.com/mem0ai/mem0

---
Refs #252