### PR TITLE
docs(CLAUDE.md): record AgentKB → user-level hooks migration (#259)

### DIFF
--- a/.mercury/docs/research/agentkb-fork-salvage-audit-2026-04-17.md
+++ b/.mercury/docs/research/agentkb-fork-salvage-audit-2026-04-17.md
@@ -1,0 +1,162 @@
+# AgentKB Fork Salvage Audit
+
+> **Context**: Mercury #252 mem0 adoption complete (Phases A+B+C merged 2026-04-17). The AgentKB fork `392fyc/claude-memory-compiler` (fork of `coleam00/claude-memory-compiler`) is slated for maintenance-mode / archival. Before archiving, inventory Mercury-specific additions for possible re-use.
+>
+> **Scope**: 14 fork-only commits, 19 changed files, +2,710 / -341 lines vs upstream `origin/main`.
+
+## Commit inventory (fork/main vs origin/main)
+
+| SHA | Scope | Mercury issue |
+|---|---|---|
+| b61ff0d | feat: Mercury customizations (timezone, schema, knowledge dirs) | bootstrap |
+| 3b3ac22 | diagnose(flush): capture bundled CLI stderr + env vars | #232 |
+| a0e1f0b | feat(scripts): rsync one-way mirror to NAS | infra |
+| d11e6a5 | Merge branch 'main' | merge |
+| 4cb9b78 | fix(flush): strip CLAUDE_CODE_USE_POWERSHELL_TOOL | #232 |
+| 8c8af29 | feat: S41-S47 Mercury AgentKB infra updates | infra |
+| b8f6f73 | docs: fix AGENTS.md drift | docs |
+| 5fd201f | fix(rsync): off-LAN fallback via CF Tunnel | #242 |
+| f11358a | feat(phase4-1): re-merge session continuity + flush terminal fix | #238 |
+| 7fd15d5 | feat(orchestrator): --visible mode + UTF-8 stdout fix | #241 |
+| e10476f | fix(flush): bypass Agent SDK for PreCompact reliability | #232 |
+| 436459f | fix(flush): CREATE_NO_WINDOW vs DETACHED_PROCESS | #232 |
+| d0ad7d3 | feat(memory/phase-b): wire mem0 ingest into flush | **#252** |
+| 4ebf9a7 | test(memory/phase-c): cross-session + telemetry + regression validation | **#252** |
+
+## Re-use classification
+
+### Category 1 — Already migrated to Mercury (safe to retire on AgentKB)
+
+| File | State |
+|---|---|
+| `scripts/mem0_hooks.py` | Cherry-picked from Mercury 599d313. Mercury is source of truth. |
+| `scripts/mem0_bridge.py` | AgentKB-only glue; only valuable if AgentKB hooks stay alive. Retire if archiving. |
+| `scripts/mem0_phase_c.py` | AgentKB-only validation. Rebuild path exists in Mercury if needed later. |
+
+### Category 2 — HIGH salvage value (re-use in Mercury before archival)
+
+**`scripts/handoff-orchestrator.py` (267 LOC)**
+- Spawns continuation Claude Code session via Agent SDK, writes `session_chain` SQLite entries.
+- Already referenced in Mercury `/handoff` skill docs and project state; the runtime script lives in AgentKB.
+- **Action**: move into Mercury (`scripts/handoff-orchestrator.py`) since `/handoff` is a Mercury-owned skill. Update `/handoff:auto` to invoke from Mercury path. Drop the AgentKB copy once the Mercury path is live. (Follow-up issue needed.)
+
+**`scripts/skill_stats.py` (195 LOC)**
+- Parses Claude Code transcript JSONL, extracts Skill tool invocations, writes to `stats/skill-usage.db`.
+- Cross-project telemetry — valuable in Mercury and any other repo, not AgentKB-specific.
+- **Action**: move into Mercury (`scripts/skill_stats.py`) or publish as standalone utility. Schema (SQLite: skill, args, session_id, timestamp, project, invocation_seq) is already stable. (Follow-up issue needed.)
+
+**`scripts/flush.py` (392 LOC, of which ~205 lines are Mercury-added fixes)**
+- Mercury-added fixes: Agent SDK bypass, CLAUDE_* env sanitization, CREATE_NO_WINDOW, auto-memory checkpoint write, compile trigger gated by `COMPILE_AFTER_HOUR`, mem0_bridge call, terminal-flash fix.
+- Tightly coupled to AgentKB's daily-log archive + compile pipeline. Only reuseable if Mercury ever builds its own flush equivalent.
+- **Action**: leave in AgentKB for now (coupled). Extract `_find_claude_exe()` + env-sanitization pattern as a Mercury utility later if needed.
+
+### Category 3 — MEDIUM salvage value (repo-specific but reusable pattern)
+
+**`scripts/rsync-agentkb-to-nas.sh` (109 LOC) + `rsync-invoke.ps1` (113 LOC) + `rsync-exclude.list`**
+- One-way NAS mirror with off-LAN CF Tunnel fallback, Windows Task Scheduler hourly trigger, single-instance lock, Cygwin/MSYS2 fd-incompat workaround via PowerShell proxy.
+- Pattern worth preserving; the scripts themselves are AgentKB-pathed.
+- **Action**: copy as templates to Mercury `scripts/` with `${SOURCE_DIR}` parameter and doc the Cygwin quirk + CF Tunnel fallback in Mercury guides. Record `AgentKB/scripts/rsync-*` as the original reference. (Follow-up issue needed.)
+
+**`hooks/session-end.py` (251 LOC) + Mercury additions to `pre-compact.py`**
+- Mercury's live integration point for auto-memory. Same design pattern could apply to any Claude Code hook consumer.
+- **Action**: pattern documented in `.mercury/docs/guides/mem0-setup.md` already. If Mercury ever replaces AgentKB with a native hook runner, adapt these. Not urgent.
+
+### Category 4 — LOW salvage value (AgentKB-specific / already in Mercury)
+
+| File | Reason |
+|---|---|
+| `schema/README.md` | AgentKB/Karpathy-KB architecture doc; not relevant once archived. |
+| `AGENTS.md` changes | AgentKB identity; Mercury has its own CLAUDE.md. |
+| `pyproject.toml` (mem0ai + qdrant-client deps) | Dependency list specific to AgentKB venv. Mercury already has `requirements-mem0.txt`. |
+| `scripts/config.py` (small path change) | Trivial. |
+| `.gitignore`, `.gitattributes`, `uv.lock` | Repo mechanics, no portable value. |
+
+### Category 5 — OBSOLETED by mem0 migration
+
+| File | Reason |
+|---|---|
+| `scripts/compile.py` (unchanged from upstream) | Will no longer be the primary knowledge path — mem0 stores atomic facts continuously instead of end-of-day batch compile. Can stay in AgentKB as legacy; Mercury does not need it. |
+| `scripts/lint.py`, `scripts/query.py` | Lint/query against daily logs — same obsolescence. Leave in AgentKB for archive-mode reads. |
+
+## Recommended follow-ups (post-archival prep)
+
+Before marking AgentKB fork archived, file Mercury issues for:
+
+1. **Issue: port `handoff-orchestrator.py` to Mercury** — reads `session-checkpoint.md`, writes `session_chain` SQLite, spawns new Claude Code. Referenced by `/handoff:auto` skill. Medium effort, ~1 session.
+2. **Issue: port `skill_stats.py` to Mercury** — transcript JSONL → SQLite telemetry. Standalone, reusable across repos. Small effort, ~30 min.
+3. **Issue: template-ize `rsync-*nas*` as Mercury `scripts/sync-to-nas.*`** — parameterize `${SOURCE_DIR}`, preserve Cygwin fd-fix + CF Tunnel fallback. Small effort, ~30 min.
+4. **Issue: AgentKB fork archival notice** — README banner "archived; see Mercury #252 / mem0 memory layer for replacement". No code change.
+
+## Decision matrix
+
+| Action | When to do |
+|---|---|
+| Port handoff-orchestrator + skill_stats + rsync templates to Mercury | Before archiving AgentKB. Otherwise hooks/skills that depend on them break. |
+| Archive AgentKB fork with README banner | After the three ports land. |
+| Remove AgentKB dependencies from Mercury global `settings.json` (hooks) | After Mercury owns `handoff-orchestrator.py` + `flush.py` equivalent OR after accepting that live flush is no longer desired. |
+| Update Mercury CLAUDE.md `Related Repositories` table | After archival to reflect maintenance-mode status. |
+
+## Unverified / open questions
+
+- Does Mercury still need file-based daily log archive (via AgentKB `flush.py`) alongside mem0, or is mem0 + git history sufficient? If dropping, the flush chain + compile.py can archive cleanly. If keeping, Mercury must own a flush equivalent OR keep AgentKB fork alive as a runtime dependency.
+- `handoff-orchestrator.py` reads `stats/skill-usage.db` path hard-coded to AgentKB dir; on port to Mercury, needs parameterization.
+- `rsync-invoke.ps1` assumes scoop-installed cwRsync; Mercury port may want to support multiple install paths.
+
+---
+
+**Bottom line**: three script groups are worth preserving (~470 LOC of handoff orchestrator + skill stats + rsync templates). Everything else is either already-in-Mercury, trivially adaptable, or obsoleted by mem0. Proposal: land three small Mercury PRs (ports) over the next session or two, then flip AgentKB fork to archived-with-banner status.
+
+---
+
+## Addendum 2026-04-17 — Destination check for each salvageable item
+
+After user-supplied context review, each salvage target gets re-homed rather than all landing in Mercury proper.
+
+### 1. `handoff-orchestrator.py` → **`claude-handoff` plugin repo** (not Mercury)
+
+- Verified: `github.com/392fyc/claude-handoff` already exists as a dedicated plugin repo with:
+  - `hooks/` containing `session-start.py` + `hooks.json` (no `handoff-orchestrator.py` yet)
+  - `session_chain/` containing `__init__.py` + `db.py` + `tests/` (the SQLite layer already ported here)
+  - `skills/handoff/`
+- **Action**: port `scripts/handoff-orchestrator.py` from AgentKB into `claude-handoff/hooks/` or a new `claude-handoff/orchestrator/` directory. Coupling is natural — the orchestrator already imports `session_chain.db`, which lives in that repo.
+- Mercury then only consumes the plugin, never owns the orchestrator code itself.
+
+### 2. `skill_stats.py` → **user-level** (`~/.claude/`), not project-level
+
+- Verified: `~/.claude/` has no `skill_stats*` / `skill-usage.db`. Current hook registration in `~/.claude/settings.json` runs the AgentKB-pathed script, scoping writes to a Mercury-only DB.
+- **Action**: move `skill_stats.py` + its SQLite to `~/.claude/scripts/skill_stats.py` + `~/.claude/stats/skill-usage.db`. Hook registration stays in the user-level `settings.json` (already the right scope) — just re-point the command path. Cross-project analytics come for free once the AgentKB prefix is gone.
+- Open question: is the DB value-worth-preserving? Current rows are Mercury-only and arguably disposable. If so, archive the file and start fresh at user-level.
+
+### 3. `rsync-*` (mem2nas) → **re-target to mem0-state**, keep in AgentKB until archival, then move
+
+- Current rsync mirrors the entire AgentKB tree. Post-mem0 adoption, the value-bearing payload is:
+  - `AgentKB/scripts/mem0-state/qdrant/` (vector store)
+  - `AgentKB/scripts/mem0-state/history.db` (SQLite history)
+- **Action**: parameterize via `SOURCE_DIR` env var and move the scripts into wherever owns the hooks (likely `~/.claude/scripts/`). Target NAS path stays the same. Cygwin/MSYS2 fd-fix + CF Tunnel off-LAN fallback remain intact.
+
+### 4. `session-end.py` / `pre-compact.py` — **user-level `~/.claude/hooks/`**, not Mercury-level
+
+- Verified: `~/.claude/settings.json` registers `SessionEnd` + `PreCompact` with commands pointing at `$AGENTKB_DIR/hooks/`. When AgentKB archives, these commands BREAK silently unless re-homed first.
+- **Action**: move both hook scripts + `flush.py` + `mem0_hooks.py` + `mem0_bridge.py` to `~/.claude/hooks/` (or `~/.claude/scripts/`). Update `settings.json` command paths from `$AGENTKB_DIR/...` to the new user-level locations.
+- This makes the hooks repo-agnostic (they no longer need an AgentKB checkout) and removes the AgentKB runtime dependency entirely.
+- Mercury CLAUDE.md `Related Repositories` table should drop the `$AGENTKB_DIR` row once this is done.
+
+### 5. `claude-mem` as alternative daily-log source — **REJECT**
+
+- Verified via web 2026-04-17: `claude-mem` (thedotmack) captures to `memory/auto-capture/YYYY-MM-DD.md` with its own hybrid SQLite+Chroma pipeline and Bun HTTP worker on `localhost:37777`.
+- Research #250 already evaluated and REJECTED claude-mem (AGPL + solo maintainer + 10-version-in-10-days churn + no clean mount path). Running it alongside mem0 would double-ingest session content and add a second runtime (Bun) for no benefit.
+- **Action**: no adoption. Daily-log archiving remains with AgentKB `flush.py` path until a lighter in-Mercury / in-claude-handoff alternative is needed. If the file-archive dimension is still desired after re-homing hooks (step 4), keep the `append_to_daily_log` branch in the ported `flush.py` writing to `~/.claude/daily/` or similar — no external dependency needed.
+
+## Revised recommended follow-ups
+
+File these issues before archival banner:
+
+1. **Port `handoff-orchestrator.py` into `claude-handoff` repo** — natural home, `session_chain/db.py` already sits there. Medium effort.
+2. **Promote `skill_stats.py` to user-level (`~/.claude/`)** — cross-project analytics. Small effort.
+3. **Re-home `session-end.py` + `pre-compact.py` + `flush.py` + `mem0_hooks.py` + `mem0_bridge.py` to user-level `~/.claude/hooks/` + `~/.claude/scripts/`**, repoint `~/.claude/settings.json`. Medium effort — this is the critical path for removing AgentKB as a runtime dependency.
+4. **Parameterize and move `rsync-*` (mem2nas)** — new target is `~/.claude/scripts/mem0-state/` after step 3 completes. Small effort.
+5. **Only AFTER steps 3+4**: archive AgentKB fork with README banner.
+
+## Critical path dependency
+
+Steps 1, 3, and 4 must land before AgentKB can be archived without breaking live workflow. Step 2 and step 5 (claude-mem) are independent.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,10 +36,20 @@ Mercury 的部分功能跨仓库运作。以下表格记录外部仓库与 Mercu
 
 **跨仓库开发注意事项：**
 - `dev-pipeline` 等 skill 假设单仓库工作，跨仓库任务需直接实现
-- 用户级 hooks / scripts 变更不走 Mercury PR 流程（直接编辑 `~/.claude/`，需要 backup 后验证）
-- 新环境验证: 运行 `ls ~/.claude/hooks/ ~/.claude/scripts/` 看到 `pre-compact.py`/`session-end.py`/`flush.py`/`mem0_hooks.py`/`mem0_bridge.py` 即为 #259 后状态；`grep AGENTKB ~/.claude/settings.json` 应返回 0 行
-- 安装依赖: `cd ~/.claude && uv sync` 建立 `~/.claude/.venv/` 并装 mem0ai + qdrant-client
+- 用户级 hooks / scripts 变更不走 Mercury PR 流程。相关路径里 `~/.claude` 等价于 `${CLAUDE_CONFIG_DIR:-$HOME/.claude}`；命令示例可任选一种书写，env 形式在多账户 / CI 下更可移植
+- 新环境验证: 运行 `ls "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/" "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/scripts/"` 看到 `pre-compact.py`/`session-end.py`/`flush.py`/`mem0_hooks.py`/`mem0_bridge.py` 即为 #259 后状态；`grep AGENTKB "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json"` 应返回 0 行
+- 安装依赖: `cd "${CLAUDE_CONFIG_DIR:-$HOME/.claude}" && uv sync` 建立 `.venv/` 并装 mem0ai + qdrant-client
 - 回滚通道: `MERCURY_MEM0_DISABLED=1` / `AGENTKB_MEM0_DISABLED=1` / `uv remove mem0ai` 任一即可 no-op mem0 写入路径
+
+**用户级变更治理（避免"仓库外漂移"）：**
+- **变更记录位置**: 每次修改 `~/.claude/hooks/`、`~/.claude/scripts/`、`~/.claude/settings.json` 时，在 Mercury 内开对应 Issue（类似 #259），在 Issue 下记录"命令清单 + 最终 diff 摘要 + 验证步骤"。Issue 关闭即成为该用户级变更的权威记录
+- **验证清单（必须全部通过）**:
+  1. `settings.json` JSON 合法（`python -c "import json; json.load(open('settings.json'))"`）
+  2. 每个涉及的 hook 脚本在合成 stdin 下 exit 0（见 #259 PR body 的验证示例）
+  3. 相关单测或 smoke test 通过（如 `mem0_bridge_test.py` 7/7）
+  4. 一次真实 hook 触发观察无回归
+- **回滚步骤**: 所有用户级变更前先 `cp ~/.claude/settings.json ~/.claude/settings.json.backup-pre-<issue>`；发现回归时 `mv` 回去即可；mem0 层额外可通过 env var 软关
+- **环境依赖审计**: 定期跑 `grep -rE "AGENTKB_DIR|\$AGENTKB" ~/.claude/` 确认未遗漏旧路径引用
 
 ## MUST
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,14 +42,14 @@ Mercury 的部分功能跨仓库运作。以下表格记录外部仓库与 Mercu
 - 回滚通道: `MERCURY_MEM0_DISABLED=1` / `AGENTKB_MEM0_DISABLED=1` / `uv remove mem0ai` 任一即可 no-op mem0 写入路径
 
 **用户级变更治理（避免"仓库外漂移"）：**
-- **变更记录位置**: 每次修改 `~/.claude/hooks/`、`~/.claude/scripts/`、`~/.claude/settings.json` 时，在 Mercury 内开对应 Issue（类似 #259），在 Issue 下记录"命令清单 + 最终 diff 摘要 + 验证步骤"。Issue 关闭即成为该用户级变更的权威记录
+- **变更记录位置**: 每次修改 `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/`、`.../scripts/`、`.../settings.json` 时，在 Mercury 内开对应 Issue（类似 #259），在 Issue 下记录"命令清单 + 最终 diff 摘要 + 验证步骤"。Issue 关闭即成为该用户级变更的权威记录
 - **验证清单（必须全部通过）**:
   1. `settings.json` JSON 合法（`python -c "import json; json.load(open('settings.json'))"`）
   2. 每个涉及的 hook 脚本在合成 stdin 下 exit 0（见 #259 PR body 的验证示例）
   3. 相关单测或 smoke test 通过（如 `mem0_bridge_test.py` 7/7）
   4. 一次真实 hook 触发观察无回归
-- **回滚步骤**: 所有用户级变更前先 `cp ~/.claude/settings.json ~/.claude/settings.json.backup-pre-<issue>`；发现回归时 `mv` 回去即可；mem0 层额外可通过 env var 软关
-- **环境依赖审计**: 定期跑 `grep -rE "AGENTKB_DIR|\$AGENTKB" ~/.claude/` 确认未遗漏旧路径引用
+- **回滚步骤**: 所有用户级变更前先 `CC="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"; cp "$CC/settings.json" "$CC/settings.json.backup-pre-<issue>"`；发现回归时 `mv` 回去即可；mem0 层额外可通过 env var 软关
+- **环境依赖审计**: 定期跑 `grep -rE "AGENTKB_DIR|\$AGENTKB" "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/"` 确认未遗漏旧路径引用
 
 ## MUST
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,18 +25,21 @@ Read these docs on demand when you need the corresponding information:
 
 ## Related Repositories
 
-Mercury 的部分功能跨仓库运作。以下仓库通过 `$AGENTKB_DIR` 环境变量关联，不作为 submodule 挂载。
+Mercury 的部分功能跨仓库运作。以下表格记录外部仓库与 Mercury 的关系。
 
-| Repo | Location (env var) | Purpose | 关系 |
-|------|-------------------|---------|------|
-| **AgentKB** | `$AGENTKB_DIR` | Memory Layer — 存储层、编译层、周期维护 | hooks 注册在全局 settings.json，脚本在 AgentKB |
-| **Mercury_KB** | *(archived, 无 env var)* | 项目专属 KB (Obsidian vault, archived) | 已归档，被 AgentKB 取代 |
+| Repo | Location | Purpose | 关系 |
+|------|----------|---------|------|
+| **Memory layer (user-level)** | `~/.claude/hooks/` + `~/.claude/scripts/` | mem0 adapter + bridge + flush + session-start/end hooks | 运行时独立于任何 git 仓库；mem0 Qdrant 数据在 `~/.claude/scripts/mem0-state/` |
+| **claude-handoff** | 插件仓库 <https://github.com/392fyc/claude-handoff> | Session handoff / 续接 + `session_chain` SQLite | 作为本地插件挂载在 `~/.claude/settings.json` marketplace |
+| **AgentKB (archival-pending)** | `$AGENTKB_DIR` | 旧 Memory 层（Karpathy-style KB），Mercury #252 后被 mem0 取代 | 待归档；salvage 审计见 `.mercury/docs/research/agentkb-fork-salvage-audit-2026-04-17.md` |
+| **Mercury_KB** | *(archived)* | 项目专属 Obsidian vault (archived) | 已归档，早于 AgentKB 被取代 |
 
 **跨仓库开发注意事项：**
 - `dev-pipeline` 等 skill 假设单仓库工作，跨仓库任务需直接实现
-- AgentKB 的 hooks/scripts 变更不走 Mercury PR 流程（独立仓库）
-- AgentKB hooks 已迁移到全局 `~/.claude/settings.json`（非项目级），命令中使用 `$AGENTKB_DIR` 引用路径
-- 新环境验证: 运行 `cat ~/.claude/settings.json | grep AGENTKB` 确认全局 hooks 已注册
+- 用户级 hooks / scripts 变更不走 Mercury PR 流程（直接编辑 `~/.claude/`，需要 backup 后验证）
+- 新环境验证: 运行 `ls ~/.claude/hooks/ ~/.claude/scripts/` 看到 `pre-compact.py`/`session-end.py`/`flush.py`/`mem0_hooks.py`/`mem0_bridge.py` 即为 #259 后状态；`grep AGENTKB ~/.claude/settings.json` 应返回 0 行
+- 安装依赖: `cd ~/.claude && uv sync` 建立 `~/.claude/.venv/` 并装 mem0ai + qdrant-client
+- 回滚通道: `MERCURY_MEM0_DISABLED=1` / `AGENTKB_MEM0_DISABLED=1` / `uv remove mem0ai` 任一即可 no-op mem0 写入路径
 
 ## MUST
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ Mercury 的部分功能跨仓库运作。以下表格记录外部仓库与 Mercu
 **用户级变更治理（避免"仓库外漂移"）：**
 - **变更记录位置**: 每次修改 `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/`、`.../scripts/`、`.../settings.json` 时，在 Mercury 内开对应 Issue（类似 #259），在 Issue 下记录"命令清单 + 最终 diff 摘要 + 验证步骤"。Issue 关闭即成为该用户级变更的权威记录
 - **验证清单（必须全部通过）**:
-  1. `settings.json` JSON 合法（`python -c "import json; json.load(open('settings.json'))"`）
+  1. `settings.json` JSON 合法（`python -c "import json,os; json.load(open(os.path.expandvars('${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json')))"`）
   2. 每个涉及的 hook 脚本在合成 stdin 下 exit 0（见 #259 PR body 的验证示例）
   3. 相关单测或 smoke test 通过（如 `mem0_bridge_test.py` 7/7）
   4. 一次真实 hook 触发观察无回归


### PR DESCRIPTION
## Summary

Part of #259. The live hooks (pre-compact, session-end, session-start) + mem0 runtime (flush.py, mem0_hooks.py, mem0_bridge.py) have been re-homed out of the AgentKB fork into user-level \`~/.claude/\`. This PR updates Mercury's \`CLAUDE.md\` \`Related Repositories\` section to reflect the new layout.

## Out-of-tree actions already completed (not in this PR — user-level, no git repo)

- Copied 6 Python files from \`AgentKB/hooks/\` + \`AgentKB/scripts/\` to \`~/.claude/hooks/\` + \`~/.claude/scripts/\`
- Created \`~/.claude/pyproject.toml\` + ran \`uv sync\` → \`~/.claude/.venv/\` with mem0ai 1.0.11 + qdrant-client 1.17.1
- Updated \`~/.claude/settings.json\` hook commands from \`\$AGENTKB_DIR/...\` → \`\${CLAUDE_CONFIG_DIR:-\$HOME/.claude}/...\` (3 hooks: SessionStart, SessionEnd, PreCompact)
- \`grep AGENTKB ~/.claude/settings.json\` returns 0 lines (verified)

## Runtime validation (2026-04-18)

- pre-compact.py + session-end.py + session-start.py all exit 0 on synthetic input
- pre-compact.py with a real 6-turn transcript spawned flush.py via \`uv run --directory ~/.claude python ...\`, claude CLI round-tripped, daily log written to \`~/.claude/daily/2026-04-18.md\`
- mem0_bridge_test.py at user-level: 7/7 offline no-raise checks pass
- Mercury still functions normally (the session-level switch happened in-session without breakage)

## Unblocks

- #260 (rsync re-target) — depends on new \`~/.claude/scripts/mem0-state/\` location
- AgentKB fork archival — can proceed after #260 + Mercury #261 + claude-handoff #3 also land

## Test plan

- [x] settings.json JSON validity check passes
- [x] All three hook scripts exit 0 with synthetic stdin
- [x] Live pre-compact → uv run → flush.py → claude CLI end-to-end works
- [x] Daily log written to \`~/.claude/daily/\`
- [ ] Observe one real in-session PreCompact / SessionEnd event after merge to confirm no regressions

Refs #259