### PR TITLE
feat(loop-detector): Phase 4-4 enhancement A+B — multi-level timeout + stall diagnostic report

### DIFF
--- a/.mercury/config/loop-detector.json
+++ b/.mercury/config/loop-detector.json
@@ -3,5 +3,8 @@
   "no_progress_threshold": 5,
   "same_error_threshold": 5,
   "duplicate_call_threshold": 3,
-  "read_write_ratio_threshold": 8
+  "read_write_ratio_threshold": 8,
+  "timeout_soft_sec": 60,
+  "timeout_idle_sec": 300,
+  "timeout_hard_sec": 900
 }

--- a/.mercury/docs/EXECUTION-PLAN.md
+++ b/.mercury/docs/EXECUTION-PLAN.md
@@ -322,10 +322,11 @@ adapters/         # 适配层
 3. ✅ rollback 路径验证（unset env var / revert hook）
 4. ✅ escape-hatch 防死锁（smoke test 已证）
 
-### 4-4. 卡死检测 (S37, #226) — 核心已交付，增强待定
+### 4-4. 卡死检测 (S37, #226) — 核心已交付，增强分两批
 - ✅ sliding window 循环检测已实现并交付 (PR #229, #231, merged)
-- ⏳ 增强: 多级超时（soft → idle → hard）
-- ⏳ 增强: 卡死后自动生成诊断报告 + 通知用户（依赖 Phase 5 Notify Hub）
+- ✅ 增强 A: 多级超时 (soft → idle → hard) — Issue #290 落地
+- ✅ 增强 B: 卡死后诊断报告 → 写文件 (.mercury/state/stall-reports/) — Issue #290 落地
+- ⏳ 增强 C (Phase 5 依赖): 卡死后推送通知给用户（随 Phase 5 Notify Hub 落地）
 
 **产出**: agent 可以自动跨 session 继续工作
 **人类干预点**: ~~技术方案选择（已完成，Option D）~~；首次 session 接力时确认状态传递完整性

--- a/.mercury/docs/research/phase4-5-circular-dep-breakpoint-2026-04-24.md
+++ b/.mercury/docs/research/phase4-5-circular-dep-breakpoint-2026-04-24.md
@@ -1,0 +1,358 @@
+# Phase 4-4 / Phase 5 Circular Dependency — Break-point Analysis
+
+> Status: **Design proposal (awaiting main-agent decision)** | Author: designer sub-agent | Date: 2026-04-24
+> Scope: Resolve the apparent deadlock between EXECUTION-PLAN.md Phase 4-4 "enhancement" and Phase 5 "Notify Hub"
+> Out of scope: Implementation; EXECUTION-PLAN.md itself is not modified by this doc
+> Related: `.mercury/docs/DIRECTION.md` §3 Module 3 (Notify Hub), §3 Module 4 (Quality Gate), §4 (mount strategy)
+>          `.mercury/docs/EXECUTION-PLAN.md` Phase 4 (L241-333), Phase 5 (L337-362)
+>          `.mercury/docs/research/phase4-3-compact-prevention-eval.md` §4-3 B.3 (already deferred to Phase 5)
+>          Issue #226 (sliding-window loop detector — shipped), Issue #289 (Claude Code Routines research — open)
+
+---
+
+## 1. Problem Statement
+
+EXECUTION-PLAN.md currently reads as if Phase 4-4 "enhancement" and Phase 5 "Notify Hub" form a closed
+dependency loop:
+
+```
+Phase 4-4 enhancement: needs "通知用户" (notify user on stall) ─┐
+                                                                 │
+Phase 5 Notify Hub: 前置条件 "Phase 1-4 全部能力"  ─────────────┤
+                                                                 │
+Phase 4 complete: requires 4-4 enhancement done  ◄──────────────┘
+```
+
+Surface reading: each blocks the others, nothing ships.
+
+The symptom matters because:
+
+1. Phase 4-4 **core** (sliding-window loop detector, Issue #226) already shipped via PRs #229/#231
+   and has fired in real sessions (three times in the S72-predecessor stretch, including during the
+   preparation of this doc). The `no_progress` / `duplicate_call` / `same_error` / `read_write_ratio`
+   signals work and reset correctly — see `adapters/mercury-loop-detector/hook.cjs` L139-149.
+2. Phase 4-3 B.3 ("连续 block 3× 无响应 → Notify Hub 通知") was also explicitly deferred to Phase 5
+   in `phase4-3-compact-prevention-eval.md` §4-3 B.3. So both 4-3 and 4-4 have a dangling
+   "notify" tail that converges on the same Phase-5 dependency.
+3. Mercury is otherwise ready to close Phase 4 and move on.
+
+This document re-reads each dependency claim in EXECUTION-PLAN.md against the actual shipped code
+and finds the loop is **largely declarative, not real**.
+
+---
+
+## 2. Dependency Graph Re-analysis
+
+### 2.1 Parsing every Phase 4-4 / Phase 5 claim in EXECUTION-PLAN.md
+
+| # | Claim (verbatim paraphrase) | Line | Classification |
+|---|------------------------------|------|----------------|
+| C1 | Phase 4-4: sliding window 循环检测已实现并交付 | 326 | **Shipped fact** — PRs #229/#231 merged, hook.cjs in tree. |
+| C2 | Phase 4-4 增强: 多级超时 (soft → idle → hard) | 327 | **Unimplemented enhancement.** No external dependency; pure local state machine. |
+| C3 | Phase 4-4 增强: 卡死后自动生成诊断报告 + 通知用户（依赖 Phase 5 Notify Hub） | 328 | **Composite** — diagnostic report ≠ notify. Report=write-to-file, Notify=push-to-human. |
+| C4 | Phase 5 可用开发模式: 全部 Phase 1-4 能力 + Session Continuity | 341 | **Idealized ordering**, not a capability gate. "可用开发模式" is about using Mercury to build Phase 5, not about Phase 5 itself requiring 4-4. |
+| C5 | Phase 5-3 与其他模块集成: Session Continuity 通知 / Quality Gate stop 被拦截通知 / Dev Pipeline 任务完成通知 | 355-357 | **Consumer list** — Phase 5 advertises itself to upstream modules. Implies loose coupling via event interface, not a build-order dependency. |
+| C6 | Phase 4 完成后解锁: agent 可长时间自主工作 ← 核心里程碑 | 333 | Core milestone already satisfied by 4-2+4-3+4-4 core; C2/C3 are optional polish, not gate conditions. |
+
+### 2.2 True dependency graph (cleaned)
+
+```
+                        ┌────────────────────────────────────────┐
+                        │  Phase 4-4 CORE (shipped)              │
+                        │  - sliding-window loop detector         │
+                        │  - 4 signal types                       │
+                        │  - independent counters                 │
+                        │  - per-session reset                    │
+                        └──────────────────┬─────────────────────┘
+                                           │
+                   ┌───────────────────────┼───────────────────────┐
+                   │                       │                       │
+         ┌─────────▼──────────┐  ┌─────────▼──────────┐  ┌────────▼────────────┐
+         │ C2 Multi-level     │  │ C3.a Diagnostic    │  │ C3.b Notify user    │
+         │ timeout            │  │ report → file      │  │ on stall            │
+         │                    │  │                    │  │                     │
+         │ Dep: state machine │  │ Dep: loop detector │  │ Dep: Notify channel │
+         │      only          │  │      fire event    │  │      (Phase 5 MVP)  │
+         │ STANDALONE         │  │ STANDALONE         │  │ NEEDS CHANNEL       │
+         └────────────────────┘  └────────────────────┘  └────────┬────────────┘
+                                                                   │
+                                           ┌───────────────────────▼───────────┐
+                                           │ Phase 5 Notify Hub                │
+                                           │ (dep: ONE outbound channel,       │
+                                           │  NOT "all Phase 1-4 能力")        │
+                                           └───────────────────────────────────┘
+```
+
+### 2.3 Kind of dependency — key distinctions
+
+| Kind | Example in our plan | Real blocker? |
+|------|---------------------|---------------|
+| **Capability dependency** (A needs B's code to exist) | C3.b → Phase 5 outbound channel | Yes, but only on ONE channel, not the whole Hub |
+| **Temporal dependency declaration** ("Phase 5 前置条件 Phase 1-4 全部能力") | C4 | No — it's a planning ideal, not a build gate. Phase 5 MVP can run with just Phase 1 (pr-flow existed in Phase 1) for test harnessing |
+| **Event consumer coupling** (A emits, B decides whether to listen) | C5 | No — publisher/subscriber pattern, each side ships independently |
+| **IO coupling — write-to-file** (report artifact) | C3.a | No external dep at all; it's just `fs.writeFileSync` inside the hook |
+| **IO coupling — push-to-human** (notification) | C3.b | Yes — needs transport. But transport can be mounted, not built |
+
+Conclusion: the "cycle" exists only because EXECUTION-PLAN.md glued together three orthogonal things
+in one bullet (L328: `卡死后自动生成诊断报告 + 通知用户（依赖 Phase 5 Notify Hub）`). Splitting them
+dissolves the cycle.
+
+---
+
+## 3. Break-point Candidates
+
+### Summary matrix
+
+| # | Approach | EXEC-PLAN edits | First-session scope | Friction | Yield | DIRECTION alignment |
+|---|----------|-----------------|---------------------|----------|-------|---------------------|
+| A | Split 4-4 enhancement: ship non-notify half now, defer notify half | L325-328, L330-333 | 1 session | Low | Medium-High | Excellent — modular, no custom orchestrator |
+| B | Mount external Notify channel, unblock C3.b in the same breath | L337-362, Issue #289 fold-in | 2 sessions (research + mount) | Medium (Mode D eval required) | High | Good — follows P1 mount-over-self-build; adapter must stay ≤200 LOC |
+| C | Rewrite EXEC-PLAN: Phase 5 MVP first, 4-4 enhancement follows | L337-362, Phase ordering | 2 sessions | High — mental model disruption | High if executed cleanly | OK — just a reordering |
+| D | Close Phase 4 as-is, reclassify 4-4 enhancement as Phase 5 scope | L325-333, L337-362 | 0.5 session (doc-only) | Very low | Low-Medium — unblocks future work but adds nothing today | Excellent — honest about current state |
+| E | Hybrid: A + B in sequence (A first, B at next natural opening) | L325-333 now, L337-362 later | 1 session now | Low now, Medium later | High over 2-3 sessions | Excellent |
+
+### 3.A — Split 4-4 enhancement along the notify boundary
+
+**Core idea.** The L328 bullet mashes three things together:
+`(i) multi-level timeout + (ii) diagnostic report + (iii) notify user`.
+Carve (iii) out into a separate bullet that explicitly says "needs Phase 5 channel", and ship (i) and (ii)
+now without waiting.
+
+**What to edit in EXECUTION-PLAN.md (main-agent applies — designer does not edit).**
+
+- L325-328 current body:
+  ```
+  ### 4-4. 卡死检测 (S37, #226) — 核心已交付，增强待定
+  - ✅ sliding window 循环检测已实现并交付 (PR #229, #231, merged)
+  - ⏳ 增强: 多级超时（soft → idle → hard）
+  - ⏳ 增强: 卡死后自动生成诊断报告 + 通知用户（依赖 Phase 5 Notify Hub）
+  ```
+- Replace with:
+  ```
+  ### 4-4. 卡死检测 (S37, #226) — 核心已交付，增强分两批
+  - ✅ sliding window 循环检测已实现并交付 (PR #229, #231, merged)
+  - ⏳ 增强 A (Phase 4 内可做): 多级超时 (soft → idle → hard)
+  - ⏳ 增强 B (Phase 4 内可做): 卡死后诊断报告 → 写文件 (.mercury/state/stall-reports/)
+  - ⏳ 增强 C (Phase 5 依赖): 卡死后推送通知给用户（随 Phase 5 Notify Hub 落地）
+  ```
+
+**First-session scope (for main-agent dispatch plan):**
+
+- Dispatch dev sub-agent to extend `adapters/mercury-loop-detector/hook.cjs` with:
+  - Multi-level timeout counter fields in the state file (soft / idle / hard)
+  - On stall fire: serialize `{session_id, stall_type, last_5_tool_calls, err_sig, timestamp}` to
+    `.mercury/state/stall-reports/<session_id>-<ts>.json` before the existing reset
+  - Keep current adapter ≤200 LOC (now ~200; if it crosses, split into `hook.cjs` + `report.cjs`)
+- Add a pruning rule (keep last 50 reports, unlink older) so state dir stays bounded
+- Dual-verify gate, PR to develop, pr-flow skill
+
+**Friction.** Low. Pure local code, no mount, no new external dep.
+
+**Yield.** Medium-High. User gets forensic data on every stall (huge for Phase 5 debug later), plus
+multi-level timeout is a commonly-missed Mercury capability. Does not unblock `C3.b` notify.
+
+**Risk.** Adapter crosses 200 LOC if both enhancements land together — plan to split file if so.
+
+### 3.B — Mount external Notify channel (Phase 5 MVP via mount)
+
+**Core idea.** DIRECTION.md §3 Module 3 explicitly lists Notify Hub as "self-build worthy" because
+the **routing and unified outlet** are Mercury-specific, but **transport** is commodity. We can
+mount one transport now (ntfy.sh HTTP-POST / Apprise / Telegram Bot) behind a thin adapter, unblocking
+C3.b and every other deferred "notify user" bullet (including 4-3 B.3).
+
+**Candidate transports (Mode D 五标准 must be evaluated by main-agent before committing):**
+
+| Candidate | Transport model | License | Adapter size estimate | Risk |
+|-----------|-----------------|---------|----------------------|------|
+| ntfy.sh (public server or self-host) | HTTP POST to `https://ntfy.sh/<topic>` | Apache-2.0 | ~40-60 LOC (curl/fetch wrapper) | Public topic = eavesdropping unless ACL'd; self-host adds infra |
+| Apprise (Python lib) | Library call dispatches to 110+ targets | BSD-2-Clause | ~80-120 LOC (Python subprocess wrapper from Node) | Adds Python runtime dep; Mercury already has uv for mem0 so acceptable |
+| Telegram Bot API (direct) | HTTPS POST to `api.telegram.org` | N/A (API, not lib) | ~50-80 LOC | Requires bot token secret handling; 1 transport only |
+| Claude Code Channels (native) | `channels_send()` primitive | N/A | ~20 LOC if Channels shipped | **Needs verification of 2026-04 API availability** |
+
+> **Do not pre-commit to any candidate in this doc.** Main agent must run Mode D five-criteria eval
+> (社区活跃度 / 接口稳定性 / 可剥离性 / 维护者信誉 / 替代成本) and record decision in an ADR
+> before mount. Do not introduce AGPL/GPL libs. Record `upstream_sha_at_import` via `gh api` per
+> Mercury cherry-pick protocol.
+
+**First-session scope:**
+
+1. Open Issue "Phase 5 MVP: single-channel Notify adapter"
+2. Dispatch research sub-agent (Mode C, `/autoresearch`) to compare the 4 candidates; produce ADR
+3. Main agent selects one based on ADR; user-confirm before mount
+4. Dispatch dev sub-agent (Mode D): create `adapters/mercury-notify/` with `adapter.{cjs,py}`,
+   README, UPSTREAM.md, manifest entry, attribution header
+5. Minimal interface: `notify(severity, title, body, [action_url])` → returns transport-specific ack
+6. Wire one caller site: 4-3 B.3 fallback (the simplest existing consumer)
+
+**Friction.** Medium. Requires:
+- User decision on which transport (the choice leaks PII/phone/secrets — user-level concern)
+- Secret management for bot tokens (out-of-repo env var, never commit)
+- Mode D eval cycle (~1 session of research before implementation)
+
+**Yield.** High. One mount satisfies 4-3 B.3, 4-4 C3.b, and every future "notify" bullet in Phase 5-3.
+Phase 5 becomes a series of small "add another channel" adapter increments instead of a monolith.
+
+**Interaction with Issue #289 (Claude Code Routines).** Important — do not conflate:
+- Routines = **scheduled background task spawner** (the "who triggers the notify") — analog to cron/GHA
+- Notify Hub = **outbound push transport** (the "how the notify reaches the human")
+- The two are orthogonal layers. #289 research output should be folded in as a **trigger backend**
+  option for Phase 5-3 cases 1 and 3 (session-switch and task-complete notifications), not as
+  a replacement for the outbound channel. Main agent should keep #289 as separate research,
+  and Phase 5 MVP explicitly does not wait on it.
+
+### 3.C — Reorder EXECUTION-PLAN.md so Phase 5 MVP precedes 4-4 enhancement
+
+**Core idea.** Flip the sequence: declare Phase 4 complete at current state, rewrite Phase 5 to be
+"MVP first, integrations later", and put the 4-4 enhancement bullet inside Phase 5 as a consumer.
+
+**What to edit in EXECUTION-PLAN.md:**
+- L241-333: add "Phase 4 Complete ✅" header block before 4-4 restatement; move the C2/C3 bullets out
+- L337-362: rewrite Phase 5 into 5-0 (MVP mount, single channel), 5-1 (interface, renumbered), 5-2, 5-3
+- Update L384-392 Phase-order table
+
+**First-session scope.** Rewrite doc only; implementation starts session 2. Session 1 is pure
+Mode A (requirements + structure reshuffle with user confirm).
+
+**Friction.** High.
+- Mental-model disruption — a lot of cross-references in memory/session-state docs assume Phase order
+- User has to re-verify phase table + execution-plan nav links + handoff docs that cite phases
+- Higher blast radius for minor gain
+
+**Yield.** High if executed cleanly — gives a coherent narrative where Notify is a first-class
+early module. But that's also what **Approach B's Mode D eval step naturally produces** — Approach C
+is a superset of B with added doc churn.
+
+**Verdict preview.** Approach B delivers C's yield without the doc-rewrite tax. Not recommended.
+
+### 3.D — Close Phase 4, open fresh "Phase-Notify" milestone (no enhancement)
+
+**Core idea.** Be honest: Phase 4 core is done; the enhancement was wishlist. Stop claiming Phase 4
+is unfinished because of an optional enhancement. Create a Phase 4.5 / "Notify" milestone covering
+what was C3.b + 4-3 B.3 + Phase 5-3 integrations, close the loop conceptually.
+
+**What to edit in EXECUTION-PLAN.md:**
+- L325-333: reduce 4-4 to just "✅ core shipped"; remove C2/C3 bullets (or move to a backlog doc)
+- Add a new section "Phase 4.5: Notify-gated Enhancements" or just merge enhancements into Phase 5
+  scope wholesale
+- L337-362: unchanged, but noting that 4-4 enhancements are now Phase 5 consumers
+
+**First-session scope:** doc-only, 0.5 session. Main agent + user confirm the scope shift.
+
+**Friction.** Very low — it's a planning-doc correction.
+
+**Yield.** Low-Medium. No new capability ships, just clearer boundaries. But clears the "Phase 4
+not done" mental weight, which has real cost: every session-start doc reads "Phase 4 still has
+unfinished enhancements".
+
+**Use case.** Good as a *lead-in* to Approach B — do D first (doc hygiene), then B (build the channel).
+
+### 3.E — Hybrid: A now + B at next natural opening (RECOMMENDED)
+
+**Core idea.** Ship Approach A immediately (session 1 — pure local enhancement, no external dep,
+no user decision required mid-task). Then at session 2-3 when the user has bandwidth for a Mode D
+mount decision, run Approach B to unlock all deferred "notify" tails in one stroke. Do D's doc
+cleanup opportunistically inside A's PR.
+
+**Why this is not just "A+B sequential".** The claim is: **session 1 requires zero user decisions**
+(fits `feedback_auto_run_mode` — pipeline work proceeds without asking), while session 2 is where
+the architectural commitment (which transport) happens. This is the healthiest rhythm.
+
+---
+
+## 4. Recommendation
+
+### Primary: **Approach E (Hybrid — A now, B next, D opportunistically)**
+
+**Rationale.**
+- A is mechanically unblocked today. No external dep, no user decision, fits auto-run mode.
+- A's diagnostic-report artifact (stall JSON in `.mercury/state/stall-reports/`) is exactly the
+  forensic input Phase 5-3 needs when deciding what to put in a notification body. We want that
+  data collected BEFORE building the transport, not after.
+- B is the right shape for Phase 5 MVP: one mount, one adapter, ≤200 LOC, no custom orchestrator.
+  It satisfies DIRECTION.md §3 Module 3 exactly.
+- D is essentially free if folded into A's PR body / CHANGELOG (`clarify Phase 4-4 enhancement
+  scope split` is a one-paragraph plan edit).
+
+**First-session scope (for main-agent dispatch):**
+
+1. Open Issue "Phase 4-4 enhancement A+B: multi-level timeout + diagnostic report"
+2. Dispatch dev sub-agent (Mode B) to extend `adapters/mercury-loop-detector/`:
+   - Add soft/idle/hard timeout counters to state schema
+   - On stall fire, write report JSON to `.mercury/state/stall-reports/` before reset
+   - Keep current adapter's 200 LOC cap; split into `hook.cjs` + `report.cjs` if it crosses
+3. Update EXECUTION-PLAN.md L325-328 per Approach A's text (main agent writes, or Dev sub-agent
+   does if scope allows)
+4. `/dual-verify` + `/pr-flow` as usual
+5. Soak 1 session (natural use) to confirm no regression in existing loop detection
+
+**Session-2 follow-up scope (do not dispatch in session 1):**
+
+1. Open Issue "Phase 5 MVP: single-channel Notify adapter — candidate eval"
+2. Dispatch research sub-agent (Mode C) for Notify transport eval — outputs an ADR
+3. **Wait for user decision** on transport (this is a real decision point — secret handling,
+   privacy posture, self-host vs public)
+4. If approved, Mode D mount + adapter in session 3
+
+### Human decision point (not auto-runnable — flag for main agent)
+
+- **Transport choice (session 2).** The user must pick ntfy/Apprise/Telegram/Channels. This involves
+  where messages land (phone / desktop / IM), who else can see them (public topic vs auth), and
+  whether we accept a Python runtime dep. Not an architecture call — a personal-workflow call.
+- **Secret handling (session 2).** Bot tokens must live outside the repo. User must confirm env-var
+  placement (probably `$HOME/.claude/settings.json` env block, per existing `MERCURY_MEM0_DISABLED`
+  precedent) and rotation plan.
+
+### Explicitly **not recommended** (with reasons, so the team does not relitigate)
+
+- **Approach C (full doc reorder).** High friction for doc churn that Approach E achieves cheaply.
+  The only scenario where C is better: user decides Phase 5 is the next focus AND wants a narrative
+  rewrite for publication. Not worth it for internal clarity alone.
+- **"Build our own Notify Hub from scratch before mounting anything".** Violates DIRECTION.md P1
+  (lightweight body + external mount) and CLAUDE.md `DO NOT build custom orchestrator layers`.
+  Notify transport is a solved problem; do not reinvent.
+- **Pure Approach D (close Phase 4, no enhancement).** Leaves users blind when loop detector fires
+  (current state: block message only, no forensic trail). Throws away low-hanging fruit.
+- **"Wait for #289 Routines research before any action".** #289 is about scheduled **trigger**
+  backends, not about outbound **transport**. They are orthogonal. Gating Phase 4 closure on a P2
+  research task is a category error.
+
+---
+
+## 5. Rollback / Exit Criteria
+
+If Approach A's soak reveals problems in session 1:
+
+| Symptom | Likely cause | Fallback |
+|---------|--------------|----------|
+| Adapter crosses 200 LOC unsplittable | Too many enhancements bundled | Split into `adapters/mercury-loop-detector/` (core) + `adapters/mercury-stall-reporter/` (diagnostic) — two adapters, each ≤200 LOC |
+| New false-positive stall fires after soft/idle/hard timeouts added | Timer logic interacts with existing counters | Revert timeout portion; keep diagnostic-report portion (they are independent) |
+| Diagnostic report disk usage grows unbounded | Pruning rule wrong | Tighten retention from 50 → 10 reports, or move storage out of repo (`$HOME/.claude/mercury/stall-reports/`) |
+| User reports the feature feels intrusive | Cognitive noise > value | Feature-flag via `MERCURY_STALL_REPORT_DISABLED=1` env var (matches existing `MERCURY_MEM0_DISABLED` pattern) |
+
+If Approach B's research (session 2) finds no transport meets DIRECTION five-criteria:
+
+| Finding | Response |
+|---------|----------|
+| All candidates fail 可剥离性 or 维护者信誉 | Fall back to Claude Code Channels if its API shipped; else defer Phase 5 MVP another cycle and close the enhancement-C bullet as "Phase 5 未来任务" |
+| Only ntfy.sh qualifies but user rejects public topic | Recommend self-hosted ntfy container on NAS (AgentVol01 already runs Container Station) — adds infra but keeps transport independence |
+| All candidates fine but user cannot commit to transport choice | Use GitHub Issue comment as transport MVP (we already have the token) — lowest-privacy, zero-infra baseline to unblock Phase 5 skeleton; user can swap later |
+
+If Approach E as a whole stalls after two sessions:
+
+1. Formally adopt Approach D (doc-only close of Phase 4) and move on to Phase 6 evaluation
+2. Log the Notify-related deferrals as a single "Phase 5 deferred cohort" Issue with explicit
+   re-evaluation conditions (e.g. "unfreeze when user acquires consistent mobile workflow that
+   makes notifications valuable")
+
+---
+
+## 6. Appendix — What this doc does NOT do
+
+- Does not edit EXECUTION-PLAN.md (out of scope per task statement).
+- Does not dispatch dev agents (designer role forbids).
+- Does not pre-select the Phase 5 transport — that is Mode D eval work by main/research agent.
+- Does not fold Issue #289 research into Phase 5 work — the two are orthogonal; main agent
+  handles sequencing.
+- Does not evaluate whether the loop-detector itself needs changes unrelated to stall reports
+  (e.g. the known S37 `no_progress` false-positive on long cron-heavy sequences). That is its
+  own backlog item.

--- a/adapters/mercury-loop-detector/hook.cjs
+++ b/adapters/mercury-loop-detector/hook.cjs
@@ -148,20 +148,22 @@ function main() {
   if (tr) {
     process.stderr.write(tr.message + '\n');
     if (tr.should_block) {
-      writeStallReport(cwd, session_id, 'timeout_hard', tr.message, state,
+      const fullReason = `Mercury loop detector: ${tr.message}\n(Buffer reset. If this is a false positive, resume your work.)`;
+      writeStallReport(cwd, session_id, 'timeout_hard', fullReason, state,
         { name: tool_name, input_hash: ihash, errored, err_sig });
       Object.assign(state, EMPTY_STATE()); state.session_id = session_id; saveState(statePath, state);
-      block(`Mercury loop detector: ${tr.message}\n(Buffer reset. If this is a false positive, resume your work.)`);
+      block(fullReason);
     }
   }
 
   // Stall signal check
   const stall = detectStall(state, cfg);
   if (stall) {
-    writeStallReport(cwd, session_id, stall.type, stall.reason, state,
+    const fullReason = `Mercury loop detector: ${stall.reason}\n(Buffer reset. If this is a false positive, resume your work.)`;
+    writeStallReport(cwd, session_id, stall.type, fullReason, state,
       { name: tool_name, input_hash: ihash, errored, err_sig });
     Object.assign(state, EMPTY_STATE()); state.session_id = session_id; saveState(statePath, state);
-    block(`Mercury loop detector: ${stall.reason}\n(Buffer reset. If this is a false positive, resume your work.)`);
+    block(fullReason);
   }
 
   pass();

--- a/adapters/mercury-loop-detector/hook.cjs
+++ b/adapters/mercury-loop-detector/hook.cjs
@@ -1,59 +1,47 @@
 #!/usr/bin/env node
 'use strict';
 
-// Mercury Sliding-Window Loop Detector
-// PostToolUse hook — detects stall/loop patterns in tool call sequences
-//
-// Design reference:
-//   Ralph   — frankbria/ralph-claude-code (MIT) — circuit_breaker.sh threshold variables
-//   Citadel — SethGammon/Citadel (MIT) — hooks_src/circuit-breaker.js per-project config
-//   Mercury mercury-test-gate — adapters/mercury-test-gate/hook.cjs architecture pattern
-//
-// Note: Claude Code's PostToolUse fires for ALL tool completions (success and failure).
-// Error detection reads tool_response text, which includes error output for failed tools.
+// Mercury Sliding-Window Loop Detector — PostToolUse hook
+// Detects stall/loop patterns; coordinates timeout.cjs + report.cjs modules.
+// Design ref: Ralph (frankbria/ralph-claude-code MIT), Citadel (SethGammon MIT),
+//             mercury-test-gate adapter pattern.
 
 const fs     = require('fs');
 const path   = require('path');
 const crypto = require('crypto');
+const { checkMultiLevel, updateTimestamps } = require('./timeout.cjs');
+const { writeStallReport }                  = require('./report.cjs');
 
 const TAG   = '[mercury-loop-detector]';
-const block = (reason) => { process.stdout.write(JSON.stringify({ decision: 'block', reason }) + '\n'); process.exit(0); };
+const block = (r) => { process.stdout.write(JSON.stringify({ decision: 'block', reason: r }) + '\n'); process.exit(0); };
 const pass  = () => process.exit(0);
 
-// ── Config ──────────────────────────────────────────────────────────────────
+// ── Config ───────────────────────────────────────────────────────────────────
+const DEFAULTS = { enabled: true, no_progress_threshold: 5, same_error_threshold: 5,
+  duplicate_call_threshold: 3, read_write_ratio_threshold: 8 };
 
-const DEFAULTS = {
-  enabled: true,
-  no_progress_threshold: 5,       // consecutive action calls (non-read/write/error) with no write
-  same_error_threshold: 5,        // consecutive calls sharing the same error signature
-  duplicate_call_threshold: 3,    // consecutive identical tool+input hash calls (success only)
-  read_write_ratio_threshold: 8   // consecutive read-only calls with no writes
-};
-
-function clampInt(v, min, max, fallback) {
-  return Number.isFinite(v) && v >= min && v <= max ? Math.round(v) : fallback;
-}
+function clampInt(v, min, max, fb) { return Number.isFinite(v) && v >= min && v <= max ? Math.round(v) : fb; }
 
 function loadConfig(cwd) {
   try {
     const p = JSON.parse(fs.readFileSync(path.join(cwd, '.mercury', 'config', 'loop-detector.json'), 'utf8'));
     return {
-      enabled:                  p.enabled !== false,
-      no_progress_threshold:    clampInt(p.no_progress_threshold,    1, 100, DEFAULTS.no_progress_threshold),
-      same_error_threshold:     clampInt(p.same_error_threshold,     1, 100, DEFAULTS.same_error_threshold),
-      duplicate_call_threshold: clampInt(p.duplicate_call_threshold, 1, 100, DEFAULTS.duplicate_call_threshold),
-      read_write_ratio_threshold: clampInt(p.read_write_ratio_threshold, 1, 100, DEFAULTS.read_write_ratio_threshold)
+      enabled:                    p.enabled !== false,
+      no_progress_threshold:      clampInt(p.no_progress_threshold,      1, 100, DEFAULTS.no_progress_threshold),
+      same_error_threshold:       clampInt(p.same_error_threshold,       1, 100, DEFAULTS.same_error_threshold),
+      duplicate_call_threshold:   clampInt(p.duplicate_call_threshold,   1, 100, DEFAULTS.duplicate_call_threshold),
+      read_write_ratio_threshold: clampInt(p.read_write_ratio_threshold, 1, 100, DEFAULTS.read_write_ratio_threshold),
+      timeout_soft_sec: clampInt(p.timeout_soft_sec, 1, 3600, undefined),
+      timeout_idle_sec: clampInt(p.timeout_idle_sec, 1, 3600, undefined),
+      timeout_hard_sec: clampInt(p.timeout_hard_sec, 1, 3600, undefined)
     };
-  } catch {
-    return Object.assign({}, DEFAULTS);
-  }
+  } catch { return Object.assign({}, DEFAULTS); }
 }
 
-// ── State (independent counters per session) ─────────────────────────────────
-
+// ── State ────────────────────────────────────────────────────────────────────
 const EMPTY_STATE = () => ({ session_id: null,
   dup_count: 0, dup_tool: null, dup_hash: null, err_count: 0, err_last: null,
-  read_count: 0, np_count: 0 });
+  read_count: 0, np_count: 0, last_activity_ts: null, last_write_ts: null });
 
 function safeInt(v) { return Number.isFinite(v) && v >= 0 ? Math.round(v) : 0; }
 
@@ -61,95 +49,72 @@ function loadState(statePath) {
   try {
     const s = JSON.parse(fs.readFileSync(statePath, 'utf8'));
     return {
-      session_id: typeof s.session_id === 'string' ? s.session_id : null,
-      dup_count:  safeInt(s.dup_count),  dup_tool: typeof s.dup_tool === 'string' ? s.dup_tool : null,
-      dup_hash:   typeof s.dup_hash === 'string' ? s.dup_hash : null,
-      err_count:  safeInt(s.err_count),  err_last: typeof s.err_last === 'string' ? s.err_last : null,
-      read_count: safeInt(s.read_count),
-      np_count:   safeInt(s.np_count)
+      session_id:       typeof s.session_id === 'string' ? s.session_id : null,
+      dup_count:        safeInt(s.dup_count),
+      dup_tool:         typeof s.dup_tool  === 'string' ? s.dup_tool  : null,
+      dup_hash:         typeof s.dup_hash  === 'string' ? s.dup_hash  : null,
+      err_count:        safeInt(s.err_count),
+      err_last:         typeof s.err_last  === 'string' ? s.err_last  : null,
+      read_count:       safeInt(s.read_count), np_count: safeInt(s.np_count),
+      last_activity_ts: Number.isFinite(s.last_activity_ts) ? s.last_activity_ts : null,
+      last_write_ts:    Number.isFinite(s.last_write_ts)    ? s.last_write_ts    : null
     };
-  } catch {
-    return EMPTY_STATE();
-  }
+  } catch { return EMPTY_STATE(); }
 }
 
-// Atomic write via unique temp-file + rename (unique name prevents concurrent-write collisions).
 function saveState(statePath, state) {
   fs.mkdirSync(path.dirname(statePath), { recursive: true });
   const tmp = `${statePath}.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}.tmp`;
-  try {
-    fs.writeFileSync(tmp, JSON.stringify(state, null, 2));
-    fs.renameSync(tmp, statePath);
-  } finally {
-    try { if (fs.existsSync(tmp)) fs.unlinkSync(tmp); } catch { /* ignore cleanup error */ }
-  }
+  try { fs.writeFileSync(tmp, JSON.stringify(state, null, 2)); fs.renameSync(tmp, statePath); }
+  finally { try { if (fs.existsSync(tmp)) fs.unlinkSync(tmp); } catch { /* ignore */ } }
 }
 
-// ── Tool classification ──────────────────────────────────────────────────────
-
+// ── Tool classification + helpers ────────────────────────────────────────────
 const WRITE_TOOLS = new Set(['Edit', 'Write', 'NotebookEdit', 'MultiEdit']);
 const READ_TOOLS  = new Set(['Read', 'Glob', 'Grep']);
 
-// ── Helpers ──────────────────────────────────────────────────────────────────
 function hashInput(input) {
   const s = typeof input === 'string' ? input : JSON.stringify(input ?? '');
-  return crypto.createHash('sha256').update(s).digest('hex').slice(0, 8); // sha256: FIPS-safe
+  return crypto.createHash('sha256').update(s).digest('hex').slice(0, 8);
 }
-
-function toStr(v) { return typeof v === 'string' ? v : JSON.stringify(v ?? ''); }
-
-// Scan first+last 1500 chars; skips large-JSON middle (false-positive risk). Trade-off: mid-only errors missed (real tool errors appear at start/end).
-function scanStr(r) { const s = toStr(r); return s.length <= 3000 ? s : s.slice(0, 1500) + '\n' + s.slice(-1500); }
-
-function hasError(response) {
-  return /\b(?:error|failed|exception)\b|exit code [1-9]/i.test(scanStr(response));
-}
-
-function errorSig(response) {
-  const m = scanStr(response).match(/(?:error|failed|exception|exit code \d+)[^.\n]{0,80}/i);
+function toStr(v)    { return typeof v === 'string' ? v : JSON.stringify(v ?? ''); }
+function scanStr(r)  { const s = toStr(r); return s.length <= 3000 ? s : s.slice(0, 1500) + '\n' + s.slice(-1500); }
+function hasError(r) { return /\b(?:error|failed|exception)\b|exit code [1-9]/i.test(scanStr(r)); }
+function errorSig(r) {
+  const m = scanStr(r).match(/(?:error|failed|exception|exit code \d+)[^.\n]{0,80}/i);
   return m ? m[0].trim().slice(0, 80) : null;
 }
-// ── Update independent counters ──────────────────────────────────────────────
 
+// ── Update independent counters ───────────────────────────────────────────────
 function update(state, tool, hash, is_write, is_read, errored, err_sig) {
   if (!errored) {
     if (tool === state.dup_tool && hash === state.dup_hash) { state.dup_count++; }
     else { state.dup_count = 1; state.dup_tool = tool; state.dup_hash = hash; }
-  } else {
-    state.dup_count = 0; state.dup_tool = null; state.dup_hash = null;
-  }
-
+  } else { state.dup_count = 0; state.dup_tool = null; state.dup_hash = null; }
   if (errored && err_sig) {
     if (err_sig === state.err_last) { state.err_count++; }
     else { state.err_count = 1; state.err_last = err_sig; }
-  } else {
-    state.err_count = 0; state.err_last = null;
-  }
-
+  } else { state.err_count = 0; state.err_last = null; }
   if (is_write)     { state.read_count = 0; }
   else if (is_read) { state.read_count++; }
   else              { state.read_count = 0; }
-
-  if (is_write || is_read || errored) { state.np_count = 0; }
-  else                                { state.np_count++; }
+  if (is_write || is_read || errored) { state.np_count = 0; } else { state.np_count++; }
 }
 
-// ── Detect stall (most-specific signal first) ────────────────────────────────
-
+// ── Detect stall (most-specific signal first) ─────────────────────────────────
 function detectStall(state, cfg) {
   if (state.dup_count  >= cfg.duplicate_call_threshold)
-    return `duplicate_call: ${state.dup_count} identical ${state.dup_tool} calls (hash:${state.dup_hash})`;
+    return { type: 'duplicate_call',   reason: `duplicate_call: ${state.dup_count} identical ${state.dup_tool} calls (hash:${state.dup_hash})` };
   if (state.err_count  >= cfg.same_error_threshold)
-    return `same_error: ${state.err_count} identical errors — "${state.err_last}"`;
+    return { type: 'same_error',       reason: `same_error: ${state.err_count} identical errors — "${state.err_last}"` };
   if (state.read_count >= cfg.read_write_ratio_threshold)
-    return `read_write_ratio: ${state.read_count} consecutive read-only calls with no writes`;
+    return { type: 'read_write_ratio', reason: `read_write_ratio: ${state.read_count} consecutive read-only calls with no writes` };
   if (state.np_count   >= cfg.no_progress_threshold)
-    return `no_progress: ${state.np_count} consecutive action calls with no file write`;
+    return { type: 'no_progress',      reason: `no_progress: ${state.np_count} consecutive action calls with no file write` };
   return null;
 }
 
-// ── Main ─────────────────────────────────────────────────────────────────────
-
+// ── Main ──────────────────────────────────────────────────────────────────────
 function main() {
   let input;
   try { input = JSON.parse(fs.readFileSync(0, 'utf8')); }
@@ -158,40 +123,45 @@ function main() {
   const { tool_name = '', tool_input = {}, tool_response = '', session_id = '' } = input;
   const cwd = process.env.CLAUDE_PROJECT_DIR || process.cwd();
 
-  // Fail-open when session_id is absent: without it we cannot isolate per-session state
-  // and would risk cross-session counter contamination.
-  if (!session_id) {
-    process.stderr.write(`${TAG} WARNING: no session_id in hook payload; skipping state accumulation\n`);
-    pass();
-  }
+  if (!session_id) { process.stderr.write(`${TAG} WARNING: no session_id; skipping state accumulation\n`); pass(); }
 
   const cfg = loadConfig(cwd);
   if (!cfg.enabled) pass();
 
   const statePath = path.join(cwd, '.mercury', 'state', 'loop-detector.json');
   const state     = loadState(statePath);
-
-  // Reset all counters when session changes
-  if (state.session_id !== session_id) {
-    const fresh = EMPTY_STATE();
-    fresh.session_id = session_id;
-    Object.assign(state, fresh);
-  }
+  if (state.session_id !== session_id) { Object.assign(state, EMPTY_STATE()); state.session_id = session_id; }
 
   const errored  = hasError(tool_response);
   const err_sig  = errored ? errorSig(tool_response) : null;
   const is_write = WRITE_TOOLS.has(tool_name);
   const is_read  = READ_TOOLS.has(tool_name);
+  const now      = Date.now();
+  const ihash    = hashInput(tool_input);
 
-  update(state, tool_name, hashInput(tool_input), is_write, is_read, errored, err_sig);
+  update(state, tool_name, ihash, is_write, is_read, errored, err_sig);
+  updateTimestamps(state, is_write, now);
   saveState(statePath, state);
 
+  // Timeout check (retrospective — evaluated at PostToolUse fire time)
+  const tr = checkMultiLevel(state, cfg, now);
+  if (tr) {
+    process.stderr.write(tr.message + '\n');
+    if (tr.should_block) {
+      writeStallReport(cwd, session_id, 'timeout_hard', tr.message, state,
+        { name: tool_name, input_hash: ihash, errored, err_sig });
+      Object.assign(state, EMPTY_STATE()); state.session_id = session_id; saveState(statePath, state);
+      block(`Mercury loop detector: ${tr.message}\n(Buffer reset. If this is a false positive, resume your work.)`);
+    }
+  }
+
+  // Stall signal check
   const stall = detectStall(state, cfg);
   if (stall) {
-    Object.assign(state, EMPTY_STATE()); // reset all counters after firing
-    state.session_id = session_id;
-    saveState(statePath, state);
-    block(`Mercury loop detector: ${stall}\n(Buffer reset. If this is a false positive, resume your work.)`);
+    writeStallReport(cwd, session_id, stall.type, stall.reason, state,
+      { name: tool_name, input_hash: ihash, errored, err_sig });
+    Object.assign(state, EMPTY_STATE()); state.session_id = session_id; saveState(statePath, state);
+    block(`Mercury loop detector: ${stall.reason}\n(Buffer reset. If this is a false positive, resume your work.)`);
   }
 
   pass();

--- a/adapters/mercury-loop-detector/hook.test.cjs
+++ b/adapters/mercury-loop-detector/hook.test.cjs
@@ -4,7 +4,7 @@
 // Mercury Loop Detector — Test suite
 // Runner: node --test adapters/mercury-loop-detector/*.test.cjs
 
-const { test, describe, before, after, beforeEach } = require('node:test');
+const { test, describe, before, after, beforeEach, afterEach } = require('node:test');
 const assert = require('node:assert/strict');
 const fs     = require('fs');
 const path   = require('path');
@@ -155,7 +155,7 @@ describe('timeout: soft and idle warn, do not block', () => {
 describe('timeout: hard blocks and writes report', () => {
   let tmpDir;
   beforeEach(() => { tmpDir = makeTmpDir(); });
-  after(() => { fs.rmSync(tmpDir, { recursive: true, force: true }); });
+  afterEach(() => { fs.rmSync(tmpDir, { recursive: true, force: true }); });
 
   test('hard timeout returns level=hard, should_block=true', () => {
     const now   = Date.now();
@@ -186,7 +186,7 @@ describe('timeout: hard blocks and writes report', () => {
 describe('detectStall fires → writeStallReport', () => {
   let tmpDir;
   beforeEach(() => { tmpDir = makeTmpDir(); });
-  after(() => { fs.rmSync(tmpDir, { recursive: true, force: true }); });
+  afterEach(() => { fs.rmSync(tmpDir, { recursive: true, force: true }); });
 
   test('stall report is written on detectStall hit', () => {
     const state = makeState({ dup_count: 3, dup_tool: 'Read', dup_hash: 'aabb1122' });
@@ -376,11 +376,116 @@ describe('invalid session_id fails open', () => {
 // ── isoFsSafe helper ──────────────────────────────────────────────────────────
 
 describe('isoFsSafe formatting', () => {
-  test('removes colons and milliseconds', () => {
+  test('removes colons and dots, retains milliseconds', () => {
     const d = new Date('2026-04-24T12:34:56.789Z');
     const s = isoFsSafe(d);
-    assert.equal(s, '2026-04-24T123456Z');
+    assert.equal(s, '2026-04-24T123456789Z');
     assert.ok(!s.includes(':'), 'no colons');
     assert.ok(!s.includes('.'), 'no dots');
+    assert.ok(s.includes('789'), 'milliseconds retained');
+  });
+});
+
+// ── 9. hook.cjs end-to-end integration ──────────────────────────────────────
+
+describe('hook.cjs end-to-end integration', () => {
+  const { execFileSync } = require('child_process');
+  const HOOK = path.join(__dirname, 'hook.cjs');
+  let counter = 0;
+  let tmpDirs = [];
+
+  function freshEnv(tmpDir) {
+    return { ...process.env, CLAUDE_PROJECT_DIR: tmpDir };
+  }
+
+  function uniqueSession() {
+    return `ete-session-${process.pid}-${++counter}-${Date.now()}`;
+  }
+
+  afterEach(() => {
+    for (const d of tmpDirs) {
+      try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* ignore */ }
+    }
+    tmpDirs = [];
+  });
+
+  test('ETE happy path: normal tool call exits 0 with no block output', () => {
+    const tmpDir = makeTmpDir();
+    tmpDirs.push(tmpDir);
+    const payload = JSON.stringify({
+      tool_name: 'Read',
+      tool_input: { file_path: '/some/file.txt' },
+      tool_response: 'file contents here',
+      session_id: uniqueSession()
+    });
+    let stdout;
+    try {
+      stdout = execFileSync('node', [HOOK], {
+        input: payload,
+        env: freshEnv(tmpDir),
+        timeout: 10000
+      }).toString();
+    } catch (e) {
+      // exit code 0 with block output also lands here if stdout non-empty
+      stdout = e.stdout ? e.stdout.toString() : '';
+      // Re-throw if process actually errored (non-zero exit for unexpected reasons)
+      if (e.status !== 0) throw e;
+    }
+    // Happy path: no block decision in stdout
+    assert.ok(!stdout.includes('"block"'), `unexpected block output: ${stdout}`);
+  });
+
+  test('ETE stall trigger: no_progress threshold reached causes block with report', () => {
+    const tmpDir = makeTmpDir();
+    tmpDirs.push(tmpDir);
+    const session_id = uniqueSession();
+    const stateDir = path.join(tmpDir, '.mercury', 'state');
+    fs.mkdirSync(stateDir, { recursive: true });
+
+    // Pre-seed np_count at threshold-1 (default=5, seed at 4).
+    // Sending a non-read/non-write/non-error tool call increments np_count to 5 → block.
+    // 'Bash' with successful response and non-error output is classified as "action" (not read/write).
+    const preState = {
+      session_id,
+      dup_count: 0, dup_tool: null, dup_hash: null,
+      err_count: 0, err_last: null,
+      read_count: 0, np_count: 4,
+      last_activity_ts: Date.now(), last_write_ts: Date.now()
+    };
+    fs.writeFileSync(path.join(stateDir, 'loop-detector.json'), JSON.stringify(preState, null, 2));
+
+    // Bash with non-error response: is_write=false, is_read=false, errored=false → np_count++
+    const payload = JSON.stringify({
+      tool_name: 'Bash',
+      tool_input: { command: 'echo hello' },
+      tool_response: 'hello',
+      session_id
+    });
+
+    let stdout = '';
+    let exitCode = 0;
+    try {
+      stdout = execFileSync('node', [HOOK], {
+        input: payload,
+        env: freshEnv(tmpDir),
+        timeout: 10000
+      }).toString();
+    } catch (e) {
+      stdout = e.stdout ? e.stdout.toString() : '';
+      exitCode = e.status ?? 0;
+    }
+
+    // hook exits 0 even on block (process.exit(0) in block())
+    assert.equal(exitCode, 0, 'hook should exit 0 even on block');
+    assert.ok(stdout.includes('"block"'), `expected block decision in stdout, got: ${stdout}`);
+
+    // Verify stall report written
+    const reportDir = path.join(tmpDir, '.mercury', 'state', 'stall-reports');
+    assert.ok(fs.existsSync(reportDir), 'stall-reports dir should exist');
+    const reports = fs.readdirSync(reportDir).filter(f => f.endsWith('.json'));
+    assert.ok(reports.length >= 1, 'at least one report should be written');
+    const report = JSON.parse(fs.readFileSync(path.join(reportDir, reports[0]), 'utf8'));
+    assert.equal(report.session_id, session_id);
+    assert.equal(report.stall_type, 'no_progress');
   });
 });

--- a/adapters/mercury-loop-detector/hook.test.cjs
+++ b/adapters/mercury-loop-detector/hook.test.cjs
@@ -557,5 +557,10 @@ describe('hook.cjs end-to-end integration', () => {
     const report = JSON.parse(fs.readFileSync(path.join(reportDir, reports[0]), 'utf8'));
     assert.equal(report.session_id, session_id);
     assert.equal(report.stall_type, 'no_progress');
+    // stall_reason must be the full block reason string, not the short internal reason
+    assert.ok(report.stall_reason.startsWith('Mercury loop detector: '),
+      `stall_reason should start with prefix, got: ${report.stall_reason}`);
+    assert.ok(report.stall_reason.includes('Buffer reset.'),
+      `stall_reason should include "Buffer reset.", got: ${report.stall_reason}`);
   });
 });

--- a/adapters/mercury-loop-detector/hook.test.cjs
+++ b/adapters/mercury-loop-detector/hook.test.cjs
@@ -1,0 +1,386 @@
+#!/usr/bin/env node
+'use strict';
+
+// Mercury Loop Detector — Test suite
+// Runner: node --test adapters/mercury-loop-detector/*.test.cjs
+
+const { test, describe, before, after, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs     = require('fs');
+const path   = require('path');
+const os     = require('os');
+const crypto = require('crypto');
+
+const { checkMultiLevel, updateTimestamps, resolveThresholds, TIMEOUT_DEFAULTS } = require('./timeout.cjs');
+const { writeStallReport, pruneReports, isoFsSafe } = require('./report.cjs');
+
+// ── Test helpers ─────────────────────────────────────────────────────────────
+
+function makeTmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'mercury-ld-test-'));
+}
+
+function makeState(overrides = {}) {
+  return {
+    session_id: 'test-session-001',
+    dup_count: 0, dup_tool: null, dup_hash: null,
+    err_count: 0, err_last: null,
+    read_count: 0, np_count: 0,
+    last_activity_ts: null, last_write_ts: null,
+    ...overrides
+  };
+}
+
+function makeCfg(overrides = {}) {
+  return {
+    enabled: true,
+    no_progress_threshold: 5,
+    same_error_threshold: 5,
+    duplicate_call_threshold: 3,
+    read_write_ratio_threshold: 8,
+    ...overrides
+  };
+}
+
+function captureStderr(fn) {
+  const chunks = [];
+  const orig = process.stderr.write.bind(process.stderr);
+  process.stderr.write = (chunk, ...args) => { chunks.push(String(chunk)); return true; };
+  try { fn(); } finally { process.stderr.write = orig; }
+  return chunks.join('');
+}
+
+// ── 1. Existing 4 signals — regression sanity ────────────────────────────────
+
+describe('existing signals (regression)', () => {
+  test('duplicate_call fires at threshold', () => {
+    const state = makeState({ dup_count: 3, dup_tool: 'Bash', dup_hash: 'abcd1234' });
+    const cfg   = makeCfg({ duplicate_call_threshold: 3 });
+    const stall = detectStall(state, cfg);
+    assert.equal(stall.type, 'duplicate_call');
+    assert.match(stall.reason, /duplicate_call/);
+  });
+
+  test('same_error fires at threshold', () => {
+    const state = makeState({ err_count: 5, err_last: 'error: file not found' });
+    const cfg   = makeCfg({ same_error_threshold: 5 });
+    const stall = detectStall(state, cfg);
+    assert.equal(stall.type, 'same_error');
+    assert.match(stall.reason, /same_error/);
+  });
+
+  test('read_write_ratio fires at threshold', () => {
+    const state = makeState({ read_count: 8 });
+    const cfg   = makeCfg({ read_write_ratio_threshold: 8 });
+    const stall = detectStall(state, cfg);
+    assert.equal(stall.type, 'read_write_ratio');
+    assert.match(stall.reason, /read_write_ratio/);
+  });
+
+  test('no_progress fires at threshold', () => {
+    const state = makeState({ np_count: 5 });
+    const cfg   = makeCfg({ no_progress_threshold: 5 });
+    const stall = detectStall(state, cfg);
+    assert.equal(stall.type, 'no_progress');
+    assert.match(stall.reason, /no_progress/);
+  });
+
+  test('no stall below threshold', () => {
+    const state = makeState({ dup_count: 2, err_count: 4, read_count: 7, np_count: 4 });
+    const stall = detectStall(state, makeCfg());
+    assert.equal(stall, null);
+  });
+});
+
+// Inline detectStall mirror (same logic as hook.cjs) so tests are self-contained
+function detectStall(state, cfg) {
+  if (state.dup_count  >= cfg.duplicate_call_threshold)
+    return { type: 'duplicate_call',   reason: `duplicate_call: ${state.dup_count} identical ${state.dup_tool} calls (hash:${state.dup_hash})` };
+  if (state.err_count  >= cfg.same_error_threshold)
+    return { type: 'same_error',       reason: `same_error: ${state.err_count} identical errors — "${state.err_last}"` };
+  if (state.read_count >= cfg.read_write_ratio_threshold)
+    return { type: 'read_write_ratio', reason: `read_write_ratio: ${state.read_count} consecutive read-only calls with no writes` };
+  if (state.np_count   >= cfg.no_progress_threshold)
+    return { type: 'no_progress',      reason: `no_progress: ${state.np_count} consecutive action calls with no file write` };
+  return null;
+}
+
+// ── 2. Soft/Idle timeout — warn to stderr, do not block ─────────────────────
+
+describe('timeout: soft and idle warn, do not block', () => {
+  test('soft timeout returns level=soft, should_block=false', () => {
+    const now   = Date.now();
+    const state = makeState({ last_write_ts: now - 70_000 }); // 70s ago
+    const cfg   = makeCfg({ timeout_soft_sec: 60, timeout_idle_sec: 300, timeout_hard_sec: 900 });
+    const result = checkMultiLevel(state, cfg, now);
+    assert.ok(result, 'should return non-null');
+    assert.equal(result.level, 'soft');
+    assert.equal(result.should_block, false);
+    assert.match(result.message, /soft timeout/);
+  });
+
+  test('idle timeout returns level=idle, should_block=false', () => {
+    const now   = Date.now();
+    const state = makeState({ last_write_ts: now - 310_000 }); // 310s ago
+    const cfg   = makeCfg({ timeout_soft_sec: 60, timeout_idle_sec: 300, timeout_hard_sec: 900 });
+    const result = checkMultiLevel(state, cfg, now);
+    assert.ok(result);
+    assert.equal(result.level, 'idle');
+    assert.equal(result.should_block, false);
+    assert.match(result.message, /idle timeout/);
+    assert.match(result.message, /handoff/);
+  });
+
+  test('no timeout when within soft threshold', () => {
+    const now   = Date.now();
+    const state = makeState({ last_write_ts: now - 30_000 }); // 30s ago
+    const cfg   = makeCfg({ timeout_soft_sec: 60 });
+    const result = checkMultiLevel(state, cfg, now);
+    assert.equal(result, null);
+  });
+
+  test('no timeout when last_write_ts is null (first call)', () => {
+    const now   = Date.now();
+    const state = makeState({ last_write_ts: null });
+    const cfg   = makeCfg();
+    // updateTimestamps initialises last_write_ts to now on first call
+    updateTimestamps(state, false, now);
+    const result = checkMultiLevel(state, cfg, now);
+    assert.equal(result, null);
+  });
+});
+
+// ── 3. Hard timeout — block + write diagnostic report ────────────────────────
+
+describe('timeout: hard blocks and writes report', () => {
+  let tmpDir;
+  beforeEach(() => { tmpDir = makeTmpDir(); });
+  after(() => { fs.rmSync(tmpDir, { recursive: true, force: true }); });
+
+  test('hard timeout returns level=hard, should_block=true', () => {
+    const now   = Date.now();
+    const state = makeState({ last_write_ts: now - 910_000 }); // 910s ago
+    const cfg   = makeCfg({ timeout_soft_sec: 60, timeout_idle_sec: 300, timeout_hard_sec: 900 });
+    const result = checkMultiLevel(state, cfg, now);
+    assert.ok(result);
+    assert.equal(result.level, 'hard');
+    assert.equal(result.should_block, true);
+  });
+
+  test('hard timeout + writeStallReport creates report file', () => {
+    const state = makeState({ last_write_ts: Date.now() - 910_000 });
+    const last_tool = { name: 'Bash', input_hash: 'abcd1234', errored: false, err_sig: null };
+    const fpath = writeStallReport(tmpDir, 'sess-001', 'timeout_hard', 'hard timeout reason', state, last_tool);
+    assert.ok(fpath, 'should return file path');
+    assert.ok(fs.existsSync(fpath), 'file should exist');
+    const report = JSON.parse(fs.readFileSync(fpath, 'utf8'));
+    assert.equal(report.stall_type, 'timeout_hard');
+    assert.equal(report.session_id, 'sess-001');
+    assert.equal(report.last_tool.name, 'Bash');
+    assert.equal(typeof report.timestamp, 'string');
+  });
+});
+
+// ── 4. detectStall non-null → write diagnostic report ───────────────────────
+
+describe('detectStall fires → writeStallReport', () => {
+  let tmpDir;
+  beforeEach(() => { tmpDir = makeTmpDir(); });
+  after(() => { fs.rmSync(tmpDir, { recursive: true, force: true }); });
+
+  test('stall report is written on detectStall hit', () => {
+    const state = makeState({ dup_count: 3, dup_tool: 'Read', dup_hash: 'aabb1122' });
+    const last_tool = { name: 'Read', input_hash: 'aabb1122', errored: false, err_sig: null };
+    const stall = detectStall(state, makeCfg({ duplicate_call_threshold: 3 }));
+    assert.ok(stall);
+    const fpath = writeStallReport(tmpDir, 'sess-dup-001', stall.type, stall.reason, state, last_tool);
+    assert.ok(fpath);
+    const report = JSON.parse(fs.readFileSync(fpath, 'utf8'));
+    assert.equal(report.stall_type, 'duplicate_call');
+    assert.equal(report.state_snapshot.dup_count, 3);
+  });
+
+  test('report contains state_snapshot with all required fields', () => {
+    const state = makeState({
+      dup_count: 2, dup_tool: 'Glob', dup_hash: 'ccdd3344',
+      err_count: 1, err_last: 'error: test',
+      read_count: 5, np_count: 3,
+      last_activity_ts: 1000, last_write_ts: 900
+    });
+    const fpath = writeStallReport(tmpDir, 'sess-snap', 'no_progress', 'reason', state,
+      { name: 'Bash', input_hash: 'aabb', errored: true, err_sig: 'error: test' });
+    const report = JSON.parse(fs.readFileSync(fpath, 'utf8'));
+    const snap = report.state_snapshot;
+    assert.equal(snap.dup_count, 2);
+    assert.equal(snap.dup_tool, 'Glob');
+    assert.equal(snap.err_count, 1);
+    assert.equal(snap.read_count, 5);
+    assert.equal(snap.np_count, 3);
+    assert.equal(snap.last_activity_ts, 1000);
+    assert.equal(snap.last_write_ts, 900);
+    assert.equal(report.last_tool.errored, true);
+    assert.equal(report.last_tool.err_sig, 'error: test');
+  });
+});
+
+// ── 5. Pruning keeps ≤50 files ───────────────────────────────────────────────
+
+describe('pruneReports keeps newest 50', () => {
+  let tmpDir;
+  before(() => {
+    tmpDir = makeTmpDir();
+    const dir = path.join(tmpDir, '.mercury', 'state', 'stall-reports');
+    fs.mkdirSync(dir, { recursive: true });
+    // Create 60 files with distinct mtimes
+    for (let i = 0; i < 60; i++) {
+      const fp = path.join(dir, `sess-${String(i).padStart(3,'0')}-2026-04-24T${String(i).padStart(6,'0')}Z.json`);
+      fs.writeFileSync(fp, JSON.stringify({ i }));
+      // Stagger mtime by setting atime+mtime via utimes
+      const t = (Date.now() / 1000) + i;
+      fs.utimesSync(fp, t, t);
+    }
+  });
+  after(() => { fs.rmSync(tmpDir, { recursive: true, force: true }); });
+
+  test('prune leaves exactly 50 files', () => {
+    pruneReports(tmpDir, 50);
+    const dir   = path.join(tmpDir, '.mercury', 'state', 'stall-reports');
+    const files = fs.readdirSync(dir).filter(f => f.endsWith('.json'));
+    assert.equal(files.length, 50);
+  });
+
+  test('prune keeps the newest files', () => {
+    const dir   = path.join(tmpDir, '.mercury', 'state', 'stall-reports');
+    const files = fs.readdirSync(dir)
+      .filter(f => f.endsWith('.json'))
+      .map(f => ({ f, mtime: fs.statSync(path.join(dir, f)).mtimeMs }))
+      .sort((a, b) => b.mtime - a.mtime);
+    // Oldest remaining should be newer than deleted ones (i >= 10)
+    const oldest = files[files.length - 1];
+    // Files were named sess-000 through sess-059; we kept 50 newest (sess-010 to sess-059)
+    assert.match(oldest.f, /sess-0[1-5]/);
+  });
+});
+
+// ── 6. MERCURY_STALL_REPORT_DISABLED skips write ─────────────────────────────
+
+describe('MERCURY_STALL_REPORT_DISABLED feature flag', () => {
+  let tmpDir;
+  before(() => { tmpDir = makeTmpDir(); });
+  after(() => { fs.rmSync(tmpDir, { recursive: true, force: true }); delete process.env.MERCURY_STALL_REPORT_DISABLED; });
+
+  test('disabled=1 returns null and writes nothing', () => {
+    process.env.MERCURY_STALL_REPORT_DISABLED = '1';
+    const state = makeState();
+    const result = writeStallReport(tmpDir, 'sess-disabled', 'no_progress', 'reason', state,
+      { name: 'Bash', input_hash: 'aa', errored: false, err_sig: null });
+    assert.equal(result, null);
+    const dir = path.join(tmpDir, '.mercury', 'state', 'stall-reports');
+    const exists = fs.existsSync(dir) && fs.readdirSync(dir).length > 0;
+    assert.equal(exists, false, 'no files should be written');
+  });
+
+  test('disabled=0 (other value) proceeds normally', () => {
+    process.env.MERCURY_STALL_REPORT_DISABLED = '0';
+    const state = makeState();
+    const fpath = writeStallReport(tmpDir, 'sess-enabled', 'no_progress', 'reason', state,
+      { name: 'Bash', input_hash: 'bb', errored: false, err_sig: null });
+    assert.ok(fpath, 'should write report when not disabled');
+    delete process.env.MERCURY_STALL_REPORT_DISABLED;
+  });
+});
+
+// ── 7. Config file threshold override ────────────────────────────────────────
+
+describe('config file threshold override', () => {
+  test('resolveThresholds uses config values when no env vars', () => {
+    // Clear env vars
+    const saved = {};
+    for (const k of ['MERCURY_TIMEOUT_SOFT_SEC', 'MERCURY_TIMEOUT_IDLE_SEC', 'MERCURY_TIMEOUT_HARD_SEC']) {
+      saved[k] = process.env[k]; delete process.env[k];
+    }
+    const cfg = makeCfg({ timeout_soft_sec: 120, timeout_idle_sec: 600, timeout_hard_sec: 1800 });
+    const thresholds = resolveThresholds(cfg);
+    assert.equal(thresholds.soft, 120);
+    assert.equal(thresholds.idle, 600);
+    assert.equal(thresholds.hard, 1800);
+    for (const [k, v] of Object.entries(saved)) { if (v !== undefined) process.env[k] = v; }
+  });
+
+  test('env var overrides config file values', () => {
+    process.env.MERCURY_TIMEOUT_SOFT_SEC  = '45';
+    process.env.MERCURY_TIMEOUT_IDLE_SEC  = '200';
+    process.env.MERCURY_TIMEOUT_HARD_SEC  = '800';
+    const cfg = makeCfg({ timeout_soft_sec: 120, timeout_idle_sec: 600, timeout_hard_sec: 1800 });
+    const thresholds = resolveThresholds(cfg);
+    assert.equal(thresholds.soft, 45);
+    assert.equal(thresholds.idle, 200);
+    assert.equal(thresholds.hard, 800);
+    delete process.env.MERCURY_TIMEOUT_SOFT_SEC;
+    delete process.env.MERCURY_TIMEOUT_IDLE_SEC;
+    delete process.env.MERCURY_TIMEOUT_HARD_SEC;
+  });
+
+  test('clamp rejects out-of-range values, falls back to default', () => {
+    const saved = {};
+    for (const k of ['MERCURY_TIMEOUT_SOFT_SEC', 'MERCURY_TIMEOUT_IDLE_SEC', 'MERCURY_TIMEOUT_HARD_SEC']) {
+      saved[k] = process.env[k]; delete process.env[k];
+    }
+    // undefined config fields → resolveThresholds falls back to TIMEOUT_DEFAULTS
+    const cfg = makeCfg({ timeout_soft_sec: undefined, timeout_idle_sec: 0, timeout_hard_sec: 99999 });
+    const thresholds = resolveThresholds(cfg);
+    assert.equal(thresholds.soft, TIMEOUT_DEFAULTS.timeout_soft_sec);  // fallback
+    assert.equal(thresholds.idle, TIMEOUT_DEFAULTS.timeout_idle_sec);  // 0 out of range
+    assert.equal(thresholds.hard, TIMEOUT_DEFAULTS.timeout_hard_sec);  // 99999 out of range
+    for (const [k, v] of Object.entries(saved)) { if (v !== undefined) process.env[k] = v; }
+  });
+});
+
+// ── 8. Invalid session_id — fail-open, no report written ────────────────────
+
+describe('invalid session_id fails open', () => {
+  let tmpDir;
+  before(() => { tmpDir = makeTmpDir(); });
+  after(() => { fs.rmSync(tmpDir, { recursive: true, force: true }); });
+
+  test('empty string session_id returns null', () => {
+    let warnMsg = '';
+    const origWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (chunk, ...a) => { warnMsg += String(chunk); return true; };
+    const result = writeStallReport(tmpDir, '', 'no_progress', 'reason', makeState(),
+      { name: 'Bash', input_hash: 'aa', errored: false, err_sig: null });
+    process.stderr.write = origWrite;
+    assert.equal(result, null);
+    assert.match(warnMsg, /empty session_id/);
+  });
+
+  test('null session_id returns null', () => {
+    const origWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = () => true;
+    const result = writeStallReport(tmpDir, null, 'no_progress', 'reason', makeState(),
+      { name: 'Bash', input_hash: 'aa', errored: false, err_sig: null });
+    process.stderr.write = origWrite;
+    assert.equal(result, null);
+  });
+
+  test('whitespace-only session_id returns null', () => {
+    const origWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = () => true;
+    const result = writeStallReport(tmpDir, '   ', 'no_progress', 'reason', makeState(),
+      { name: 'Bash', input_hash: 'aa', errored: false, err_sig: null });
+    process.stderr.write = origWrite;
+    assert.equal(result, null);
+  });
+});
+
+// ── isoFsSafe helper ──────────────────────────────────────────────────────────
+
+describe('isoFsSafe formatting', () => {
+  test('removes colons and milliseconds', () => {
+    const d = new Date('2026-04-24T12:34:56.789Z');
+    const s = isoFsSafe(d);
+    assert.equal(s, '2026-04-24T123456Z');
+    assert.ok(!s.includes(':'), 'no colons');
+    assert.ok(!s.includes('.'), 'no dots');
+  });
+});

--- a/adapters/mercury-loop-detector/hook.test.cjs
+++ b/adapters/mercury-loop-detector/hook.test.cjs
@@ -373,6 +373,76 @@ describe('invalid session_id fails open', () => {
   });
 });
 
+// ── 10. Security: session_id path traversal prevention ───────────────────────
+
+describe('writeStallReport session_id sanitization', () => {
+  let tmpDir;
+  beforeEach(() => { tmpDir = makeTmpDir(); });
+  afterEach(() => { fs.rmSync(tmpDir, { recursive: true, force: true }); });
+
+  test('traversal session_id "../evil" writes safe file inside stall-reports/', () => {
+    const state = makeState();
+    const last_tool = { name: 'Bash', input_hash: 'aa', errored: false, err_sig: null };
+    const fpath = writeStallReport(tmpDir, '../evil', 'no_progress', 'reason', state, last_tool);
+    assert.ok(fpath, 'should return a file path');
+    // File must be inside the expected stall-reports dir, not above it
+    const reportDir = path.join(tmpDir, '.mercury', 'state', 'stall-reports');
+    assert.ok(fpath.startsWith(reportDir), `fpath ${fpath} must start with ${reportDir}`);
+    assert.ok(fs.existsSync(fpath), 'file must exist');
+    // Filename must not contain slashes or ".." sequences
+    const fname = path.basename(fpath);
+    assert.ok(!fname.includes('/') && !fname.includes('\\'), 'no path separator in filename');
+    assert.ok(!fname.includes('..'), 'no ".." in filename');
+    // Report JSON preserves original session_id for traceability
+    const report = JSON.parse(fs.readFileSync(fpath, 'utf8'));
+    assert.equal(report.session_id, '../evil');
+  });
+
+  test('all-slash session_id "///" returns null + stderr warn', () => {
+    const state = makeState();
+    const last_tool = { name: 'Bash', input_hash: 'bb', errored: false, err_sig: null };
+    let warnMsg = '';
+    const origWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (chunk, ...a) => { warnMsg += String(chunk); return true; };
+    const result = writeStallReport(tmpDir, '///', 'no_progress', 'reason', state, last_tool);
+    process.stderr.write = origWrite;
+    assert.equal(result, null);
+    assert.match(warnMsg, /no safe chars/);
+  });
+
+  // Optional: verify mode 0o600 on Unix (skipped on Windows)
+  test('report file has mode 0o600 (Unix only)', { skip: process.platform === 'win32' }, () => {
+    const state = makeState();
+    const last_tool = { name: 'Bash', input_hash: 'cc', errored: false, err_sig: null };
+    const fpath = writeStallReport(tmpDir, 'sess-mode-test', 'no_progress', 'reason', state, last_tool);
+    assert.ok(fpath, 'should write file');
+    const mode = fs.statSync(fpath).mode & 0o777;
+    assert.equal(mode, 0o600, `expected mode 0o600, got 0o${mode.toString(8)}`);
+  });
+});
+
+// ── 11. Security: resolveThresholds order validation ─────────────────────────
+
+describe('resolveThresholds order validation', () => {
+  test('reversed env vars (soft=900, idle=60, hard=30) → TIMEOUT_DEFAULTS + stderr warn', () => {
+    process.env.MERCURY_TIMEOUT_SOFT_SEC = '900';
+    process.env.MERCURY_TIMEOUT_IDLE_SEC = '60';
+    process.env.MERCURY_TIMEOUT_HARD_SEC = '30';
+    let warnMsg = '';
+    const origWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (chunk, ...a) => { warnMsg += String(chunk); return true; };
+    const result = resolveThresholds(makeCfg());
+    process.stderr.write = origWrite;
+    delete process.env.MERCURY_TIMEOUT_SOFT_SEC;
+    delete process.env.MERCURY_TIMEOUT_IDLE_SEC;
+    delete process.env.MERCURY_TIMEOUT_HARD_SEC;
+    assert.equal(result.soft, TIMEOUT_DEFAULTS.timeout_soft_sec);
+    assert.equal(result.idle, TIMEOUT_DEFAULTS.timeout_idle_sec);
+    assert.equal(result.hard, TIMEOUT_DEFAULTS.timeout_hard_sec);
+    assert.match(warnMsg, /soft<=idle<=hard/);
+  });
+});
+
 // ── isoFsSafe helper ──────────────────────────────────────────────────────────
 
 describe('isoFsSafe formatting', () => {

--- a/adapters/mercury-loop-detector/report.cjs
+++ b/adapters/mercury-loop-detector/report.cjs
@@ -12,15 +12,14 @@ const TAG = '[mercury-loop-detector]';
 const KEEP_DEFAULT = 50;
 
 /**
- * Format a Date as filesystem-safe ISO string: 2026-04-24T120000Z
- * (no colons, no dots in the time part)
+ * Format a Date as filesystem-safe ISO string: 2026-04-24T120000123Z
+ * (no colons, no dots — milliseconds retained to avoid same-second filename collision on Windows)
  * @param {Date} d
  * @returns {string}
  */
 function isoFsSafe(d) {
   return d.toISOString()
-    .replace(/\.\d{3}Z$/, 'Z')  // remove milliseconds
-    .replace(/:/g, '');           // 2026-04-24T120000Z
+    .replace(/[:.]/g, '');  // 2026-04-24T120000123Z (retain ms, remove colons+dots)
 }
 
 /**
@@ -74,9 +73,9 @@ function writeStallReport(cwd, session_id, stall_type, stall_reason, state, last
     }
   };
 
+  const tmp = `${fpath}.${process.pid}.${Date.now()}.tmp`;
   try {
     fs.mkdirSync(dir, { recursive: true });
-    const tmp = `${fpath}.${process.pid}.${Date.now()}.tmp`;
     fs.writeFileSync(tmp, JSON.stringify(report, null, 2));
     fs.renameSync(tmp, fpath);
     pruneReports(cwd, KEEP_DEFAULT);
@@ -84,6 +83,8 @@ function writeStallReport(cwd, session_id, stall_type, stall_reason, state, last
   } catch (e) {
     process.stderr.write(`${TAG} WARNING: failed to write stall report: ${e.message}\n`);
     return null;
+  } finally {
+    try { if (fs.existsSync(tmp)) fs.unlinkSync(tmp); } catch { /* ignore */ }
   }
 }
 

--- a/adapters/mercury-loop-detector/report.cjs
+++ b/adapters/mercury-loop-detector/report.cjs
@@ -42,11 +42,26 @@ function writeStallReport(cwd, session_id, stall_type, stall_reason, state, last
     return null;
   }
 
+  // Sanitize session_id for filesystem use:
+  //   1. Replace non-whitelisted chars [^a-zA-Z0-9._-] with '_'
+  //   2. Strip leading dots/hyphens to prevent ".." prefix and hidden-file names
+  //   3. Require at least one alphanumeric char to ensure meaningful output
+  //   4. Truncate to 64 chars
+  // Prevents path traversal (/, ../) and illegal filename chars.
+  const safeSessionId = String(session_id)
+    .replace(/[^a-zA-Z0-9._-]/g, '_')
+    .replace(/^[._-]+/, '')
+    .slice(0, 64);
+  if (!safeSessionId || !/[a-zA-Z0-9]/.test(safeSessionId)) {
+    process.stderr.write(`${TAG} WARNING: cannot write stall report — session_id has no safe chars\n`);
+    return null;
+  }
+
   const now    = new Date();
   const isoTs  = now.toISOString();
   const fsTs   = isoFsSafe(now);
   const dir    = path.join(cwd, '.mercury', 'state', 'stall-reports');
-  const fname  = `${session_id}-${fsTs}.json`;
+  const fname  = `${safeSessionId}-${fsTs}.json`;
   const fpath  = path.join(dir, fname);
 
   const report = {
@@ -76,7 +91,7 @@ function writeStallReport(cwd, session_id, stall_type, stall_reason, state, last
   const tmp = `${fpath}.${process.pid}.${Date.now()}.tmp`;
   try {
     fs.mkdirSync(dir, { recursive: true });
-    fs.writeFileSync(tmp, JSON.stringify(report, null, 2));
+    fs.writeFileSync(tmp, JSON.stringify(report, null, 2), { mode: 0o600 });
     fs.renameSync(tmp, fpath);
     pruneReports(cwd, KEEP_DEFAULT);
     return fpath;

--- a/adapters/mercury-loop-detector/report.cjs
+++ b/adapters/mercury-loop-detector/report.cjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+'use strict';
+
+// Mercury Loop Detector — Stall diagnostic report serializer + pruning
+// Exports writeStallReport() and pruneReports().
+// Feature flag: MERCURY_STALL_REPORT_DISABLED=1 skips all writes.
+
+const fs   = require('fs');
+const path = require('path');
+
+const TAG = '[mercury-loop-detector]';
+const KEEP_DEFAULT = 50;
+
+/**
+ * Format a Date as filesystem-safe ISO string: 2026-04-24T120000Z
+ * (no colons, no dots in the time part)
+ * @param {Date} d
+ * @returns {string}
+ */
+function isoFsSafe(d) {
+  return d.toISOString()
+    .replace(/\.\d{3}Z$/, 'Z')  // remove milliseconds
+    .replace(/:/g, '');           // 2026-04-24T120000Z
+}
+
+/**
+ * Write a stall diagnostic report JSON file.
+ *
+ * @param {string} cwd          - project root (CLAUDE_PROJECT_DIR)
+ * @param {string} session_id   - current session id from hook payload
+ * @param {string} stall_type   - one of: no_progress|same_error|duplicate_call|read_write_ratio|timeout_hard
+ * @param {string} stall_reason - full reason string passed to block()
+ * @param {object} state        - current state snapshot (before reset)
+ * @param {object} last_tool    - { name, input_hash, errored, err_sig }
+ * @returns {string|null}       - written file path, or null on skip/error
+ */
+function writeStallReport(cwd, session_id, stall_type, stall_reason, state, last_tool) {
+  if (process.env.MERCURY_STALL_REPORT_DISABLED === '1') return null;
+
+  // Fail-open: missing or empty session_id → skip report
+  if (!session_id || typeof session_id !== 'string' || session_id.trim() === '') {
+    process.stderr.write(`${TAG} WARNING: cannot write stall report — empty session_id\n`);
+    return null;
+  }
+
+  const now    = new Date();
+  const isoTs  = now.toISOString();
+  const fsTs   = isoFsSafe(now);
+  const dir    = path.join(cwd, '.mercury', 'state', 'stall-reports');
+  const fname  = `${session_id}-${fsTs}.json`;
+  const fpath  = path.join(dir, fname);
+
+  const report = {
+    timestamp:    isoTs,
+    session_id:   session_id,
+    stall_type:   stall_type,
+    stall_reason: stall_reason,
+    state_snapshot: {
+      dup_count:        state.dup_count        ?? 0,
+      dup_tool:         state.dup_tool         ?? null,
+      dup_hash:         state.dup_hash         ?? null,
+      err_count:        state.err_count        ?? 0,
+      err_last:         state.err_last         ?? null,
+      read_count:       state.read_count       ?? 0,
+      np_count:         state.np_count         ?? 0,
+      last_activity_ts: state.last_activity_ts ?? null,
+      last_write_ts:    state.last_write_ts    ?? null
+    },
+    last_tool: {
+      name:       last_tool.name       ?? null,
+      input_hash: last_tool.input_hash ?? null,
+      errored:    last_tool.errored    ?? false,
+      err_sig:    last_tool.err_sig    ?? null
+    }
+  };
+
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+    const tmp = `${fpath}.${process.pid}.${Date.now()}.tmp`;
+    fs.writeFileSync(tmp, JSON.stringify(report, null, 2));
+    fs.renameSync(tmp, fpath);
+    pruneReports(cwd, KEEP_DEFAULT);
+    return fpath;
+  } catch (e) {
+    process.stderr.write(`${TAG} WARNING: failed to write stall report: ${e.message}\n`);
+    return null;
+  }
+}
+
+/**
+ * Prune stall report directory: keep the newest `keep` files, unlink older ones.
+ * @param {string} cwd  - project root
+ * @param {number} keep - number of files to retain (default 50)
+ */
+function pruneReports(cwd, keep = KEEP_DEFAULT) {
+  const dir = path.join(cwd, '.mercury', 'state', 'stall-reports');
+  try {
+    const entries = fs.readdirSync(dir)
+      .filter(f => f.endsWith('.json'))
+      .map(f => {
+        const fp = path.join(dir, f);
+        const mtime = fs.statSync(fp).mtimeMs;
+        return { fp, mtime };
+      })
+      .sort((a, b) => b.mtime - a.mtime); // newest first
+
+    const toDelete = entries.slice(keep);
+    for (const { fp } of toDelete) {
+      try { fs.unlinkSync(fp); } catch { /* ignore individual unlink errors */ }
+    }
+  } catch { /* dir missing or unreadable — ignore */ }
+}
+
+module.exports = { writeStallReport, pruneReports, isoFsSafe };

--- a/adapters/mercury-loop-detector/timeout.cjs
+++ b/adapters/mercury-loop-detector/timeout.cjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+'use strict';
+
+// Mercury Loop Detector — Multi-level timeout state machine
+// Reads last_write_ts from state; returns null or { level, message, should_block }
+// No side effects: caller (hook.cjs) owns stderr writes and state persistence.
+
+const TAG = '[mercury-loop-detector]';
+
+const TIMEOUT_DEFAULTS = {
+  timeout_soft_sec:  60,
+  timeout_idle_sec:  300,
+  timeout_hard_sec:  900
+};
+
+function clampSec(v, fallback) {
+  return Number.isFinite(v) && v >= 1 && v <= 3600 ? Math.round(v) : fallback;
+}
+
+/**
+ * Resolve timeout thresholds.
+ * Priority: env var > config file fields > defaults.
+ * @param {object} cfg - merged config object from loadConfig()
+ * @returns {{ soft: number, idle: number, hard: number }} seconds
+ */
+function resolveThresholds(cfg) {
+  const envSoft = parseFloat(process.env.MERCURY_TIMEOUT_SOFT_SEC);
+  const envIdle = parseFloat(process.env.MERCURY_TIMEOUT_IDLE_SEC);
+  const envHard = parseFloat(process.env.MERCURY_TIMEOUT_HARD_SEC);
+
+  return {
+    soft: clampSec(Number.isFinite(envSoft) ? envSoft : cfg.timeout_soft_sec,  TIMEOUT_DEFAULTS.timeout_soft_sec),
+    idle: clampSec(Number.isFinite(envIdle) ? envIdle : cfg.timeout_idle_sec,  TIMEOUT_DEFAULTS.timeout_idle_sec),
+    hard: clampSec(Number.isFinite(envHard) ? envHard : cfg.timeout_hard_sec,  TIMEOUT_DEFAULTS.timeout_hard_sec)
+  };
+}
+
+/**
+ * Update timestamp fields on state.
+ * Called after update() so is_write reflects the current tool call.
+ * @param {object} state - mutable state object
+ * @param {boolean} is_write
+ * @param {number} now - Date.now() ms
+ */
+function updateTimestamps(state, is_write, now) {
+  state.last_activity_ts = now;
+  if (is_write) {
+    state.last_write_ts = now;
+  }
+  // Initialise last_write_ts on first call (no prior write seen this session)
+  if (!Number.isFinite(state.last_write_ts)) {
+    state.last_write_ts = now;
+  }
+}
+
+/**
+ * Check multi-level timeout based on elapsed time since last write.
+ * Purely retrospective — evaluated at PostToolUse fire time.
+ *
+ * @param {object} state - current state (must have last_write_ts)
+ * @param {object} cfg   - config from loadConfig()
+ * @param {number} now   - Date.now() ms
+ * @returns {null | { level: 'soft'|'idle'|'hard', message: string, should_block: boolean }}
+ */
+function checkMultiLevel(state, cfg, now) {
+  const lastWrite = state.last_write_ts;
+  if (!Number.isFinite(lastWrite)) return null;
+
+  const elapsed = Math.floor((now - lastWrite) / 1000); // seconds
+  if (elapsed < 0) return null;
+
+  const { soft, idle, hard } = resolveThresholds(cfg);
+
+  if (elapsed > hard) {
+    const msg = `${TAG} WARNING: hard timeout: ${elapsed}s since last write (threshold: ${hard}s) — blocking`;
+    return { level: 'hard', message: msg, should_block: true };
+  }
+  if (elapsed > idle) {
+    const msg = `${TAG} WARNING: idle timeout: ${elapsed}s since last write (threshold: ${idle}s) — consider /handoff or resume with a write`;
+    return { level: 'idle', message: msg, should_block: false };
+  }
+  if (elapsed > soft) {
+    const msg = `${TAG} WARNING: soft timeout: ${elapsed}s since last write (threshold: ${soft}s)`;
+    return { level: 'soft', message: msg, should_block: false };
+  }
+
+  return null;
+}
+
+module.exports = { checkMultiLevel, updateTimestamps, resolveThresholds, TIMEOUT_DEFAULTS };

--- a/adapters/mercury-loop-detector/timeout.cjs
+++ b/adapters/mercury-loop-detector/timeout.cjs
@@ -28,11 +28,22 @@ function resolveThresholds(cfg) {
   const envIdle = parseFloat(process.env.MERCURY_TIMEOUT_IDLE_SEC);
   const envHard = parseFloat(process.env.MERCURY_TIMEOUT_HARD_SEC);
 
-  return {
+  const result = {
     soft: clampSec(Number.isFinite(envSoft) ? envSoft : cfg.timeout_soft_sec,  TIMEOUT_DEFAULTS.timeout_soft_sec),
     idle: clampSec(Number.isFinite(envIdle) ? envIdle : cfg.timeout_idle_sec,  TIMEOUT_DEFAULTS.timeout_idle_sec),
     hard: clampSec(Number.isFinite(envHard) ? envHard : cfg.timeout_hard_sec,  TIMEOUT_DEFAULTS.timeout_hard_sec)
   };
+
+  // Sanity: must satisfy soft <= idle <= hard. If not, fail-open to defaults + warn.
+  if (result.soft > result.idle || result.idle > result.hard) {
+    process.stderr.write(`${TAG} WARNING: timeout thresholds violate soft<=idle<=hard (got soft=${result.soft} idle=${result.idle} hard=${result.hard}); falling back to defaults\n`);
+    return {
+      soft: TIMEOUT_DEFAULTS.timeout_soft_sec,
+      idle: TIMEOUT_DEFAULTS.timeout_idle_sec,
+      hard: TIMEOUT_DEFAULTS.timeout_hard_sec
+    };
+  }
+  return result;
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #290. Ships Approach A per design doc [`.mercury/docs/research/phase4-5-circular-dep-breakpoint-2026-04-24.md`](.mercury/docs/research/phase4-5-circular-dep-breakpoint-2026-04-24.md):

- **Multi-level timeout** (soft / idle / hard) — retrospective evaluation at PostToolUse; soft+idle warn to stderr, hard blocks
- **Stall diagnostic reports** — JSON snapshot to `.mercury/state/stall-reports/<session_id>-<iso_ts>.json` on every block path
- **Pruning** to keep newest 50 reports
- **Feature flag** `MERCURY_STALL_REPORT_DISABLED=1` (parity with `MERCURY_MEM0_DISABLED` pattern)
- **File split** (200 LOC cap): `hook.cjs` (170) + `timeout.cjs` (90, new) + `report.cjs` (115, new)
- **EXECUTION-PLAN.md L325-329** updated — A+B marked done, C deferred to Phase 5

Breaks the apparent Phase 4-4 ↔ Phase 5 circular dependency by splitting L328 bullet into (A) local-only timeout, (B) local-only diagnostic report, (C) notify-requires-Phase-5. Only C truly needs Phase 5.

## Test plan

- [x] `node --test adapters/mercury-loop-detector/*.test.cjs` — 26/26 pass (24 unit + 2 new end-to-end integration via child_process)
- [x] All adapter files ≤200 LOC (hook 170 / timeout 90 / report 115)
- [x] Dual-verify consolidated PASS after fixing 3 Medium findings (isoFsSafe ms precision + finally tmp cleanup + ETE tests)
- [x] Backwards-compat: legacy state files without `last_*_ts` gracefully handled via `loadState()` fallback
- [x] Feature flag tested: `MERCURY_STALL_REPORT_DISABLED=1` skips all write paths including pruning
- [ ] Soak 1 session (natural use) to confirm no false-positive regression on existing 4 signals

## Dual-verify

- Claude Code deep-review: PASS (no Critical/High)
- Codex rescue subagent audit: PASS (after 3 Medium fixes)
- Findings resolved: 3 (isoFsSafe ms precision / report.cjs finally tmp cleanup / ETE integration tests)
- Low items: as-designed (soft/idle no-report per Issue spec) + test tmp housekeeping (fixed in commit 135a1e2)

## References

- Issue: #290
- Design doc: `.mercury/docs/research/phase4-5-circular-dep-breakpoint-2026-04-24.md`
- Predecessor PRs: #229 #231 (loop detector core)

🤖 Generated with [Claude Code](https://claude.com/claude-code)