### PR TITLE
fix(dev-pipeline): handle Windows worktree cleanup file lock (#265)

### DIFF
--- a/.claude/skills/dev-pipeline/SKILL.md
+++ b/.claude/skills/dev-pipeline/SKILL.md
@@ -235,9 +235,21 @@ Based on the acceptance verdict:
 
 ```bash
 rm -f "$SHA_FILE"
-# Remove the isolated worktree and its branch (--force so uncommitted state does not block).
-git worktree remove --force "${WORKTREE_PATH}"
-git branch -d "${TASK_BRANCH}"
+# Remove the isolated worktree and its branch.
+# On Windows, `git worktree remove --force` may partially succeed: git metadata
+# (.git/worktrees/<name>/) is removed but the physical directory is retained due
+# to OS file locks (see Mercury #265). Retry once after a short sleep, then fall
+# back to rm -rf on the residual directory.
+git worktree remove --force "${WORKTREE_PATH}" || {
+  sleep 2
+  git worktree remove --force "${WORKTREE_PATH}" || true
+}
+if [ -d "${WORKTREE_PATH}" ] && [ ! -L "${WORKTREE_PATH}" ]; then
+  rm -rf "${WORKTREE_PATH}" || true
+fi
+# `|| true`: if git metadata still references the worktree (extreme retry-failure path),
+# `git branch -d` would refuse with "branch is checked out". Don't abort the cleanup chain.
+git branch -d "${TASK_BRANCH}" || true
 ```
 
 This runs on `pass`, `blocked`, escalation after `partial`/`fail`, and on iteration-cap escalation. The ONLY paths that skip cleanup are intra-iteration dev re-dispatches (because Phase 3 still needs the SHA and the worktree is still active). If the loop terminates without reaching one of these branches (e.g. host crash), the SHA file at `${TMPDIR:-/tmp}/dev-pipeline-task-start-sha-${BRANCH_KEY}` will be cleaned up on the next pipeline run against the same branch (the new invocation overwrites it) or by OS tmp eviction; orphaned worktrees under `.worktrees/` can be reclaimed by `scripts/worktree-reaper.sh --prune`.
@@ -251,12 +263,7 @@ On pass:
 2. If user requested PR: invoke `/pr-flow`
 3. Mark related GitHub Project item Done (via `/gh-project-flow` if Mercury self-dev) or via `Closes #N` in PR (general case)
 4. Summarize in Chinese for the user
-5. After PR merge is confirmed, run the Phase 5 Cleanup block as the final action:
-   ```bash
-   rm -f "$SHA_FILE"
-   git worktree remove --force "${WORKTREE_PATH}"
-   git branch -d "${TASK_BRANCH}"
-   ```
+5. After PR merge is confirmed, run the **Phase 5 Cleanup block** as the final action (see Phase 5 above — the retry + rm-rf fallback logic is the SoT and is not duplicated here).
 
 **Single source of truth**: the Phase 5 Cleanup block is the only authoritative description of when `$SHA_FILE` is removed. Phase 6 only reaches it via the `pass` branch above. If you find yourself debating "should I clean up here", re-read Phase 5.
 

--- a/.claude/skills/dev-pipeline/SKILL.md
+++ b/.claude/skills/dev-pipeline/SKILL.md
@@ -242,14 +242,28 @@ rm -f "$SHA_FILE"
 # back to rm -rf on the residual directory.
 git worktree remove --force "${WORKTREE_PATH}" || {
   sleep 2
-  git worktree remove --force "${WORKTREE_PATH}" || true
+  git worktree remove --force "${WORKTREE_PATH}" || echo "WARN: git worktree remove retry failed for ${WORKTREE_PATH}" >&2
 }
-if [ -d "${WORKTREE_PATH}" ] && [ ! -L "${WORKTREE_PATH}" ]; then
-  rm -rf "${WORKTREE_PATH}" || true
+# rm -rf fallback: require non-empty path, existing dir, not a symlink, AND path whitelist.
+# The case pattern `*/.worktrees/*` constrains deletion to Mercury's managed worktree root
+# (Phase 2 sets WORKTREE_PATH="${REPO_ROOT}/.worktrees/${TASK_ID}", so the check refuses to
+# delete anything outside that conventional layout even if the variable is corrupted).
+# `rm -- "${path}"` uses POSIX rm's `--` end-of-options terminator (rm(1)).
+if [ -n "${WORKTREE_PATH}" ] && [ -d "${WORKTREE_PATH}" ] && [ ! -L "${WORKTREE_PATH}" ]; then
+  case "${WORKTREE_PATH}" in
+    */.worktrees/*)
+      rm -rf -- "${WORKTREE_PATH}" || echo "WARN: rm -rf fallback failed for ${WORKTREE_PATH}" >&2
+      ;;
+    *)
+      echo "WARN: refuse to rm -rf unexpected path: ${WORKTREE_PATH}" >&2
+      ;;
+  esac
 fi
-# `|| true`: if git metadata still references the worktree (extreme retry-failure path),
-# `git branch -d` would refuse with "branch is checked out". Don't abort the cleanup chain.
-git branch -d "${TASK_BRANCH}" || true
+# `|| echo WARN`: surface cleanup failures to stderr rather than silently swallowing them.
+# If worktree metadata still references the branch (extreme retry-failure path), `git branch -d`
+# refuses with "branch is checked out". We warn and continue — orphan branch can be reclaimed
+# by `scripts/worktree-reaper.sh --prune` on the next cycle.
+git branch -d "${TASK_BRANCH}" || echo "WARN: git branch -d ${TASK_BRANCH} failed (likely still registered in a worktree)" >&2
 ```
 
 This runs on `pass`, `blocked`, escalation after `partial`/`fail`, and on iteration-cap escalation. The ONLY paths that skip cleanup are intra-iteration dev re-dispatches (because Phase 3 still needs the SHA and the worktree is still active). If the loop terminates without reaching one of these branches (e.g. host crash), the SHA file at `${TMPDIR:-/tmp}/dev-pipeline-task-start-sha-${BRANCH_KEY}` will be cleaned up on the next pipeline run against the same branch (the new invocation overwrites it) or by OS tmp eviction; orphaned worktrees under `.worktrees/` can be reclaimed by `scripts/worktree-reaper.sh --prune`.

--- a/.claude/skills/dev-pipeline/SKILL.md
+++ b/.claude/skills/dev-pipeline/SKILL.md
@@ -245,17 +245,19 @@ git worktree remove --force "${WORKTREE_PATH}" || {
   git worktree remove --force "${WORKTREE_PATH}" || echo "WARN: git worktree remove retry failed for ${WORKTREE_PATH}" >&2
 }
 # rm -rf fallback: require non-empty path, existing dir, not a symlink, AND path whitelist.
-# The case pattern `*/.worktrees/*` constrains deletion to Mercury's managed worktree root
-# (Phase 2 sets WORKTREE_PATH="${REPO_ROOT}/.worktrees/${TASK_ID}", so the check refuses to
-# delete anything outside that conventional layout even if the variable is corrupted).
-# `rm -- "${path}"` uses POSIX rm's `--` end-of-options terminator (rm(1)).
+# The case pattern pins the allowed root to *this repo's* `${REPO_ROOT}/.worktrees/` prefix so
+# a corrupted WORKTREE_PATH cannot delete a different repo's worktree directory. We recompute
+# REPO_ROOT here (Phase 2's local var is out of scope by Phase 5) and fall back to a pattern
+# that matches nothing if we are outside a git repo — refuse-by-default semantics.
+# `rm -rf -- "${path}"` uses POSIX rm's `--` end-of-options terminator (rm(1)).
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
 if [ -n "${WORKTREE_PATH}" ] && [ -d "${WORKTREE_PATH}" ] && [ ! -L "${WORKTREE_PATH}" ]; then
   case "${WORKTREE_PATH}" in
-    */.worktrees/*)
+    "${REPO_ROOT}/.worktrees/"*)
       rm -rf -- "${WORKTREE_PATH}" || echo "WARN: rm -rf fallback failed for ${WORKTREE_PATH}" >&2
       ;;
     *)
-      echo "WARN: refuse to rm -rf unexpected path: ${WORKTREE_PATH}" >&2
+      echo "WARN: refuse to rm -rf path outside ${REPO_ROOT:-<unknown>}/.worktrees/: ${WORKTREE_PATH}" >&2
       ;;
   esac
 fi

--- a/.claude/skills/dev-pipeline/SKILL.md
+++ b/.claude/skills/dev-pipeline/SKILL.md
@@ -281,7 +281,7 @@ On pass:
 2. If user requested PR: invoke `/pr-flow`
 3. Mark related GitHub Project item Done (via `/gh-project-flow` if Mercury self-dev) or via `Closes #N` in PR (general case)
 4. Summarize in Chinese for the user
-5. After PR merge is confirmed, run the **Phase 5 Cleanup block** as the final action (see Phase 5 above — the retry + rm-rf fallback logic is the SoT and is not duplicated here).
+5. After PR merge is confirmed, run the **Phase 5 Cleanup block** as the final action (see Phase 5 above — the retry + `rm -rf` fallback logic is the SoT and is not duplicated here).
 
 **Single source of truth**: the Phase 5 Cleanup block is the only authoritative description of when `$SHA_FILE` is removed. Phase 6 only reaches it via the `pass` branch above. If you find yourself debating "should I clean up here", re-read Phase 5.
 

--- a/.claude/skills/dev-pipeline/SKILL.md
+++ b/.claude/skills/dev-pipeline/SKILL.md
@@ -251,13 +251,15 @@ git worktree remove --force "${WORKTREE_PATH}" || {
 # that matches nothing if we are outside a git repo — refuse-by-default semantics.
 # `rm -rf -- "${path}"` uses POSIX rm's `--` end-of-options terminator (rm(1)).
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
-if [ -n "${WORKTREE_PATH}" ] && [ -d "${WORKTREE_PATH}" ] && [ ! -L "${WORKTREE_PATH}" ]; then
+if [ -z "${REPO_ROOT}" ]; then
+  echo "WARN: cannot determine REPO_ROOT (cwd not in a git repo) — skipping rm -rf fallback for ${WORKTREE_PATH}" >&2
+elif [ -n "${WORKTREE_PATH}" ] && [ -d "${WORKTREE_PATH}" ] && [ ! -L "${WORKTREE_PATH}" ]; then
   case "${WORKTREE_PATH}" in
     "${REPO_ROOT}/.worktrees/"*)
       rm -rf -- "${WORKTREE_PATH}" || echo "WARN: rm -rf fallback failed for ${WORKTREE_PATH}" >&2
       ;;
     *)
-      echo "WARN: refuse to rm -rf path outside ${REPO_ROOT:-<unknown>}/.worktrees/: ${WORKTREE_PATH}" >&2
+      echo "WARN: refuse to rm -rf path outside ${REPO_ROOT}/.worktrees/: ${WORKTREE_PATH}" >&2
       ;;
   esac
 fi


### PR DESCRIPTION
## Summary
- Phase 5 Cleanup block hardened for Windows: `git worktree remove --force` may partially succeed (git metadata removed but physical directory retained due to OS file locks). New flow: try → sleep 2 → retry → if directory still exists (and not a symlink), `rm -rf` fallback.
- `git branch -d` gets `|| true` so an extreme retry-failure path (worktree metadata still present) does not abort the cleanup chain mid-way.
- Phase 6 pass-branch cleanup is deduped: it now references Phase 5 as the single source of truth instead of duplicating the bash block.

## Why Option A (SKILL-layer retry) over B (reaper) / C (docs only)
Issue #265 listed three options. Picked A because it makes cleanup succeed in-line at the moment the pipeline finishes, rather than relying on `scripts/worktree-reaper.sh --prune` (Option B) running on a separate cadence. Reaper still serves as the periodic safety net for orphan accumulation across runs — Option A and Option B are complementary, not competing.

## Test plan
- [ ] Manual: trigger dev-pipeline pass on Windows with a worktree that has an open file handle from a still-running editor; verify Phase 5 cleanup completes (worktree gone + branch gone) without manual intervention.
- [ ] Read-through: Phase 6 reference to Phase 5 is unambiguous (single source of truth).
- [ ] No regression on Linux/macOS where the first `git worktree remove --force` already succeeds (retry path is `|| true`-guarded, no false errors).

## Dual-verify status
- **Claude inline review (Opus 4.7)**: PASS after must-fix applied — original diff missed `|| true` on `git branch -d` (would abort cleanup chain on extreme retry-failure path) and lacked symlink guard on `rm -rf`. Both fixed in this PR.
- **Codex companion audit**: dispatched (job `bpbs2h38a`) but no result returned within ~10 minutes; `~/.codex/session_index.jsonl` shows no new entry on 2026-04-19. Codex companion link appears unavailable. Per dual-verify skill Fallback section: low-risk variation (~15 LOC SKILL.md, documentation-grade bash) qualifies for single-reviewer fallback.

## Follow-up (nice-to-have, not blocking)
- Capture stderr from the silent `|| true` chain to a `/tmp/worktree-cleanup.log` so future debugging has visibility into which retry stage tripped. Can ship as a separate PR.

Closes #265