### PR TITLE
docs(phase-4-3): mark env var VERIFIED + record B.2 implementation (#270)

### DIFF
--- a/.mercury/docs/EXECUTION-PLAN.md
+++ b/.mercury/docs/EXECUTION-PLAN.md
@@ -288,9 +288,36 @@ adapters/         # 适配层
 2. Mercury dev-pipeline 分发 N 个 subagent 时能自动创建 N 个隔离 worktree 并在 PR merge 后清理（4-2.b）
 3. agent 在 context 耗尽后自动启动新 session 并继续之前的任务（Phase 4 整体目标）
 
-### 4-3. Compact-prevention 模式
-- 接近 context 上限时主动 `/handoff`
-- PreCompact/PostCompact hooks 重定位
+### 4-3. Compact-prevention 模式 — B.1 landed (soak), B.2 Implemented (pending soak)
+
+研究：`.mercury/docs/research/phase4-3-compact-prevention-eval.md` (S60)。Option B 分层执行。
+
+#### 4-3. S4 prerequisite — ✅ CLOSED PARTIAL (S61, Issue #268, 2026-04-19)
+- `context_window.used_percentage` PRESENT in statusline stdin, ABSENT in PreCompact/SessionStart/SessionEnd hook payloads
+- 决定 B.1 走 statusline wrapper 路径，B.2 必须用 `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` env var gate（不能依赖 hook payload 读阈值）
+
+#### 4-3. B.1 statusline advisory — ✅ Implemented, soak 中 (S61, Issue #269, 2026-04-19)
+- `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/statusline-context.sh` 包装 claude-hud，≥75% 时 append `⚠ CTX n% /handoff`
+- 阈值 env var `MERCURY_CTX_ADVISORY_PCT` override；Windows UTF-8 fixed (`PYTHONIOENCODING=utf-8`)
+- Soak 验证：2+ sessions 确认无 regression + null-safe + 渲染正确
+
+#### 4-3. B.2 PreCompact block + CLAUDE_AUTOCOMPACT_PCT_OVERRIDE — ✅ Implemented, pending real-session soak (S63, Issue #270, 2026-04-20)
+- `settings.json.env.CLAUDE_AUTOCOMPACT_PCT_OVERRIDE: "75"` (official env var **VERIFIED** via code.claude.com/docs/en/env-vars)
+- `pre-compact.py` 首次 auto-trigger 返回 `{"decision":"block","reason":...}`；同 session 第 2 次 auto-trigger → escape-hatch 放行；`trigger=manual` 从不 block
+- Per-session counter at `scripts/pre-compact-block-counter.json`；决策与计数写 `flush.log`
+- Smoke test 3/3 PASS（auto first block、auto second escape、manual never-block）
+- 待真实 soak：(1) block reason 能否进入 main agent 下一轮 context + (2) `/handoff:auto` 后 next session 状态正确
+
+#### 4-3. B.3 Notify Hub fallback — Defer to Phase 5
+- 连续 block 3× 无响应 → 通过 Notify Hub 发通知；无需独立 issue，随 Phase 5 一并实装
+
+**期望产出**（soak 验证前尚未确认端到端）：agent 在 context 接近上限时收到 block reason，触发 handoff；原 flush-to-memory 路径不变
+**人类干预点**：B.1+B.2 soak 期间观察真实触发，确认决策字串进入 main loop
+**验收标准**：
+1. Session 自然达到 75% 时 block reason 在下一轮 context 可见
+2. `/handoff:auto` 后 next session starts clean
+3. rollback 路径验证（unset env var / revert hook）
+4. escape-hatch 防死锁 ✅（smoke test 已证）
 
 ### 4-4. 卡死检测 (S37, #226) — 核心已交付，增强待定
 - ✅ sliding window 循环检测已实现并交付 (PR #229, #231, merged)

--- a/.mercury/docs/EXECUTION-PLAN.md
+++ b/.mercury/docs/EXECUTION-PLAN.md
@@ -288,7 +288,7 @@ adapters/         # 适配层
 2. Mercury dev-pipeline 分发 N 个 subagent 时能自动创建 N 个隔离 worktree 并在 PR merge 后清理（4-2.b）
 3. agent 在 context 耗尽后自动启动新 session 并继续之前的任务（Phase 4 整体目标）
 
-### 4-3. Compact-prevention 模式 — B.1 landed (soak), B.2 Implemented (pending soak)
+### 4-3. Compact-prevention 模式 — B.1 Implemented (acceptance-pending), B.2 Implemented (acceptance-pending)
 
 研究：`.mercury/docs/research/phase4-3-compact-prevention-eval.md` (S60)。Option B 分层执行。
 
@@ -301,7 +301,7 @@ adapters/         # 适配层
 - 阈值 env var `MERCURY_CTX_ADVISORY_PCT` override；Windows UTF-8 fixed (`PYTHONIOENCODING=utf-8`)
 - Soak 验证：2+ sessions 确认无 regression + null-safe + 渲染正确
 
-#### 4-3. B.2 PreCompact block + CLAUDE_AUTOCOMPACT_PCT_OVERRIDE — ✅ Implemented, pending real-session soak (S63, Issue #270, 2026-04-20)
+#### 4-3. B.2 PreCompact block + CLAUDE_AUTOCOMPACT_PCT_OVERRIDE — ✅ Implemented, acceptance-pending (S63, Issue #270, 2026-04-19 UTC)
 - `settings.json.env.CLAUDE_AUTOCOMPACT_PCT_OVERRIDE: "75"` (official env var **VERIFIED** via code.claude.com/docs/en/env-vars)
 - `pre-compact.py` 首次 auto-trigger 返回 `{"decision":"block","reason":...}`；同 session 第 2 次 auto-trigger → escape-hatch 放行；`trigger=manual` 从不 block
 - Per-session counter at `scripts/pre-compact-block-counter.json`；决策与计数写 `flush.log`

--- a/.mercury/docs/EXECUTION-PLAN.md
+++ b/.mercury/docs/EXECUTION-PLAN.md
@@ -302,6 +302,7 @@ adapters/         # 适配层
 - Soak 验证：2+ sessions 确认无 regression + null-safe + 渲染正确
 
 #### 4-3. B.2 PreCompact block + CLAUDE_AUTOCOMPACT_PCT_OVERRIDE — ✅ Implemented, acceptance-pending (S63, Issue #270, 2026-04-19 UTC)
+- **Rollout order 偏离说明**：Issue #270 原定 "B.1 soak ≥ 2 sessions 后再推 B.2"；S63 用户指令提前 B.2 实装，B.1+B.2 现在并行 soak（S62+S63 作为 B.1 的 2 session soak 期，尚未观察到 statusline regression）。若 B.1 soak 期间发现问题，B.2 的 env var + hook 可独立回滚不影响 B.1
 - `settings.json.env.CLAUDE_AUTOCOMPACT_PCT_OVERRIDE: "75"` (official env var **VERIFIED** via code.claude.com/docs/en/env-vars)
 - `pre-compact.py` 首次 auto-trigger 返回 `{"decision":"block","reason":...}`；同 session 第 2 次 auto-trigger → escape-hatch 放行；`trigger=manual` 从不 block
 - Per-session counter at `scripts/pre-compact-block-counter.json`；决策与计数写 `flush.log`

--- a/.mercury/docs/research/phase4-3-compact-prevention-eval.md
+++ b/.mercury/docs/research/phase4-3-compact-prevention-eval.md
@@ -56,7 +56,7 @@ Goal: detect "approaching context limit" *before* compaction begins, from a posi
 
 ### S1. `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` + PreCompact-block
 
-**Mechanism**: lower `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` to e.g. `60` so auto-compact triggers at 60% usage (default ~83.5%). PreCompact(auto) then blocks with `decision: block`, reason = "Mercury: please run /handoff auto to preserve working context". Main agent sees stderr / block message next turn.
+**Mechanism**: lower `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` to e.g. `60` so auto-compact triggers at 60% usage (default ~95% per official env-vars reference, superseding third-party `claudefa.st` 83.5% claim — see Verification notes). PreCompact(auto) then blocks with `decision: block`, reason = "Mercury: please run /handoff auto to preserve working context". Main agent is expected to see stderr / block message next turn — **empirical verification pending per §6 Open Question 2** (B.2 soak).
 
 | Dimension | Eval |
 |---|---|
@@ -297,6 +297,6 @@ Local source (Mercury baseline):
 - `PreCompact` `{"decision": "block", "reason": ...}` — confirmed in `code.claude.com/docs/en/hooks`.
 - `SessionStart` `source: "compact"` matcher — confirmed in `code.claude.com/docs/en/hooks`.
 - `InstructionsLoaded` `load_reason: "compact"` — confirmed in `code.claude.com/docs/en/hooks`.
-- Auto-compact `~83.5%` trigger / `33K` buffer — **third-party source only**, marked UNVERIFIED against official telemetry.
-- `remaining_percentage` field — **third-party source only**, UNVERIFIED; B.1 implementation must probe first.
-- `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` env var — GitHub issue thread confirms; **UNVERIFIED** against official env-var reference page (not yet located).
+- Auto-compact `~83.5%` trigger / `33K` buffer — third-party source; **corrected to ~95% default** per official env-vars reference (see `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` note below, 2026-04-20). 33K buffer figure remains UNVERIFIED.
+- `remaining_percentage` field — **VERIFIED** 2026-04-19 (S61, Issue #268): PRESENT in statusline stdin (`context_window.used_percentage`), ABSENT in all hook payloads (PreCompact / SessionStart / SessionEnd / PostCompact). B.1 uses statusline wrapper path; B.2 cannot depend on hook payload and uses `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` gate instead.
+- `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` env var — **VERIFIED** 2026-04-20 against <https://code.claude.com/docs/en/env-vars>. Accepts 1-100; default ~95%; values above default have no effect (see anthropics/claude-code#31806). Aligns with `context_window.used_percentage` statusline field. Related: `CLAUDE_CODE_AUTO_COMPACT_WINDOW` for token-window override.


### PR DESCRIPTION
## Summary

Records that Phase 4-3 B.2 (PreCompact block + `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` env var) has been implemented at the user-level config layer (`~/.claude/settings.json` + `~/.claude/hooks/pre-compact.py`). The user-level changes are NOT part of this repo — they are recorded in Issue #270 per CLAUDE.md user-level variance governance.

**Mercury repo changes (this PR, 2 files):**

1. `.mercury/docs/research/phase4-3-compact-prevention-eval.md` — factual corrections:
   - `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` UNVERIFIED → VERIFIED against <https://code.claude.com/docs/en/env-vars> (accepts 1-100; default ~95%; values above default have no effect per anthropics/claude-code#31806; aligns with `context_window.used_percentage` statusline field)
   - `remaining_percentage` UNVERIFIED → VERIFIED per Issue #268 verdict (PRESENT in statusline stdin, ABSENT in hook payloads)
   - Default threshold corrected 83.5% → 95% (third-party `claudefa.st` source superseded by official env-vars reference; 33K buffer figure remains UNVERIFIED)

2. `.mercury/docs/EXECUTION-PLAN.md` — Phase 4-3 expanded from stub to tracked sections:
   - S4 prereq CLOSED PARTIAL (S61, #268)
   - B.1 Implemented, soak (S61, #269)
   - B.2 Implemented, pending real-session soak (S63, #270)
   - B.3 deferred to Phase 5

## User-level B.2 details (recorded in Issue #270)

- `settings.json.env.CLAUDE_AUTOCOMPACT_PCT_OVERRIDE: "75"`
- `hooks/pre-compact.py` +40 LOC: `BLOCK_COUNTER_FILE`, `_should_block()`, block decision on first auto-trigger, escape-hatch on 2nd attempt, `trigger=manual` never blocks
- Per-session counter at `scripts/pre-compact-block-counter.json`
- 3/3 synthetic smoke tests PASS (auto first block / auto second escape / manual never-block)

## Test plan

- [x] Research doc claims cross-checked against official env-vars reference
- [x] `remaining_percentage` claim cross-checked against Issue #268 verdict
- [x] No internal inconsistency after 83.5% → 95% correction
- [x] Smoke tests 3/3 PASS on user-level hook
- [x] dual-verify ran: code-reviewer PASS, codex-rescue BLOCKING → 2 over-claim findings fixed (research doc §S1 mechanism + EXECUTION-PLAN 产出 line now reflect "pending soak")
- [ ] Real-session soak: block reason reaches main agent next-turn context
- [ ] Real-session soak: `/handoff:auto` → next session clean
- [ ] Rollback path drilled (unset env var or revert hook)

## Related

- Closes prerequisite verification portion of #270 (user-level implementation); Issue #270 remains OPEN pending real-session soak
- Refs #268 (S4 verdict PARTIAL, unblocked B.2)
- Refs #269 (B.1 statusline advisory, soaking in parallel)

Generated with Claude Code