### PR TITLE
feat(worktree): Phase 4-2.b dev-pipeline integration + orphan reaper (#247)

### DIFF
--- a/.claude/skills/dev-pipeline/SKILL.md
+++ b/.claude/skills/dev-pipeline/SKILL.md
@@ -63,15 +63,16 @@ Before invoking this skill, the following must be true:
   ],
   "verifyCommands": [
     "<exact bash command to validate, e.g. pnpm test packages/foo>"
-  ]
+  ],
+  "worktreePath": "<absolute path — injected by Main in Phase 2; leave blank here>"
 }
 ```
 
-**Gate**: every field non-empty. If definitionOfDone contains a subjective phrase (clean, elegant, good), rewrite it as a measurable criterion or escalate to the user.
+**Gate**: every field non-empty (except `worktreePath`, which is filled by Main in Phase 2). If definitionOfDone contains a subjective phrase (clean, elegant, good), rewrite it as a measurable criterion or escalate to the user.
 
 ## Phase 2: Dispatch Dev
 
-**Before dispatching**, capture the task-start SHA so Phase 3 can compute the diff range correctly (do not rely on `HEAD~1`). Store it OUTSIDE the working tree to avoid repo pollution:
+**Before dispatching**, capture the task-start SHA and create the isolated worktree for this task:
 
 ```bash
 TASK_START_SHA=$(git rev-parse HEAD)
@@ -82,26 +83,40 @@ BRANCH_KEY=$(git rev-parse --abbrev-ref HEAD | tr '/' '_' | tr -cd '[:alnum:]_-'
 SHA_FILE="${TMPDIR:-/tmp}/dev-pipeline-task-start-sha-${BRANCH_KEY}"
 echo "$TASK_START_SHA" > "$SHA_FILE"
 # Phase 6 cleanup: rm -f "$SHA_FILE"
+
+# Create isolated worktree for this task. Main creates the branch; Dev never does.
+# TaskBundle.taskId is the short slug from Phase 1 (e.g. "247-worktree-per-task").
+TASK_ID="<taskId from TaskBundle>"
+TASK_BRANCH="feat/${TASK_ID}"   # or feature/${TASK_ID}-<slug> per git-flow.md convention
+REPO_ROOT=$(git rev-parse --show-toplevel)
+WORKTREE_PATH="${REPO_ROOT}/.worktrees/${TASK_ID}"
+git worktree add "${WORKTREE_PATH}" -b "${TASK_BRANCH}"
+# Inject absolute path back into the TaskBundle before dispatch:
+#   TaskBundle.worktreePath = "${WORKTREE_PATH}"
+# Phase 6 cleanup: git worktree remove --force "${WORKTREE_PATH}" && git branch -d "${TASK_BRANCH}"
 ```
 
-The file is keyed by the current branch name (slash-sanitized). This is stable across Bash invocations within the same pipeline run, and concurrent pipelines collide only if they are on the same branch — which would be a pre-existing git conflict anyway. Phase 6 hand-off must remove it.
+The SHA file is keyed by the current branch name (slash-sanitized). This is stable across Bash invocations within the same pipeline run, and concurrent pipelines collide only if they are on the same branch — which would be a pre-existing git conflict anyway. Phase 6 hand-off must remove both it and the worktree.
 
 Use the Agent tool with subagent_type set to dev. The prompt template:
 
 ```
 You are operating under the dev agent role (.claude/agents/dev.md). Implement the following task and return a JSON receipt as your final message.
 
+**Working directory: `<worktreePath>` (isolated git worktree). Use `cd <worktreePath>` before any file operation.**
+
 ## TaskBundle
-[paste TaskBundle JSON built in Phase 1]
+[paste TaskBundle JSON built in Phase 1, with worktreePath field filled in]
 
 ## Execution Protocol
-1. Read every file listed in readScope.
-2. Implement within allowedWriteScope only. Touching anything in mustNotTouch is forbidden.
-3. Run every command in verifyCommands. ALL must pass before you commit.
-4. Self-fix once if a verifyCommand fails. If it still fails, STOP and report — do NOT commit broken code.
-5. Commit with format type(scope): summary (Mercury convention).
-6. Push to current branch.
-7. Output the JSON receipt below as your FINAL message.
+1. cd <worktreePath> — all file reads/writes and git commands run from this directory.
+2. Read every file listed in readScope.
+3. Implement within allowedWriteScope only. Touching anything in mustNotTouch is forbidden.
+4. Run every command in verifyCommands. ALL must pass before you commit.
+5. Self-fix once if a verifyCommand fails. If it still fails, STOP and report — do NOT commit broken code.
+6. Commit with format type(scope): summary (Mercury convention).
+7. Push to current branch.
+8. Output the JSON receipt below as your FINAL message.
 
 ## Receipt template
 {
@@ -121,6 +136,7 @@ You are operating under the dev agent role (.claude/agents/dev.md). Implement th
 - git switch, git checkout, git branch, git reset, git rebase, git merge, git push --force
 - git add -A or git add .
 - Modifying CLAUDE.md or any file under .claude/agents/
+- Creating or modifying git worktrees (Main's responsibility)
 - Picking up additional work after the receipt is filed
 ```
 
@@ -219,9 +235,12 @@ Based on the acceptance verdict:
 
 ```bash
 rm -f "$SHA_FILE"
+# Remove the isolated worktree and its branch (--force so uncommitted state does not block).
+git worktree remove --force "${WORKTREE_PATH}"
+git branch -d "${TASK_BRANCH}"
 ```
 
-This runs on `pass`, `blocked`, escalation after `partial`/`fail`, and on iteration-cap escalation. The ONLY paths that skip cleanup are intra-iteration dev re-dispatches (because Phase 3 still needs the SHA). If the loop terminates without reaching one of these branches (e.g. host crash), the file at `${TMPDIR:-/tmp}/dev-pipeline-task-start-sha-${BRANCH_KEY}` will be cleaned up on the next pipeline run against the same branch (the new invocation overwrites it) or by OS tmp eviction; the branch-key naming prevents cross-branch collision.
+This runs on `pass`, `blocked`, escalation after `partial`/`fail`, and on iteration-cap escalation. The ONLY paths that skip cleanup are intra-iteration dev re-dispatches (because Phase 3 still needs the SHA and the worktree is still active). If the loop terminates without reaching one of these branches (e.g. host crash), the SHA file at `${TMPDIR:-/tmp}/dev-pipeline-task-start-sha-${BRANCH_KEY}` will be cleaned up on the next pipeline run against the same branch (the new invocation overwrites it) or by OS tmp eviction; orphaned worktrees under `.worktrees/` can be reclaimed by `scripts/worktree-reaper.sh --prune`.
 
 ## Phase 6: Hand-off
 
@@ -232,7 +251,12 @@ On pass:
 2. If user requested PR: invoke `/pr-flow`
 3. Mark related GitHub Project item Done (via `/gh-project-flow` if Mercury self-dev) or via `Closes #N` in PR (general case)
 4. Summarize in Chinese for the user
-5. Run the Phase 5 Cleanup block (`rm -f "$SHA_FILE"`) as the final action
+5. After PR merge is confirmed, run the Phase 5 Cleanup block as the final action:
+   ```bash
+   rm -f "$SHA_FILE"
+   git worktree remove --force "${WORKTREE_PATH}"
+   git branch -d "${TASK_BRANCH}"
+   ```
 
 **Single source of truth**: the Phase 5 Cleanup block is the only authoritative description of when `$SHA_FILE` is removed. Phase 6 only reaches it via the `pass` branch above. If you find yourself debating "should I clean up here", re-read Phase 5.
 

--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,7 @@ CLAUDE.local.md
 CLAUDE.md
 
 # Git worktrees (transient, managed by Main Agent)
-.worktrees/
+/.worktrees/
 
 # Mercury runtime state
 .mercury/state/test-gate-attempts.json

--- a/.mercury/docs/guides/worktree-workflow.md
+++ b/.mercury/docs/guides/worktree-workflow.md
@@ -21,9 +21,9 @@ rules and merge procedures.
 
 | Actor | Responsibility |
 |-------|----------------|
-| Main Agent | Creates worktree + branch before dispatch; injects `worktreePath` into TaskBundle; merges/deletes after PR merge |
-| Dev Agent | Works exclusively inside `worktreePath`; never switches branches or leaves the worktree |
-| Orchestrator | (Future) automates worktree creation via `prepareBundleTaskExecution`; detects orphaned worktrees |
+| Main Agent | Creates worktree + branch before dispatch; injects `worktreePath` into TaskBundle; removes worktree + branch after PR merge |
+| Dev Agent | Uses `cd <worktreePath>` before any file operation; never switches branches or creates/modifies worktrees |
+| Reaper | `scripts/worktree-reaper.sh` — detects and removes orphaned worktrees (no open PR, older than 7 days) |
 
 ---
 
@@ -35,7 +35,7 @@ Main: git worktree add <path> -b <branch>
   --> TaskBundle.branch = <branch>
         |
         v
-Dispatch -> Dev Agent works inside worktreePath
+Dispatch -> Dev Agent: cd <worktreePath>, work exclusively inside it
         |
         v
 Dev: commit + push (from within worktreePath, never switches branch)
@@ -44,7 +44,7 @@ Dev: commit + push (from within worktreePath, never switches branch)
 Main: review -> PR -> review bot -> merge
         |
         v
-Main: git worktree remove <path> + git branch -d <branch>
+Main: git worktree remove --force <path> + git branch -d <branch>
 ```
 
 ---
@@ -53,190 +53,117 @@ Main: git worktree remove <path> + git branch -d <branch>
 
 | Artifact | Pattern | Example |
 |----------|---------|---------|
-| Worktree path | `.worktrees/{taskId}` | `.worktrees/TASK-a1b2c3d4` |
-| Branch | `feature/{taskId}-{slug}` (existing rule; `taskId` includes `TASK-` prefix) | `feature/TASK-a1b2c3d4-add-auth` |
+| Worktree path | `.worktrees/{taskId}` | `.worktrees/247-worktree-per-task` |
+| Branch | `feat/{taskId}` or `feat/{taskId}-{slug}` per git-flow.md | `feat/247-worktree-per-task` |
 
-The worktree root (`.worktrees/`) belongs in `.gitignore` — worktrees are
-transient and must not be committed.
+The worktree root (`.worktrees/`) is listed in `.gitignore` as `/.worktrees/` —
+worktrees are transient and must not be committed.
 
 ---
 
-## TaskBundle Schema Extension (Proposal)
+## TaskBundle Schema Extension
 
-> **Note:** `worktreePath` and `dependsOn` are proposed fields not yet present
-> on the `TaskBundle` interface in `packages/core/src/types.ts`. They require a
-> future implementation step that adds the fields to the interface and enforces
-> the `worktreePath`+`branch` co-set invariant via Zod schema or a runtime guard.
+`worktreePath` is a first-class field in the TaskBundle. Main fills it in
+Phase 2 of the dev-pipeline skill before dispatching to the dev agent:
 
-Add two optional fields to `TaskBundle`:
-
-```typescript
-interface TaskBundle {
-  // ... existing fields ...
-
-  /** Absolute path to the git worktree for this task.
-   *  Set by Main Agent before dispatch; Dev Agent works exclusively here.
-   *  Undefined for tasks that pre-date worktree workflow or single-task sessions.
-   *  Design constraint: worktreePath and branch must always be set together. */
-  worktreePath?: string;
-
-  /** Task IDs this task depends on. The scheduler must complete dependsOn tasks
-   *  before dispatching this one. Parallel-safe tasks leave this unset or empty. */
-  dependsOn?: string[];
+```json
+{
+  "taskId": "247-worktree-per-task",
+  "worktreePath": "/absolute/path/to/repo/.worktrees/247-worktree-per-task",
+  "...": "other fields"
 }
 ```
+
+The dev agent receives `worktreePath` in its prompt and runs `cd <worktreePath>`
+before every file operation. Dev never creates or removes worktrees.
+
+---
+
+## Dev-Pipeline Integration
+
+Worktree management is embedded in the
+[`dev-pipeline` skill](.../../.claude/skills/dev-pipeline/SKILL.md):
+
+| Phase | Action |
+|-------|--------|
+| **Phase 2 — Dispatch Dev** | Main runs `git worktree add "${REPO_ROOT}/.worktrees/${TASK_ID}" -b "${TASK_BRANCH}"` then injects the absolute path into `TaskBundle.worktreePath` before dispatch |
+| **Phase 2 — Dev prompt** | Prompt explicitly instructs dev to `cd <worktreePath>` before any file operation |
+| **Phase 2 — Forbidden list** | Dev agents are forbidden from "Creating or modifying git worktrees (Main's responsibility)" |
+| **Phase 5 — Cleanup** | On every terminal exit path (pass, blocked, escalation): `git worktree remove --force "${WORKTREE_PATH}" && git branch -d "${TASK_BRANCH}"` |
+| **Phase 6 — Step 5.1** | After PR merge confirmed, same cleanup block runs as final action |
 
 ---
 
 ## Dispatch Protocol (Main Agent)
 
-Before dispatching a task that will run in parallel with other active tasks,
-Main Agent MUST:
+Before dispatching a task, Main MUST:
 
 1. **Create the branch and worktree:**
 
    ```bash
-   git worktree add .worktrees/{taskId} -b feature/{taskId}-{slug}
+   REPO_ROOT=$(git rev-parse --show-toplevel)
+   WORKTREE_PATH="${REPO_ROOT}/.worktrees/${TASK_ID}"
+   git worktree add "${WORKTREE_PATH}" -b "${TASK_BRANCH}"
    ```
 
-2. **Inject into TaskBundle** (via `update_task` RPC or at task creation):
+2. **Inject into TaskBundle:**
 
    ```json
-   { "worktreePath": "/absolute/path/.worktrees/{taskId}",
-     "branch": "feature/{taskId}-{slug}" }
+   { "worktreePath": "/absolute/path/.worktrees/{taskId}" }
    ```
 
-3. **Emphasise in dispatch prompt** (to be handled by `buildDevPrompt` when
-   `task.worktreePath` is set — see Prompt Integration section below):
-   > You are working inside the isolated worktree at `<worktreePath>`.
-   > Do not navigate outside this directory. Do not switch branches.
+3. **Instruct dev in dispatch prompt:**
+   > Working directory: `<worktreePath>`. Use `cd <worktreePath>` before any file operation.
 
 4. **After PR merge**, clean up:
 
    ```bash
-   git worktree remove .worktrees/{taskId}
-   git branch -d feature/{taskId}-{slug}
+   git worktree remove --force "${WORKTREE_PATH}"
+   git branch -d "${TASK_BRANCH}"
    ```
 
 ---
 
-## Prompt Integration
+## Orphan Reaper
 
-`buildDevPrompt` (in `packages/orchestrator/src/task-manager.ts`) will, when
-implemented, prepend a worktree constraint block when `task.worktreePath` is
-set. When implemented, this block will replace the existing Dev Agent Git
-Permissions table for worktree-enabled tasks, making the isolation constraint
-explicit rather than implicit. This is a planned integration and is not yet
-implemented.
+`scripts/worktree-reaper.sh` detects and removes worktrees that have no open
+PR and are older than `WORKTREE_AGE_DAYS` days (default: 7).
 
-Proposed block:
+```bash
+# Preview what would be reaped (safe, default)
+bash scripts/worktree-reaper.sh --dry-run
 
-```markdown
-## Worktree Isolation
-You are working in an isolated git worktree.
-Working directory: {worktreePath}
-Branch: {branch}
-
-CONSTRAINTS:
-- All git operations must execute within {worktreePath}
-- Do NOT run git checkout, git switch, or git branch -d
-- Do NOT navigate to the main working directory or other worktrees
-- Commits and pushes go to branch {branch} only
+# Actually delete orphaned worktrees
+bash scripts/worktree-reaper.sh --prune
 ```
 
----
+The script:
+- Uses `gh pr list --state open` to identify active PR branches
+- Keeps any worktree whose branch has an open PR, regardless of age
+- Keeps any worktree newer than `WORKTREE_AGE_DAYS` days
+- On `--prune`: runs `git worktree remove --force` + `git branch -d`
+- Supports `WORKTREE_ROOT` and `WORKTREE_AGE_DAYS` env var overrides
 
-## Dependency Management
+Run via `scripts/worktree-reaper.sh --dry-run` at session start to inspect
+any worktrees left behind by interrupted pipeline runs.
 
-```text
-dependsOn: []          -> fully independent -> dispatch immediately, own worktree
-dependsOn: [taskId]    -> wait for taskId to reach status=completed before dispatch
-```
-
-The scheduler (future orchestrator enhancement) checks `dependsOn` before each
-dispatch wave. Tasks with unresolved dependencies are held in `drafted` status
-until prerequisites complete.
-
-For the current session (spec-only), dependency enforcement remains manual:
-Main Agent reviews `dependsOn` fields before dispatching.
+Tests: `bash tests/test_worktree_reaper.sh` (exits 0, TAP output).
 
 ---
 
 ## Merge Strategy
 
-Each worktree produces an independent PR (`feature/{taskId}-{slug}` into
-`develop`). PRs are merged in dependency order when dependencies exist.
-Conflicts are resolved by Main Agent via rebase before merge; after rebasing a
-pushed branch, `--force-with-lease` is used to update the PR branch (direct
-force-push without lease is prohibited).
+Each worktree produces an independent PR (`feat/{taskId}` into `develop`).
+PRs are merged in dependency order when dependencies exist. Conflicts are
+resolved by Main Agent via rebase before merge; after rebasing a pushed branch,
+`--force-with-lease` is used to update the PR branch (direct force-push without
+lease is prohibited).
 
 ```text
-develop --> feature/TASK-a1b2c3d4-add-auth     (independent)         -> PR -> merge
-        --> feature/TASK-e5f6g7h8-add-logging  (independent)         -> PR -> merge
-        --> feature/TASK-i9j0k1l2-refactor-auth (dependsOn TASK-a1b2c3d4) -> wait -> PR -> merge
+develop --> feat/TASK-a1b2c3d4-add-auth     (independent)         -> PR -> merge
+        --> feat/TASK-e5f6g7h8-add-logging  (independent)         -> PR -> merge
+        --> feat/TASK-i9j0k1l2-refactor-auth (dependsOn TASK-a1b2c3d4) -> wait -> PR -> merge
 ```
-
----
-
-## Orphan Detection
-
-A worktree is orphaned when its associated task has reached a terminal state
-(`verified`, `closed`, or `failed`) but the worktree directory still exists,
-and no non-terminal task currently references that worktree path.
-Detection rule:
-
-```bash
-# Terminal TaskStatus values: verified, closed, failed
-# Non-terminal TaskStatus values: drafted, dispatched, in_progress,
-#   implementation_done, main_review, acceptance, blocked
-
-git worktree list | grep ".worktrees/" | while read wt_path _rest; do
-  taskId=$(basename "$wt_path")
-
-  # 1. Get task status via get_task RPC
-  status=$(orchestrator-rpc '{"method":"get_task","params":{"taskId":"'"$taskId"'"}}' \
-    | jq -r '.status // "unknown"')
-
-  # 2. Check if terminal
-  if [[ "$status" =~ ^(verified|closed|failed)$ ]]; then
-
-    # 3. Verify no non-terminal task still references this worktree path
-    active_refs=$(orchestrator-rpc '{"method":"list_tasks","params":{}}' \
-      | jq -r '.tasks[]
-          | select(
-              (.status | IN("drafted","dispatched","in_progress",
-                            "implementation_done","main_review","acceptance","blocked"))
-              and .worktreePath == "'"$wt_path"'"
-            )
-          | .taskId')
-
-    if [[ -z "$active_refs" ]]; then
-      echo "ORPHAN: $wt_path (task $taskId is $status, no active references)"
-      # request manual confirmation before removal — may contain uncommitted work
-    fi
-  fi
-done
-```
-
-Main Agent runs orphan detection at session start. Removal requires explicit
-confirmation — worktrees may contain uncommitted work.
-
----
-
-## Future Orchestrator Interface
-
-The following orchestrator methods are proposed for a future implementation
-phase (not part of this spec release):
-
-| Method | Description |
-|--------|-------------|
-| `createWorktree(taskId, branchSlug)` | git worktree add + updates TaskBundle |
-| `removeWorktree(taskId)` | git worktree remove + branch delete |
-| `listOrphanedWorktrees()` | Cross-references worktree list with task statuses |
-| `prepareParallelWave(taskIds[])` | Creates worktrees for all tasks in a wave batch |
-
-`dispatch_task` RPC response will include `worktreePath` when a worktree is
-active for the task.
 
 ---
 
@@ -244,20 +171,17 @@ active for the task.
 
 | Existing Rule | How Worktree Workflow Satisfies It |
 |---------------|-------------------------------------|
-| Dev agents must never switch branches ([`git-flow.md`](git-flow.md)) | Worktree is branch-locked at creation; the same branch cannot be checked out in multiple worktrees simultaneously, ensuring work isolation |
+| Dev agents must never switch branches ([`git-flow.md`](git-flow.md)) | Worktree is branch-locked at creation; the same branch cannot be checked out in multiple worktrees simultaneously |
 | All code enters develop through PRs ([`git-flow.md`](git-flow.md)) | Each worktree branch becomes an independent PR |
 | Main creates branches, Dev does not ([`git-flow.md`](git-flow.md)) | Main creates worktree+branch pre-dispatch; Dev only commits |
 
 ---
 
-## Open Questions (deferred to implementation phase)
+## Open Questions (deferred)
 
 1. Should `.worktrees/` be nested inside the repo root or alongside it (sibling
-   directory)? Sibling avoids any risk of accidentally committing worktree state.
-   Current spec uses repo-root nesting (`.worktrees/{taskId}`).
+   directory)? Current implementation uses repo-root nesting (`.worktrees/{taskId}`).
 2. For tasks that share a dependency, should the dependent task inherit the
-   parent's worktree or get a fresh one from develop? Fresh worktree is safer
-   and keeps each task's change set isolated for review.
+   parent's worktree or get a fresh one from develop? Fresh worktree is safer.
 3. How does the acceptance agent reference files — via worktree path or repo
-   root? Acceptance likely needs the repo root for blind review, since the
-   worktree is task-specific and may diverge from the base.
+   root? Acceptance likely needs the repo root for blind review.

--- a/scripts/worktree-reaper.sh
+++ b/scripts/worktree-reaper.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env sh
+# scripts/worktree-reaper.sh
+# Orphan worktree reaper for Mercury dev-pipeline.
+#
+# Lists entries under .worktrees/, cross-checks against open PRs, and removes
+# any worktree whose branch has no open PR and is older than AGE_DAYS days.
+#
+# Usage:
+#   ./scripts/worktree-reaper.sh            # dry-run (default — prints WOULD REAP)
+#   ./scripts/worktree-reaper.sh --dry-run  # same
+#   ./scripts/worktree-reaper.sh --prune    # actually delete orphaned worktrees
+#
+# Environment overrides:
+#   WORKTREE_ROOT   directory to scan (default: .worktrees relative to repo root)
+#   WORKTREE_AGE_DAYS  minimum age in days before a worktree is eligible (default: 7)
+
+set -eu
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+MODE="${1:---dry-run}"
+case "$MODE" in
+  --dry-run|--prune) ;;
+  *)
+    printf 'Usage: %s [--dry-run|--prune]\n' "$0" >&2
+    exit 1
+    ;;
+esac
+
+# Locate the repository root so the script works from any cwd.
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
+  printf 'ERROR: not inside a git repository\n' >&2
+  exit 1
+}
+
+WT_ROOT="${WORKTREE_ROOT:-${REPO_ROOT}/.worktrees}"
+AGE_DAYS="${WORKTREE_AGE_DAYS:-7}"
+
+# ---------------------------------------------------------------------------
+# Guard: nothing to do if .worktrees/ does not exist
+# ---------------------------------------------------------------------------
+if [ ! -d "$WT_ROOT" ]; then
+  printf 'No %s directory — nothing to do\n' "$WT_ROOT"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Fetch open PR branch names (empty string if gh is unavailable or repo has none)
+# ---------------------------------------------------------------------------
+ACTIVE_BRANCHES=""
+if command -v gh >/dev/null 2>&1; then
+  ACTIVE_BRANCHES=$(gh pr list --state open --json headRefName --jq '.[].headRefName' 2>/dev/null || true)
+fi
+
+# ---------------------------------------------------------------------------
+# Compute age threshold in epoch seconds
+# ---------------------------------------------------------------------------
+NOW=$(date +%s)
+THRESHOLD=$(( AGE_DAYS * 86400 ))
+
+# ---------------------------------------------------------------------------
+# Scan worktrees
+# ---------------------------------------------------------------------------
+FOUND=0
+for wt in "${WT_ROOT}"/*/; do
+  # glob may not expand if directory is empty
+  [ -d "$wt" ] || continue
+  FOUND=1
+
+  task_id=$(basename "$wt")
+
+  # Determine which branch the worktree is on
+  branch=$(git -C "$wt" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+
+  # Determine mtime of the worktree directory.
+  # stat differs between GNU (Linux) and BSD (macOS); try both forms.
+  mtime_epoch=$(stat -c '%Y' "$wt" 2>/dev/null \
+              || stat -f '%m' "$wt" 2>/dev/null \
+              || printf '0')
+
+  age_sec=$(( NOW - mtime_epoch ))
+
+  # Guard: keep worktrees with an open PR regardless of age
+  if [ -n "$branch" ] && printf '%s\n' "$ACTIVE_BRANCHES" | grep -qxF "$branch" 2>/dev/null; then
+    printf 'KEEP    : %s (active PR on branch "%s")\n' "$task_id" "$branch"
+    continue
+  fi
+
+  # Guard: keep worktrees that are still fresh
+  if [ "$age_sec" -lt "$THRESHOLD" ]; then
+    printf 'KEEP    : %s (fresh — age %ds < threshold %ds)\n' \
+      "$task_id" "$age_sec" "$THRESHOLD"
+    continue
+  fi
+
+  # Eligible orphan
+  if [ "$MODE" = "--prune" ]; then
+    if git worktree remove --force "$wt" 2>/dev/null; then
+      # Attempt to delete the branch; non-fatal if it is already gone or merged
+      git branch -d "$branch" 2>/dev/null || true
+      printf 'REAPED  : %s (branch "%s", age %ds)\n' "$task_id" "$branch" "$age_sec"
+    else
+      printf 'ERROR   : failed to remove worktree %s\n' "$wt" >&2
+    fi
+  else
+    printf 'WOULD REAP: %s (branch "%s", age %ds >= threshold %ds) [dry-run]\n' \
+      "$task_id" "$branch" "$age_sec" "$THRESHOLD"
+  fi
+done
+
+if [ "$FOUND" = "0" ]; then
+  printf 'No worktree entries found under %s\n' "$WT_ROOT"
+fi

--- a/scripts/worktree-reaper.sh
+++ b/scripts/worktree-reaper.sh
@@ -37,6 +37,15 @@ REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
 WT_ROOT="${WORKTREE_ROOT:-${REPO_ROOT}/.worktrees}"
 AGE_DAYS="${WORKTREE_AGE_DAYS:-7}"
 
+# Validate AGE_DAYS: must be a non-negative integer. Negative or non-numeric
+# values would produce bogus thresholds (negative → every worktree "eligible").
+case "$AGE_DAYS" in
+  ''|*[!0-9]*)
+    printf 'ERROR: WORKTREE_AGE_DAYS must be a non-negative integer, got "%s"\n' "$AGE_DAYS" >&2
+    exit 1
+    ;;
+esac
+
 # ---------------------------------------------------------------------------
 # Guard: nothing to do if .worktrees/ does not exist
 # ---------------------------------------------------------------------------
@@ -46,11 +55,22 @@ if [ ! -d "$WT_ROOT" ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# Fetch open PR branch names (empty string if gh is unavailable or repo has none)
+# Fetch open PR branch names. Critical to distinguish "no open PRs" from
+# "gh call failed" — in --prune mode an API glitch that returns empty would
+# otherwise delete worktrees whose PRs are actually still open.
 # ---------------------------------------------------------------------------
 ACTIVE_BRANCHES=""
+GH_PR_FETCH_OK=0
 if command -v gh >/dev/null 2>&1; then
-  ACTIVE_BRANCHES=$(gh pr list --state open --json headRefName --jq '.[].headRefName' 2>/dev/null || true)
+  if ACTIVE_BRANCHES=$(gh pr list --state open --json headRefName --jq '.[].headRefName' 2>/dev/null); then
+    GH_PR_FETCH_OK=1
+  fi
+fi
+
+if [ "$MODE" = "--prune" ] && [ "$GH_PR_FETCH_OK" -ne 1 ]; then
+  printf 'ERROR: cannot fetch open PR branches via gh — refusing to prune\n' >&2
+  printf '       Install gh, authenticate, or rerun with --dry-run.\n' >&2
+  exit 1
 fi
 
 # ---------------------------------------------------------------------------
@@ -63,11 +83,29 @@ THRESHOLD=$(( AGE_DAYS * 86400 ))
 # Scan worktrees
 # ---------------------------------------------------------------------------
 FOUND=0
+# Resolve WT_ROOT once so we can confirm each candidate stays inside it.
+ROOT_REAL=$(cd "$WT_ROOT" 2>/dev/null && pwd -P || printf '')
 for wt in "${WT_ROOT}"/*/; do
   # glob may not expand if directory is empty
   [ -d "$wt" ] || continue
-  FOUND=1
+  # Skip symlinks — never follow links out of WT_ROOT
+  [ -L "$wt" ] && continue
 
+  # Verify realpath still lives under WT_ROOT (defends against symlink targets
+  # inside the directory tree and against mount shenanigans)
+  wt_real=$(cd "$wt" 2>/dev/null && pwd -P || printf '')
+  if [ -z "$wt_real" ] || [ -z "$ROOT_REAL" ]; then
+    continue
+  fi
+  case "$wt_real" in
+    "$ROOT_REAL"/*) ;;
+    *)
+      printf 'SKIP    : %s — realpath escapes %s\n' "$wt" "$ROOT_REAL" >&2
+      continue
+      ;;
+  esac
+
+  FOUND=1
   task_id=$(basename "$wt")
 
   # Determine which branch the worktree is on

--- a/tests/test_worktree_reaper.sh
+++ b/tests/test_worktree_reaper.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# tests/test_worktree_reaper.sh
+# Unit tests for scripts/worktree-reaper.sh
+#
+# Tests:
+#   1. --dry-run does NOT delete any directory
+#   2. --prune deletes only the stale orphan (no open PR, age > 7 days)
+#   3. --prune keeps a fresh worktree (age < 7 days)
+#   4. --prune keeps a stale worktree that has an open PR
+#
+# Strategy:
+#   - Creates a temporary directory to act as WORKTREE_ROOT
+#   - Stubs `gh` and `git` commands via a PATH shim directory
+#   - Uses `touch -d '30 days ago'` (or Perl fallback) to backdate the stale entry
+#   - Does NOT exercise real git worktree add/remove — stubs git to echo/exit 0
+#     for worktree and branch commands so the script can run offline
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REAPER="${SCRIPT_DIR}/../scripts/worktree-reaper.sh"
+
+# ---------------------------------------------------------------------------
+# Helper: portable timestamp backdating
+# ---------------------------------------------------------------------------
+backdate() {
+  # $1 = path, $2 = days ago
+  local path="$1" days="$2"
+  if touch -d "${days} days ago" "$path" 2>/dev/null; then
+    return 0
+  fi
+  # macOS / BSD touch uses -t or -A; fall back to perl
+  if command -v perl >/dev/null 2>&1; then
+    perl -e "use POSIX; my \$t = time() - ${days}*86400; utime(\$t,\$t,'${path}');"
+    return 0
+  fi
+  echo "SKIP: cannot backdate timestamps on this platform — skipping age-related tests" >&2
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Setup: temp workspace
+# ---------------------------------------------------------------------------
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+WT_ROOT="${TMP}/worktrees"
+SHIM_DIR="${TMP}/shims"
+mkdir -p "$WT_ROOT" "$SHIM_DIR"
+
+# Stale orphan: no open PR, age > 7 days
+STALE_DIR="${WT_ROOT}/TASK-stale"
+mkdir -p "$STALE_DIR"
+backdate "$STALE_DIR" 30 || { echo "1..0 # SKIP cannot backdate"; exit 0; }
+
+# Fresh entry: no open PR but younger than 7 days
+FRESH_DIR="${WT_ROOT}/TASK-fresh"
+mkdir -p "$FRESH_DIR"
+# mtime is now (fresh by default)
+
+# Stale-but-has-PR entry: age > 7 days but an open PR exists
+STALE_PR_DIR="${WT_ROOT}/TASK-stale-with-pr"
+mkdir -p "$STALE_PR_DIR"
+backdate "$STALE_PR_DIR" 30
+
+# ---------------------------------------------------------------------------
+# Shim: gh — returns headRefName for TASK-stale-with-pr's branch only
+# ---------------------------------------------------------------------------
+cat > "${SHIM_DIR}/gh" <<'EOF'
+#!/usr/bin/env sh
+# Fake `gh pr list` — returns one open PR on feat/TASK-stale-with-pr
+if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
+  printf 'feat/TASK-stale-with-pr\n'
+  exit 0
+fi
+exit 0
+EOF
+chmod +x "${SHIM_DIR}/gh"
+
+# ---------------------------------------------------------------------------
+# Shim: git
+#   - rev-parse --show-toplevel  → TMP (repo root so WT_ROOT stays under TMP)
+#   - rev-parse --abbrev-ref HEAD (run inside a worktree dir) → derive branch from dirname
+#   - worktree remove --force <path> → rm -rf <path>  (simulate removal)
+#   - branch -d <branch> → no-op
+#   - anything else → delegate to real git if available, else no-op
+# ---------------------------------------------------------------------------
+cat > "${SHIM_DIR}/git" <<EOF
+#!/usr/bin/env sh
+# Fake git shim for worktree-reaper tests
+
+# rev-parse --show-toplevel
+if [ "\$1" = "rev-parse" ] && [ "\$2" = "--show-toplevel" ]; then
+  printf '%s\n' "${TMP}"
+  exit 0
+fi
+
+# rev-parse --abbrev-ref HEAD  (called with -C <worktree-path>)
+if [ "\$1" = "-C" ] && [ "\$3" = "rev-parse" ] && [ "\$4" = "--abbrev-ref" ] && [ "\$5" = "HEAD" ]; then
+  wt_path="\$2"
+  task=\$(basename "\$wt_path")
+  printf 'feat/%s\n' "\$task"
+  exit 0
+fi
+
+# worktree remove --force <path>
+if [ "\$1" = "worktree" ] && [ "\$2" = "remove" ] && [ "\$3" = "--force" ]; then
+  rm -rf "\$4"
+  exit 0
+fi
+
+# branch -d <branch>
+if [ "\$1" = "branch" ] && [ "\$2" = "-d" ]; then
+  exit 0
+fi
+
+# fallback: silently succeed
+exit 0
+EOF
+chmod +x "${SHIM_DIR}/git"
+
+# ---------------------------------------------------------------------------
+# Run reaper with shim PATH
+# ---------------------------------------------------------------------------
+run_reaper() {
+  WORKTREE_ROOT="$WT_ROOT" WORKTREE_AGE_DAYS=7 \
+    PATH="${SHIM_DIR}:${PATH}" \
+    bash "$REAPER" "$@"
+}
+
+# ---------------------------------------------------------------------------
+# TAP output
+# ---------------------------------------------------------------------------
+TESTS=4
+printf '1..%d\n' "$TESTS"
+
+# Test 1: --dry-run leaves all directories intact
+OUTPUT=$(run_reaper --dry-run 2>&1)
+if [ -d "$STALE_DIR" ] && [ -d "$FRESH_DIR" ] && [ -d "$STALE_PR_DIR" ]; then
+  printf 'ok 1 - dry-run does not delete anything\n'
+else
+  printf 'not ok 1 - dry-run deleted a directory\n'
+  printf '# Output:\n%s\n' "$OUTPUT"
+fi
+
+# Test 2: --dry-run output mentions WOULD REAP for stale orphan
+if printf '%s\n' "$OUTPUT" | grep -q 'WOULD REAP.*TASK-stale'; then
+  printf 'ok 2 - dry-run reports WOULD REAP for stale orphan\n'
+else
+  printf 'not ok 2 - dry-run did not report WOULD REAP for TASK-stale\n'
+  printf '# Output:\n%s\n' "$OUTPUT"
+fi
+
+# Test 3: --prune deletes ONLY the stale orphan
+run_reaper --prune >/dev/null 2>&1 || true
+
+if [ ! -d "$STALE_DIR" ]; then
+  printf 'ok 3 - --prune removed the stale orphan TASK-stale\n'
+else
+  printf 'not ok 3 - --prune did NOT remove TASK-stale\n'
+fi
+
+# Test 4: --prune kept TASK-fresh and TASK-stale-with-pr
+if [ -d "$FRESH_DIR" ] && [ -d "$STALE_PR_DIR" ]; then
+  printf 'ok 4 - --prune kept TASK-fresh and TASK-stale-with-pr\n'
+else
+  printf 'not ok 4 - --prune incorrectly deleted a non-orphan entry\n'
+  [ -d "$FRESH_DIR" ]    || printf '# TASK-fresh was deleted\n'
+  [ -d "$STALE_PR_DIR" ] || printf '# TASK-stale-with-pr was deleted\n'
+fi


### PR DESCRIPTION
## Summary

Closes #247

Revised scope per [issue comment](https://github.com/392fyc/Mercury/issues/247#issuecomment-4273432979): prompt-driven integration in dev-pipeline SKILL.md + lightweight orphan reaper, instead of a 60-80 LOC Python/bash API wrapper.

### Changes

- **`.claude/skills/dev-pipeline/SKILL.md`**
  - Phase 1 TaskBundle schema: adds `worktreePath` field
  - Phase 2: Main captures task-start SHA, creates worktree via `git worktree add .worktrees/<taskId> -b <branch>` BEFORE dispatching dev, injects absolute path into TaskBundle
  - Phase 2 Forbidden list: dev subagent cannot create/modify worktrees (Main's responsibility)
  - Phase 2 dev prompt: instructs `cd <worktreePath>` before any file operation
  - Phase 5 Cleanup: extends `$SHA_FILE` removal to also run `git worktree remove --force` + `git branch -d` on all terminal exit paths
  - Phase 6 step 5.1: explicit worktree removal after PR merge confirmation
- **`scripts/worktree-reaper.sh`**: POSIX sh, `--dry-run` default, `--prune` to delete. Cross-checks against open PRs via `gh pr list`. Age threshold 7 days (configurable via `WORKTREE_AGE_DAYS` env).
- **`tests/test_worktree_reaper.sh`**: 4 TAP tests — dry-run no-delete, dry-run output format, prune removes stale orphan, prune preserves fresh + PR-backed entries.
- **`.gitignore`**: `/.worktrees/` anchored entry.
- **`.mercury/docs/guides/worktree-workflow.md`**: aligned with SKILL.md; replaced "Orchestrator (Future)" with reaper section.

### Upstream dependency

`claude-handoff` session_chain v0.3.0 (PR #8, merged) provides `worktree_path` as first-class column for cross-session continuity.

## Test plan

- [x] `bash tests/test_worktree_reaper.sh` — 4/4 TAP tests pass
- [x] `bash -n scripts/worktree-reaper.sh` — syntax OK
- [x] dev-pipeline SKILL.md grep verifies `git worktree add` / `remove` / worktreePath injection
- [ ] End-to-end on next dev-pipeline dispatch: verify Main creates `.worktrees/<taskId>`, dev works there, Phase 6 removes after merge
- [ ] Reaper: create a stale orphan manually, run `scripts/worktree-reaper.sh --prune`, confirm deletion

🤖 Generated with [Claude Code](https://claude.com/claude-code)