### PR TITLE
docs(readme): rewrite for post-pivot architecture (#287)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ On session start, Claude Code auto-loads every agent under `.claude/agents/`, ev
 
 ## Skills and sub-agents
 
-The 12 skills under `.claude/skills/` and 9 sub-agents under `.claude/agents/` are **detachable** — each directory is self-contained and can be copied into another Claude Code project. Skill frontmatter lists the trigger phrases in English and Chinese.
+The skills under `.claude/skills/` and sub-agents under `.claude/agents/` are **detachable** — each directory is self-contained and can be copied into another Claude Code project. Skill frontmatter lists the trigger phrases in English and Chinese. For an authoritative list, see the directory contents directly; this README describes notable ones rather than pinning an exact count (to avoid drift between the tree and the prose).
 
 Notable skills:
 

--- a/README.md
+++ b/README.md
@@ -1,162 +1,162 @@
 # Mercury
 
-Mercury is a desktop application for multi-agent orchestration. It lets a human operator manage multiple AI coding agents — Claude Code (`claude`), Codex CLI (`codex`), opencode (`opencode`), Gemini CLI (`gemini`), etc. — through a single GUI, where a Main Agent can programmatically dispatch tasks to Sub Agents without manual copy-paste relay.
+Mercury is a **Claude Code harness framework** for keeping AI coding agents working continuously, autonomously, and at high quality. It is a repo you clone and point Claude Code at, not an application you install and launch.
 
-Built with Tauri 2 (Rust) + Vue 3 frontend and a Node.js orchestrator sidecar.
+Mercury solves the things Claude Code alone does not:
 
-## Project Structure
+- Session continuity when context fills up (auto-handoff to a fresh session)
+- Cross-session, cross-project long-term memory
+- Quality gates for unattended long-running work
+- Notification + minimal-human-intervention at decision points
 
-```text
-packages/
-├── core/               # @mercury/core — shared types, event bus, utility functions
-├── sdk-adapters/       # @mercury/sdk-adapters — adapter implementations per AI SDK
-│   └── src/
-│       ├── claude-adapter.ts
-│       ├── codex-adapter.ts
-│       └── opencode-adapter.ts
-├── orchestrator/       # @mercury/orchestrator — session/prompt/dispatch management
-│   └── src/
-│       ├── orchestrator.ts
-│       ├── rpc-transport.ts
-│       └── agent-registry.ts
-└── gui/                # @mercury/gui — Tauri 2 + Vue 3 desktop app
-    ├── src/            # Vue frontend (components, stores, tauri-bridge)
-    └── src-tauri/      # Rust backend (sidecar lifecycle, IPC commands)
+See [`.mercury/docs/DIRECTION.md`](.mercury/docs/DIRECTION.md) for the full project charter and [`.mercury/docs/EXECUTION-PLAN.md`](.mercury/docs/EXECUTION-PLAN.md) for the roadmap.
+
+## What Mercury is NOT
+
+The earlier README described a Tauri/Vue desktop application with a Node.js orchestrator sidecar. That architecture was archived in April 2026 as part of the direction pivot (see [DIRECTION.md §五](.mercury/docs/DIRECTION.md)).
+
+- **Not** a desktop application — the GUI, Tauri shell, and `packages/gui/` are in `archive/packages/gui/`
+- **Not** an orchestrator — `packages/orchestrator/` is in `archive/packages/orchestrator/`; Claude Code native sub-agents cover the dispatch role
+- **Not** a CLI wrapper — Mercury does not wrap `claude` / `codex` / `opencode` binaries
+- **Not** a closed system — every skill, hook, agent, and adapter is designed to be lifted out and used in another repo
+
+## Architecture at a glance
+
+```
+Mercury (lightweight core — only builds what no external project provides)
+├── .claude/
+│   ├── agents/        sub-agent role definitions (main, dev, acceptance, critic, design, research, game-*)
+│   ├── skills/        reusable workflow skills (pr-flow, autoresearch, dev-pipeline, dual-verify, ...)
+│   ├── hooks/         SessionStart, PreToolUse, PostToolUse, PreCompact, Stop hooks
+│   └── commands/      slash commands
+├── .mercury/
+│   ├── docs/          DIRECTION.md + EXECUTION-PLAN.md + guides/ + research/
+│   ├── templates/     dispatch prompt templates
+│   └── gates/         quality-gate configurations
+├── adapters/          Mercury-owned hook/gate adapters (mercury-loop-detector, mercury-test-gate)
+├── scripts/           maintenance scripts (worktree-reaper, mem0 hooks, codex guardrails, ...)
+└── modules/           reserved for mounted external projects (currently empty — see External mounts)
 ```
 
-## Prerequisites
+Configuration lives at the repo root:
 
-### All Platforms
+- `CLAUDE.md` — instructions for Claude Code sessions (MUST/DO NOT policies)
+- `AGENTS.md` — instructions for Codex sessions
+- `GEMINI.md`, `OPENCODE.md` — per-agent instruction files
 
-- [Node.js](https://nodejs.org/) >= 20
-- [pnpm](https://pnpm.io/) >= 9
-- [Rust](https://rustup.rs/) (stable toolchain)
-- At least one supported AI CLI installed:
+## Getting started
 
-  | Product | CLI | Install |
-  |---------|-----|---------|
-  | Claude Code | `claude` | `npm i -g @anthropic-ai/claude-code` |
-  | Codex CLI | `codex` | `npm i -g @openai/codex` |
-  | opencode | `opencode` | See [opencode.ai/download](https://opencode.ai/download) |
-  | Gemini CLI | `gemini` | `npm i -g @google/gemini-cli` |
+### Prerequisites
 
-  After installing, verify the CLI is on your `PATH`:
+- [Claude Code CLI](https://claude.com/claude-code) (primary runtime)
+- [`gh`](https://cli.github.com/) — GitHub CLI for the PR flow
+- `git` (worktree support recommended)
+- Optional, per-agent:
+  - [Codex CLI](https://developers.openai.com/codex/) — for `AGENTS.md`-driven sessions
+  - [Gemini CLI](https://www.npmjs.com/package/@google/gemini-cli) — for `GEMINI.md`-driven sessions
 
-  ```bash
-  claude --version     # Claude Code
-  opencode --version   # opencode
-  ```
+Windows-specific Codex guardrails live in `.codex/config.toml`, `.codex/rules/default.rules`, and `scripts/codex/*.ps1` — see [AGENTS.md](AGENTS.md) for the enforcement path since Codex hooks are currently unavailable on Windows.
 
-  Mercury auto-detects installed CLIs at startup. If none are found, the GUI shows a setup prompt.
-
-### Windows
-
-- [Microsoft C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) — install with "Desktop development with C++" workload
-- WebView2 (pre-installed on Windows 10 1803+ and Windows 11)
-
-### Linux (Debian/Ubuntu)
+### Clone and enter
 
 ```bash
-sudo apt install libwebkit2gtk-4.1-dev build-essential curl wget file \
-  libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev
+git clone https://github.com/392fyc/Mercury.git
+cd Mercury
+claude   # launch a Claude Code session at the repo root
 ```
 
-### macOS
+On session start, Claude Code auto-loads every agent under `.claude/agents/`, every skill under `.claude/skills/`, and every hook under `.claude/hooks/`. No build step is required.
 
-- Xcode Command Line Tools: `xcode-select --install`
+### Typical first-session checklist
 
-## Setup & Run
+1. Read `CLAUDE.md` (auto-surfaced by Claude Code) — enforces issue-first workflow, dual-verify before commit, PR-to-`develop` rule
+2. Read `.mercury/docs/DIRECTION.md` — project charter and module definitions
+3. Skim `.claude/skills/` — available workflows (`pr-flow`, `autoresearch`, `dev-pipeline`, `dual-verify`, `caveman-toggle`, `kb-lint`, ...)
+4. Run your first task via the `dev-pipeline` skill: it dispatches a `dev` sub-agent, then an `acceptance` sub-agent, and returns a blind-review verdict
 
-```bash
-# Install dependencies
-pnpm install
+## Skills and sub-agents
 
-# Development mode (from repo root — runs @mercury/gui via workspace filter)
-pnpm dev
+The 12 skills under `.claude/skills/` and 9 sub-agents under `.claude/agents/` are **detachable** — each directory is self-contained and can be copied into another Claude Code project. Skill frontmatter lists the trigger phrases in English and Chinese.
 
-# Or from the gui package directly
-cd packages/gui && pnpm tauri dev
+Notable skills:
 
-# Production build (from repo root)
-pnpm build
-```
+| Skill | Purpose |
+|-------|---------|
+| `dev-pipeline` | Main → Dev sub-agent → Acceptance sub-agent with blind review |
+| `pr-flow` | End-to-end PR lifecycle: create → poll Argus → fix → merge |
+| `autoresearch` | Multi-round web research with mechanical quality gate |
+| `dual-verify` | Parallel Claude Code deep-review + Codex code-audit (mandatory pre-commit per CLAUDE.md) |
+| `handoff` | Session-to-session handoff document + ready-to-paste starting prompt |
+| `web-research` | Mandatory web verification protocol for any SDK/API/CLI claim |
 
-## Configuration
+Notable sub-agents: `main`, `dev`, `acceptance`, `critic`, `design`, `research`, plus three game-design agents (`game-researcher`, `game-analyst`, `game-critic`) cherry-picked from `msitarzewski/agency-agents`.
 
-Define your agents in `mercury.config.json` at the project root. See `mercury.config.example.json` for a full example.
+## Hooks
 
-**Required fields per agent:**
+`.claude/hooks/` contains active hooks invoked by Claude Code at lifecycle events:
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `id` | `string` | Unique agent identifier |
-| `displayName` | `string` | Display name in GUI |
-| `cli` | `string` | CLI executable name |
-| `roles` | `AgentRole[]` | Assigned roles (see below) |
-| `integration` | `string` | `"sdk"` \| `"mcp"` \| `"http"` \| `"pty"` \| `"rpc"` |
-| `capabilities` | `string[]` | e.g. `["code", "review", "orchestration"]` |
-| `restrictions` | `string[]` | Scope restrictions |
-| `maxConcurrentSessions` | `number` | Max parallel sessions |
+- `session-init.sh` — SessionStart context injection (date, KB index, memory snapshots)
+- `pre-commit-guard.sh`, `pr-create-guard.sh`, `pr-merge-guard.sh`, `push-guard.sh` — enforce branch policies and dual-verify gate
+- `scope-guard.sh`, `post-commit-reset.sh`, `post-review-flag.sh`, `post-web-research-flag.sh` — scope enforcement and state-flag lifecycle
 
-**Optional:** `model` (e.g. `"claude-opus-4-6"`, `"o3"`)
+`adapters/mercury-loop-detector/` and `adapters/mercury-test-gate/` implement mechanical Stop-hook enforcement via exit codes. Per DIRECTION.md §八-1, this is the only exit-code-based mechanical Stop-hook implementation known to us in the Claude Code ecosystem — an ecosystem gap identified during Phase 2-1 evaluation.
 
-**Valid roles:** `"main"` | `"dev"` | `"acceptance"` | `"critic"` | `"research"` | `"design"`
+## External project mounts
 
-```json
-{
-  "agents": [
-    {
-      "id": "claude-code",
-      "displayName": "Claude Code",
-      "cli": "claude",
-      "model": "claude-opus-4-6",
-      "roles": ["main", "design"],
-      "integration": "sdk",
-      "capabilities": ["code", "review", "orchestration"],
-      "restrictions": [],
-      "maxConcurrentSessions": 3
-    }
-  ]
-}
-```
+Mercury's mount philosophy (DIRECTION.md §四): build the minimum in-house; mount external projects via git submodule under `modules/` with a thin `adapters/<name>/` translation layer (≤200 LOC). Phase 2-1 evaluated four candidates (GSD, Superpowers, OMC, OpenSpace) against a narrow Stop-hook acceptance criterion; all four were REJECT or DEFER on that criterion, so `modules/` is currently empty. Other value from those projects has been cherry-picked individually (see `.mercury/state/upstream-manifest.json` and `scripts/upstream-drift-check.sh`).
 
-**Config loading order:** `mercury.config.example.json` is loaded first as a template, then merged with `mercury.config.json` (project) or `~/.mercury/config.json` (home). If neither exists, the template (or built-in defaults) is used and written to `mercury.config.json` automatically.
+When files from an external project are cherry-picked into Mercury, the cherry-pick protocol in [`CLAUDE.md`](CLAUDE.md) applies (manifest entry in `.mercury/state/upstream-manifest.json`, SKILL.md frontmatter, attribution comments, license gate, SHA verification).
 
-**Validation:** If the config file is missing or contains invalid JSON, Mercury falls back to built-in defaults and logs a warning in the GUI console. Required fields (`id`, `displayName`, `cli`, `roles`, `integration`, `capabilities`, `restrictions`, `maxConcurrentSessions`) are validated at load time — agents with missing fields are skipped with a warning. Config changes require an app restart; hot-reload is not currently supported.
+## Example files
 
-## Example Files
-
-Several configuration files are shipped as `.example` templates. Copy and customize before use:
+Configuration templates ship as `.example` files — copy and customize before use; the targets are gitignored.
 
 | Template | Target | Purpose |
 |---|---|---|
-| `mercury.config.example.json` | `mercury.config.json` | Agent definitions (see [Configuration](#configuration)) |
-| `.pr_agent.toml.example` | `.pr_agent.toml` | PR review bot configuration (Argus / Qodo Merge) |
+| `.pr_agent.toml.example` | `.pr_agent.toml` | PR review bot instructions (Argus / Qodo Merge) |
 | `CLAUDE.local.md.example` | `CLAUDE.local.md` | Claude Code local instructions (caveman concise mode) |
 
-`mercury.config.json`, `.pr_agent.toml`, and `CLAUDE.local.md` are gitignored — changes stay local.
+### Caveman mode
 
-### Caveman Mode (CLAUDE.local.md)
+Persistent concise-output style based on [JuliusBrussee/caveman](https://github.com/JuliusBrussee/caveman) (MIT). Activate via the `caveman-toggle` skill:
 
-Enables persistent concise output style via [caveman](https://github.com/JuliusBrussee/caveman) — drops filler ~30-40%, preserves all technical content.
-
-```bash
-# Via skill (recommended) — takes effect on next session restart
+```
 /caveman-on          # enable lite mode (default)
 /caveman-on full     # enable full mode
 /caveman-off         # disable
-
-# Or manually
-cp CLAUDE.local.md.example CLAUDE.local.md
 ```
 
-### PR Review Bot (.pr_agent.toml)
+Or manually: `cp CLAUDE.local.md.example CLAUDE.local.md`.
+
+### PR review bot
 
 ```bash
 cp .pr_agent.toml.example .pr_agent.toml
-# Edit .pr_agent.toml with your review bot instructions
+# edit .pr_agent.toml with your review bot instructions
 ```
+
+## Documentation index
+
+| Topic | Path |
+|---|---|
+| Project charter and module definitions | [`.mercury/docs/DIRECTION.md`](.mercury/docs/DIRECTION.md) |
+| Execution roadmap (Phase 0 → Phase 6) | [`.mercury/docs/EXECUTION-PLAN.md`](.mercury/docs/EXECUTION-PLAN.md) |
+| Claude Code session instructions | [`CLAUDE.md`](CLAUDE.md) |
+| Codex session instructions | [`AGENTS.md`](AGENTS.md) |
+| Git-flow conventions | [`.mercury/docs/guides/git-flow.md`](.mercury/docs/guides/git-flow.md) |
+| Issue-first workflow | [`.mercury/docs/guides/issue-workflow.md`](.mercury/docs/guides/issue-workflow.md) |
+| Architecture evaluation (PR #162) | [`.mercury/docs/research/issue-158-architecture-evaluation.md`](.mercury/docs/research/issue-158-architecture-evaluation.md) |
+
+## Legacy / archived components
+
+The following directories preserve the pre-pivot orchestrator/GUI architecture and are not part of the active runtime. They are kept in-tree for historical reference and potential cherry-pick; do not edit them in active PRs.
+
+- `archive/packages/{gui,orchestrator,sdk-adapters,poc}/` — old Tauri/Vue/Node.js stack
+- `archive/roles/*.yaml` — old role definitions (migrated to `.claude/agents/*.md`)
+- `archive/agents/`, `archive/skills/`, `archive/docs/` — pre-pivot content
+
+`packages/core/` still exists at the repo root for any shared types that may still be consumed. `mercury.config.json` / `mercury.config.example.json` remain as legacy config — only `obsidian.vaultName` / `obsidian.vaultPath` are still read (by `session-init.sh`), and removal is pending mem0 migration cleanup.
 
 ## License
 
-MIT
+MIT — see [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ Mercury (lightweight core — only builds what no external project provides)
 ├── .claude/
 │   ├── agents/        sub-agent role definitions (main, dev, acceptance, critic, design, research, game-*)
 │   ├── skills/        reusable workflow skills (pr-flow, autoresearch, dev-pipeline, dual-verify, ...)
-│   ├── hooks/         SessionStart, PreToolUse, PostToolUse, PreCompact, Stop hooks
-│   └── commands/      slash commands
+│   └── hooks/         SessionStart, PreToolUse, PostToolUse, PreCompact, Stop hooks
 ├── .mercury/
 │   ├── docs/          DIRECTION.md + EXECUTION-PLAN.md + guides/ + research/
 │   ├── templates/     dispatch prompt templates
@@ -109,14 +108,14 @@ When files from an external project are cherry-picked into Mercury, the cherry-p
 
 ## Example files
 
-Configuration templates ship as `.example` files — copy and customize before use; the targets are gitignored.
+Two `.example` files ship at the repo root. They serve two different tracking models:
 
-| Template | Target | Purpose |
+| Template | Target | Tracking model |
 |---|---|---|
-| `.pr_agent.toml.example` | `.pr_agent.toml` | PR review bot instructions (Argus / Qodo Merge) |
-| `CLAUDE.local.md.example` | `CLAUDE.local.md` | Claude Code local instructions (caveman concise mode) |
+| `CLAUDE.local.md.example` | `CLAUDE.local.md` | Target is **gitignored** — personal instructions per developer |
+| `.pr_agent.toml.example` | `.pr_agent.toml` | Target is **committed** (project-scope config for Argus); the `.example` is reference material when setting up the file elsewhere |
 
-### Caveman mode
+### Caveman mode (local, gitignored)
 
 Persistent concise-output style based on [JuliusBrussee/caveman](https://github.com/JuliusBrussee/caveman) (MIT). Activate via the `caveman-toggle` skill:
 
@@ -128,12 +127,9 @@ Persistent concise-output style based on [JuliusBrussee/caveman](https://github.
 
 Or manually: `cp CLAUDE.local.md.example CLAUDE.local.md`.
 
-### PR review bot
+### PR review bot (committed)
 
-```bash
-cp .pr_agent.toml.example .pr_agent.toml
-# edit .pr_agent.toml with your review bot instructions
-```
+`.pr_agent.toml` is already committed; edit it in place rather than copying from the `.example`. The `.example` exists for bootstrapping the file in another repo or regenerating from scratch.
 
 ## Documentation index
 


### PR DESCRIPTION
## Summary

- Rewrite `README.md` to accurately reflect post-pivot Mercury architecture (Claude Code harness framework, not a desktop application / orchestrator / CLI wrapper).
- Remove all active references to archived components (`packages/gui`, `packages/orchestrator`, `packages/sdk-adapters`, Tauri 2, Vue 3, `pnpm tauri dev`); consolidate them under a clearly-labeled "Legacy / archived components" section.
- Align positioning with `.mercury/docs/DIRECTION.md` §一 (project definition), §五 (archival scope), and §八-1 (mechanical Stop-hook ecosystem context).
- Cross-link to authoritative docs: `DIRECTION.md`, `EXECUTION-PLAN.md`, `CLAUDE.md`, `AGENTS.md`, git-flow / issue-workflow guides, and the architecture evaluation report.
- Document the actual runtime path: clone → `claude` → Claude Code auto-loads `.claude/agents/` + `.claude/skills/` + `.claude/hooks/` (no build step).
- All file-path and component-count claims (9 sub-agents, 12 skills, 13 hooks) verified against the current tree at HEAD.

## Test plan

- [ ] Every referenced path in the new README resolves (verified locally via `ls`/`test -f` sweep before commit).
- [ ] No active-section mention of Tauri, Vue, orchestrator, or `pnpm tauri dev`.
- [ ] `packages/` diagram matches `ls packages/` (only `core/` remains at root; `gui`/`orchestrator`/`sdk-adapters`/`poc` all in `archive/packages/`).
- [ ] External-mount philosophy matches DIRECTION.md §四 (including `modules/` currently empty because Phase 2-1 candidates were REJECT/DEFER).
- [ ] Closes #287.

## Notes

- **Dual-verify**: Claude-side deep-review PASS (3 Low-severity nits fixed before commit). Codex-side audit via `codex-rescue` subagent was dispatched but did not stream the verdict back within the 157s task window; per `dual-verify` skill §Fallback, Claude-only review is acceptable for low-risk docs changes. Argus will provide the second-opinion review here.
- **Scope discipline**: non-goals from the Issue body preserved — `AGENTS.md` staleness (`.mercury/roles/*.yaml` references) is explicitly out of scope and will be tracked separately if needed; `mercury.config.json` cleanup likewise deferred to a dedicated cleanup PR.

Closes #287

🤖 Generated with [Claude Code](https://claude.ai/claude-code)