### PR TITLE
refactor(skills): extract worktree+branch cleanup into shared script (#274)

### DIFF
--- a/.claude/skills/dev-pipeline/SKILL.md
+++ b/.claude/skills/dev-pipeline/SKILL.md
@@ -235,39 +235,28 @@ Based on the acceptance verdict:
 
 ```bash
 rm -f "$SHA_FILE"
-# Remove the isolated worktree and its branch.
-# On Windows, `git worktree remove --force` may partially succeed: git metadata
-# (.git/worktrees/<name>/) is removed but the physical directory is retained due
-# to OS file locks (see Mercury #265). Retry once after a short sleep, then fall
-# back to rm -rf on the residual directory.
-git worktree remove --force "${WORKTREE_PATH}" || {
-  sleep 2
-  git worktree remove --force "${WORKTREE_PATH}" || echo "WARN: git worktree remove retry failed for ${WORKTREE_PATH}" >&2
-}
-# rm -rf fallback: require non-empty path, existing dir, not a symlink, AND path whitelist.
-# The case pattern pins the allowed root to *this repo's* `${REPO_ROOT}/.worktrees/` prefix so
-# a corrupted WORKTREE_PATH cannot delete a different repo's worktree directory. We recompute
-# REPO_ROOT here (Phase 2's local var is out of scope by Phase 5) and fall back to a pattern
-# that matches nothing if we are outside a git repo — refuse-by-default semantics.
-# `rm -rf -- "${path}"` uses POSIX rm's `--` end-of-options terminator (rm(1)).
+
+# Worktree + branch cleanup is delegated to scripts/cleanup-worktree-branch.sh, which also backs
+# Phase 7 of the pr-flow skill. Keeping one source of truth avoids drift (see Mercury #274).
+#
+# --force invokes the retry + rm -rf fallback (whitelisted to $REPO_ROOT/.worktrees/) needed for
+# the Windows file-lock case (Mercury #265). --worktree-path is the path Main created in Phase 2;
+# passing it explicitly skips discovery since dev-pipeline always knows the exact path.
+#
+# BASE_BRANCH positional arg is Main's current branch — the parent branch Main was on when it
+# created the worktree. The script uses BASE_BRANCH only if HEAD happens to be on TASK_BRANCH at
+# cleanup time, which cannot occur under normal dev-pipeline flow (Main stays on its own branch
+# while the dev subagent operates in the isolated worktree on TASK_BRANCH). In any degenerate
+# state where that invariant is violated, `git switch` to Main's own branch is a safe no-op.
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
-if [ -z "${REPO_ROOT}" ]; then
-  echo "WARN: cannot determine REPO_ROOT (cwd not in a git repo) — skipping rm -rf fallback for ${WORKTREE_PATH}" >&2
-elif [ -n "${WORKTREE_PATH}" ] && [ -d "${WORKTREE_PATH}" ] && [ ! -L "${WORKTREE_PATH}" ]; then
-  case "${WORKTREE_PATH}" in
-    "${REPO_ROOT}/.worktrees/"*)
-      rm -rf -- "${WORKTREE_PATH}" || echo "WARN: rm -rf fallback failed for ${WORKTREE_PATH}" >&2
-      ;;
-    *)
-      echo "WARN: refuse to rm -rf path outside ${REPO_ROOT}/.worktrees/: ${WORKTREE_PATH}" >&2
-      ;;
-  esac
+if [ -z "$REPO_ROOT" ]; then
+  echo "WARN: cannot determine REPO_ROOT — skipping worktree/branch cleanup" >&2
+else
+  bash "$REPO_ROOT/scripts/cleanup-worktree-branch.sh" \
+    "$TASK_BRANCH" "$(git rev-parse --abbrev-ref HEAD)" \
+    --force --worktree-path "$WORKTREE_PATH" \
+    || echo "WARN: cleanup-worktree-branch.sh exited non-zero — see stderr" >&2
 fi
-# `|| echo WARN`: surface cleanup failures to stderr rather than silently swallowing them.
-# If worktree metadata still references the branch (extreme retry-failure path), `git branch -d`
-# refuses with "branch is checked out". We warn and continue — orphan branch can be reclaimed
-# by `scripts/worktree-reaper.sh --prune` on the next cycle.
-git branch -d "${TASK_BRANCH}" || echo "WARN: git branch -d ${TASK_BRANCH} failed (likely still registered in a worktree)" >&2
 ```
 
 This runs on `pass`, `blocked`, escalation after `partial`/`fail`, and on iteration-cap escalation. The ONLY paths that skip cleanup are intra-iteration dev re-dispatches (because Phase 3 still needs the SHA and the worktree is still active). If the loop terminates without reaching one of these branches (e.g. host crash), the SHA file at `${TMPDIR:-/tmp}/dev-pipeline-task-start-sha-${BRANCH_KEY}` will be cleaned up on the next pipeline run against the same branch (the new invocation overwrites it) or by OS tmp eviction; orphaned worktrees under `.worktrees/` can be reclaimed by `scripts/worktree-reaper.sh --prune`.

--- a/.claude/skills/pr-flow/SKILL.md
+++ b/.claude/skills/pr-flow/SKILL.md
@@ -352,60 +352,19 @@ rm -f .pr-flow-iteration-* .pr-flow-check-count-* .pr-flow-last-checked-* .pr-fl
 
 BRANCH=$(gh pr view "$PR_NUMBER" --json headRefName --jq '.headRefName')
 
-# Snapshot worktree paths BEFORE switching branch (switch changes main repo's association)
-# Identify main worktree to exclude it from cleanup
-WT_FAIL=0
-MAIN_WT=$(git rev-parse --show-toplevel)
-WT_LIST=$(git worktree list --porcelain 2>&1) || {
-  echo "WARNING: git worktree list failed — skipping worktree and branch cleanup"
-  WT_FAIL=1
-}
-WT_PATHS=""
-if [ "$WT_FAIL" -eq 0 ]; then
-  WT_PATHS=$(echo "$WT_LIST" | awk -v ref="branch refs/heads/$BRANCH" '
-    /^worktree / { path = substr($0, 10) }
-    $0 == ref { print path }
-  ')
-fi
-
-# Switch off branch (must happen before branch deletion).
-# Reuse BASE_BRANCH computed at the start of the skill — do NOT hardcode "develop",
-# because repos without a develop branch (master-only) would fail here.
-if [ "$(git rev-parse --abbrev-ref HEAD)" = "$BRANCH" ]; then
-  if ! git switch "$BASE_BRANCH" 2>/dev/null && ! git checkout "$BASE_BRANCH" 2>/dev/null; then
-    echo "WARNING: failed to switch off branch $BRANCH to $BASE_BRANCH — skipping cleanup"
-    WT_FAIL=1
-  fi
-fi
-
-# Clean up worktree(s) using pre-switch snapshot
-if [ "$WT_FAIL" -eq 0 ]; then
-  while IFS= read -r wt_path; do
-    [ -z "$wt_path" ] && continue
-    # Skip main worktree — only remove additional worktrees
-    [ "$wt_path" = "$MAIN_WT" ] && continue
-    if ! git -C "$wt_path" status --porcelain >/dev/null 2>&1; then
-      echo "WARNING: worktree $wt_path is inaccessible — pruning"
-      git worktree prune --expire=now || { WT_FAIL=1; continue; }
-      # Verify prune removed THIS specific path (not just any branch association)
-      if git worktree list --porcelain | grep -Fq "worktree $wt_path"; then
-        echo "WARNING: worktree $wt_path still registered after prune"
-        WT_FAIL=1
-      fi
-    elif [ -n "$(git -C "$wt_path" status --porcelain)" ]; then
-      echo "WARNING: worktree $wt_path has uncommitted changes — skipping"
-      WT_FAIL=1
-    else
-      git worktree remove "$wt_path" || WT_FAIL=1
-    fi
-  done <<< "$WT_PATHS"
-fi
-
-# Delete local branch only if all worktree cleanup succeeded
-if [ "$WT_FAIL" -eq 0 ]; then
-  git branch -d "$BRANCH" || echo "NOTE: local branch $BRANCH could not be deleted"
+# Worktree + branch cleanup is delegated to scripts/cleanup-worktree-branch.sh, which also backs
+# Phase 5 of the dev-pipeline skill. Keeping one source of truth avoids drift (see Mercury #274).
+#
+# No --force flag here: pr-flow cleanup runs AFTER merge, so dirty worktrees usually indicate
+# unintended state and should be preserved for human review rather than silently removed.
+# No --worktree-path either: pr-flow discovers matching worktrees dynamically because the skill
+# does not own the creation step. BASE_BRANCH was computed at the top of the skill.
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+if [ -z "$REPO_ROOT" ]; then
+  echo "WARNING: cannot determine REPO_ROOT — skipping worktree/branch cleanup"
 else
-  echo "Skipping branch deletion — worktree cleanup incomplete"
+  bash "$REPO_ROOT/scripts/cleanup-worktree-branch.sh" "$BRANCH" "$BASE_BRANCH" \
+    || echo "NOTE: cleanup-worktree-branch.sh reported incomplete cleanup — see stderr"
 fi
 ```
 

--- a/scripts/cleanup-worktree-branch.sh
+++ b/scripts/cleanup-worktree-branch.sh
@@ -79,15 +79,16 @@ run() {
   "$@"
 }
 
-# ---------- discover worktrees ----------
-# IMPORTANT: discovery MUST happen BEFORE the pre-switch below. `git switch` changes
-# the main worktree's branch association in `git worktree list --porcelain`, which
-# would alter what auto-discovery finds.
-
+# Discover worktrees BEFORE pre-switch: `git switch` changes the main worktree's branch
+# association in `git worktree list --porcelain`, altering discovery results.
 WT_FAIL=0
 WT_PATHS=""
-
 if [ -n "$EXPLICIT_WT_PATH" ]; then
+  # --worktree-path is high-risk user input. Reject newlines so a value cannot expand into
+  # multiple paths inside the while-read loop below.
+  case "$EXPLICIT_WT_PATH" in
+    *$'\n'*|*$'\r'*) die "--worktree-path must be a single-line path" ;;
+  esac
   WT_PATHS="$EXPLICIT_WT_PATH"
 else
   if ! WT_LIST=$(git worktree list --porcelain 2>&1); then
@@ -99,9 +100,7 @@ else
     $0 == ref { print path }
   ')
 fi
-
-# ---------- pre-switch (leave BRANCH if HEAD is on it) ----------
-
+# Pre-switch off BRANCH if HEAD is on it (required before branch -d).
 if [ "$(git rev-parse --abbrev-ref HEAD 2>/dev/null)" = "$BRANCH" ]; then
   if ! run git switch "$BASE_BRANCH" 2>/dev/null; then
     if ! run git checkout "$BASE_BRANCH" 2>/dev/null; then
@@ -111,16 +110,14 @@ if [ "$(git rev-parse --abbrev-ref HEAD 2>/dev/null)" = "$BRANCH" ]; then
   fi
 fi
 
-# ---------- worktree removal ----------
-
 remove_force() {
   # dev-pipeline: retry Windows file-lock, then rm -rf within $REPO_ROOT/.worktrees/ whitelist.
   # Canonicalize the path via `cd && pwd -P` before the whitelist check so a caller cannot
   # escape via `..` segments (textual prefix match alone is not enough — #277 review finding).
   local wt="$1"
-  run git worktree remove --force "$wt" && return 0
+  run git worktree remove --force -- "$wt" && return 0
   sleep 2
-  run git worktree remove --force "$wt" && return 0
+  run git worktree remove --force -- "$wt" && return 0
   warn "git worktree remove retry failed for $wt"
   [ -n "$wt" ] && [ -d "$wt" ] && [ ! -L "$wt" ] || return 1
   local wt_canon
@@ -150,6 +147,9 @@ remove_safe() {
   if ! git -C "$wt" status --porcelain >/dev/null 2>&1; then
     warn "worktree $wt is inaccessible — pruning"
     run git worktree prune --expire=now || return 1
+    # In dry-run mode `run` is a no-op: the prune above didn't actually execute, so the
+    # post-action verification below would incorrectly report failure. Short-circuit.
+    [ "$DRY_RUN" -eq 1 ] && return 0
     if git worktree list --porcelain | grep -Fq "worktree $wt"; then
       warn "worktree $wt still registered after prune"
       return 1
@@ -160,7 +160,7 @@ remove_safe() {
     warn "worktree $wt has uncommitted changes — skipping"
     return 1
   fi
-  run git worktree remove "$wt"
+  run git worktree remove -- "$wt"
 }
 
 while IFS= read -r wt_path; do
@@ -183,12 +183,12 @@ done <<< "$WT_PATHS"
 #     original Phase 7 guard (dirty worktree → preserve branch so the user can inspect).
 
 if [ "$WT_FAIL" -eq 0 ]; then
-  if ! run git branch -d "$BRANCH"; then
+  if ! run git branch -d -- "$BRANCH"; then
     warn "git branch -d $BRANCH failed (likely still registered in a worktree)"
   fi
   exit 0
 elif [ "$FORCE" -eq 1 ]; then
-  if ! run git branch -d "$BRANCH"; then
+  if ! run git branch -d -- "$BRANCH"; then
     warn "git branch -d $BRANCH failed (worktree cleanup incomplete — expected)"
   fi
   exit 1

--- a/scripts/cleanup-worktree-branch.sh
+++ b/scripts/cleanup-worktree-branch.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# cleanup-worktree-branch.sh — shared worktree + branch cleanup for dev-pipeline + pr-flow.
+#
+# Unifies two prior inline implementations (dev-pipeline/SKILL.md Phase 5 cleanup block
+# and pr-flow/SKILL.md Phase 7 cleanup block) behind one SoT script to eliminate drift.
+#
+# Usage:
+#   cleanup-worktree-branch.sh <BRANCH> <BASE_BRANCH> [options]
+#
+# Positional:
+#   BRANCH        Branch whose worktree(s) should be removed and whose local ref should be deleted.
+#   BASE_BRANCH   Branch to switch HEAD to before worktree removal (if HEAD is currently on BRANCH).
+#
+# Options:
+#   --force                    Use `git worktree remove --force` + Windows file-lock retry + rm -rf fallback.
+#                              Skips uncommitted-changes check. Intended for dev-pipeline where the
+#                              worktree is throwaway by construction.
+#   --worktree-path <path>     Explicit worktree path to clean (skip discovery). Intended for
+#                              dev-pipeline where the path was created by the same skill run.
+#                              Without this flag, the script discovers all worktrees whose branch
+#                              matches BRANCH via `git worktree list --porcelain`.
+#   --dry-run                  Print destructive commands without executing them.
+#
+# Exit codes:
+#   0   All worktrees removed AND local branch deleted.
+#   1   Worktree cleanup incomplete (at least one worktree remove failed or a worktree had
+#       uncommitted changes in safe mode). Local branch is NOT deleted in this case.
+#   2   Invalid arguments or unrecoverable git error (not inside a repo, etc.).
+#
+# Safety:
+#   The rm -rf fallback (activated only under --force + Windows file-lock) is restricted to paths
+#   matching "<REPO_ROOT>/.worktrees/*" and refuses to follow symlinks. Any other path triggers a
+#   warning and is left on disk.
+
+set -u
+
+# ---------- utilities ----------
+
+die() {
+  echo "cleanup-worktree-branch: $1" >&2
+  exit 2
+}
+
+warn() {
+  echo "WARN: $1" >&2
+}
+
+# ---------- arg parse ----------
+
+BRANCH=""
+BASE_BRANCH=""
+FORCE=0
+DRY_RUN=0
+EXPLICIT_WT_PATH=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --force) FORCE=1; shift ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    --worktree-path)
+      [ $# -ge 2 ] || die "--worktree-path requires a value"
+      EXPLICIT_WT_PATH="$2"
+      shift 2
+      ;;
+    -h|--help)
+      sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    --) shift; break ;;
+    -*)
+      die "unknown flag: $1"
+      ;;
+    *)
+      if [ -z "$BRANCH" ]; then
+        BRANCH="$1"
+      elif [ -z "$BASE_BRANCH" ]; then
+        BASE_BRANCH="$1"
+      else
+        die "too many positional arguments; got: $1"
+      fi
+      shift
+      ;;
+  esac
+done
+
+[ -n "$BRANCH" ] || die "missing BRANCH argument"
+[ -n "$BASE_BRANCH" ] || die "missing BASE_BRANCH argument"
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || die "not inside a git repository"
+MAIN_WT="$REPO_ROOT"
+
+run() {
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "[dry-run] $*"
+    return 0
+  fi
+  "$@"
+}
+
+# ---------- discover worktrees ----------
+# IMPORTANT: discovery MUST happen BEFORE the pre-switch below. `git switch` changes
+# the main worktree's branch association in `git worktree list --porcelain`, which
+# would alter what auto-discovery finds.
+
+WT_FAIL=0
+WT_PATHS=""
+
+if [ -n "$EXPLICIT_WT_PATH" ]; then
+  WT_PATHS="$EXPLICIT_WT_PATH"
+else
+  if ! WT_LIST=$(git worktree list --porcelain 2>&1); then
+    warn "git worktree list failed — skipping worktree and branch cleanup"
+    exit 1
+  fi
+  WT_PATHS=$(echo "$WT_LIST" | awk -v ref="branch refs/heads/$BRANCH" '
+    /^worktree / { path = substr($0, 10) }
+    $0 == ref { print path }
+  ')
+fi
+
+# ---------- pre-switch (leave BRANCH if HEAD is on it) ----------
+
+if [ "$(git rev-parse --abbrev-ref HEAD 2>/dev/null)" = "$BRANCH" ]; then
+  if ! run git switch "$BASE_BRANCH" 2>/dev/null; then
+    if ! run git checkout "$BASE_BRANCH" 2>/dev/null; then
+      warn "failed to switch off branch $BRANCH to $BASE_BRANCH — skipping cleanup"
+      exit 1
+    fi
+  fi
+fi
+
+# ---------- worktree removal ----------
+
+remove_force() {
+  # dev-pipeline semantics: --force, retry once on transient Windows file lock,
+  # fall back to rm -rf within the $REPO_ROOT/.worktrees/ whitelist.
+  local wt="$1"
+  if run git worktree remove --force "$wt"; then
+    return 0
+  fi
+  sleep 2
+  if run git worktree remove --force "$wt"; then
+    return 0
+  fi
+  warn "git worktree remove retry failed for $wt"
+  if [ -n "$wt" ] && [ -d "$wt" ] && [ ! -L "$wt" ]; then
+    case "$wt" in
+      "$REPO_ROOT/.worktrees/"*)
+        if run rm -rf -- "$wt"; then
+          # Prune stale worktree metadata that still references the now-deleted path,
+          # otherwise subsequent `git branch -d` may refuse ("branch is checked out").
+          run git worktree prune 2>/dev/null || true
+          return 0
+        fi
+        warn "rm -rf fallback failed for $wt"
+        return 1
+        ;;
+      *)
+        warn "refuse to rm -rf path outside $REPO_ROOT/.worktrees/: $wt"
+        return 1
+        ;;
+    esac
+  fi
+  return 1
+}
+
+remove_safe() {
+  # pr-flow semantics: no --force. Inaccessible worktrees are pruned; dirty worktrees are
+  # preserved (and reported as failure so the branch is not deleted).
+  local wt="$1"
+  if ! git -C "$wt" status --porcelain >/dev/null 2>&1; then
+    warn "worktree $wt is inaccessible — pruning"
+    if ! run git worktree prune --expire=now; then
+      return 1
+    fi
+    if git worktree list --porcelain | grep -Fq "worktree $wt"; then
+      warn "worktree $wt still registered after prune"
+      return 1
+    fi
+    return 0
+  fi
+  if [ -n "$(git -C "$wt" status --porcelain)" ]; then
+    warn "worktree $wt has uncommitted changes — skipping"
+    return 1
+  fi
+  run git worktree remove "$wt"
+}
+
+while IFS= read -r wt_path; do
+  [ -z "$wt_path" ] && continue
+  [ "$wt_path" = "$MAIN_WT" ] && continue
+  if [ "$FORCE" -eq 1 ]; then
+    remove_force "$wt_path" || WT_FAIL=1
+  else
+    remove_safe "$wt_path" || WT_FAIL=1
+  fi
+done <<< "$WT_PATHS"
+
+# ---------- branch deletion ----------
+# Mode semantics:
+#   --force (dev-pipeline): ALWAYS attempt `git branch -d`. The original Phase 5 block did this
+#     unconditionally because on Windows file-lock, `git worktree remove --force` can partially
+#     succeed (metadata gone, directory retained) — the branch is still deletable even though
+#     WT_FAIL=1. git itself refuses safely if the branch is still checked out somewhere.
+#   safe mode (pr-flow): skip branch deletion when worktree cleanup is incomplete, matching the
+#     original Phase 7 guard (dirty worktree → preserve branch so the user can inspect).
+
+if [ "$WT_FAIL" -eq 0 ]; then
+  if ! run git branch -d "$BRANCH"; then
+    warn "git branch -d $BRANCH failed (likely still registered in a worktree)"
+  fi
+  exit 0
+elif [ "$FORCE" -eq 1 ]; then
+  if ! run git branch -d "$BRANCH"; then
+    warn "git branch -d $BRANCH failed (worktree cleanup incomplete — expected)"
+  fi
+  exit 1
+else
+  echo "Skipping branch deletion — worktree cleanup incomplete" >&2
+  exit 1
+fi

--- a/scripts/cleanup-worktree-branch.sh
+++ b/scripts/cleanup-worktree-branch.sh
@@ -60,8 +60,11 @@ MAIN_WT="$REPO_ROOT"
 
 # Cross-repo observability (per Mercury feedback_cross_repo_declare): print repo + remote so
 # a user or log reader can verify at a glance which repo this invocation is operating on.
+# Strip any embedded credentials (`https://user:token@host/...` or `ssh://user@host/...`) before
+# logging — the remote URL may contain secrets and this runs in CI/terminal scrollback contexts.
 REPO_REMOTE=$(git remote get-url origin 2>/dev/null || echo "(no origin)")
-echo "cleanup-worktree-branch: repo=$REPO_ROOT remote=$REPO_REMOTE branch=$BRANCH base=$BASE_BRANCH force=$FORCE dry-run=$DRY_RUN" >&2
+REPO_REMOTE_SAFE=$(printf '%s' "$REPO_REMOTE" | sed -E 's#(^[a-z]+://)[^/@]*@#\1#')
+echo "cleanup-worktree-branch: repo=$REPO_ROOT remote=$REPO_REMOTE_SAFE branch=$BRANCH base=$BASE_BRANCH force=$FORCE dry-run=$DRY_RUN" >&2
 
 run() {
   if [ "$DRY_RUN" -eq 1 ]; then

--- a/scripts/cleanup-worktree-branch.sh
+++ b/scripts/cleanup-worktree-branch.sh
@@ -1,36 +1,17 @@
 #!/usr/bin/env bash
 # cleanup-worktree-branch.sh — shared worktree + branch cleanup for dev-pipeline + pr-flow.
+# Single source of truth for the inline blocks that diverged in S62 (see Mercury #274).
 #
-# Unifies two prior inline implementations (dev-pipeline/SKILL.md Phase 5 cleanup block
-# and pr-flow/SKILL.md Phase 7 cleanup block) behind one SoT script to eliminate drift.
+# Usage: cleanup-worktree-branch.sh <BRANCH> <BASE_BRANCH> [--force] [--worktree-path PATH] [--dry-run]
 #
-# Usage:
-#   cleanup-worktree-branch.sh <BRANCH> <BASE_BRANCH> [options]
+# --force: dev-pipeline semantics — `git worktree remove --force` with retry + rm -rf fallback
+#   whitelisted to $REPO_ROOT/.worktrees/ (symlink-guarded) + unconditional `git branch -d` attempt.
+# (no flag): pr-flow semantics — safe mode; dirty worktrees are preserved, branch kept for review.
+# --worktree-path PATH: skip auto-discovery (used by dev-pipeline which creates the path itself).
+# --dry-run: print destructive commands without executing.
 #
-# Positional:
-#   BRANCH        Branch whose worktree(s) should be removed and whose local ref should be deleted.
-#   BASE_BRANCH   Branch to switch HEAD to before worktree removal (if HEAD is currently on BRANCH).
-#
-# Options:
-#   --force                    Use `git worktree remove --force` + Windows file-lock retry + rm -rf fallback.
-#                              Skips uncommitted-changes check. Intended for dev-pipeline where the
-#                              worktree is throwaway by construction.
-#   --worktree-path <path>     Explicit worktree path to clean (skip discovery). Intended for
-#                              dev-pipeline where the path was created by the same skill run.
-#                              Without this flag, the script discovers all worktrees whose branch
-#                              matches BRANCH via `git worktree list --porcelain`.
-#   --dry-run                  Print destructive commands without executing them.
-#
-# Exit codes:
-#   0   All worktrees removed AND local branch deleted.
-#   1   Worktree cleanup incomplete (at least one worktree remove failed or a worktree had
-#       uncommitted changes in safe mode). Local branch is NOT deleted in this case.
-#   2   Invalid arguments or unrecoverable git error (not inside a repo, etc.).
-#
-# Safety:
-#   The rm -rf fallback (activated only under --force + Windows file-lock) is restricted to paths
-#   matching "<REPO_ROOT>/.worktrees/*" and refuses to follow symlinks. Any other path triggers a
-#   warning and is left on disk.
+# Exit: 0 = complete; 1 = worktree cleanup incomplete (branch preservation in safe mode);
+#       2 = invalid args / not inside a git repo.
 
 set -u
 
@@ -89,6 +70,11 @@ done
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || die "not inside a git repository"
 MAIN_WT="$REPO_ROOT"
 
+# Cross-repo observability (per Mercury feedback_cross_repo_declare): print repo + remote so
+# a user or log reader can verify at a glance which repo this invocation is operating on.
+REPO_REMOTE=$(git remote get-url origin 2>/dev/null || echo "(no origin)")
+echo "cleanup-worktree-branch: repo=$REPO_ROOT remote=$REPO_REMOTE branch=$BRANCH base=$BASE_BRANCH force=$FORCE dry-run=$DRY_RUN" >&2
+
 run() {
   if [ "$DRY_RUN" -eq 1 ]; then
     echo "[dry-run] $*"
@@ -132,47 +118,35 @@ fi
 # ---------- worktree removal ----------
 
 remove_force() {
-  # dev-pipeline semantics: --force, retry once on transient Windows file lock,
-  # fall back to rm -rf within the $REPO_ROOT/.worktrees/ whitelist.
+  # dev-pipeline: retry Windows file-lock, then rm -rf within $REPO_ROOT/.worktrees/ whitelist.
   local wt="$1"
-  if run git worktree remove --force "$wt"; then
-    return 0
-  fi
+  run git worktree remove --force "$wt" && return 0
   sleep 2
-  if run git worktree remove --force "$wt"; then
-    return 0
-  fi
+  run git worktree remove --force "$wt" && return 0
   warn "git worktree remove retry failed for $wt"
-  if [ -n "$wt" ] && [ -d "$wt" ] && [ ! -L "$wt" ]; then
-    case "$wt" in
-      "$REPO_ROOT/.worktrees/"*)
-        if run rm -rf -- "$wt"; then
-          # Prune stale worktree metadata that still references the now-deleted path,
-          # otherwise subsequent `git branch -d` may refuse ("branch is checked out").
-          run git worktree prune 2>/dev/null || true
-          return 0
-        fi
-        warn "rm -rf fallback failed for $wt"
-        return 1
-        ;;
-      *)
-        warn "refuse to rm -rf path outside $REPO_ROOT/.worktrees/: $wt"
-        return 1
-        ;;
-    esac
-  fi
-  return 1
+  [ -n "$wt" ] && [ -d "$wt" ] && [ ! -L "$wt" ] || return 1
+  case "$wt" in
+    "$REPO_ROOT/.worktrees/"*)
+      if run rm -rf -- "$wt"; then
+        run git worktree prune 2>/dev/null || true   # clear stale metadata
+        return 0
+      fi
+      warn "rm -rf fallback failed for $wt"
+      return 1
+      ;;
+    *)
+      warn "refuse to rm -rf path outside $REPO_ROOT/.worktrees/: $wt"
+      return 1
+      ;;
+  esac
 }
 
 remove_safe() {
-  # pr-flow semantics: no --force. Inaccessible worktrees are pruned; dirty worktrees are
-  # preserved (and reported as failure so the branch is not deleted).
+  # pr-flow: preserve dirty worktrees. Inaccessible → prune; clean → plain remove.
   local wt="$1"
   if ! git -C "$wt" status --porcelain >/dev/null 2>&1; then
     warn "worktree $wt is inaccessible — pruning"
-    if ! run git worktree prune --expire=now; then
-      return 1
-    fi
+    run git worktree prune --expire=now || return 1
     if git worktree list --porcelain | grep -Fq "worktree $wt"; then
       warn "worktree $wt still registered after prune"
       return 1

--- a/scripts/cleanup-worktree-branch.sh
+++ b/scripts/cleanup-worktree-branch.sh
@@ -63,10 +63,12 @@ MAIN_WT="$REPO_ROOT"
 # Strip any embedded credentials (`https://user:token@host/...` or `ssh://user@host/...`) before
 # logging — the remote URL may contain secrets and this runs in CI/terminal scrollback contexts.
 REPO_REMOTE=$(git remote get-url origin 2>/dev/null || echo "(no origin)")
-# Redact any `user:pass@` userinfo block regardless of scheme. Covers HTTPS (`https://u:p@h/...`),
-# SSH-URL (`ssh://u:p@h/...`), and SCP-like (`u:p@h:path`). Leaves `git@host:path` alone because
-# it has no colon inside the userinfo (SSH standard, no credential material).
-REPO_REMOTE_SAFE=$(printf '%s' "$REPO_REMOTE" | sed -E 's#[^/@[:space:]]+:[^/@[:space:]]+@#[REDACTED]@#g')
+# Redact credential-bearing userinfo. Rule 1: any userinfo after a URL scheme (covers both
+# https://token@ and https://u:p@). Rule 2: SCP-like `user:pass@host:path` (requires `:` inside
+# userinfo so plain `git@host:path` SSH — no credentials — passes through unchanged).
+REPO_REMOTE_SAFE=$(printf '%s' "$REPO_REMOTE" \
+  | sed -E 's#([a-z][a-z0-9+.-]*://)[^/@[:space:]]+@#\1[REDACTED]@#g' \
+  | sed -E 's#^[^/@[:space:]]+:[^/@[:space:]]+@#[REDACTED]@#')
 echo "cleanup-worktree-branch: repo=$REPO_ROOT remote=$REPO_REMOTE_SAFE branch=$BRANCH base=$BASE_BRANCH force=$FORCE dry-run=$DRY_RUN" >&2
 
 run() {

--- a/scripts/cleanup-worktree-branch.sh
+++ b/scripts/cleanup-worktree-branch.sh
@@ -63,7 +63,10 @@ MAIN_WT="$REPO_ROOT"
 # Strip any embedded credentials (`https://user:token@host/...` or `ssh://user@host/...`) before
 # logging — the remote URL may contain secrets and this runs in CI/terminal scrollback contexts.
 REPO_REMOTE=$(git remote get-url origin 2>/dev/null || echo "(no origin)")
-REPO_REMOTE_SAFE=$(printf '%s' "$REPO_REMOTE" | sed -E 's#(^[a-z]+://)[^/@]*@#\1#')
+# Redact any `user:pass@` userinfo block regardless of scheme. Covers HTTPS (`https://u:p@h/...`),
+# SSH-URL (`ssh://u:p@h/...`), and SCP-like (`u:p@h:path`). Leaves `git@host:path` alone because
+# it has no colon inside the userinfo (SSH standard, no credential material).
+REPO_REMOTE_SAFE=$(printf '%s' "$REPO_REMOTE" | sed -E 's#[^/@[:space:]]+:[^/@[:space:]]+@#[REDACTED]@#g')
 echo "cleanup-worktree-branch: repo=$REPO_ROOT remote=$REPO_REMOTE_SAFE branch=$BRANCH base=$BASE_BRANCH force=$FORCE dry-run=$DRY_RUN" >&2
 
 run() {

--- a/scripts/cleanup-worktree-branch.sh
+++ b/scripts/cleanup-worktree-branch.sh
@@ -1,32 +1,17 @@
 #!/usr/bin/env bash
-# cleanup-worktree-branch.sh — shared worktree + branch cleanup for dev-pipeline + pr-flow.
-# Single source of truth for the inline blocks that diverged in S62 (see Mercury #274).
-#
+# cleanup-worktree-branch.sh — shared worktree + branch cleanup (dev-pipeline Phase 5 + pr-flow
+# Phase 7). SoT for the inline blocks that diverged in S62 (see Mercury #274).
 # Usage: cleanup-worktree-branch.sh <BRANCH> <BASE_BRANCH> [--force] [--worktree-path PATH] [--dry-run]
-#
-# --force: dev-pipeline semantics — `git worktree remove --force` with retry + rm -rf fallback
-#   whitelisted to $REPO_ROOT/.worktrees/ (symlink-guarded) + unconditional `git branch -d` attempt.
-# (no flag): pr-flow semantics — safe mode; dirty worktrees are preserved, branch kept for review.
-# --worktree-path PATH: skip auto-discovery (used by dev-pipeline which creates the path itself).
-# --dry-run: print destructive commands without executing.
-#
-# Exit: 0 = complete; 1 = worktree cleanup incomplete (branch preservation in safe mode);
-#       2 = invalid args / not inside a git repo.
+#   --force        dev-pipeline: retry + rm -rf whitelist + unconditional `git branch -d`
+#   (no flag)      pr-flow safe mode: preserve dirty worktrees, gated branch delete
+#   --worktree-path PATH  skip auto-discovery
+#   --dry-run      print destructive commands without executing
+# Exit: 0 complete | 1 worktree cleanup incomplete | 2 invalid args / not in a git repo
 
 set -u
 
-# ---------- utilities ----------
-
-die() {
-  echo "cleanup-worktree-branch: $1" >&2
-  exit 2
-}
-
-warn() {
-  echo "WARN: $1" >&2
-}
-
-# ---------- arg parse ----------
+die()  { echo "cleanup-worktree-branch: $1" >&2; exit 2; }
+warn() { echo "WARN: $1" >&2; }
 
 BRANCH=""
 BASE_BRANCH=""
@@ -44,7 +29,7 @@ while [ $# -gt 0 ]; do
       shift 2
       ;;
     -h|--help)
-      sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'
+      sed -n '2,9p' "$0" | sed 's/^# \{0,1\}//'
       exit 0
       ;;
     --) shift; break ;;
@@ -68,6 +53,9 @@ done
 [ -n "$BASE_BRANCH" ] || die "missing BASE_BRANCH argument"
 
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || die "not inside a git repository"
+# Canonical form: resolve symlinks and `..` so the rm -rf whitelist cannot be bypassed by
+# a caller passing e.g. "$REPO_ROOT/.worktrees/../etc" that textually matches the prefix.
+REPO_ROOT_CANON=$(cd "$REPO_ROOT" && pwd -P) || die "cannot canonicalize REPO_ROOT"
 MAIN_WT="$REPO_ROOT"
 
 # Cross-repo observability (per Mercury feedback_cross_repo_declare): print repo + remote so
@@ -119,23 +107,30 @@ fi
 
 remove_force() {
   # dev-pipeline: retry Windows file-lock, then rm -rf within $REPO_ROOT/.worktrees/ whitelist.
+  # Canonicalize the path via `cd && pwd -P` before the whitelist check so a caller cannot
+  # escape via `..` segments (textual prefix match alone is not enough — #277 review finding).
   local wt="$1"
   run git worktree remove --force "$wt" && return 0
   sleep 2
   run git worktree remove --force "$wt" && return 0
   warn "git worktree remove retry failed for $wt"
   [ -n "$wt" ] && [ -d "$wt" ] && [ ! -L "$wt" ] || return 1
-  case "$wt" in
-    "$REPO_ROOT/.worktrees/"*)
-      if run rm -rf -- "$wt"; then
+  local wt_canon
+  wt_canon=$(cd "$wt" 2>/dev/null && pwd -P) || {
+    warn "cannot canonicalize $wt — refusing rm -rf fallback"
+    return 1
+  }
+  case "$wt_canon" in
+    "$REPO_ROOT_CANON/.worktrees/"*)
+      if run rm -rf -- "$wt_canon"; then
         run git worktree prune 2>/dev/null || true   # clear stale metadata
         return 0
       fi
-      warn "rm -rf fallback failed for $wt"
+      warn "rm -rf fallback failed for $wt_canon"
       return 1
       ;;
     *)
-      warn "refuse to rm -rf path outside $REPO_ROOT/.worktrees/: $wt"
+      warn "refuse to rm -rf path outside $REPO_ROOT_CANON/.worktrees/ (canonical: $wt_canon)"
       return 1
       ;;
   esac

--- a/tests/test_cleanup_worktree_branch.sh
+++ b/tests/test_cleanup_worktree_branch.sh
@@ -232,6 +232,29 @@ test_force_deletes_branch_even_on_wt_fail() {
   cleanup_sandbox "$sb"
 }
 
+# ---------- test: remote URL credentials are stripped from observability echo ----------
+TOTAL=$((TOTAL + 1))
+test_remote_credential_strip() {
+  local sb
+  sb=$(mk_sandbox) || { fail "setup failed"; return; }
+  (
+    cd "$sb" || exit 1
+    # Inject a fake origin URL with embedded credentials. The script's observability echo
+    # MUST strip the userinfo before logging (per #277 iter-3 finding).
+    git remote add origin "https://user:supersecret-token@example.com/repo.git"
+    git worktree remove --force "$sb/.worktrees/feat-test"
+    out=$(bash "$SCRIPT" feat/test main 2>&1)
+    # Token must not appear in output
+    echo "$out" | grep -q "supersecret-token" && { echo "credential leaked in log: $out"; exit 1; }
+    # Sanitized form must appear (starts with https:// and omits the userinfo)
+    echo "$out" | grep -q "remote=https://example.com/repo.git" || { echo "sanitized remote not found"; exit 1; }
+  )
+  if [ $? -eq 0 ]; then pass "remote URL credentials stripped from observability echo"
+  else fail "remote URL credentials stripped from observability echo"
+  fi
+  cleanup_sandbox "$sb"
+}
+
 # ---------- test: rm -rf whitelist resists `..` path traversal ----------
 TOTAL=$((TOTAL + 1))
 test_rmrf_traversal_guard() {
@@ -289,6 +312,7 @@ test_pre_switch_runs
 test_force_deletes_branch_even_on_wt_fail
 test_no_worktree_still_deletes_branch
 test_rmrf_traversal_guard
+test_remote_credential_strip
 
 echo ""
 echo "Summary: $((TOTAL - FAILED))/$TOTAL tests passed"

--- a/tests/test_cleanup_worktree_branch.sh
+++ b/tests/test_cleanup_worktree_branch.sh
@@ -232,6 +232,30 @@ test_force_deletes_branch_even_on_wt_fail() {
   cleanup_sandbox "$sb"
 }
 
+# ---------- test: --worktree-path rejects newline injection ----------
+TOTAL=$((TOTAL + 1))
+test_worktree_path_rejects_newline() {
+  local sb
+  sb=$(mk_sandbox) || { fail "setup failed"; return; }
+  (
+    cd "$sb" || exit 1
+    mkdir -p "$sb/innocent-target"
+    echo "sentinel" > "$sb/innocent-target/SENTINEL"
+    git worktree remove --force "$sb/.worktrees/feat-test"
+    # Path with embedded newline: the first line is an attacker-controlled target.
+    local malicious="$sb/innocent-target"$'\n'"$sb/.worktrees/feat-test"
+    out=$(bash "$SCRIPT" feat/test main --force --worktree-path "$malicious" 2>&1)
+    rc=$?
+    [ "$rc" -eq 2 ] || { echo "expected exit 2, got $rc"; exit 1; }
+    echo "$out" | grep -q "single-line path" || { echo "no rejection message"; exit 1; }
+    [ -f "$sb/innocent-target/SENTINEL" ] || { echo "sentinel deleted — newline injection worked"; exit 1; }
+  )
+  if [ $? -eq 0 ]; then pass "--worktree-path rejects newline-injected value"
+  else fail "--worktree-path rejects newline-injected value"
+  fi
+  cleanup_sandbox "$sb"
+}
+
 # ---------- test: remote URL credentials are stripped from observability echo ----------
 TOTAL=$((TOTAL + 1))
 test_remote_credential_strip() {
@@ -332,6 +356,7 @@ test_force_deletes_branch_even_on_wt_fail
 test_no_worktree_still_deletes_branch
 test_rmrf_traversal_guard
 test_remote_credential_strip
+test_worktree_path_rejects_newline
 
 echo ""
 echo "Summary: $((TOTAL - FAILED))/$TOTAL tests passed"

--- a/tests/test_cleanup_worktree_branch.sh
+++ b/tests/test_cleanup_worktree_branch.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+# test_cleanup_worktree_branch.sh — behavior tests for scripts/cleanup-worktree-branch.sh
+#
+# Usage: bash tests/test_cleanup_worktree_branch.sh
+#
+# Runs in an ephemeral sandbox under TMPDIR. Each test creates a fresh git repo, sets up the
+# pre-conditions, invokes the script, asserts post-conditions, and tears down. Exit code is the
+# number of failed tests (0 = all pass).
+
+set -u
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+SCRIPT="$REPO_ROOT/scripts/cleanup-worktree-branch.sh"
+
+[ -x "$SCRIPT" ] || { echo "FAIL: $SCRIPT not executable"; exit 1; }
+
+FAILED=0
+TOTAL=0
+
+pass() { echo "PASS: $1"; }
+fail() { echo "FAIL: $1"; FAILED=$((FAILED + 1)); }
+
+# Create an isolated sandbox repo. Caller receives the sandbox path on stdout.
+mk_sandbox() {
+  local sb
+  sb=$(mktemp -d)
+  (
+    cd "$sb" || exit 1
+    git init -q -b main
+    git config user.email "test@example.com"
+    git config user.name "Test"
+    echo "seed" > README.md
+    git add README.md
+    git commit -q -m "seed"
+    # Feature branch + worktree sitting on it
+    git branch feat/test
+    mkdir -p .worktrees
+    git worktree add .worktrees/feat-test feat/test -q
+  ) || return 1
+  echo "$sb"
+}
+
+cleanup_sandbox() {
+  local sb="$1"
+  # best-effort: worktrees might still be registered
+  [ -d "$sb" ] || return 0
+  (cd "$sb" && git worktree list --porcelain 2>/dev/null | awk '/^worktree /{print substr($0,10)}' | while read -r p; do
+    [ "$p" = "$sb" ] && continue
+    git worktree remove --force "$p" 2>/dev/null || true
+  done) || true
+  rm -rf "$sb" 2>/dev/null || true
+}
+
+# ---------- test: happy path with --force + explicit path ----------
+TOTAL=$((TOTAL + 1))
+test_force_explicit_path() {
+  local sb
+  sb=$(mk_sandbox) || { fail "setup failed"; return; }
+  (
+    cd "$sb" || exit 1
+    bash "$SCRIPT" feat/test main --force --worktree-path "$sb/.worktrees/feat-test"
+    rc=$?
+    [ "$rc" -eq 0 ] || { echo "exit code $rc"; exit 1; }
+    # worktree gone
+    [ ! -d "$sb/.worktrees/feat-test" ] || { echo "worktree still exists"; exit 1; }
+    # branch gone
+    git show-ref --verify --quiet refs/heads/feat/test && { echo "branch not deleted"; exit 1; } || true
+  )
+  if [ $? -eq 0 ]; then pass "force + explicit path removes worktree and branch"
+  else fail "force + explicit path removes worktree and branch"
+  fi
+  cleanup_sandbox "$sb"
+}
+
+# ---------- test: safe mode + auto-discovery on clean worktree ----------
+TOTAL=$((TOTAL + 1))
+test_safe_auto_discover() {
+  local sb
+  sb=$(mk_sandbox) || { fail "setup failed"; return; }
+  (
+    cd "$sb" || exit 1
+    bash "$SCRIPT" feat/test main
+    rc=$?
+    [ "$rc" -eq 0 ] || { echo "exit code $rc"; exit 1; }
+    [ ! -d "$sb/.worktrees/feat-test" ] || { echo "worktree still exists"; exit 1; }
+    git show-ref --verify --quiet refs/heads/feat/test && { echo "branch not deleted"; exit 1; } || true
+  )
+  if [ $? -eq 0 ]; then pass "safe mode + auto-discover removes clean worktree and branch"
+  else fail "safe mode + auto-discover removes clean worktree and branch"
+  fi
+  cleanup_sandbox "$sb"
+}
+
+# ---------- test: dry-run preserves state ----------
+TOTAL=$((TOTAL + 1))
+test_dry_run() {
+  local sb
+  sb=$(mk_sandbox) || { fail "setup failed"; return; }
+  (
+    cd "$sb" || exit 1
+    out=$(bash "$SCRIPT" feat/test main --force --dry-run 2>&1)
+    rc=$?
+    [ "$rc" -eq 0 ] || { echo "exit code $rc"; exit 1; }
+    # worktree + branch must still exist
+    [ -d "$sb/.worktrees/feat-test" ] || { echo "worktree removed in dry-run"; exit 1; }
+    git show-ref --verify --quiet refs/heads/feat/test || { echo "branch removed in dry-run"; exit 1; }
+    echo "$out" | grep -q '\[dry-run\]' || { echo "no [dry-run] marker in output"; exit 1; }
+  )
+  if [ $? -eq 0 ]; then pass "dry-run preserves worktree and branch"
+  else fail "dry-run preserves worktree and branch"
+  fi
+  cleanup_sandbox "$sb"
+}
+
+# ---------- test: safe mode refuses dirty worktree ----------
+TOTAL=$((TOTAL + 1))
+test_safe_mode_dirty_skip() {
+  local sb
+  sb=$(mk_sandbox) || { fail "setup failed"; return; }
+  (
+    cd "$sb" || exit 1
+    # Introduce uncommitted changes in the worktree
+    echo "dirty" > "$sb/.worktrees/feat-test/dirty.txt"
+    bash "$SCRIPT" feat/test main 2>&1
+    rc=$?
+    [ "$rc" -eq 1 ] || { echo "expected exit 1, got $rc"; exit 1; }
+    # worktree + branch preserved
+    [ -d "$sb/.worktrees/feat-test" ] || { echo "worktree removed despite dirty"; exit 1; }
+    git show-ref --verify --quiet refs/heads/feat/test || { echo "branch removed despite dirty worktree"; exit 1; }
+  )
+  if [ $? -eq 0 ]; then pass "safe mode skips dirty worktree and preserves branch"
+  else fail "safe mode skips dirty worktree and preserves branch"
+  fi
+  cleanup_sandbox "$sb"
+}
+
+# ---------- test: missing args -> exit 2 ----------
+TOTAL=$((TOTAL + 1))
+test_missing_args() {
+  local sb
+  sb=$(mk_sandbox) || { fail "setup failed"; return; }
+  (
+    cd "$sb" || exit 1
+    bash "$SCRIPT" 2>/dev/null
+    rc=$?
+    [ "$rc" -eq 2 ] || { echo "expected exit 2, got $rc"; exit 1; }
+    bash "$SCRIPT" feat/test 2>/dev/null
+    rc=$?
+    [ "$rc" -eq 2 ] || { echo "expected exit 2 for one-arg, got $rc"; exit 1; }
+  )
+  if [ $? -eq 0 ]; then pass "missing args exit 2"
+  else fail "missing args exit 2"
+  fi
+  cleanup_sandbox "$sb"
+}
+
+# ---------- test: rm -rf fallback refuses path outside .worktrees/ ----------
+TOTAL=$((TOTAL + 1))
+test_rmrf_whitelist_guard() {
+  # Bind a path that does NOT match $REPO_ROOT/.worktrees/. Use --force + explicit path.
+  # The script will attempt `git worktree remove --force` which succeeds if git knows it, or
+  # fails (retry + fallback). We only care that the fallback does not fire outside the
+  # whitelist. Simulate by pointing to a path outside .worktrees/ that git has never registered
+  # — `git worktree remove --force` returns non-zero, retry non-zero, then the case-guard
+  # should refuse.
+  local sb
+  sb=$(mk_sandbox) || { fail "setup failed"; return; }
+  (
+    cd "$sb" || exit 1
+    mkdir -p "$sb/not-a-worktree"
+    echo "sentinel" > "$sb/not-a-worktree/SENTINEL"
+    bash "$SCRIPT" feat/test main --force --worktree-path "$sb/not-a-worktree" 2>&1 | grep -q "refuse to rm -rf" \
+      || { echo "expected 'refuse to rm -rf' warning"; exit 1; }
+    # Sentinel must still be present — rm -rf fallback MUST NOT have fired
+    [ -f "$sb/not-a-worktree/SENTINEL" ] || { echo "sentinel deleted — whitelist bypass"; exit 1; }
+  )
+  if [ $? -eq 0 ]; then pass "rm -rf fallback refuses path outside .worktrees/"
+  else fail "rm -rf fallback refuses path outside .worktrees/"
+  fi
+  cleanup_sandbox "$sb"
+}
+
+# ---------- test: pre-switch fires when HEAD is on target branch ----------
+TOTAL=$((TOTAL + 1))
+test_pre_switch_runs() {
+  local sb
+  sb=$(mk_sandbox) || { fail "setup failed"; return; }
+  (
+    cd "$sb" || exit 1
+    # Main worktree HEAD is on main. Move it to feat/test so cleanup must switch off.
+    # Remove the extra worktree first (so switching is legal — can't checkout a branch
+    # that's already checked out in another worktree).
+    git worktree remove --force "$sb/.worktrees/feat-test"
+    git switch feat/test
+    bash "$SCRIPT" feat/test main
+    rc=$?
+    [ "$rc" -eq 0 ] || { echo "exit code $rc"; exit 1; }
+    # HEAD should have moved back to main
+    [ "$(git rev-parse --abbrev-ref HEAD)" = "main" ] || { echo "HEAD not switched to main"; exit 1; }
+    git show-ref --verify --quiet refs/heads/feat/test && { echo "branch not deleted"; exit 1; } || true
+  )
+  if [ $? -eq 0 ]; then pass "pre-switch moves HEAD to base branch before cleanup"
+  else fail "pre-switch moves HEAD to base branch before cleanup"
+  fi
+  cleanup_sandbox "$sb"
+}
+
+# ---------- test: --force still deletes branch when worktree cleanup fails ----------
+TOTAL=$((TOTAL + 1))
+test_force_deletes_branch_even_on_wt_fail() {
+  # Simulate the Windows file-lock scenario: --force + a worktree that git removes from
+  # metadata but whose physical directory we then block. On Linux we simulate by pointing
+  # --worktree-path at a real directory that is NOT under `$REPO_ROOT/.worktrees/` so the
+  # rm -rf fallback refuses, forcing WT_FAIL=1. In --force mode the branch should STILL
+  # be deleted (matches pre-refactor dev-pipeline behavior).
+  local sb
+  sb=$(mk_sandbox) || { fail "setup failed"; return; }
+  (
+    cd "$sb" || exit 1
+    mkdir -p "$sb/outside"
+    # Remove the real worktree first so the branch is not "checked out" anywhere.
+    git worktree remove --force "$sb/.worktrees/feat-test"
+    bash "$SCRIPT" feat/test main --force --worktree-path "$sb/outside" 2>&1
+    rc=$?
+    # Exit 1 because WT_FAIL=1 (whitelist refused), but branch should be deleted.
+    [ "$rc" -eq 1 ] || { echo "expected exit 1, got $rc"; exit 1; }
+    git show-ref --verify --quiet refs/heads/feat/test && { echo "branch NOT deleted in force-mode"; exit 1; } || true
+  )
+  if [ $? -eq 0 ]; then pass "force mode deletes branch even when worktree cleanup fails"
+  else fail "force mode deletes branch even when worktree cleanup fails"
+  fi
+  cleanup_sandbox "$sb"
+}
+
+# ---------- test: branch with no registered worktree -> safe mode still deletes branch ----------
+TOTAL=$((TOTAL + 1))
+test_no_worktree_still_deletes_branch() {
+  local sb
+  sb=$(mk_sandbox) || { fail "setup failed"; return; }
+  (
+    cd "$sb" || exit 1
+    # Remove the worktree first so the branch exists but has no registered worktree.
+    git worktree remove --force "$sb/.worktrees/feat-test"
+    bash "$SCRIPT" feat/test main
+    rc=$?
+    [ "$rc" -eq 0 ] || { echo "expected exit 0, got $rc"; exit 1; }
+    git show-ref --verify --quiet refs/heads/feat/test && { echo "branch not deleted"; exit 1; } || true
+  )
+  if [ $? -eq 0 ]; then pass "safe mode deletes branch when no worktree is registered"
+  else fail "safe mode deletes branch when no worktree is registered"
+  fi
+  cleanup_sandbox "$sb"
+}
+
+# ---------- run all tests ----------
+
+test_force_explicit_path
+test_safe_auto_discover
+test_dry_run
+test_safe_mode_dirty_skip
+test_missing_args
+test_rmrf_whitelist_guard
+test_pre_switch_runs
+test_force_deletes_branch_even_on_wt_fail
+test_no_worktree_still_deletes_branch
+
+echo ""
+echo "Summary: $((TOTAL - FAILED))/$TOTAL tests passed"
+exit $FAILED

--- a/tests/test_cleanup_worktree_branch.sh
+++ b/tests/test_cleanup_worktree_branch.sh
@@ -235,22 +235,39 @@ test_force_deletes_branch_even_on_wt_fail() {
 # ---------- test: remote URL credentials are stripped from observability echo ----------
 TOTAL=$((TOTAL + 1))
 test_remote_credential_strip() {
+  # Covers three forms Argus flagged across iter-3 and iter-4:
+  #   (a) https://user:token@host/path — classic HTTPS with token
+  #   (b) ssh://user:token@host/path   — SSH URL form with token
+  #   (c) user:token@host:path         — SCP-like form with credentials
+  # All must be redacted. Plain `git@host:path` SSH (no colon in userinfo) must pass through.
   local sb
   sb=$(mk_sandbox) || { fail "setup failed"; return; }
   (
     cd "$sb" || exit 1
-    # Inject a fake origin URL with embedded credentials. The script's observability echo
-    # MUST strip the userinfo before logging (per #277 iter-3 finding).
-    git remote add origin "https://user:supersecret-token@example.com/repo.git"
     git worktree remove --force "$sb/.worktrees/feat-test"
+
+    for url_variant in \
+      "https://user:supersecret@example.com/repo.git" \
+      "ssh://user:supersecret@example.com/repo.git" \
+      "user:supersecret@example.com:repo.git"; do
+      git remote remove origin 2>/dev/null || true
+      git remote add origin "$url_variant"
+      # Reuse the same branch for each variant: recreate feat/test if it was deleted by a prior run.
+      git show-ref --verify --quiet refs/heads/feat/test || git branch feat/test
+      out=$(bash "$SCRIPT" feat/test main 2>&1)
+      echo "$out" | grep -q "supersecret" && { echo "credential leaked for variant: $url_variant => $out"; exit 1; }
+      echo "$out" | grep -q "\[REDACTED\]@" || { echo "no [REDACTED] marker for variant: $url_variant"; exit 1; }
+    done
+
+    # Bare git@host:path SSH (no colon in userinfo — not a credential form) must pass through unchanged.
+    git remote remove origin
+    git remote add origin "git@example.com:repo.git"
+    git show-ref --verify --quiet refs/heads/feat/test || git branch feat/test
     out=$(bash "$SCRIPT" feat/test main 2>&1)
-    # Token must not appear in output
-    echo "$out" | grep -q "supersecret-token" && { echo "credential leaked in log: $out"; exit 1; }
-    # Sanitized form must appear (starts with https:// and omits the userinfo)
-    echo "$out" | grep -q "remote=https://example.com/repo.git" || { echo "sanitized remote not found"; exit 1; }
+    echo "$out" | grep -q "remote=git@example.com:repo.git" || { echo "plain git@host:path mangled: $out"; exit 1; }
   )
-  if [ $? -eq 0 ]; then pass "remote URL credentials stripped from observability echo"
-  else fail "remote URL credentials stripped from observability echo"
+  if [ $? -eq 0 ]; then pass "remote URL credentials stripped across https/ssh/scp-like forms"
+  else fail "remote URL credentials stripped across https/ssh/scp-like forms"
   fi
   cleanup_sandbox "$sb"
 }

--- a/tests/test_cleanup_worktree_branch.sh
+++ b/tests/test_cleanup_worktree_branch.sh
@@ -232,6 +232,31 @@ test_force_deletes_branch_even_on_wt_fail() {
   cleanup_sandbox "$sb"
 }
 
+# ---------- test: rm -rf whitelist resists `..` path traversal ----------
+TOTAL=$((TOTAL + 1))
+test_rmrf_traversal_guard() {
+  # Attacker passes a path that textually starts with "$REPO_ROOT/.worktrees/" but, after
+  # canonicalization, resolves OUTSIDE the whitelist via `..`. The script MUST refuse and
+  # preserve the sentinel file in the escape target.
+  local sb
+  sb=$(mk_sandbox) || { fail "setup failed"; return; }
+  (
+    cd "$sb" || exit 1
+    mkdir -p "$sb/escape-target"
+    echo "sentinel" > "$sb/escape-target/SENTINEL"
+    # Traversal path: textually inside .worktrees/ but resolves to $sb/escape-target.
+    local traversal="$sb/.worktrees/../escape-target"
+    git worktree remove --force "$sb/.worktrees/feat-test"
+    bash "$SCRIPT" feat/test main --force --worktree-path "$traversal" 2>&1 | grep -q "refuse to rm -rf" \
+      || { echo "expected 'refuse to rm -rf' warning on traversal path"; exit 1; }
+    [ -f "$sb/escape-target/SENTINEL" ] || { echo "sentinel deleted — traversal guard bypassed"; exit 1; }
+  )
+  if [ $? -eq 0 ]; then pass "rm -rf refuses canonicalized path outside whitelist (traversal guard)"
+  else fail "rm -rf refuses canonicalized path outside whitelist (traversal guard)"
+  fi
+  cleanup_sandbox "$sb"
+}
+
 # ---------- test: branch with no registered worktree -> safe mode still deletes branch ----------
 TOTAL=$((TOTAL + 1))
 test_no_worktree_still_deletes_branch() {
@@ -263,6 +288,7 @@ test_rmrf_whitelist_guard
 test_pre_switch_runs
 test_force_deletes_branch_even_on_wt_fail
 test_no_worktree_still_deletes_branch
+test_rmrf_traversal_guard
 
 echo ""
 echo "Summary: $((TOTAL - FAILED))/$TOTAL tests passed"

--- a/tests/test_cleanup_worktree_branch.sh
+++ b/tests/test_cleanup_worktree_branch.sh
@@ -249,7 +249,9 @@ test_remote_credential_strip() {
     for url_variant in \
       "https://user:supersecret@example.com/repo.git" \
       "ssh://user:supersecret@example.com/repo.git" \
-      "user:supersecret@example.com:repo.git"; do
+      "user:supersecret@example.com:repo.git" \
+      "https://supersecret@example.com/repo.git" \
+      "https://supersecret-gh-pat-12345@example.com/repo.git"; do
       git remote remove origin 2>/dev/null || true
       git remote add origin "$url_variant"
       # Reuse the same branch for each variant: recreate feat/test if it was deleted by a prior run.


### PR DESCRIPTION
## Summary

Consolidates `dev-pipeline/SKILL.md` Phase 5 and `pr-flow/SKILL.md` Phase 7 inline cleanup blocks into a single shared script `scripts/cleanup-worktree-branch.sh`. Motivation: S62 fixed a Windows file-lock bug in dev-pipeline (PR #271) but the same fix never reached pr-flow — exactly the kind of drift Issue #274 was filed to prevent.

**New file: `scripts/cleanup-worktree-branch.sh` (~215 LOC bash)**
- `--force` preserves dev-pipeline semantics: `git worktree remove --force` retry + `rm -rf` fallback whitelisted to `$REPO_ROOT/.worktrees/` (symlink-guarded) + unconditional `git branch -d` attempt even if worktree cleanup failed (matches Windows file-lock path).
- safe mode preserves pr-flow semantics: dirty-worktree preservation, base-branch pre-switch, gated branch delete (only when `WT_FAIL=0`).
- `--dry-run` new affordance, not present in either original.
- `--worktree-path` explicit path skips discovery (dev-pipeline already knows the path).

**Net impact on SKILL.md files:**
- `dev-pipeline/SKILL.md`: -20 LOC (Phase 5 cleanup block now 9 lines instead of 37)
- `pr-flow/SKILL.md`: -44 LOC (Phase 7 cleanup block now 10 lines instead of 62)

**Tests: `tests/test_cleanup_worktree_branch.sh`** — 9 behavior tests, all passing:
1. force + explicit path removes worktree and branch
2. safe mode + auto-discover removes clean worktree and branch
3. dry-run preserves state
4. safe mode skips dirty worktree and preserves branch
5. missing args → exit 2
6. rm -rf fallback refuses path outside `.worktrees/`
7. pre-switch moves HEAD to base branch before cleanup
8. force mode deletes branch even when worktree cleanup fails
9. safe mode deletes branch when no worktree is registered

**Dual-verify**: `code-reviewer` (HIGH severity `--force` branch-delete regression + 2 MEDIUM findings — all addressed) + `critic` (PASS with reservations — clarifying comment added for dev-pipeline BASE_BRANCH semantics).

Closes #274

## Test plan

- [x] `bash tests/test_cleanup_worktree_branch.sh` → 9/9 passing
- [x] dev-pipeline Phase 5 call site passes correct flags
- [x] pr-flow Phase 7 call site passes correct flags
- [x] Whitelist guard rejects paths outside `$REPO_ROOT/.worktrees/`

Generated with Claude Code