### PR TITLE
fix(pr-flow): include .pr-flow-last-checked-* in Phase 7 cleanup (#273)

### DIFF
--- a/.claude/skills/pr-flow/SKILL.md
+++ b/.claude/skills/pr-flow/SKILL.md
@@ -139,7 +139,7 @@ CronCreate:
 
 When cron reports reviews arrived:
 1. `CronDelete` the polling job
-2. Clean up: `rm -f .pr-flow-check-count-*`
+2. Clean up: `rm -f .pr-flow-check-count-* .pr-flow-last-checked-*`
 3. Proceed to Phase 3
 
 ## Phase 3: Read + Triage ALL Findings
@@ -348,7 +348,7 @@ gh pr merge "$PR_NUMBER" --squash --delete-branch
 ## Phase 7: Cleanup
 
 ```bash
-rm -f .pr-flow-iteration-* .pr-flow-check-count-* .pr-flow-multi.txt
+rm -f .pr-flow-iteration-* .pr-flow-check-count-* .pr-flow-last-checked-* .pr-flow-multi.txt
 
 BRANCH=$(gh pr view "$PR_NUMBER" --json headRefName --jq '.headRefName')
 


### PR DESCRIPTION
## Summary
- Two cleanup points in the pr-flow skill now remove the `.pr-flow-last-checked-<PR_NUMBER>` state files created by the review-polling cron.
- Phase 2 teardown (`rm -f` after `CronDelete`) and Phase 7 final cleanup both add the new glob `.pr-flow-last-checked-*`.

## Motivation
Observed on PR #271 (the #265 follow-up run): after the full pr-flow lifecycle completed, `.pr-flow-last-checked-271` remained in the repo root as an orphan. The review-polling state file was introduced alongside the "Review polling field selection" change but was not added to the two cleanup glob lists. Two-character patch fixes that.

Structural fix (centralizing state-file glob naming so producer and cleaner cannot drift) is tracked separately in the shared-cleanup-script refactor Issue.

## Test plan
- [ ] Read-through: both Phase 2 step 2 (line 142) and Phase 7 cleanup block (line 351) include the new glob.
- [ ] Next pr-flow run (on a future PR) leaves no `.pr-flow-last-checked-*` behind.

## Dual-verify status
- **Claude inline review (Opus 4.7)**: PASS — diff is purely additive glob entries; no behavior change beyond extra `rm -f` coverage; `rm -f` on a glob with zero matches is a no-op, so no regression risk.
- **Codex companion audit**: unavailable (same link issue observed on PR #271). Per skill Fallback section, this ~2-line doc-only change qualifies for single-reviewer fallback.

Closes #273