### PR TITLE
feat(notify-hub): Phase 5 MVP — bidirectional Telegram via channel router/client + notify (#293)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,5 +1,15 @@
 {
   "mcpServers": {
+    "mercury-orchestrator": {
+      "type": "http",
+      "url": "http://127.0.0.1:7654/mcp"
+    },
+    "codex": {
+      "type": "stdio",
+      "command": "codex",
+      "args": ["mcp-server"],
+      "env": {}
+    },
     "mercury-telegram": {
       "command": "node",
       "args": ["./adapters/mercury-channel-client/channel.cjs"]

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,14 +1,8 @@
 {
   "mcpServers": {
-    "mercury-orchestrator": {
-      "type": "http",
-      "url": "http://127.0.0.1:7654/mcp"
-    },
-    "codex": {
-      "type": "stdio",
-      "command": "codex",
-      "args": ["mcp-server"],
-      "env": {}
+    "mercury-telegram": {
+      "command": "node",
+      "args": ["./adapters/mercury-channel-client/channel.cjs"]
     }
   }
 }

--- a/.mercury/docs/research/phase5-bidirectional-feasibility-2026-04-25.md
+++ b/.mercury/docs/research/phase5-bidirectional-feasibility-2026-04-25.md
@@ -1,0 +1,242 @@
+# Phase 5 双向交互 MVP 可行性分析
+
+> Status: research output | Date: 2026-04-25 | Lane: `main`
+> Author: research subagent (af31ba4c) | Session: S74
+
+---
+
+## 1. 问题定义
+
+**核心阻塞点**：Mercury bot 进程收到用户 Telegram 消息后，如何将该消息送入"用户当前正在运行的 Claude Code 会话"并让 Claude 将其当作 user prompt 处理？
+
+MVP 用户决策已确定（Telegram / 长轮询 / `node-telegram-bot-api` / 单用户白名单），现有 ADR (`phase5-mvp-telegram-adr-2026-04-25.md`) 仅覆盖 outbound（Mercury → 手机）。本文研究 inbound（手机 → 正在运行的 Claude Code session）的技术可行性。
+
+---
+
+## 2. 六个研究问题各自的 Verdict
+
+### Q1. 官方"外部消息注入"接口
+
+**Verdict: 不存在直接注入接口，但存在官方 Channels API（研究预览）**
+
+完整 CLI 参考（`https://code.claude.com/docs/en/cli`）确认：
+
+- 无 `--message` / `--send` / `--inject` 等"向正在运行的 session 发消息"的 CLI flag
+- 无任何 IPC socket / named pipe / REST 接口供外部进程注入
+- `claude -r "<session>" "query"` 可以 resume 一个已有 session，但这会**开启新的交互进程**，不是注入现有进程
+- `--resume` / `-r` + `-p` 组合：`claude -c -p "query"` 可以 continue 最近 session 并立即执行一个 prompt，但这同样是**启动新进程**而非注入
+
+**关键发现**：`claude remote-control` 命令（v2.1.51+）和 `--channels` flag（v2.1.80+）是两个不同的官方机制，覆盖"外部驱动本地 session"这个需求。详见 Q3/Q2。
+
+**引用 URL**：`https://code.claude.com/docs/en/cli`
+
+---
+
+### Q2. UserPromptSubmit hook 是否能"主动注入"
+
+**Verdict: 不能。只有拦截/修改，无法在无用户输入时主动触发。**
+
+UserPromptSubmit hook 是在用户已经按下 Enter 发送消息**之后**、Claude 处理之前触发的钩子。其 `additionalContext` 字段可以向 prompt 追加内容，但触发条件是"用户发消息"这个事件本身。
+
+bot 无法在用户不操作时通过 hook 向 idle session 注入消息。这条路径是**拦截器**，不是**注入器**。
+
+---
+
+### Q3. Channels API — 官方 Telegram 双向注入机制
+
+**Verdict: 可行，且 Anthropic 有官方 Telegram channel plugin。这是最接近"注入正在运行的 session"的官方路径。**
+
+**关键事实**（来源：`https://code.claude.com/docs/en/channels` 和 `https://code.claude.com/docs/en/channels-reference`）：
+
+- Channels 是 MCP server，由 Claude Code 作为子进程启动，通过 stdio 通信
+- 启动命令：`claude --channels plugin:telegram@claude-plugins-official`
+- 当 Telegram bot 收到消息时，channel MCP server 通过 `notifications/claude/channel` 协议将消息推入**当前运行的 Claude Code session**
+- 消息以 `<channel source="telegram" ...>` XML 标签注入 Claude 上下文，Claude 读取并响应
+- Claude 通过 `reply` MCP tool 回复，消息发回 Telegram chat
+- **官方支持双向**：inbound + outbound + 权限审批 relay
+
+**约束**：
+- 要求 claude.ai 账号认证（不支持 API key）
+- 研究预览阶段（v2.1.80+），flag 语法可能变化
+- 需要 [Bun](https://bun.sh) 运行时（官方 plugin 用 Bun 编写）
+- session 必须保持运行（idle session 收不到消息）
+- 官方 Telegram plugin 源码：`https://github.com/anthropics/claude-plugins-official/tree/main/external_plugins/telegram`
+- 自定义 channel 在研究预览期需 `--dangerously-load-development-channels` flag
+
+**这条路径是"真双向"**：消息进入正在运行的 session，Claude 在同一个 session 上下文里响应，回复发回 Telegram。
+
+---
+
+### Q4. Routines `/fire` 是否能注入已有 session
+
+**Verdict: 不能。`/fire` 只能创建新 session，且是 fire-and-forget。**
+
+来自 `phase5-sizing-2026-04-25.md` §1.2（2026-04-25 WebFetch 确认）：
+
+> "Each successful request creates a new session. There is no idempotency key."
+> "The request returns once the session is created. It does not stream session output or wait for the session to complete."
+
+Routines 与注入现有 session 完全不相关。这条路径已在 S73 研究中排除。
+
+**引用 URL**：`https://platform.claude.com/docs/en/api/claude-code/routines-fire`
+
+---
+
+### Q5. 同类项目双向实现 pattern
+
+**openclaw `telegram-claude-poc.py`（seedprod）**：
+
+来源：`https://raw.githubusercontent.com/seedprod/openclaw-prompts-and-skills/main/telegram-claude-poc.py`
+
+Pattern：**开新 session，非注入已有 session**。
+
+- 用 `subprocess.run()` 调用 `claude -p <message>` CLI
+- 用 `--resume <session_id>` 保持多轮会话连续性
+- session_id 持久化到 `~/.telegram-claude-sessions.json`
+- 用户发 `/new` 清空 session_id，下次重建
+
+这是"每条 Telegram 消息 spawn 一个新 claude 进程"的模式。优点：简单；缺点：每条消息等待新进程启动 + 无法共享现有 session 的上下文（内存、hook 状态等）。
+
+**breverdbidder/claude-code-telegram-control**：
+
+来源：`https://raw.githubusercontent.com/breverdbidder/claude-code-telegram-control/main/README.md`
+
+Pattern：**MCP server 模式，Claude 主动调用 Telegram 工具**。
+
+- 暴露 MCP 工具（`telegram_send`, `telegram_ask`, `telegram_notify`, `telegram_send_file`）
+- Claude 在 autonomous session 中主动 call 这些工具
+- 这是 outbound-only（Claude 主动通知），不是 inbound（用户发消息驱动 Claude）
+
+**moazbuilds/claudeclaw**：repo 返回 404，不存在。
+
+---
+
+### Q6. Agent SDK 编程式持有 session
+
+**Verdict: 可行，这是路径 B 的核心机制。**
+
+Claude Agent SDK（原 Claude Code SDK，已改名）：
+
+- TypeScript 包：`@anthropic-ai/claude-agent-sdk`（注：`@anthropic-ai/claude-code` 是老包名，已被替代）
+- Python 包：`claude-agent-sdk`
+- 文档：`https://code.claude.com/docs/en/agent-sdk/overview`
+
+**关键能力**：
+
+```typescript
+import { query } from "@anthropic-ai/claude-agent-sdk";
+
+// bot 进程自己持有 session，通过 resume 保持多轮连续
+for await (const message of query({
+  prompt: telegramUserMessage,
+  options: { resume: sessionId, allowedTools: [...] }
+})) { ... }
+```
+
+- SDK 在 bot 进程内部直接持有 session（非外部注入）
+- `resume` 参数可以恢复已有 session ID，保持对话上下文
+- SDK 捆绑了 Claude Code 原生二进制，不需要独立安装 `claude` CLI
+- **需要 API key**（不支持 claude.ai 订阅账号，不同于 Channels）
+- 这个模式下 bot 进程**就是** session owner，不存在"注入他人 session"的问题
+
+**约束**：
+- 需要 `ANTHROPIC_API_KEY`（计费方式与订阅不同，按 token 计费）
+- 与用户手动开的 Claude Code terminal session 是**完全独立的两个 session**（不共享上下文、不共享 hook 状态）
+- SDK session 没有 terminal UI，纯 headless
+
+---
+
+## 3. 决策矩阵 — 4 个候选实现路径
+
+| 路径 | 方式 | 复杂度 | 是否真双向 | 阻塞/限制 |
+|------|------|--------|-----------|-----------|
+| **A. Channels API（官方 Telegram plugin）** | `claude --channels plugin:telegram@claude-plugins-official`；MCP server 推送消息进 session | 低-中（需 Bun；安装 plugin；配置 allowlist） | **是（真双向）**：消息进现有 session，Claude 同 session 响应，reply 工具回 Telegram | 研究预览（flag 语法不稳定）；需 claude.ai 订阅账号；session 必须保持运行；Bun 依赖 |
+| **B. Agent SDK 持有独立 session** | bot 进程用 `@anthropic-ai/claude-agent-sdk` 自己起一个 headless session，`resume` 保持多轮 | 中（需 API key；独立 session 与用户 terminal session 无关） | **是（真双向）**：bot 拥有 session，任意发 prompt，任意接收响应 | 需要 API key（按 token 计费）；与用户手动开的 Claude Code session 完全隔离；无 terminal UI |
+| **C. openclaw pattern：spawn 新 session per message** | `subprocess.run(['claude', '-p', msg, '--resume', sessionId])` | 低（纯 CLI 调用；无新 runtime 依赖） | **半双向**：每条消息启动新进程，resume 共享 conversation 历史，但每次进程启动有延迟（3-8秒）；无法共享 hook/内存 | 每消息冷启动延迟；openclaw 本身无 LICENSE 不可 cherry-pick；与 Mercury 本地 hook 状态隔离 |
+| **D. tmux/screen send-keys** | bot 向 tmux pane 发字符序列模拟键盘输入 | 低（纯 shell）| **是（注入现有 session）**：真正向用户正在用的 terminal session 发消息 | 高度脆弱（依赖 terminal 状态/focus/滚动）；需要 tmux 且 session 在 tmux pane 内；prompt 注入风险；不跨平台 |
+
+---
+
+## 4. 推荐路径 + 理由
+
+**推荐：路径 A（Channels API）作为主路径，路径 C 作为兼容降级**
+
+**路径 A 理由**：
+
+1. **官方支持**：Anthropic 有官方 Telegram channel plugin，源码开放（MIT 待确认）。不需要自己实现双向协议。
+2. **真双向**：消息在同一个 Claude Code session 内处理，共享 session 上下文、技能、hooks、CLAUDE.md。
+3. **权限 relay**：用户可以从 Telegram 批准/拒绝 Claude 的 tool use，这是 Mercury "远程确认"特性（DIRECTION.md §3 Module 3）的完整实现。
+4. **与现有 MVP outbound 兼容**：outbound（`adapters/mercury-notify/notify.cjs`）和 inbound（Channels）是正交的；outbound 先落地，inbound 后加，无冲突。
+5. **LOC 影响**：Mercury 只需写启动脚本和白名单配置（~30 LOC），核心 channel 逻辑由官方 plugin 承担。
+
+**路径 A 的额外约束（需用户确认）**：
+- 用户必须用 `claude --channels plugin:telegram@claude-plugins-official` 启动 Claude Code，而非普通 `claude`（或者 `/config` 设为全局启用）
+- 需要安装 Bun（`bun --version` 检查）
+- 研究预览阶段：flag 可能变化，需关注 changelog
+
+**路径 C 作为降级**：若用户不想依赖研究预览 feature，或 Channels 在特定环境下不可用，openclaw pattern（`claude -p --resume <id>`）是零依赖的降级方案，但每条消息有 ~5s 冷启动延迟。
+
+---
+
+## 5. 不可行情况下的降级方案
+
+若 Channels API 被封锁（企业策略 / 研究预览退出 / Bun 不可安装）：
+
+**最接近双向的次优方案：路径 C（spawn + resume）**
+
+- bot 收到 Telegram 消息 → `claude -p "<msg>" -r <session_id> --output-format json`
+- 解析 JSON 输出取 Claude 回复 → 发回 Telegram
+- session_id 缓存在本地文件
+- **限制**：每消息 5-8s 延迟；与用户 terminal session 隔离；hook 状态不共享
+
+这不是"注入现有 session"，而是"独立的 bot session"。从用户体验角度是可接受的双向交互，只是技术上两个 session。
+
+---
+
+## 6. 对 Issue #293 的影响
+
+### ADR 是否需要重写
+
+**需要新增一节**，原 ADR 只覆盖 outbound（Phase 5-1）。双向部分（Phase 5-2）现在有了可行的技术路径，建议在 Issue #293 comment 中记录本研究结论，并将"Path A: Channels API"作为 Phase 5-2 的首选方案。
+
+原 ADR 的 outbound 决策（raw `fetch` + HTML + 4000 truncate）**不受影响**，仍然正确——但用户已选改为 `node-telegram-bot-api` lib 因为"一步到位"，这部分需要由 main agent 在 ADR 重写中调整。
+
+### LOC 估算变化
+
+| 部分 | 原估算 | 修订 |
+|------|--------|------|
+| outbound `notify.cjs` | 60-80 LOC | 不变 |
+| inbound Channels（路径 A） | 未估算（Phase 5-2 defer） | ~30-50 LOC（启动脚本 + 白名单配置 + Mercury hook 集成）；核心由官方 plugin 承担 |
+| 总 Phase 5 全双向 MVP | — | ~80-130 LOC（低于 200 LOC 硬限） |
+
+**如果选路径 C（降级）**：bot.js 约 80-120 LOC（长轮询 + subprocess + session 缓存），无新 runtime 依赖。
+
+### Caller wire 选择
+
+Channels API 路径下，inbound 消息直接进 Claude session，不需要 Mercury 额外的 caller wire。Claude 自身处理 Telegram 消息，通过 reply tool 回复。这与 outbound notify（loop detector → `notify.cjs` → Telegram）是完全独立的两条数据流。
+
+---
+
+## 7. Sources
+
+**WebFetch（2026-04-25，本 session 实际获取）：**
+- [CLI reference](https://code.claude.com/docs/en/cli) — 完整 CLI flag 列表，确认无直接注入接口
+- [Channels — push events into a running session](https://code.claude.com/docs/en/channels) — 官方 Telegram/Discord/iMessage channel，包括安装步骤和 session 启动方式
+- [Channels reference — build your own channel](https://code.claude.com/docs/en/channels-reference) — MCP notification 协议、reply tool、permission relay 完整规范
+- [Remote Control](https://code.claude.com/docs/en/remote-control) — `claude remote-control` 命令，确认这是"通过 claude.ai 驱动本地 session"而非编程 API
+- [Agent SDK overview](https://code.claude.com/docs/en/agent-sdk/overview) — `@anthropic-ai/claude-agent-sdk` 包，programmatic session 持有
+
+**WebFetch（2026-04-25，openclaw + breverdbidder）：**
+- [openclaw telegram-claude-poc.py](https://raw.githubusercontent.com/seedprod/openclaw-prompts-and-skills/main/telegram-claude-poc.py) — spawn + resume pattern 确认
+- [breverdbidder claude-code-telegram-control README](https://raw.githubusercontent.com/breverdbidder/claude-code-telegram-control/main/README.md) — MCP outbound tools pattern（非 inbound 注入）
+
+**项目文档（本 session 读取）：**
+- `.mercury/docs/research/phase5-sizing-2026-04-25.md` — Routines `/fire` fire-and-forget 确认
+- `.mercury/docs/research/phase5-mvp-telegram-adr-2026-04-25.md` — 原 ADR 决策矩阵
+
+**WebSearch（2026-04-25）：**
+- [@anthropic-ai/claude-code npm](https://www.npmjs.com/package/@anthropic-ai/claude-code) — 旧包名（现已更名为 `@anthropic-ai/claude-agent-sdk`）
+- [@anthropic-ai/claude-agent-sdk npm](https://www.npmjs.com/package/@anthropic-ai/claude-agent-sdk) — 当前 SDK 包名
+
+**官方 plugin 源码（未 WebFetch，供后续读取）：**
+- [Telegram channel plugin source](https://github.com/anthropics/claude-plugins-official/tree/main/external_plugins/telegram) — 官方实现参考（license 待 gh api 验证）

--- a/.mercury/docs/research/phase5-mvp-telegram-adr-2026-04-25.md
+++ b/.mercury/docs/research/phase5-mvp-telegram-adr-2026-04-25.md
@@ -1,0 +1,632 @@
+# Phase 5 MVP Telegram Notify Adapter — Transport ADR (v2 Bidirectional)
+
+> Status: **Decision doc (S74 main lane)** | Date: 2026-04-25 | Lane: `main`
+> Scope: 完整双向 Telegram 集成（outbound 推送 + inbound 远程操控）
+> Supersedes: v1 outbound-only ADR (S74 上半段)
+> Dependencies: `phase5-sizing-2026-04-25.md` / `phase5-bidirectional-feasibility-2026-04-25.md` / `router-llm-backend-2026-04-25.md`
+> Related: Mercury Issue #293 / claude-handoff PR (待开)
+
+---
+
+## 1. Scope 变更说明（v1 → v2）
+
+v1 ADR 假设 MVP 单向（Mercury → 手机推送），双向 defer Phase 5-2。
+
+v2 反映以下用户决策（S74 中段）：
+- **MVP 一步到位**：双向交互（手机 → 正在跑的 Claude Code session 当 user prompt）
+- **多 session 同步运行支持**：硬限 3 session
+- **任务标识自动推导 + 可 override**（方案 C）
+- **0 LLM router MVP**：纯 deterministic 路由
+- **库选 `node-telegram-bot-api`**（一步到位的双向需求让库的依赖链赚回来）
+
+---
+
+## 2. 架构总览
+
+### 2.1 三 adapter 拆分
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Telegram (api.telegram.org)                                │
+└─────────────────────────────────────────────────────────────┘
+              ▲                                ▲
+              │ getUpdates / sendMessage       │
+              │ (node-telegram-bot-api lib)    │
+              │                                │
+┌─────────────▼────────────────────────────────┴─────────────┐
+│  adapters/mercury-channel-router/  (long-running process)  │
+│  - Telegram bot polling (single connection per token)      │
+│  - IPC server (localhost HTTP)                             │
+│  - Ownership election (which session is "active")          │
+│  - Task label resolution (branch name → label)             │
+│  - Command parser (/status /cancel /continue /list)        │
+│  - Allowlist gate (sender ID check)                        │
+│  - Session count limit (max 3)                             │
+└────────────┬───────────────────────┬───────────────────────┘
+             │ IPC                   │ IPC
+             │ (HTTP localhost)      │ (HTTP localhost)
+             │                       │
+┌────────────▼──────────┐  ┌─────────▼──────────────┐
+│ mercury-channel-      │  │ mercury-notify/        │
+│ client/               │  │                        │
+│ (one per Claude Code  │  │ (called from hooks /   │
+│  session, MCP server) │  │  scripts that don't    │
+│                       │  │  have a Claude session)│
+│ - Spawned by          │  │                        │
+│   Claude Code         │  │ - HTTP POST to router  │
+│ - Notification        │  │   /notify endpoint     │
+│   listener            │  │ - Used by loop         │
+│ - Reply MCP tool      │  │   detector, post-      │
+│ - Permission relay    │  │   commit hooks, etc.   │
+└───────────────────────┘  └────────────────────────┘
+        ▲                            ▲
+        │ stdio                      │ exec
+        │                            │
+┌───────┴──────────────┐  ┌──────────┴─────────────┐
+│ Claude Code session  │  │ Mercury hook scripts   │
+│ (loaded via          │  │ (hook.cjs / *.sh)      │
+│  --channels flag)    │  │                        │
+└──────────────────────┘  └────────────────────────┘
+```
+
+### 2.2 数据流
+
+**Inbound（手机 → Claude Code）**：
+1. 用户在 Telegram 给 bot 发消息
+2. Router `getUpdates` 拉到消息
+3. Router 检查 sender 在白名单
+4. Router 解析消息（前缀 `@<label>` / 命令 `/<cmd>` / 自由文本）
+5. Router 决定路由目标 session
+6. Router 通过 IPC 推消息给目标 session 的 channel-client
+7. channel-client 通过 MCP `notifications/claude/channel` 推到 Claude
+8. Claude 处理并通过 `reply` MCP tool 回复
+9. channel-client 把 reply 通过 IPC 转给 router
+10. Router 加 `[<label>]` 前缀后 sendMessage 回 Telegram
+
+**Outbound from Claude session（Claude → 手机）**：
+- 走 step 8-10 的 reply 路径
+
+**Outbound from hook（Mercury 内部进程 → 手机）**：
+- hook script 调 `mercury-notify/notify(severity, title, body)`
+- notify 通过 IPC POST 到 router `/notify`
+- Router 加 `[<label>]` 前缀（从 PWD/branch 推导）后 sendMessage
+
+### 2.3 IPC 通道选择
+
+**localhost HTTP**（Bun.serve / Node http）：
+- 跨平台（Windows/MSYS2/WSL/Native bash 全工作）
+- 无 Unix socket 兼容性顾虑
+- 端口：`MERCURY_ROUTER_PORT`（默认 8788，可 env var 覆盖）
+- 仅监听 127.0.0.1，外部不可达
+
+替代选项 rejected：
+- Unix socket：Windows 10+ 才支持，MSYS2 还有边缘 case
+- Named pipe：跨 Linux/Mac 不可移植
+- TCP non-localhost：暴露面太大
+
+---
+
+## 3. 用户决策 + 研究依据汇总
+
+### 3.1 Outbound transport（v1 沿用）
+
+| Q | 决策 | 来源 |
+|---|------|------|
+| Q1 Privacy | Telegram bot（authenticated） | S73 用户 Q1 |
+| Q2 Secret | `~/.claude/settings.json` env | S73 用户 Q2 |
+| Q3 Payload | HTML parse_mode + 4000 char 截断 | S73 用户 Q3 + Q3 research |
+| Library | `node-telegram-bot-api` v0.67.0 MIT | S74 用户翻库决定 |
+
+### 3.2 Bidirectional 路径（v2 新增）
+
+| Q | 决策 | 来源 |
+|---|------|------|
+| Q7 路径 | A2 自建 router + 自定义 channel | bidirectional research |
+| Q8 任务标识 | 方案 C: branch name → `#<N>` 推导 + override | 用户 confirm |
+| Q9 LLM 后端 | 0 LLM MVP（纯 regex） | router-llm research |
+| Q10 限 session | 硬限 3 | 用户决策 |
+
+---
+
+## 4. `mercury-channel-router/` 详细设计
+
+### 4.1 启动机制
+
+**触发**：第一个带 `--channels` 的 Claude Code session 启动时，channel-client 的 MCP server 探测 router 端口；端口空 → spawn router 进程；端口占 → attach。
+
+**伪代码（channel-client 内）**：
+```js
+async function ensureRouter() {
+  const port = process.env.MERCURY_ROUTER_PORT || 8788;
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/health`, {
+      signal: AbortSignal.timeout(500)
+    });
+    if (res.ok) return; // already running
+  } catch {}
+  // Spawn router
+  spawn('node', [
+    path.join(MERCURY_ADAPTERS, 'mercury-channel-router/router.cjs')
+  ], {
+    detached: true,
+    stdio: 'ignore',
+    windowsHide: true
+  }).unref();
+  // Wait for /health
+  for (let i = 0; i < 20; i++) {
+    await sleep(250);
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/health`);
+      if (res.ok) return;
+    } catch {}
+  }
+  throw new Error('router did not start within 5s');
+}
+```
+
+**优点**：用户不需要单独启 router；零部署摩擦。
+
+### 4.2 IPC 协议（HTTP endpoints）
+
+| Method | Path | 调用方 | 作用 |
+|--------|------|--------|------|
+| GET | `/health` | channel-client / notify | 探活 |
+| POST | `/register` | channel-client | 注册新 session（含 session_id, project_path, branch, pid） |
+| DELETE | `/register/<session_id>` | channel-client | 注销 session（exit 前调） |
+| POST | `/take-ownership/<session_id>` | channel-client | 主动声明"我是当前 active" |
+| POST | `/notify` | notify.cjs / 任意 hook | 发出站消息（{severity, title, body, label?}） |
+| POST | `/reply` | channel-client | Claude 通过 reply tool 后转发到 Telegram |
+| GET | `/sessions` | channel-client (admin) | 返回当前注册的所有 session |
+| WS | `/inbox/<session_id>` | channel-client | 长连接接收路由器推来的消息 |
+
+**WebSocket** vs **SSE** vs **long polling**：
+- WebSocket 双向，但 Bun WS 实现成熟
+- SSE 单向（router → client），需 client 反向 POST
+- long polling 兼容性最好，延迟最高
+- **MVP 选 SSE**（router → client） + POST（client → router）：实现简单，跨平台稳定
+
+### 4.3 Ownership 选举
+
+**规则**：任何时刻只有一个 session 是 `active`，接收用户不加前缀的消息。
+
+**初始 active**：第一个 register 的 session。
+
+**变更触发**：
+- 显式：channel-client 调 `/take-ownership` （比如用户在某个 tab 输入了内容触发 hook）
+- 隐式：router 收到 sender 加 `@<label>` 时不变更 ownership（精确路由），不加时 ownership 不变；但 channel-client 在每次 `notifications/claude/channel` 处理后调 `/take-ownership` 让"刚响应的 session"成为下次默认
+
+**MVP 简化**：让 channel-client 在收到任意 inbound 消息处理完毕后调 `/take-ownership`——即"最近响应的 session 自动成为 active"。
+
+### 4.4 任务标识解析（方案 C）
+
+**Router 收到 `/register` 时记录 session 元数据，包含 label 推导**：
+
+```js
+function deriveLabel({ project_path, branch }) {
+  // 1. branch name 模式：feature/lane-<name>/TASK-<N>-<slug>
+  const m1 = branch.match(/^feature\/(?:lane-[\w-]+\/)?TASK-(\d+)-([\w-]+)/);
+  if (m1) return `#${m1[1]} ${m1[2]}`.slice(0, 30);
+  // 2. branch name 模式：feature/<slug>
+  const m2 = branch.match(/^feature\/([\w-]+)/);
+  if (m2) return m2[1].slice(0, 30);
+  // 3. cwd basename fallback
+  return path.basename(project_path).slice(0, 30);
+}
+```
+
+**Override**：channel-client 启动时读 `.mercury/state/session-label.txt` 如存在则覆盖 router 推导。Mercury 命令 `/label "<custom>"`（未来添加）写入此文件。
+
+**Label 显示**：所有 router → Telegram 的消息都加 `[<label>]` 前缀。
+
+### 4.5 限 session 数策略
+
+**硬限 3**：
+- `/register` 第 4 个 session 时返回 HTTP 429
+- channel-client 收到 429 时 stderr 警告 + Claude Code 仍正常启动（仅无 Telegram 功能）
+- router 已注册 session 退出（DELETE /register）后释放配额
+
+### 4.6 Telegram polling
+
+**库**：`node-telegram-bot-api` v0.67.0
+- 长轮询模式 `bot.startPolling()`
+- 单进程独占 token（多 router 实例会撞 offset）
+- 使用 lock file `~/.mercury/router.lock` 防止误启多实例
+
+**Bot 凭据**：从 env var `MERCURY_TELEGRAM_BOT_TOKEN` 读取（来自 `~/.claude/settings.json` 的 env block，因为 router 由 Claude Code 子进程 spawn，继承环境）。
+
+### 4.7 消息路由规则（0 LLM）
+
+**收到 Telegram message 后**：
+
+```js
+function route(msg, sessions, currentActive) {
+  // 1. Allowlist gate
+  if (!isAllowed(msg.from.id)) return null; // silent drop
+
+  const text = msg.text.trim();
+
+  // 2. Bot commands
+  if (text.startsWith('/status')) return { type: 'cmd', cmd: 'status' };
+  if (text.startsWith('/list'))   return { type: 'cmd', cmd: 'list' };
+  if (text.startsWith('/cancel')) return { type: 'cmd', cmd: 'cancel', args: parseArgs(text) };
+
+  // 3. Explicit prefix
+  const prefixMatch = text.match(/^@([\w-]+)\s+(.+)$/s);
+  if (prefixMatch) {
+    const target = sessions.find(s => s.label.startsWith(prefixMatch[1]));
+    if (target) return { type: 'route', session_id: target.id, content: prefixMatch[2] };
+    return { type: 'error', text: `No session matching @${prefixMatch[1]}` };
+  }
+
+  // 4. Permission verdict (yes/no <id>)
+  const verdictMatch = text.match(/^\s*(y|yes|n|no)\s+([a-km-z]{5})\s*$/i);
+  if (verdictMatch) return { type: 'verdict', verdict: verdictMatch[1], request_id: verdictMatch[2] };
+
+  // 5. Default: route to current active
+  if (!currentActive) return { type: 'error', text: 'No active session' };
+  return { type: 'route', session_id: currentActive, content: text };
+}
+```
+
+### 4.8 命令处理
+
+| 命令 | 行为 |
+|------|------|
+| `/status` | 返回 router 状态（version / uptime / active session label） |
+| `/list` | 列所有注册 session：`[#293 telegram-notify] active\n[#292 multi-lane]\n` |
+| `/cancel` | 不加前缀 → cancel current active；`/cancel @<label>` → 指定。具体怎么"cancel"传给 session 由 client 决定（注入 `<channel>` 标签让 Claude 看到指令） |
+| `/continue` | 同 `/cancel`，传 continue 信号 |
+| `/help` | 返回所有命令帮助 |
+
+### 4.9 LOC 预算
+
+| 模块 | LOC |
+|------|-----|
+| Telegram bot + lock file + auth gate | 30-40 |
+| HTTP IPC server + endpoints | 50-60 |
+| Ownership / register / session map | 30-40 |
+| Label 解析 + override 读取 | 15-20 |
+| 消息路由 + 命令处理 | 40-50 |
+| **总计** | **165-210**（target 180 LOC，硬限 200） |
+
+---
+
+## 5. `mercury-channel-client/` 详细设计
+
+### 5.1 角色
+
+由 Claude Code 通过 `--channels plugin:mercury@<marketplace>` 加载（需 dev flag `--dangerously-load-development-channels` 在 research preview 阶段）。
+
+### 5.2 实现核心
+
+```js
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+
+const mcp = new Server(
+  { name: 'mercury-telegram', version: '0.1.0' },
+  {
+    capabilities: {
+      experimental: {
+        'claude/channel': {},
+        'claude/channel/permission': {},
+      },
+      tools: {},
+    },
+    instructions: 'Telegram messages arrive as <channel source="mercury-telegram" label="..."> tags. Reply with the reply tool, passing the session_id from the tag.',
+  }
+);
+
+// 1. ensureRouter() — spawn if not running
+// 2. POST /register with {session_id, project_path, branch, pid}
+// 3. Open SSE to /inbox/<session_id>
+// 4. On SSE event: mcp.notification('notifications/claude/channel', {...})
+// 5. Register reply tool: POST /reply to router
+// 6. Register permission_request handler: POST /permission-request to router
+// 7. On process exit (SIGTERM/SIGINT): DELETE /register/<session_id>
+```
+
+### 5.3 LOC 预算
+
+| 模块 | LOC |
+|------|-----|
+| MCP server scaffolding | 20-25 |
+| ensureRouter + register/deregister | 20-25 |
+| SSE consumer + channel notification | 15-20 |
+| Reply tool handler | 10-15 |
+| Permission relay | 15-20 |
+| **总计** | **80-105**（target 90 LOC，硬限 200） |
+
+---
+
+## 6. `mercury-notify/` 详细设计（重新评估）
+
+### 6.1 v1 vs v2 对比
+
+| | v1 设计 | v2 设计 |
+|---|---|---|
+| 直连 Telegram | ✅（raw fetch） | ❌ |
+| 通过 router | N/A | ✅（HTTP POST localhost） |
+| LOC | 60-80 | 25-35 |
+
+v2 大幅简化：notify.cjs 不再持 Telegram 凭据/库，只发 HTTP 给 router。如果 router 没起，notify.cjs 静默失败 + stderr log（不 spawn router——避免 hook 路径副作用）。
+
+### 6.2 接口
+
+```js
+// notify.cjs (~30 LOC)
+async function notify(severity, title, body, options = {}) {
+  if (process.env.MERCURY_NOTIFY_DISABLED) return { ok: true, skipped: true };
+  const port = process.env.MERCURY_ROUTER_PORT || 8788;
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/notify`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ severity, title, body, ...options }),
+      signal: AbortSignal.timeout(2000)
+    });
+    if (!res.ok) return { ok: false, error: `router_${res.status}` };
+    return { ok: true };
+  } catch (e) {
+    process.stderr.write(`[mercury-notify] ${e.message}\n`);
+    return { ok: false, error: 'transport' };
+  }
+}
+module.exports = { notify };
+```
+
+### 6.3 Caller wire（不变）
+
+`adapters/mercury-loop-detector/hook.cjs` 在 stall 触发后调 `notify('error', 'Mercury stall: <type>', stallReason)`，fire-and-forget。
+
+---
+
+## 7. 边界问题与解决方案
+
+### 7.1 P0：handoff 切换的"无主时段"
+
+**问题**：旧 session `/exit` 之前 spawn 新 session，启动间隔（~5-15s）内用户消息无人接。
+
+**方案**：
+- Router 维护 `orphan_buffer`（按 ownership 时间窗口缓冲，默认保留 30s 内消息）
+- 新 session register 完成时，router 检查 `last_ownership_release_ts`，如在 30s 内 → 把 orphan messages 重放给新 session 的 inbox
+- 超过 30s → 丢弃 + 通知用户："2 messages dropped during handoff window"
+
+### 7.2 P0：新 session 启动失败
+
+**问题**：旧 session exit 前新 session 没起来 → channel 永久断。
+
+**方案**：
+- handoff skill 在 spawn 新 session 后**等新 session register**（poll router `/sessions` 确认 N+1 个 session 存在）才允许旧 session exit
+- 超时 30s 仍未 register → handoff 报错，**不允许旧 session 退出**
+- 失败时 router 主动 sendMessage `[router] handoff failed, old session preserved`
+
+### 7.3 P0：用户消息归属（已 confirm 解决方案）
+
+- 加前缀 `@<label>` → 显式
+- 命令 `/cmd` → router 内部
+- 不加前缀 → current active
+- Router reply 加 `[<label>]` 让用户看清楚谁在答
+
+### 7.4 P1：router 进程生命周期
+
+**启动**：第一个 channel-client 探测端口空时 spawn detached + unref。
+
+**退出**：router 监听 channel-client `/register` 计数，所有 session DELETE 后启动 30s grace timer，倒计时内有新 register 则取消，否则 self-exit。
+
+**Crash 恢复**：channel-client 的 SSE 连接断开时尝试重连 + 调 ensureRouter（探测端口空就 respawn）。
+
+**Lock file**：router 启动时 `flock` 在 `~/.mercury/router.lock`，第二个实例尝试 lock 失败立即 exit。
+
+### 7.5 P1：handoff plugin 集成
+
+**问题**：handoff plugin 是通用的，不该 hardcode `--channels plugin:mercury@...`。
+
+**方案**：
+- 新 env var `MERCURY_CHANNELS_FLAGS`（默认未设）
+- handoff skill 在 spawn 新 session 时检查该 env var，存在 → 注入到 launch 命令
+- Mercury 项目用户在 `~/.claude/settings.json` env 段设：
+  ```json
+  "env": {
+    "MERCURY_CHANNELS_FLAGS": "--channels plugin:mercury-telegram@local --dangerously-load-development-channels"
+  }
+  ```
+- handoff plugin 需要小改动：在 `wt -- claude -- "$SHORT_PROMPT"` 前注入 `${MERCURY_CHANNELS_FLAGS:-}`
+- 改动只 ~3 行，但需给 `392fyc/claude-handoff` 提 PR
+
+### 7.6 P1：权限 request_id 跨 session 冲突
+
+**问题**：5 letter ID 约 11M 组合，多 session 同时发起权限请求时 ID 可能撞。
+
+**方案**：
+- channel-client 在 forward 给 router 时把 ID 改写成 `<session_short>-<id>`（session_short = label 前 2 字符 / 哈希 4 字符）
+- Router 转发到 Telegram 时用改写后的 ID
+- 用户 reply `yes <session_short>-<id>` 时 router 解析 prefix 路由到正确 session
+- 同时 router 反向解析回原 ID 给 Claude Code
+
+### 7.7 P2：限 session 数怎么实施
+
+参见 §4.5。MVP 用 HTTP 429 拒绝；channel-client stderr warning。
+
+### 7.8 P2：idle session 占连接
+
+只要 session 没 `/register` DELETE，router 就当它 active。MVP 不主动 timeout。
+
+### 7.9 P3：prompt injection from compromised account
+
+不属于 Mercury 防御范围；用户级安全。文档化提醒。
+
+---
+
+## 8. handoff plugin 集成具体方案
+
+### 8.1 改动范围
+
+`D:\Mercury\claude-handoff-plugin\skills\handoff\SKILL.md` Step 5 三处 launch 命令：
+
+```bash
+# Before
+wt -w 0 nt --title "Handoff" -d "<cwd>" -- claude -- "$SHORT_PROMPT"
+tmux new-window -n handoff "claude -- '$SHORT_PROMPT'"
+tmux new-session -d -s handoff "claude -- '$SHORT_PROMPT'"
+
+# After (env var injection)
+wt -w 0 nt --title "Handoff" -d "<cwd>" -- claude ${MERCURY_CHANNELS_FLAGS:-} -- "$SHORT_PROMPT"
+tmux new-window -n handoff "claude ${MERCURY_CHANNELS_FLAGS:-} -- '$SHORT_PROMPT'"
+tmux new-session -d -s handoff "claude ${MERCURY_CHANNELS_FLAGS:-} -- '$SHORT_PROMPT'"
+```
+
+### 8.2 PR 计划
+
+- 给 `392fyc/claude-handoff` 开 PR
+- Title: "feat: support MERCURY_CHANNELS_FLAGS env var for channel propagation in auto handoff"
+- 通用化命名：env var 改为 `CLAUDE_HANDOFF_AUTO_LAUNCH_FLAGS`（避免 Mercury 特化）
+- Mercury 这边 export `CLAUDE_HANDOFF_AUTO_LAUNCH_FLAGS="--channels plugin:mercury-telegram@local --dangerously-load-development-channels"`
+
+---
+
+## 9. 依赖与前置
+
+### 9.1 Bun 运行时
+
+- 用户必须装：`https://bun.sh/docs/installation` (Windows: `powershell -c "irm bun.sh/install.ps1 | iex"`)
+- Mercury 文档化：`adapters/mercury-channel-client/README.md` 第一行写"requires Bun"
+- 安装目录建议 `D:\Program Files\bun`（按 Mercury D 盘规则）
+
+### 9.2 claude.ai 订阅
+
+- Channels API 仅支持订阅认证（不支持 API key）
+- 用户已是 Opus 4.7 用户，满足
+
+### 9.3 启动 Claude Code 的命令变更
+
+- 以前：`claude`
+- 之后：`claude --channels plugin:mercury-telegram@local --dangerously-load-development-channels`
+- 通过 `CLAUDE_HANDOFF_AUTO_LAUNCH_FLAGS` env var 透传到 handoff 自动 spawn 的 session
+
+### 9.4 Telegram bot 凭据
+
+- `MERCURY_TELEGRAM_BOT_TOKEN` 在 `~/.claude/settings.json` env block
+- `MERCURY_TELEGRAM_ALLOWED_USER_IDS` 逗号分隔 user IDs（白名单 sender）
+
+---
+
+## 10. LOC 预算总览
+
+| Adapter | Target | Hard limit | Includes |
+|---------|--------|-----------|----------|
+| `mercury-channel-router/router.cjs` | 180 | 200 | Telegram bot + IPC + ownership + label + commands |
+| `mercury-channel-client/channel.cjs` | 90 | 200 | MCP server + IPC client + reply + permission |
+| `mercury-notify/notify.cjs` | 30 | 80 | Thin HTTP client to router |
+| **小计 实现** | **300** | — | |
+| `*/README.md` × 3 | 80 | — | docs only |
+| `*/UPSTREAM.md` × 3 | 30 | — | reference notes (no cherry-picks) |
+| handoff plugin PR diff | 6 | — | env var injection |
+| **总计** | **~416 LOC** | | 三 adapter 各自合规 200 限 |
+
+---
+
+## 11. 开发分阶段
+
+### Phase 5-1: notify.cjs + router skeleton（首 PR）
+
+- `mercury-notify/notify.cjs` 30 LOC
+- `mercury-channel-router/router.cjs` 仅 outbound 部分（接 `/notify` 转 Telegram，~80 LOC）
+- Wire `mercury-loop-detector/hook.cjs` 卡死后调 notify
+- 用户在 `~/.claude/settings.json` 设 `MERCURY_TELEGRAM_BOT_TOKEN`
+- **Demo**：触发卡死 → 手机收到 `[#NNN] Mercury stall: no_progress`
+- 关 #293 一半 scope
+
+### Phase 5-2: router 完整 + channel-client（次 PR）
+
+- `mercury-channel-router/router.cjs` 完成 inbound + ownership + commands
+- `mercury-channel-client/channel.cjs` 完整实现
+- handoff plugin PR（独立仓库）
+- **Demo**：手机发"@main /status" → 收到 `[#NNN main lane] active 3h, 1 session`
+- 关 Issue #295（待开）
+
+### Phase 5-3: 自然语言意图解析（远期 defer）
+
+- `mercury-channel-router/intent-parser.cjs` 加 LLM hook（OpenAI gpt-4o-mini direct）
+- 让用户能发"取消刚才的"这种自由文本
+- 不在本 ADR scope
+
+---
+
+## 12. 替代方案（rejected）
+
+| Option | Why rejected |
+|--------|--------------|
+| 官方 Telegram channel plugin（路径 A1） | 不支持多 session；用户需求"3 session 同步"被屏蔽 |
+| Agent SDK 持独立 session（路径 B） | bot 持有的 session 与用户 terminal 隔离，违背"接入正在用的会话"语义 |
+| spawn + resume per message（路径 C） | 5-8s 冷启动延迟；不共享 hook 状态 |
+| tmux send-keys（路径 D） | 平台脆弱、安全风险 |
+| Codex CLI 当 router LLM 后端 | 5-10s 延迟、Windows encoding 风险、无 per-call system prompt |
+| Webhook 模式（vs 长轮询） | 需要公网 IP / HTTPS 证书 / 反代；用户笔记本不在公网 |
+| LLM intent parsing in MVP | 用户 P0#3 设计纯 deterministic 已够用；增加复杂度无收益 |
+
+---
+
+## 13. 风险登记
+
+| 风险 | 概率 | 影响 | 缓解 |
+|------|------|------|------|
+| Channels API research preview 被 deprecated | 低 | 高 | Anthropic 文档承诺 2-version deprecation window |
+| 用户笔记本休眠时 router 进程死 | 中 | 中 | channel-client 重连 + 唤醒后 sendMessage 提醒"router restarted, X messages dropped" |
+| 多 session 同时跑 register 撞 ownership | 中 | 低 | 路由器侧加 mutex；MVP active 概念是软语义 |
+| Bot token 泄露 | 低 | 高 | env var only、never log；用户级安全 |
+| handoff 失败后旧 session 卡 exit 流程 | 中 | 中 | 30s timeout + 错误明示；让用户决定手动 exit |
+| Bun 运行时升级断接口 | 低 | 中 | pin Bun major version；channel-client 用稳定 Node API 而非 Bun-specific |
+
+---
+
+## 14. Sources
+
+**Phase 5 v2 ADR 综合以下 research：**
+- `phase5-sizing-2026-04-25.md` — Routines 不替代 Phase 5
+- `phase5-bidirectional-feasibility-2026-04-25.md` — Channels API 可行 + 多 session 阻塞
+- `router-llm-backend-2026-04-25.md` — Codex 不适合，0 LLM MVP
+
+**Anthropic 官方文档（WebFetch 2026-04-25）：**
+- [Channels — push events into a running session](https://code.claude.com/docs/en/channels)
+- [Channels reference — build your own channel](https://code.claude.com/docs/en/channels-reference)
+- [CLI reference](https://code.claude.com/docs/en/cli)
+- [Agent SDK overview](https://code.claude.com/docs/en/agent-sdk/overview)
+
+**npm + Telegram：**
+- `node-telegram-bot-api` v0.67.0 MIT (npm registry 2026-04-25)
+- [Telegram Bot API 9.6](https://core.telegram.org/bots/api)
+- [Bun installation](https://bun.sh/docs/installation)
+
+**项目文档：**
+- `.mercury/docs/DIRECTION.md` §3 Module 3
+- `.mercury/docs/EXECUTION-PLAN.md` Phase 5 L337-362
+- `.mercury/docs/research/phase4-5-circular-dep-breakpoint-2026-04-24.md`
+
+**待开 PR：**
+- `392fyc/claude-handoff` — env var support for auto-launch flags
+
+---
+
+## 15. 决策 checklist（实施前 user confirm）
+
+- [x] Library: `node-telegram-bot-api` v0.67.0
+- [x] Architecture: 自建 router + channel-client + notify 三 adapter
+- [x] Routing: 0 LLM, regex + commands
+- [x] Label: branch name 推导 (方案 C)
+- [x] Session limit: 硬限 3
+- [x] IPC: localhost HTTP / SSE
+- [x] LLM 后端: 不用 (MVP) ；远期 OpenAI direct
+- [ ] Bun 安装位置（建议 `D:\Program Files\bun`）
+- [ ] handoff plugin PR 由 Mercury 维护者（你）提交还是我代笔
+- [ ] 分阶段 ship（Phase 5-1 outbound 单独 PR / Phase 5-2 双向次 PR）
+
+---
+
+## 16. Next actions
+
+1. **User confirm §15 三未定项**
+2. 关闭 Issue #293 v1 ADR comment，重定向到本 v2 文件
+3. 开 Issue #295 "Phase 5-2: bidirectional via custom Channels router"
+4. Phase 5-1 dev dispatch（notify.cjs + router skeleton）
+5. handoff plugin PR

--- a/.mercury/docs/research/phase5-mvp-telegram-adr-2026-04-25.md
+++ b/.mercury/docs/research/phase5-mvp-telegram-adr-2026-04-25.md
@@ -489,9 +489,9 @@ tmux new-session -d -s handoff "claude ${MERCURY_CHANNELS_FLAGS:-} -- '$SHORT_PR
 
 ### 9.1 Bun 运行时
 
-- 用户必须装：`https://bun.sh/docs/installation` (Windows: `powershell -c "irm bun.sh/install.ps1 | iex"`)
-- Mercury 文档化：`adapters/mercury-channel-client/README.md` 第一行写"requires Bun"
-- 安装目录建议 `D:\Program Files\bun`（按 Mercury D 盘规则）
+- **Bun 是 optional**（Anthropic 文档明说"the only requirement is the MCP SDK; Bun, Node, Deno all work"）。Node 20+ 即可（与 Mercury 现有 `package.json` engines 一致）
+- 若用户选 Bun（性能优化），按平台官方安装指南：`https://bun.sh/docs/installation`
+- 安装路径由用户选择；Mercury 不规定具体磁盘位置（Windows 用户按 Mercury 项目级 D 盘规则可装到非 C 盘，但 plugin 不依赖此规则）
 
 ### 9.2 claude.ai 订阅
 

--- a/.mercury/docs/research/phase5-sizing-2026-04-25.md
+++ b/.mercury/docs/research/phase5-sizing-2026-04-25.md
@@ -1,0 +1,275 @@
+# Phase 5 Notify Hub Sizing — Post-Routines Research
+
+> Status: **Decision doc (main-agent output, S73)** | Date: 2026-04-25 | Lane: `main`
+> Scope: Determine whether Claude Code Routines (2026-04-14 launch) shrinks Phase 5 MVP scope
+> Inputs: Issue #289 body + `phase4-5-circular-dep-breakpoint-2026-04-24.md` §3.B + WebFetch of `code.claude.com/docs/en/routines` + `platform.claude.com/docs/en/api/claude-code/routines-fire`
+> Out of scope: Claude Design (A-series scenarios); transport-vendor selection ADR (separate doc, needs user input)
+
+---
+
+## 1. Research Findings — Routines canonical reference
+
+WebFetch 2026-04-25 against official Anthropic docs confirms the following facts. Per Mercury MANDATORY RESEARCH PROTOCOL, all claims below are cited to the URLs fetched unless marked UNVERIFIED.
+
+### 1.1 Trigger surface
+
+| Trigger | Minimum cadence | Where configurable | Constraints |
+|---------|-----------------|--------------------|-|
+| Scheduled | 1 hour | CLI `/schedule` + web | Custom cron via `/schedule update`; < 1h rejected |
+| API (`/fire`) | No rate floor at request level | Web only (CLI cannot create/revoke tokens) | Per-routine bearer token `sk-ant-oat01-*`; fire-and-forget; no idempotency key |
+| GitHub event | Subject to per-routine + per-account hourly caps during preview | Web only | Events = Pull Request + Release **only** (no Issues, no push, no workflow_run) |
+
+**Combinable**: one routine can attach multiple triggers simultaneously.
+
+### 1.2 API `/fire` endpoint — critical behavioral detail
+
+```
+POST https://api.anthropic.com/v1/claude_code/routines/{routine_id}/fire
+Authorization: Bearer sk-ant-oat01-...
+anthropic-beta: experimental-cc-routine-2026-04-01
+anthropic-version: 2023-06-01
+Content-Type: application/json
+```
+
+Body:
+```json
+{"text": "freeform ≤65536 chars, NOT parsed as JSON"}
+```
+
+Response (200):
+```json
+{
+  "type": "routine_fire",
+  "claude_code_session_id": "session_...",
+  "claude_code_session_url": "https://claude.ai/code/session_..."
+}
+```
+
+**Key constraints** (quoted from platform.claude.com):
+
+- *"The request returns once the session is created. It does not stream session output or wait for the session to complete."* — **fire-and-forget**
+- *"Each successful request creates a new session. There is no idempotency key."* — retries duplicate work
+- `text` field is a literal string — JSON inside is not parsed, routine receives the raw characters
+- Errors: 400 (bad beta header / >65k chars / paused routine), 401 (bad token), 404 (no routine), 429 (rate limit; honors `Retry-After`), 503 (overloaded)
+
+### 1.3 GitHub trigger details
+
+- Event categories: **Pull Request + Release only** (confirmed from docs table)
+- PR filter fields: Author / Title / Body / Base branch / Head branch / Labels / Is draft / Is merged
+- Filter operators: equals / contains / starts with / is one of / is not one of / matches regex (regex tests **whole field**, needs `.*x.*` for substring)
+- *"Each matching GitHub event starts a new session. Session reuse across events is not available"*
+- Claude GitHub App must be installed on the repo (separate from `/web-setup`)
+
+### 1.4 Session runtime
+
+- Runs as **full Claude Code cloud session** — *"no permission-mode picker and no approval prompts during a run"*
+- Repositories cloned at start from **default branch** unless prompt says otherwise
+- Can run shell commands, use **skills committed to the cloned repository** (*"use [skills](/en/skills) committed to the cloned repository"*), call connectors
+- Identity is the account owner: *"commits and pull requests carry your GitHub user, and Slack messages, Linear tickets, or other connector actions use your linked accounts"*
+
+### 1.5 Push / branch scope
+
+- Default: push only to `claude/*` prefixed branches
+- Toggle: **"Allow unrestricted branch pushes"** per-repository in the routine config
+- Confirmed from docs: *"This prevents routines from accidentally modifying protected or long-lived branches. To remove this restriction for a specific repository, enable Allow unrestricted branch pushes for that repository."*
+
+### 1.6 Versioning / breaking-change policy
+
+*"Breaking changes ship behind new dated beta header versions, and the two previous header versions continue to work so that callers have time to migrate."*
+
+→ **2-version deprecation window**. Mercury can pin `experimental-cc-routine-2026-04-01` safely until the 3rd-forward version ships.
+
+### 1.7 Usage and quota
+
+- Pro 5 / Max 15 / Team-Enterprise 25 routine runs per account per day (each triggered run)
+- **One-off schedules are exempt from the daily cap** (draw from subscription usage only)
+- Each run draws standard subscription usage (same as interactive session)
+- Organizations with "extra usage" billing can overflow on metered overage
+
+### 1.8 Connectors / transport surface
+
+- All MCP connectors connected to the claude.ai account are included by default
+- Connectors available: Slack, Linear, Google Drive, etc. (MCP ecosystem)
+- **No native Telegram / ntfy / LINE / SMS transport** — only what MCP ecosystem provides
+- Environment variables supplied via the cloud environment config (separate primitive)
+
+### 1.9 Cloud environment primitive
+
+- Controls network access level, env vars (for secrets), setup script (cached)
+- Must be configured **before** creating the routine that uses it
+- Default environment provided
+
+### 1.10 Resolution of Issue #289 UNVERIFIED questions
+
+| # | Question | Resolution |
+|---|----------|------------|
+| Q1 | Claude Design automation API? | **UNVERIFIED still** — Routines docs do not cover Claude Design. Separate research needed when user pursues A-series scenarios. No blocker for Phase 5 sizing. |
+| Q2 | Routines honors `.claude/agents/*.md` + `.claude/skills/*/SKILL.md`? | **Skills: CONFIRMED** (*"use skills committed to the cloned repository"*). **Agents: UNVERIFIED** — not explicitly mentioned, but cloud runs are full Claude Code sessions so native CLI agent-loading should apply. Flag for Phase 2 PoC validation. |
+| Q3 | Research preview breaking-change rhythm? | **CONFIRMED stable** — 2-version deprecation window via dated beta headers. |
+| Q4 | `claude/*` branch restriction vs Mercury `feature/TASK-*`? | **CONFIRMED manageable** — per-repo toggle `Allow unrestricted branch pushes`. Enables Mercury convention without removing other safeguards. Decision: if Phase 2 PoC uses Routines on Mercury repo, flip the toggle on that repo only. |
+
+---
+
+## 2. Phase 5 Sizing Decision
+
+### 2.1 The sizing question (per S73 handoff step 4)
+
+> 若 Routines + GHA 已覆盖 70%+ "何时通知" 场景 → Phase 5 MVP 只做 "消息 outbound transport" 一层
+> 若 Routines 仅适 scheduled reminder，Phase 5 仍需 full MVP (trigger + transport + callback)
+
+### 2.2 Answer — **Phase 5 DOES NOT shrink**
+
+The premise hides a layer confusion. Restating the two orthogonal Phase 5 concerns:
+
+| Phase 5 concern | What it is | What Routines offers |
+|-----------------|-----------|----------------------|
+| **Trigger backend** ("when to notify") | Decide when to dispatch a cloud-side task | ✅ Scheduled + GitHub events + API |
+| **Outbound transport** ("how the notify reaches the human") | Push a message from Mercury's local process to user's IM/device | ❌ Only via MCP connectors; no Telegram/ntfy/LINE direct |
+| **Callback from cloud trigger** ("notify when the triggered task finishes") | Async completion handoff back to user | ❌ `/fire` is fire-and-forget, no webhook-back |
+
+#### Why Routines cannot collapse Phase 5 MVP
+
+1. **Routines is cloud-initiated. Mercury's biggest notify use case is local-session-initiated.** The three canonical Phase 5-3 consumers per EXECUTION-PLAN.md L355-357 are:
+   - Session Continuity session-switch notify → fires from **local Mercury session**
+   - Quality Gate stop-intercepted notify → fires from **local hooks**
+   - Dev Pipeline task-complete notify → fires from **local agent chain**
+
+   None of these originate from a Routines trigger. They need a Mercury-local process to call an outbound channel. Routines does not reach into local sessions.
+
+2. **`/fire` is fire-and-forget.** Mercury cannot "start Routines to do work AND have Routines notify user when done" without an outbound transport, because Routines provides no completion callback. The routine itself would have to push notification via connector → we're back to needing outbound transport inside the routine.
+
+3. **Connector coverage is narrow.** Routines' "transport" is the MCP connector set (Slack/Linear/GDrive). Mercury user's stated preference in prior sessions lean toward Telegram / self-hosted ntfy / LINE — none of which are first-class MCP connectors. Going Routines-only would force either:
+   - Accept Slack as the canonical Mercury channel (workflow change)
+   - Build an MCP connector for the preferred transport (a Phase 5 Notify Hub renamed)
+
+4. **#226 loop detector fires in `adapters/mercury-loop-detector/hook.cjs` (local process).** Phase 4-4 enhancement C3.b ("notify user when stall fires") happens on laptop, not in cloud. Routines is irrelevant to this specific caller.
+
+5. **Coverage math fails the 70% gate.** Of the canonical 3 Phase 5-3 consumers + 1 Phase 4-4 enhancement C3.b, Routines covers:
+   - 0/4 by replacing the outbound layer
+   - ~1/4 as trigger substitute (Dev Pipeline task-complete could theoretically be driven by a GitHub `pull_request.closed` trigger, but Mercury's current pr-flow skill already handles this case locally)
+
+#### What Routines IS good for (Phase 5 complementary scope)
+
+- **B3 nightly Issue triage** (recommended by #289 body) — pure cloud-cron scenario, no transport needed (result is a GitHub comment, not a push notification)
+- **B1 Argus parallel review** — GitHub trigger on `pull_request.opened`, output is PR comments (uses Claude GitHub App identity, not Mercury)
+- **B2 weekly KB lint** — scheduled, output is a GitHub Issue
+- Consuming `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` env var → irrelevant (runs in cloud, not local)
+
+**Pattern**: Routines fits when the "output" is a repo-surface artifact (Issue / PR / commit). It does not fit when the output is a push notification to the human.
+
+### 2.3 Revised Phase 5 MVP scope (updates `phase4-5-circular-dep-breakpoint-2026-04-24.md` §3.B)
+
+Keep Approach B (mount external Notify channel) as recommended, with clarifications:
+
+**IN scope (Phase 5 MVP):**
+- Outbound transport adapter (`adapters/mercury-notify/`) — ≤200 LOC
+- Interface: `notify(severity, title, body, [action_url])` → transport-specific ack
+- One transport choice from the candidate eval (ntfy / Apprise / Telegram / Channels-if-shipped)
+- Wire **one** caller: 4-3 B.3 fallback OR 4-4 enhancement C3.b (whichever is the easier existing consumer)
+- Secret management: env-var in `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json` per existing `MERCURY_MEM0_DISABLED` precedent
+
+**OUT of scope (Phase 5 MVP, defer to Phase 5-2 / 5-3):**
+- Second+ transport channel
+- Two-way confirm/reply mechanism (user replies to notify → agent reacts) — docs call this "远程确认" in DIRECTION.md §3 Module 3 — needs inbound webhook; not MVP
+- Routines-based trigger backend integration (separate follow-up)
+
+**Routines integration lane (separate issue, separate phase):**
+- A new sub-module "Trigger Backend Adapters" can consume Routines as one of its backends alongside NAS cron + GHA + in-process hooks
+- Not in Phase 5 MVP; folded into Phase 5-3 or a Phase 5.5 follow-up
+- Recommended PoC start: **B3 nightly Issue triage** per #289 body — low risk, cloud-only, does not need Phase 5 transport
+
+### 2.4 Circular-dependency status
+
+Per `phase4-5-circular-dep-breakpoint-2026-04-24.md` — the cycle was declarative only. S72 shipped Approach A (Phase 4-4 enhancements A+B) via PR #291. Phase 4 core is now complete per EXECUTION-PLAN.md L334. Phase 5 MVP can proceed independently.
+
+With S73's sizing decision: Phase 5 MVP remains Approach B (mount external transport). No EXECUTION-PLAN structural change needed — only wording clarification in L342 (`可用开发模式: 全部 Phase 1-4 能力`) is already satisfied by Phase 4 completion.
+
+---
+
+## 3. Transport Candidate ADR Skeleton (3 open questions for user)
+
+The `phase4-5-circular-dep-breakpoint-2026-04-24.md` §3.B candidate list holds. Decision deferred pending user input on three questions:
+
+### Q1. Privacy posture — public vs authenticated transport?
+
+| Option | Example | Pro | Con |
+|--------|---------|-----|-----|
+| Public topic | ntfy.sh `/topic-xxxxx` | Zero secret; URL-share = subscribe | Anyone with URL can read |
+| Authenticated | Telegram bot + chat_id | Private by design | Bot token + recipient id must be stored |
+| Self-host | ntfy on AgentVol01 | Full control | Infra overhead; NAS must be reachable from local |
+
+**TBD**: user's stated privacy bar for stall reports + handoff notifications.
+
+### Q2. Secret storage location?
+
+| Option | Precedent | Risk |
+|--------|-----------|------|
+| `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json` env block | `MERCURY_MEM0_DISABLED` | Readable by any local process under user account |
+| OS keychain (Windows Credential Manager / macOS Keychain) | — | Extra platform code |
+| Separate `.env` file in repo root (gitignored) | — | Easy to leak if gitignore forgotten |
+
+**TBD**: user preference between convenience and isolation.
+
+### Q3. Diagnostic payload — where does the stall-report JSON go in the notify?
+
+Options:
+1. **Inline in notify body** — full JSON in message (can be long; may truncate)
+2. **Link to local file path** — notify carries `file:///.../.mercury/state/stall-reports/<id>.json`; user reads on same machine
+3. **Upload to gist / ntfy attachment / Telegram document** — accessible off-device; adds transport complexity
+4. **Summary only in notify + full JSON retained locally** — compromise
+
+**TBD**: user workflow — mobile-first (needs #3 or #4) vs same-machine (#2 is enough).
+
+---
+
+## 4. Recommended Next Actions
+
+### S73 closure (this session)
+
+1. ✅ Write this doc
+2. ⏳ Post summary comment to Issue #289 with Phase 5 sizing verdict + UNVERIFIED resolutions
+3. ⏳ **No EXECUTION-PLAN structural edit** — current L337-362 Phase 5 structure holds; the three open questions become transport-ADR prerequisites
+4. ⏳ **Keep #289 OPEN** as watch tracker (original stance); update next-check triggers to reflect what we learned
+5. ⏳ Handoff to S74 with Phase 5 MVP kickoff gated on user answering the 3 open questions
+
+### S74+ (Phase 5 MVP kickoff, user decision gate)
+
+1. User answers Q1-Q3 above (privacy / secret / payload)
+2. Main agent dispatches research sub-agent (Mode C) to eval 4 transport candidates against 5-criteria rubric
+3. Research outputs ADR; user confirms choice
+4. Dev sub-agent (Mode D) implements `adapters/mercury-notify/` + wire one caller
+5. Dual-verify + pr-flow
+
+### S75+ (Routines integration, separate track)
+
+- File new Issue "PoC: Routines nightly Issue triage" (B3 per #289)
+- Requires no Phase 5 MVP — independent track
+- Validates Q2 (agents support) + Q4 (branch restriction) at real cost
+
+---
+
+## 5. Appendix — What this doc does NOT do
+
+- Does not edit `.mercury/docs/EXECUTION-PLAN.md` — no structural change needed per §2.4
+- Does not pre-select transport candidate — waits on 3 user open questions
+- Does not cover Claude Design (A-series scenarios) — separate research when user pursues automation API
+- Does not create branches / PRs — design doc only; S73 handoff step 6 conditional on Phase 5 shrinking, which we determined does NOT happen
+
+---
+
+## 6. Sources
+
+**Primary (fetched 2026-04-25 via WebFetch):**
+- [Automate work with routines](https://code.claude.com/docs/en/routines) — full capability reference
+- [Trigger a routine via API](https://platform.claude.com/docs/en/api/claude-code/routines-fire) — endpoint + errors + idempotency
+
+**Project context:**
+- Issue #289 body (<https://github.com/392fyc/Mercury/issues/289>)
+- `.mercury/docs/research/phase4-5-circular-dep-breakpoint-2026-04-24.md` §3.B (S72 design)
+- `.mercury/docs/EXECUTION-PLAN.md` L337-362 (Phase 5 structure)
+- `.mercury/docs/DIRECTION.md` §3 Module 3 (Notify Hub rationale)
+
+**Related (not fetched this session, for reader follow-up):**
+- [Claude Code on the web — cloud environment](https://code.claude.com/docs/en/claude-code-on-the-web)
+- [MCP connectors](https://code.claude.com/docs/en/mcp)
+- [Beta headers policy](https://docs.claude.com/en/api/beta-headers)

--- a/.mercury/docs/research/router-llm-backend-2026-04-25.md
+++ b/.mercury/docs/research/router-llm-backend-2026-04-25.md
@@ -1,0 +1,168 @@
+# Mercury Router LLM 后端候选 — Codex vs Claude API vs No-LLM
+
+> Status: research output | Date: 2026-04-25 | Lane: main
+> Scope: 是否用 Codex CLI 替代 Claude API 作 Mercury Telegram router 的轻推理后端
+> Author: research subagent (ac40257a) + main synthesis
+
+---
+
+## 1. Codex CLI 当前能力
+
+### Q1. Headless / Programmatic 调用接口
+
+**当前版本**：0.125.0（2026-04-24 发布，npm 包名 `@openai/codex`）
+
+**Headless 调用**：`codex exec` 子命令
+
+| Flag | 作用 |
+|------|------|
+| `codex exec "<prompt>"` | 非交互执行 |
+| `--json` | JSONL 事件流 |
+| `--output-last-message <file>` | 写最终消息 |
+| `--output-schema <schema.json>` | 强制 JSON Schema 输出 |
+| `--model <name>` | 指定模型 |
+| `--ephemeral` | 不持久化 session |
+
+**模型可选**：gpt-5.5 / gpt-5.4 / gpt-5.4-mini / gpt-5.3-codex
+
+### Q2. 订阅 vs API Key 计费
+
+**关键发现**：用户当前 `~/.codex/auth.json` 显示 `"auth_mode": "apikey"`，**不是 ChatGPT 订阅登录**。
+
+| 模式 | 计费 | 限额 |
+|------|------|------|
+| ChatGPT 订阅登录 | 含在订阅 | Plus 15-80条/5h；Pro 5x 80-400条；Pro 20x 300-1600条 |
+| API Key（当前） | 按 token 计费 | 无额度限制 |
+
+切换需 `codex auth login` 重新认证。
+
+### Q3. 调用延迟
+
+**社区报告汇总**（无官方 benchmark）：
+
+- 进程启动 ~500ms
+- CLI 初始化（含后台插件发现）1-3s
+- API roundtrip（gpt-5.4-mini）~500ms-1s
+- **总计**：最乐观 2-4s，普通 5-10s
+
+对比 Claude API direct（HTTP）：~0.5-1.5s。
+
+### Q4. JSON 输出可靠性
+
+`--output-schema` 官方支持 JSON Schema 强制结构化输出。但通过进程 stdout 解析有 encoding/partial output 脆弱点。实际可靠性 UNVERIFIED。
+
+### Q5. Windows 兼容性
+
+- Windows 10 1809+ 支持，11 推荐
+- **MSYS2 bash 冲突已知问题**（Discussion #3580）
+- **PowerShell 5.1 默认 ANSI encoding，中文乱码风险**（社区 confirmed）
+- 修复：`[Console]::OutputEncoding = UTF-8` 或 PowerShell 7+
+
+---
+
+## 2. Mercury 现有 Codex 集成
+
+| 文件 | 角色 |
+|------|------|
+| `D:\Mercury\Mercury\.codex\config.toml` | 全局 `developer_instructions` 14 条强制规则 |
+| `scripts\codex\guard.ps1` | branch / commit / push 守卫 |
+| `.claude/skills/dual-verify/SKILL.md` | Codex 通过 `subagent_type: codex:codex-rescue` 调用，不是 shell exec |
+
+**用户 auth**：`~/.codex/auth.json` `auth_mode: apikey`，session 历史从 2026-02 起活跃。
+
+---
+
+## 3. 决策矩阵
+
+| 维度 | Codex CLI (`codex exec`) | Claude API direct (Haiku 3.5) | OpenAI API direct (gpt-4o-mini) | No-LLM (deterministic) |
+|------|--------------------------|-------------------------------|--------------------------------|------------------------|
+| 计费 | API key per-token / 订阅 | per-token (~$0.00025/call) | per-token (~$0.0002/call) / 订阅 | $0 |
+| 延迟 | 5-10s | 0.5-1.5s | 0.5-1s | <50ms |
+| JSON 可靠性 | 中（schema 但 stdout 脆） | 高（tool_choice/JSON mode） | 高（response_format: json_schema） | N/A |
+| Windows 兼容 | 已知坑（encoding/MSYS2） | 无（HTTP only） | 无（HTTP only） | 无 |
+| Mercury 集成 | 中（要重构 codex 调用） | 低（@anthropic-ai/sdk 成熟） | 低（openai npm 成熟） | 零 |
+| Per-call system prompt | 不支持 | 支持 | 支持 | N/A |
+
+---
+
+## 4. 关键反思 — Router MVP 是否真的需要 LLM
+
+研究发起时假设 router 需要 LLM 做"自然语言意图解析"。重新审视用户已 confirm 的 P0#3 路由方案：
+
+**用户 P0#3 设计**：
+- 加前缀 `@<label>` → 显式路由
+- 不加前缀 → 默认最近 active
+- `/status` / `/list` 命令 → 返回 session 概览
+- `/cancel` / `/continue` → 路由到目标 session
+
+这些**全部是 deterministic 的**：
+- 前缀解析：regex `^@([\w-]+)\s+(.+)$`
+- 命令解析：regex `^/(\w+)`
+- "最近 active"判定：router 自己维护 ownership 时间戳
+
+**router MVP 不需要 LLM**。
+
+LLM 推理才有用的场景（**非 MVP**）：
+- 用户发口语化自由文本"把刚才那个任务取消" → 解析意图为 `/cancel main`
+- 但这场景在 MVP 阶段可以让用户**自己加前缀**避免
+
+---
+
+## 5. 推荐
+
+### MVP（Phase 5-2 第一版）
+
+**纯 deterministic router，0 LLM 调用**。
+
+- 前缀 + 命令解析全部 regex
+- LOC 占用 ~80-120
+- 零运行成本
+- 零跨平台风险（不调任何外部 LLM CLI/API）
+
+### 未来（Phase 5-3+）扩展自然语言意图解析时
+
+**用 OpenAI API direct（gpt-4o-mini 或 gpt-5.4-mini）**，不要走 Codex CLI 壳：
+
+- 绕过 5-10s 进程启动开销
+- 当前已有 `OPENAI_API_KEY`，零配置
+- 支持 `response_format: {type: "json_schema"}`
+- 若想用订阅免 token：切到 ChatGPT 订阅登录后再调（但 OpenAI Messages API 不在订阅范围，仅 Codex CLI 在）
+
+### Codex CLI 保留现有用途
+
+- dual-verify code audit（subagent 模式，延迟不敏感）
+- 不引入 router runtime 路径
+
+---
+
+## 6. Sources
+
+**WebFetch 2026-04-25：**
+- [Command line options — Codex CLI](https://developers.openai.com/codex/cli/reference)
+- [Non-interactive mode — Codex](https://developers.openai.com/codex/noninteractive)
+- [SDK — Codex](https://developers.openai.com/codex/sdk)
+- [Models — Codex](https://developers.openai.com/codex/models)
+- [Pricing — Codex](https://developers.openai.com/codex/pricing)
+- [Windows — Codex](https://developers.openai.com/codex/windows)
+- [MSYS2 Bash Discussion #3580](https://github.com/openai/codex/discussions/3580)
+
+**WebSearch + 社区源：**
+- [ChatGPT plan Codex usage](https://help.openai.com/en/articles/11369540-using-codex-with-your-chatgpt-plan)
+- [Codex usage limits 2026](https://blog.laozhang.ai/en/posts/openai-codex-usage-limits)
+- [Codex CLI lag #18663](https://github.com/openai/codex/issues/18663)
+- [Codex CLI slow startup #9290](https://github.com/openai/codex/issues/9290)
+- [PowerShell 5.1 ANSI encoding bug](https://community.openai.com/t/incorrect-cyrillic-rendering-in-codex-agent-on-windows-due-to-powershell-5-1-default-ansi-encoding/1356123)
+
+**项目文件：**
+- `D:\Mercury\Mercury\.codex\config.toml`
+- `C:\Users\392fy\.codex\auth.json`
+- `.claude/skills/dual-verify/SKILL.md`
+
+---
+
+## 7. 对 Issue #293 / ADR 的影响
+
+- ADR 重写时 router 章节明确"MVP 0 LLM"
+- LOC 估算：router ~80-120（无 LLM 调用栈）
+- 未来扩展位置标注：`adapters/mercury-channel-router/intent-parser.cjs`（Phase 5-3 加）
+- 用户的 OpenAI 订阅在 router 工作中**用不上**——保留给 dual-verify 这种延迟不敏感任务

--- a/.mercury/state/upstream-manifest.json
+++ b/.mercury/state/upstream-manifest.json
@@ -191,4 +191,41 @@
     "import_rationale": "Game-dev A→B→C subagent chain stage 3 (adversarial validation) for SoT production trial (Issue #281)",
     "last_drift_check": null
   }
+,
+  {
+    "path": "adapters/mercury-channel-router/UPSTREAM.md",
+    "scope": "project",
+    "upstream_repo": "REFERENCES_ONLY",
+    "upstream_path": null,
+    "upstream_sha_at_import": null,
+    "upstream_license": "n/a (no code copied)",
+    "import_pr": null,
+    "import_date": "2026-04-25",
+    "import_rationale": "Reference-only adapter inspired by Anthropic Channels reference + openclaw + node-telegram-bot-api. No code cherry-picked.",
+    "last_drift_check": null
+  },
+  {
+    "path": "adapters/mercury-channel-client/UPSTREAM.md",
+    "scope": "project",
+    "upstream_repo": "REFERENCES_ONLY",
+    "upstream_path": null,
+    "upstream_sha_at_import": null,
+    "upstream_license": "n/a (no code copied)",
+    "import_pr": null,
+    "import_date": "2026-04-25",
+    "import_rationale": "Reference-only adapter inspired by Anthropic Channels reference walkthrough + @modelcontextprotocol/sdk. No code cherry-picked.",
+    "last_drift_check": null
+  },
+  {
+    "path": "adapters/mercury-notify/UPSTREAM.md",
+    "scope": "project",
+    "upstream_repo": "REFERENCES_ONLY",
+    "upstream_path": null,
+    "upstream_sha_at_import": null,
+    "upstream_license": "n/a (no code copied)",
+    "import_pr": null,
+    "import_date": "2026-04-25",
+    "import_rationale": "Original implementation. No upstream references — thin HTTP client wrapping fetch().",
+    "last_drift_check": null
+  }
 ]

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -12,6 +12,16 @@ adapters/
     UPSTREAM.md         # 上游版本记录、已知不兼容项
 ```
 
+## Adapters
+
+| Adapter | Description |
+|---------|-------------|
+| `mercury-loop-detector/` | PostToolUse hook detecting stall/loop patterns in Claude sessions |
+| `mercury-test-gate/` | PreToolUse hook enforcing test passage before destructive writes |
+| `mercury-channel-router/` | Telegram bot router (long-lived process per machine); IPC hub for all sessions |
+| `mercury-channel-client/` | MCP channel server (one per Claude Code session); bridges session to router |
+| `mercury-notify/` | Thin HTTP client for hook scripts to notify via router (fire-and-forget) |
+
 ## 约束
 
 - 适配层不超过 200 行。超过说明耦合过深，需重新评估挂载方式。

--- a/adapters/mercury-channel-client/README.md
+++ b/adapters/mercury-channel-client/README.md
@@ -1,0 +1,73 @@
+# mercury-channel-client
+
+MCP channel server — one instance per Claude Code session, bridging the session to `mercury-channel-router`.
+
+## Role
+
+- Spawned by Claude Code via `.mcp.json` when the session starts with `--dangerously-load-development-channels`.
+- Detects if the router is running; spawns it if not.
+- Registers the current session with the router (branch name, project path, pid).
+- Opens an SSE stream to receive inbound Telegram messages and forwards them as `notifications/claude/channel`.
+- Exposes a `reply` MCP tool so Claude can send messages back to Telegram.
+- Deregisters on session exit.
+
+## Startup
+
+Claude Code loads this automatically via `.mcp.json` at the project root. No manual start needed.
+
+Launch Claude Code with channels enabled:
+
+```bash
+claude --dangerously-load-development-channels server:mercury-telegram
+```
+
+## Environment Variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `MERCURY_ROUTER_PORT` | No | IPC port (default: 8788) |
+| `CLAUDE_SESSION_ID` | Auto | Set by Claude Code; used as session identity |
+| `CLAUDE_PROJECT_DIR` | Auto | Set by Claude Code; used for label derivation |
+
+## User Setup
+
+1. Ensure `.mcp.json` exists at the project root (already committed).
+2. Add bot token and allowed user IDs to `~/.claude/settings.json`:
+
+```json
+{
+  "env": {
+    "MERCURY_TELEGRAM_BOT_TOKEN": "your-bot-token",
+    "MERCURY_TELEGRAM_ALLOWED_USER_IDS": "your-telegram-user-id"
+  }
+}
+```
+
+3. Launch with:
+
+```bash
+claude --dangerously-load-development-channels server:mercury-telegram
+```
+
+## MCP Tool: reply
+
+```json
+{
+  "name": "reply",
+  "description": "Send a reply to Telegram via the channel router.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "chat_id": { "type": "number" },
+      "text":    { "type": "string" }
+    },
+    "required": ["chat_id", "text"]
+  }
+}
+```
+
+## Notes
+
+- Bun is optional — Node 18+ works fine.
+- Requires `@modelcontextprotocol/sdk` (installed via pnpm at project root).
+- Session limit is 3; if the router returns 429, the client logs a warning and Claude Code continues without Telegram.

--- a/adapters/mercury-channel-client/README.md
+++ b/adapters/mercury-channel-client/README.md
@@ -2,6 +2,8 @@
 
 MCP channel server — one instance per Claude Code session, bridging the session to `mercury-channel-router`.
 
+> **PREREQUISITE**: Claude Code MUST be launched from the **project root directory** for `.mcp.json` relative paths to resolve correctly. Launching from a subdirectory will fail to load this adapter.
+
 ## Role
 
 - Spawned by Claude Code via `.mcp.json` when the session starts with `--dangerously-load-development-channels`.

--- a/adapters/mercury-channel-client/UPSTREAM.md
+++ b/adapters/mercury-channel-client/UPSTREAM.md
@@ -1,0 +1,24 @@
+# UPSTREAM — mercury-channel-client
+
+## Origin
+
+Original implementation. No code cherry-picked from external projects.
+
+## References (inspiration only, no code copied)
+
+- **Anthropic Channels reference** — MCP notification protocol, reply tool schema, permission relay,
+  `notifications/claude/channel` format:
+  `https://code.claude.com/docs/en/channels-reference`
+- **Anthropic Channels walkthrough** — session lifecycle, `--dangerously-load-development-channels` flag:
+  `https://code.claude.com/docs/en/channels`
+- **@modelcontextprotocol/sdk** — MCP server scaffolding:
+  `https://github.com/modelcontextprotocol/typescript-sdk` (MIT)
+
+## Dependencies
+
+- `@modelcontextprotocol/sdk` ^1.29.0 (MIT) — MCP server + stdio transport
+- Node built-ins: `child_process`, `path`
+
+## License
+
+MIT (Mercury project).

--- a/adapters/mercury-channel-client/channel.cjs
+++ b/adapters/mercury-channel-client/channel.cjs
@@ -18,6 +18,7 @@ const PORT       = Number(process.env.MERCURY_ROUTER_PORT) || 8788;
 const ROUTER_CJS = path.join(__dirname, '..', 'mercury-channel-router', 'router.cjs');
 const TOKEN_FILE = path.join(os.homedir(), '.mercury', 'router.token');
 const TAG        = '[mercury-channel-client]';
+const xmlEsc = s => String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&apos;');
 
 // ── Session identity ──────────────────────────────────────────────────────────
 const SESSION_ID = process.env.CLAUDE_SESSION_ID || `cc-${process.pid}-${Date.now().toString(36)}`;
@@ -74,6 +75,7 @@ async function register() {
     body: JSON.stringify({ session_id: SESSION_ID, project_path: PROJECT_PATH, branch, pid: process.pid, short_id: SESSION_SHORT }),
   });
   if (res.status === 429) { process.stderr.write(`${TAG} session limit reached; Telegram inactive\n`); return false; }
+  if (!res.ok) { process.stderr.write(`${TAG} register failed: HTTP ${res.status}\n`); return false; }
   return true;
 }
 
@@ -173,7 +175,7 @@ async function connectInbox() {
                 params: {
                   source: 'mercury-telegram',
                   label: SESSION_ID,
-                  content: `<channel source="mercury-telegram" chat_id="${evt.from_chat}">${evt.content}</channel>`,
+                  content: `<channel source="mercury-telegram" chat_id="${String(evt.from_chat).replace(/[^0-9-]/g,'')}">${xmlEsc(evt.content)}</channel>`,
                 },
               });
             } else if (evt.type === 'verdict') {

--- a/adapters/mercury-channel-client/channel.cjs
+++ b/adapters/mercury-channel-client/channel.cjs
@@ -183,6 +183,12 @@ async function connectInbox() {
                 method: 'notifications/claude/channel/permission',
                 params: { verdict: evt.verdict, request_id: evt.request_id },
               });
+            } else if (evt.type === 'command') {
+              await mcp.notification({
+                method: 'notifications/claude/channel',
+                params: { source: 'mercury-telegram', label: SESSION_ID,
+                  content: `<channel source="mercury-telegram" chat_id="${String(evt.from_chat).replace(/[^0-9-]/g,'')}" cmd="${xmlEsc(evt.cmd)}">${xmlEsc(evt.cmd)} requested by user</channel>` },
+              });
             }
           } catch {}
         }

--- a/adapters/mercury-channel-client/channel.cjs
+++ b/adapters/mercury-channel-client/channel.cjs
@@ -9,11 +9,14 @@ const { Server } = require('@modelcontextprotocol/sdk/server/index.js');
 const { StdioServerTransport } = require('@modelcontextprotocol/sdk/server/stdio.js');
 const { CallToolRequestSchema, ListToolsRequestSchema } = require('@modelcontextprotocol/sdk/types.js');
 const crypto = require('crypto');
-const path = require('path');
+const path   = require('path');
+const fs     = require('fs');
+const os     = require('os');
 const { execSync } = require('child_process');
 
 const PORT       = Number(process.env.MERCURY_ROUTER_PORT) || 8788;
 const ROUTER_CJS = path.join(__dirname, '..', 'mercury-channel-router', 'router.cjs');
+const TOKEN_FILE = path.join(os.homedir(), '.mercury', 'router.token');
 const TAG        = '[mercury-channel-client]';
 
 // ── Session identity ──────────────────────────────────────────────────────────
@@ -25,10 +28,30 @@ const PROJECT_PATH  = process.env.CLAUDE_PROJECT_DIR || process.cwd();
 // ADR §7.6: 6-char prefix = first 6 hex chars of sha1(SESSION_ID)
 const SESSION_SHORT = crypto.createHash('sha1').update(SESSION_ID).digest('hex').slice(0,6);
 
+// ── IPC token reader (with retry for router startup race) ────────────────────
+async function readToken(retries = 5, delayMs = 200) {
+  for (let i = 0; i < retries; i++) {
+    try { return fs.readFileSync(TOKEN_FILE, 'utf8').trim(); } catch {}
+    if (i < retries - 1) await new Promise(r => setTimeout(r, delayMs));
+  }
+  return null;
+}
+
+// token cache — resolved once after router starts
+let _token = null;
+async function getToken() {
+  if (_token) return _token;
+  _token = await readToken();
+  return _token;
+}
+
 // ── Router IPC helpers ────────────────────────────────────────────────────────
 async function routerFetch(path_, opts = {}) {
   const url = `http://127.0.0.1:${PORT}${path_}`;
-  return fetch(url, { signal: AbortSignal.timeout(3000), ...opts });
+  const token = await getToken();
+  const headers = { ...(opts.headers || {}) };
+  if (token) headers['Authorization'] = `Bearer ${token}`;
+  return fetch(url, { signal: AbortSignal.timeout(3000), ...opts, headers });
 }
 
 async function ensureRouter() {
@@ -125,9 +148,10 @@ let sseActive = true;
 async function connectInbox() {
   while (sseActive) {
     try {
-      const res = await fetch(`http://127.0.0.1:${PORT}/inbox/${SESSION_ID}`, {
-        signal: AbortSignal.timeout(60000),
-      });
+      const token = await getToken();
+      const headers = token ? { Authorization: `Bearer ${token}` } : {};
+      // no AbortSignal timeout: SSE is indefinite-lived; reconnect only on real disconnect
+      const res = await fetch(`http://127.0.0.1:${PORT}/inbox/${SESSION_ID}`, { headers });
       if (!res.ok || !res.body) { await new Promise(r => setTimeout(r, 2000)); continue; }
       const reader = res.body.getReader();
       const dec    = new TextDecoder();
@@ -178,12 +202,17 @@ async function shutdown() {
 }
 process.on('SIGTERM', shutdown);
 process.on('SIGINT',  shutdown);
-process.on('exit',    () => { try { require('child_process').execSync(`node -e "require('node:http').request({hostname:'127.0.0.1',port:${PORT},path:'/register/${SESSION_ID}',method:'DELETE'}).end()"`, { timeout: 2000 }); } catch {} });
+// Fix H3: removed unsafe process.on('exit') execSync with string-interpolated shell command.
+// SIGTERM/SIGINT + beforeExit cover all normal exit paths without shell injection risk.
+process.on('beforeExit', async () => { await deregister(); });
 
 // ── Main ──────────────────────────────────────────────────────────────────────
 (async () => {
   try {
     await ensureRouter();
+    // read token after router is up (router writes token file on listen success)
+    _token = await readToken(10, 300);
+    if (!_token) process.stderr.write(`${TAG} WARNING: could not read router token; IPC calls will be unauthenticated\n`);
     const registered = await register();
     if (registered) connectInbox().catch(e => process.stderr.write(`${TAG} inbox error: ${e.message}\n`));
   } catch (e) {

--- a/adapters/mercury-channel-client/channel.cjs
+++ b/adapters/mercury-channel-client/channel.cjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+'use strict';
+
+// Mercury Channel Client — MCP server bridging Claude Code sessions to the channel router.
+// Loaded by Claude Code via .mcp.json; one instance per session.
+
+const { spawn }  = require('child_process');
+const { Server } = require('@modelcontextprotocol/sdk/server/index.js');
+const { StdioServerTransport } = require('@modelcontextprotocol/sdk/server/stdio.js');
+const { CallToolRequestSchema, ListToolsRequestSchema } = require('@modelcontextprotocol/sdk/types.js');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const PORT       = Number(process.env.MERCURY_ROUTER_PORT) || 8788;
+const ROUTER_CJS = path.join(__dirname, '..', 'mercury-channel-router', 'router.cjs');
+const TAG        = '[mercury-channel-client]';
+
+// ── Session identity ──────────────────────────────────────────────────────────
+const SESSION_ID = process.env.CLAUDE_SESSION_ID || `cc-${process.pid}-${Date.now().toString(36)}`;
+let   branch     = 'unknown';
+try { branch = execSync('git branch --show-current', { encoding: 'utf8', stdio: ['pipe','pipe','pipe'] }).trim(); } catch {}
+
+const PROJECT_PATH = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+
+// ── Router IPC helpers ────────────────────────────────────────────────────────
+async function routerFetch(path_, opts = {}) {
+  const url = `http://127.0.0.1:${PORT}${path_}`;
+  return fetch(url, { signal: AbortSignal.timeout(3000), ...opts });
+}
+
+async function ensureRouter() {
+  try {
+    const r = await fetch(`http://127.0.0.1:${PORT}/health`, { signal: AbortSignal.timeout(500) });
+    if (r.ok) return;
+  } catch {}
+  spawn('node', [ROUTER_CJS], { detached: true, stdio: 'ignore', windowsHide: true }).unref();
+  for (let i = 0; i < 20; i++) {
+    await new Promise(r => setTimeout(r, 250));
+    try { const r = await fetch(`http://127.0.0.1:${PORT}/health`); if (r.ok) return; } catch {}
+  }
+  throw new Error('router did not start within 5s');
+}
+
+async function register() {
+  const res = await routerFetch('/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ session_id: SESSION_ID, project_path: PROJECT_PATH, branch, pid: process.pid }),
+  });
+  if (res.status === 429) { process.stderr.write(`${TAG} session limit reached; Telegram inactive\n`); return false; }
+  return true;
+}
+
+async function deregister() {
+  try { await routerFetch(`/register/${SESSION_ID}`, { method: 'DELETE' }); } catch {}
+}
+
+// ── MCP server ────────────────────────────────────────────────────────────────
+const mcp = new Server(
+  { name: 'mercury-telegram', version: '0.1.0' },
+  {
+    capabilities: {
+      experimental: { 'claude/channel': {}, 'claude/channel/permission': {} },
+      tools: {},
+    },
+    instructions:
+      'Telegram messages arrive as <channel source="mercury-telegram" label="..."> tags. ' +
+      'Use the reply tool to respond, passing chat_id from the tag.',
+  }
+);
+
+// ── Tool: reply ───────────────────────────────────────────────────────────────
+mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: [{
+    name: 'reply',
+    description: 'Send a reply to Telegram via the channel router.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        chat_id: { type: 'number', description: 'Telegram chat_id from the channel tag' },
+        text:    { type: 'string', description: 'Message text (HTML allowed)' },
+      },
+      required: ['chat_id', 'text'],
+    },
+  }],
+}));
+
+mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
+  if (req.params.name !== 'reply') throw new Error(`Unknown tool: ${req.params.name}`);
+  const { chat_id, text } = req.params.arguments || {};
+  try {
+    await routerFetch('/reply', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ chat_id, text, session_id: SESSION_ID }),
+    });
+    // take ownership after responding
+    routerFetch(`/take-ownership/${SESSION_ID}`, { method: 'POST' }).catch(() => {});
+    return { content: [{ type: 'text', text: 'reply sent' }] };
+  } catch (e) {
+    return { content: [{ type: 'text', text: `reply failed: ${e.message}` }], isError: true };
+  }
+});
+
+// ── SSE inbox consumer ────────────────────────────────────────────────────────
+let sseActive = true;
+
+async function connectInbox() {
+  while (sseActive) {
+    try {
+      const res = await fetch(`http://127.0.0.1:${PORT}/inbox/${SESSION_ID}`, {
+        signal: AbortSignal.timeout(60000),
+      });
+      if (!res.ok || !res.body) { await new Promise(r => setTimeout(r, 2000)); continue; }
+      const reader = res.body.getReader();
+      const dec    = new TextDecoder();
+      let   buf    = '';
+      while (sseActive) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buf += dec.decode(value, { stream: true });
+        const parts = buf.split('\n\n');
+        buf = parts.pop();
+        for (const part of parts) {
+          const line = part.split('\n').find(l => l.startsWith('data:'));
+          if (!line) continue;
+          try {
+            const evt = JSON.parse(line.slice(5).trim());
+            if (evt.type === 'message') {
+              await mcp.notification({
+                method: 'notifications/claude/channel',
+                params: {
+                  source: 'mercury-telegram',
+                  label: SESSION_ID,
+                  content: `<channel source="mercury-telegram" chat_id="${evt.from_chat}">${evt.content}</channel>`,
+                },
+              });
+            } else if (evt.type === 'verdict') {
+              await mcp.notification({
+                method: 'notifications/claude/channel/permission',
+                params: { verdict: evt.verdict, request_id: evt.request_id },
+              });
+            }
+          } catch {}
+        }
+      }
+    } catch {
+      if (!sseActive) break;
+      // reconnect: re-ensure router then retry
+      try { await ensureRouter(); } catch {}
+      await new Promise(r => setTimeout(r, 2000));
+    }
+  }
+}
+
+// ── Graceful exit ─────────────────────────────────────────────────────────────
+async function shutdown() {
+  sseActive = false;
+  await deregister();
+  process.exit(0);
+}
+process.on('SIGTERM', shutdown);
+process.on('SIGINT',  shutdown);
+process.on('exit',    () => { try { require('child_process').execSync(`node -e "require('node:http').request({hostname:'127.0.0.1',port:${PORT},path:'/register/${SESSION_ID}',method:'DELETE'}).end()"`, { timeout: 2000 }); } catch {} });
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+(async () => {
+  try {
+    await ensureRouter();
+    const registered = await register();
+    if (registered) connectInbox().catch(e => process.stderr.write(`${TAG} inbox error: ${e.message}\n`));
+  } catch (e) {
+    process.stderr.write(`${TAG} startup error: ${e.message}\n`);
+  }
+  const transport = new StdioServerTransport();
+  await mcp.connect(transport);
+})();

--- a/adapters/mercury-channel-client/channel.cjs
+++ b/adapters/mercury-channel-client/channel.cjs
@@ -8,6 +8,7 @@ const { spawn }  = require('child_process');
 const { Server } = require('@modelcontextprotocol/sdk/server/index.js');
 const { StdioServerTransport } = require('@modelcontextprotocol/sdk/server/stdio.js');
 const { CallToolRequestSchema, ListToolsRequestSchema } = require('@modelcontextprotocol/sdk/types.js');
+const crypto = require('crypto');
 const path = require('path');
 const { execSync } = require('child_process');
 
@@ -20,7 +21,9 @@ const SESSION_ID = process.env.CLAUDE_SESSION_ID || `cc-${process.pid}-${Date.no
 let   branch     = 'unknown';
 try { branch = execSync('git branch --show-current', { encoding: 'utf8', stdio: ['pipe','pipe','pipe'] }).trim(); } catch {}
 
-const PROJECT_PATH = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+const PROJECT_PATH  = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+// ADR §7.6: 6-char prefix = first 6 hex chars of sha1(SESSION_ID)
+const SESSION_SHORT = crypto.createHash('sha1').update(SESSION_ID).digest('hex').slice(0,6);
 
 // ── Router IPC helpers ────────────────────────────────────────────────────────
 async function routerFetch(path_, opts = {}) {
@@ -45,7 +48,7 @@ async function register() {
   const res = await routerFetch('/register', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ session_id: SESSION_ID, project_path: PROJECT_PATH, branch, pid: process.pid }),
+    body: JSON.stringify({ session_id: SESSION_ID, project_path: PROJECT_PATH, branch, pid: process.pid, short_id: SESSION_SHORT }),
   });
   if (res.status === 429) { process.stderr.write(`${TAG} session limit reached; Telegram inactive\n`); return false; }
   return true;
@@ -101,6 +104,20 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
     return { content: [{ type: 'text', text: `reply failed: ${e.message}` }], isError: true };
   }
 });
+
+// ── Outbound permission_request relay (ADR §5.2 step 6 + §7.6) ───────────────
+mcp.fallbackNotificationHandler = async (notification) => {
+  if (notification.method !== 'notifications/claude/channel/permission_request') return;
+  const { tool_name = '', description = '', input_preview = '', request_id = '' } = notification.params || {};
+  const prefixed = `${SESSION_SHORT}-${request_id}`;
+  try {
+    await routerFetch('/permission-request', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ session_id: SESSION_ID, tool_name, description, input_preview, prefixed_request_id: prefixed }),
+    });
+  } catch (e) { process.stderr.write(`${TAG} permission-request relay failed: ${e.message}\n`); }
+};
 
 // ── SSE inbox consumer ────────────────────────────────────────────────────────
 let sseActive = true;

--- a/adapters/mercury-channel-router/README.md
+++ b/adapters/mercury-channel-router/README.md
@@ -1,0 +1,72 @@
+# mercury-channel-router
+
+Long-running Telegram bot + IPC server. One instance per machine.
+
+## Role
+
+- Holds the single Telegram bot polling connection (one connection per bot token).
+- Exposes a localhost HTTP IPC server for `mercury-channel-client` and `mercury-notify` to communicate with.
+- Routes inbound Telegram messages to the correct Claude Code session.
+- Handles commands: `/status`, `/list`, `/cancel`, `/continue`, `/help`.
+- Enforces sender allowlist and session limit (max 3).
+
+## Startup
+
+Do not start manually. `mercury-channel-client` spawns the router automatically on first Claude Code session start. The router exits 30 seconds after all sessions deregister.
+
+To start manually for testing:
+
+```bash
+MERCURY_TELEGRAM_BOT_TOKEN=<token> node adapters/mercury-channel-router/router.cjs
+```
+
+## Environment Variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `MERCURY_TELEGRAM_BOT_TOKEN` | Yes (for Telegram) | BotFather token |
+| `MERCURY_TELEGRAM_ALLOWED_USER_IDS` | Recommended | Comma-separated Telegram user IDs (sender allowlist). Empty = allow all. |
+| `MERCURY_TELEGRAM_CHAT_ID` | No | Default chat_id for `/notify` when no session has chatted yet |
+| `MERCURY_ROUTER_PORT` | No | IPC port (default: 8788) |
+| `MERCURY_NOTIFY_DISABLED` | No | Disables Telegram polling entirely; IPC still works |
+
+## User Setup
+
+Add to `~/.claude/settings.json` env block:
+
+```json
+{
+  "env": {
+    "MERCURY_TELEGRAM_BOT_TOKEN": "your-bot-token",
+    "MERCURY_TELEGRAM_ALLOWED_USER_IDS": "123456789",
+    "MERCURY_TELEGRAM_CHAT_ID": "123456789"
+  }
+}
+```
+
+## Launching Claude Code with Channels
+
+```bash
+claude --dangerously-load-development-channels server:mercury-telegram
+```
+
+Or set `CLAUDE_HANDOFF_AUTO_LAUNCH_FLAGS` in your environment to propagate this flag through `claude-handoff` auto-spawned sessions.
+
+## IPC Endpoints
+
+| Method | Path | Description |
+|---|---|---|
+| GET | `/health` | Liveness check |
+| POST | `/register` | Register a session |
+| DELETE | `/register/:id` | Deregister a session |
+| POST | `/take-ownership/:id` | Mark session as active |
+| POST | `/notify` | Send outbound Telegram message |
+| POST | `/reply` | Claude reply forwarded to Telegram |
+| GET | `/sessions` | List registered sessions |
+| GET | `/inbox/:id` | SSE stream of inbound events for a session |
+
+## Notes
+
+- Bun is optional — Node 18+ works fine.
+- Lock file at `~/.mercury/router.lock` prevents duplicate instances.
+- Requires `node-telegram-bot-api` (installed via pnpm at project root).

--- a/adapters/mercury-channel-router/README.md
+++ b/adapters/mercury-channel-router/README.md
@@ -25,7 +25,7 @@ MERCURY_TELEGRAM_BOT_TOKEN=<token> node adapters/mercury-channel-router/router.c
 | Variable | Required | Description |
 |---|---|---|
 | `MERCURY_TELEGRAM_BOT_TOKEN` | Yes (for Telegram) | BotFather token |
-| `MERCURY_TELEGRAM_ALLOWED_USER_IDS` | Recommended | Comma-separated Telegram user IDs (sender allowlist). Empty = allow all. |
+| `MERCURY_TELEGRAM_ALLOWED_USER_IDS` | **REQUIRED for inbound** | Comma-separated Telegram user IDs (sender allowlist). Empty = all inbound messages dropped (fail-closed). |
 | `MERCURY_TELEGRAM_CHAT_ID` | No | Default chat_id for `/notify` when no session has chatted yet |
 | `MERCURY_ROUTER_PORT` | No | IPC port (default: 8788) |
 | `MERCURY_NOTIFY_DISABLED` | No | Disables Telegram polling entirely; IPC still works |

--- a/adapters/mercury-channel-router/UPSTREAM.md
+++ b/adapters/mercury-channel-router/UPSTREAM.md
@@ -1,0 +1,26 @@
+# UPSTREAM — mercury-channel-router
+
+## Origin
+
+Original implementation. No code cherry-picked from external projects.
+
+## References (inspiration only, no code copied)
+
+- **Anthropic Channels reference** — MCP notification protocol, reply tool schema, permission relay:
+  `https://code.claude.com/docs/en/channels-reference`
+- **Anthropic Channels overview** — session lifecycle, multi-session constraints:
+  `https://code.claude.com/docs/en/channels`
+- **openclaw telegram-claude-poc.py** (seedprod) — routing + session ownership pattern inspiration:
+  `https://github.com/seedprod/openclaw-prompts-and-skills/blob/main/telegram-claude-poc.py`
+  (no license — no code copied; design pattern only)
+- **node-telegram-bot-api** — npm package used for Telegram long-polling:
+  `https://github.com/yagop/node-telegram-bot-api` (MIT)
+
+## Dependencies
+
+- `node-telegram-bot-api` ^0.67.0 (MIT) — Telegram Bot API client
+- Node built-ins: `http`, `fs`, `os`, `path`
+
+## License
+
+MIT (Mercury project).

--- a/adapters/mercury-channel-router/router.cjs
+++ b/adapters/mercury-channel-router/router.cjs
@@ -4,31 +4,43 @@
 // Mercury Channel Router — long-running Telegram bot + IPC server.
 // One instance per machine; spawned by mercury-channel-client on first session.
 
-const http = require('http');
-const fs   = require('fs');
-const os   = require('os');
-const path = require('path');
+const http   = require('http');
+const fs     = require('fs');
+const os     = require('os');
+const path   = require('path');
+const crypto = require('crypto');
 
-const PORT      = Number(process.env.MERCURY_ROUTER_PORT) || 8788;
-const LOCK_FILE = path.join(os.homedir(), '.mercury', 'router.lock');
-const MAX_SESS  = 3;
-const TAG       = '[mercury-channel-router]';
+const PORT       = Number(process.env.MERCURY_ROUTER_PORT) || 8788;
+const LOCK_FILE  = path.join(os.homedir(), '.mercury', 'router.lock');
+const TOKEN_FILE = path.join(os.homedir(), '.mercury', 'router.token');
+const MAX_SESS   = 3;
+const TAG        = '[mercury-channel-router]';
 
+// IPC auth token — written to TOKEN_FILE after server.listen succeeds
+const TOKEN = crypto.randomBytes(16).toString('hex');
+const writeToken  = () => { try { fs.mkdirSync(path.dirname(TOKEN_FILE),{recursive:true}); fs.writeFileSync(TOKEN_FILE,TOKEN,{mode:0o600}); } catch(e){process.stderr.write(`${TAG} token write error: ${e.message}\n`);} };
+const cleanupToken = () => { try { fs.unlinkSync(TOKEN_FILE); } catch {} };
+
+// Lock file — atomic O_CREAT|O_EXCL; fail-closed on EADDRINUSE (lock not yet held)
 function acquireLock() {
-  try {
-    fs.mkdirSync(path.dirname(LOCK_FILE), { recursive: true });
-    if (fs.existsSync(LOCK_FILE)) {
-      const pid = parseInt(fs.readFileSync(LOCK_FILE, 'utf8').trim(), 10);
-      if (pid && pid !== process.pid) {
-        try { process.kill(pid, 0); process.stderr.write(`${TAG} already running (pid ${pid})\n`); process.exit(1); }
-        catch { /* stale lock */ }
-      }
+  fs.mkdirSync(path.dirname(LOCK_FILE), { recursive: true });
+  for (let i = 0; i < 3; i++) {
+    try { const fd=fs.openSync(LOCK_FILE,'wx'); fs.writeSync(fd,String(process.pid)); fs.closeSync(fd); return; }
+    catch (e) {
+      if (e.code !== 'EEXIST') { process.stderr.write(`${TAG} lock error: ${e.message}\n`); return; }
+      try {
+        const pid = parseInt(fs.readFileSync(LOCK_FILE,'utf8').trim(),10);
+        if (pid && pid !== process.pid) {
+          try { process.kill(pid,0); process.stderr.write(`${TAG} already running (pid ${pid})\n`); process.exit(1); }
+          catch { fs.unlinkSync(LOCK_FILE); } // stale — retry
+        } else { fs.unlinkSync(LOCK_FILE); }
+      } catch { fs.unlinkSync(LOCK_FILE); }
     }
-    fs.writeFileSync(LOCK_FILE, String(process.pid));
-  } catch (e) { process.stderr.write(`${TAG} lock error: ${e.message}\n`); }
+  }
 }
-const releaseLock = () => { try { fs.unlinkSync(LOCK_FILE); } catch {} };
+function releaseLock() { try { const pid=parseInt(fs.readFileSync(LOCK_FILE,'utf8').trim(),10); if(pid===process.pid)fs.unlinkSync(LOCK_FILE); } catch {} }
 
+// Telegram bot
 let bot = null;
 const BOT_TOKEN = process.env.MERCURY_TELEGRAM_BOT_TOKEN;
 if (!process.env.MERCURY_NOTIFY_DISABLED && BOT_TOKEN) {
@@ -42,139 +54,155 @@ if (!process.env.MERCURY_NOTIFY_DISABLED && BOT_TOKEN) {
   process.stderr.write(`${TAG} WARNING: MERCURY_TELEGRAM_BOT_TOKEN not set; Telegram disabled\n`);
 }
 
-const ALLOWED   = new Set((process.env.MERCURY_TELEGRAM_ALLOWED_USER_IDS || '').split(',').map(s => s.trim()).filter(Boolean));
-const isAllowed = id => ALLOWED.size === 0 || ALLOWED.has(String(id));
+// Allowlist — fail-closed: empty set blocks all inbound messages
+const ALLOWED   = new Set((process.env.MERCURY_TELEGRAM_ALLOWED_USER_IDS||'').split(',').map(s=>s.trim()).filter(Boolean));
+const isAllowed = id => ALLOWED.has(String(id));
+if (BOT_TOKEN && ALLOWED.size === 0)
+  process.stderr.write(`${TAG} WARNING: ALLOWED user IDs empty; ALL inbound Telegram messages will be dropped. Set MERCURY_TELEGRAM_ALLOWED_USER_IDS to enable.\n`);
+
+// HTML escape helper — applied to all user-controlled interpolations in tgSend calls
+const htmlEsc = s => String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
 
 const sessions = new Map();
 let activeId = null, shutdownTimer = null;
 const startTs = Date.now();
 let lastChatId = null;
 
-function deriveLabel({ project_path = '', branch = '' }) {
+function deriveLabel({ project_path='', branch='' }) {
   const m1 = branch.match(/^feature\/(?:lane-[\w-]+\/)?TASK-(\d+)-([\w-]+)/);
-  if (m1) return `#${m1[1]} ${m1[2]}`.slice(0, 30);
+  if (m1) return `#${m1[1]} ${m1[2]}`.slice(0,30);
   const m2 = branch.match(/^feature\/([\w-]+)/);
-  return (m2 ? m2[1] : path.basename(project_path || process.cwd())).slice(0, 30);
+  return (m2?m2[1]:path.basename(project_path||process.cwd())).slice(0,30);
 }
 
 function sendToInbox(sid, event) {
-  const s = sessions.get(sid); if (!s) return;
-  const data = `data: ${JSON.stringify(event)}\n\n`;
-  s.sseClients = (s.sseClients || []).filter(r => { try { r.write(data); return true; } catch { return false; } });
+  const s=sessions.get(sid); if(!s) return;
+  const data=`data: ${JSON.stringify(event)}\n\n`;
+  s.sseClients=(s.sseClients||[]).filter(r=>{try{r.write(data);return true;}catch{return false;}});
 }
 
 function scheduleShutdown() {
-  if (sessions.size > 0) { clearTimeout(shutdownTimer); shutdownTimer = null; return; }
+  if (sessions.size>0){clearTimeout(shutdownTimer);shutdownTimer=null;return;}
   if (shutdownTimer) return;
   process.stderr.write(`${TAG} all sessions gone; shutting down in 30s\n`);
-  shutdownTimer = setTimeout(() => { releaseLock(); process.exit(0); }, 30000);
+  shutdownTimer=setTimeout(()=>{releaseLock();cleanupToken();process.exit(0);},30000);
 }
 
 async function tgSend(chatId, text) {
   if (!bot) return;
-  try { await bot.sendMessage(chatId, text.length > 4096 ? text.slice(0, 4090) + '…' : text, { parse_mode: 'HTML' }); }
+  try { await bot.sendMessage(chatId, text.length>4096?text.slice(0,4090)+'…':text, {parse_mode:'HTML'}); }
   catch (e) { process.stderr.write(`${TAG} sendMessage error: ${e.message}\n`); }
 }
 
 async function handleCmd(chatId, cmd, args) {
-  lastChatId = chatId;
-  if (cmd === 'status') {
-    const a = sessions.get(activeId);
-    return tgSend(chatId, `<b>Mercury Router</b>\nUptime: ${Math.round((Date.now()-startTs)/1000)}s\nSessions: ${sessions.size}/${MAX_SESS}\nActive: ${a ? a.label : 'none'}`);
+  if (cmd==='status') {
+    const a=sessions.get(activeId);
+    return tgSend(chatId,`<b>Mercury Router</b>\nUptime: ${Math.round((Date.now()-startTs)/1000)}s\nSessions: ${sessions.size}/${MAX_SESS}\nActive: ${a?htmlEsc(a.label):'none'}`);
   }
-  if (cmd === 'list') {
-    if (!sessions.size) return tgSend(chatId, 'No sessions registered.');
-    return tgSend(chatId, [...sessions.values()].map(s => `[${s.label}]${s.id===activeId?' <b>active</b>':''}`).join('\n'));
+  if (cmd==='list') {
+    if (!sessions.size) return tgSend(chatId,'No sessions registered.');
+    return tgSend(chatId,[...sessions.values()].map(s=>`[${htmlEsc(s.label)}]${s.id===activeId?' <b>active</b>':''}`).join('\n'));
   }
-  if (cmd === 'help') return tgSend(chatId, '/status /list /cancel /continue /help\n@label text — route\nyes/no &lt;id&gt; — verdict');
-  if (cmd === 'cancel' || cmd === 'continue') {
-    const t = args ? [...sessions.values()].find(s => s.label.includes(args)) : sessions.get(activeId);
-    if (!t) return tgSend(chatId, 'No matching session.');
-    sendToInbox(t.id, { type: 'command', cmd, from_chat: chatId });
-    return tgSend(chatId, `Sent /${cmd} to [${t.label}]`);
+  if (cmd==='help') return tgSend(chatId,'/status /list /cancel /continue /help\n@label text — route\nyes/no &lt;id&gt; — verdict');
+  if (cmd==='cancel'||cmd==='continue') {
+    const t=args?[...sessions.values()].find(s=>s.label.includes(args)):sessions.get(activeId);
+    if (!t) return tgSend(chatId,'No matching session.');
+    sendToInbox(t.id,{type:'command',cmd,from_chat:chatId});
+    return tgSend(chatId,`Sent /${htmlEsc(cmd)} to [${htmlEsc(t.label)}]`);
   }
 }
 
 async function routeMessage(msg) {
-  const chatId = msg.chat.id; lastChatId = chatId;
-  if (!isAllowed(msg.from?.id)) return;
-  const text = (msg.text || '').trim(); if (!text) return;
-  const cmdM = text.match(/^\/(\w+)(?:\s+(.*))?$/s);
-  if (cmdM) { await handleCmd(chatId, cmdM[1], cmdM[2]?.trim()); return; }
-  const vM = text.match(/^\s*(y|yes|n|no)\s+([\w-]+)\s*$/i);
+  if (!msg.from||msg.from.id==null) return;       // channel posts / anonymous
+  if (msg.chat?.type!=='private') return;          // refuse groups (MVP)
+  if (!isAllowed(msg.from.id)) return;             // allowlist (fail-closed)
+  const chatId=msg.chat.id;
+  lastChatId=chatId;                               // set only after passing allowlist (M5)
+  const text=(msg.text||'').trim(); if(!text) return;
+  const cmdM=text.match(/^\/(\w+)(?:\s+(.*))?$/s);
+  if (cmdM){await handleCmd(chatId,cmdM[1],cmdM[2]?.trim());return;}
+  const vM=text.match(/^\s*(y|yes|n|no)\s+([\w-]+)\s*$/i);
   if (vM) {
-    const v = /^y/i.test(vM[1])?'yes':'no', rid = vM[2];
-    const pm = rid.match(/^([a-z0-9]{6})-([a-km-z]{5})$/);
-    if (pm) { const t=[...sessions.values()].find(s=>s.shortId===pm[1]); if(t) sendToInbox(t.id,{type:'verdict',verdict:v,request_id:pm[2]}); return; }
-    for (const s of sessions.values()) sendToInbox(s.id, {type:'verdict',verdict:v,request_id:rid}); return;
+    const v=/^y/i.test(vM[1])?'yes':'no', rid=vM[2];
+    const pm=rid.match(/^([a-z0-9]{6})-([a-km-z]{5})$/);
+    if (pm){const t=[...sessions.values()].find(s=>s.shortId===pm[1]);if(t)sendToInbox(t.id,{type:'verdict',verdict:v,request_id:pm[2]});return;}
+    await tgSend(chatId,`Verdict needs prefixed ID. Use 'yes &lt;short&gt;-&lt;id&gt;' from the request.`);
+    return;
   }
-  const pM = text.match(/^@([\w-]+)\s+(.+)$/s);
-  if (pM) { const t=[...sessions.values()].find(s=>s.label.startsWith(pM[1])); t?sendToInbox(t.id,{type:'message',content:pM[2],from_chat:chatId}):await tgSend(chatId,`No session matching @${pM[1]}`); return; }
-  if (!activeId || !sessions.has(activeId)) { await tgSend(chatId, 'No active session. Use /list.'); return; }
-  sendToInbox(activeId, { type: 'message', content: text, from_chat: chatId });
+  const pM=text.match(/^@([\w-]+)\s+(.+)$/s);
+  if (pM){const t=[...sessions.values()].find(s=>s.label.startsWith(pM[1]));t?sendToInbox(t.id,{type:'message',content:pM[2],from_chat:chatId}):await tgSend(chatId,`No session matching @${htmlEsc(pM[1])}`);return;}
+  if (!activeId||!sessions.has(activeId)){await tgSend(chatId,'No active session. Use /list.');return;}
+  sendToInbox(activeId,{type:'message',content:text,from_chat:chatId});
 }
-if (bot) bot.on('message', routeMessage);
+if (bot) bot.on('message',routeMessage);
 
-const json  = (res, code, obj) => { res.writeHead(code, {'Content-Type':'application/json'}); res.end(JSON.stringify(obj)); };
-const bodyOf = req => new Promise((ok, fail) => { let b=''; req.on('data',c=>b+=c); req.on('end',()=>{try{ok(JSON.parse(b||'{}'))}catch(e){fail(e)}}); req.on('error',fail); });
+const json   = (res,code,obj)=>{res.writeHead(code,{'Content-Type':'application/json'});res.end(JSON.stringify(obj));};
+const bodyOf = req=>new Promise((ok,fail)=>{let b='';req.on('data',c=>b+=c);req.on('end',()=>{try{ok(JSON.parse(b||'{}'))}catch(e){fail(e)}});req.on('error',fail);});
 
-const server = http.createServer(async (req, res) => {
-  const url = req.url||'/', m = req.method||'GET';
-  if (m==='GET'  && url==='/health')      return json(res,200,{ok:true,sessions:sessions.size,uptime:Date.now()-startTs});
-  if (m==='GET'  && url==='/sessions')    return json(res,200,[...sessions.values()].map(({id,label,branch,pid,sseClients})=>({id,label,branch,pid,active:id===activeId,subscribers:(sseClients||[]).length})));
-  if (m==='GET'  && url.startsWith('/inbox/')) {
-    const sid=url.slice(7); if (!sessions.has(sid)) return json(res,404,{error:'session not found'});
+const server = http.createServer(async (req,res)=>{
+  const url=req.url||'/',m=req.method||'GET';
+  if (m==='GET'&&url==='/health') return json(res,200,{ok:true,sessions:sessions.size,uptime:Date.now()-startTs});
+  if (req.headers.authorization!==`Bearer ${TOKEN}`) return json(res,401,{error:'unauthorized'});
+  if (m==='GET'&&url==='/sessions') return json(res,200,[...sessions.values()].map(({id,label,branch,pid,sseClients})=>({id,label,branch,pid,active:id===activeId,subscribers:(sseClients||[]).length})));
+  if (m==='GET'&&url.startsWith('/inbox/')){
+    const sid=url.slice(7);if(!sessions.has(sid))return json(res,404,{error:'session not found'});
     res.writeHead(200,{'Content-Type':'text/event-stream','Cache-Control':'no-cache',Connection:'keep-alive'});
     res.write('data: {"type":"connected"}\n\n');
-    const s=sessions.get(sid); s.sseClients=s.sseClients||[]; s.sseClients.push(res);
-    req.on('close',()=>{ s.sseClients=(s.sseClients||[]).filter(r=>r!==res); }); return;
+    const s=sessions.get(sid);s.sseClients=s.sseClients||[];s.sseClients.push(res);
+    req.on('close',()=>{s.sseClients=(s.sseClients||[]).filter(r=>r!==res);});return;
   }
-  if (m==='POST' && url==='/register') {
-    let body; try{body=await bodyOf(req)}catch{return json(res,400,{error:'bad json'});}
+  if (m==='POST'&&url==='/register'){
+    let body;try{body=await bodyOf(req)}catch{return json(res,400,{error:'bad json'});}
     if (sessions.size>=MAX_SESS) return json(res,429,{error:'session limit reached',max:MAX_SESS});
     const {session_id,project_path,branch,pid,short_id}=body;
     if (!session_id) return json(res,400,{error:'session_id required'});
     const label=body.label||deriveLabel({project_path,branch});
     sessions.set(session_id,{id:session_id,label,project_path,branch,pid,shortId:short_id||session_id.slice(0,6),sseClients:[]});
-    if (!activeId) activeId=session_id; clearTimeout(shutdownTimer); shutdownTimer=null;
+    if (!activeId)activeId=session_id;clearTimeout(shutdownTimer);shutdownTimer=null;
     process.stderr.write(`${TAG} registered ${session_id} [${label}]\n`);
     return json(res,200,{ok:true,label,active:activeId===session_id});
   }
-  if (m==='DELETE' && url.startsWith('/register/')) {
-    const sid=url.slice(10); sessions.delete(sid);
-    if (activeId===sid) activeId=sessions.size>0?sessions.keys().next().value:null;
-    process.stderr.write(`${TAG} deregistered ${sid}\n`); scheduleShutdown(); return json(res,200,{ok:true});
+  if (m==='DELETE'&&url.startsWith('/register/')){
+    const sid=url.slice(10);sessions.delete(sid);
+    if (activeId===sid)activeId=sessions.size>0?sessions.keys().next().value:null;
+    process.stderr.write(`${TAG} deregistered ${sid}\n`);scheduleShutdown();return json(res,200,{ok:true});
   }
-  if (m==='POST' && url.startsWith('/take-ownership/')) {
-    const sid=url.slice(16); if(!sessions.has(sid)) return json(res,404,{error:'session not found'});
-    activeId=sid; return json(res,200,{ok:true});
+  if (m==='POST'&&url.startsWith('/take-ownership/')){
+    const sid=url.slice(16);if(!sessions.has(sid))return json(res,404,{error:'session not found'});
+    activeId=sid;return json(res,200,{ok:true});
   }
-  if (m==='POST' && url==='/notify') {
-    let body; try{body=await bodyOf(req)}catch{return json(res,400,{error:'bad json'});}
+  if (m==='POST'&&url==='/notify'){
+    let body;try{body=await bodyOf(req)}catch{return json(res,400,{error:'bad json'});}
     const {severity='info',title='',body:mb='',label:fl}=body;
     const lbl=fl||(sessions.get(activeId)?.label)||'mercury';
     const chatId=lastChatId||(process.env.MERCURY_TELEGRAM_CHAT_ID?Number(process.env.MERCURY_TELEGRAM_CHAT_ID):null);
-    if (chatId) await tgSend(chatId,`[${lbl}] <b>${severity.toUpperCase()}: ${title}</b>\n${mb}`);
+    if (chatId) await tgSend(chatId,`[${htmlEsc(lbl)}] <b>${htmlEsc(severity.toUpperCase())}: ${htmlEsc(title)}</b>\n${htmlEsc(mb)}`);
     return json(res,200,{ok:true});
   }
-  if (m==='POST' && url==='/reply') {
-    let body; try{body=await bodyOf(req)}catch{return json(res,400,{error:'bad json'});}
-    const {chat_id,text,label}=body; if(!chat_id||!text) return json(res,400,{error:'chat_id and text required'});
+  if (m==='POST'&&url==='/reply'){
+    let body;try{body=await bodyOf(req)}catch{return json(res,400,{error:'bad json'});}
+    const {chat_id,text,label}=body;if(!chat_id||!text)return json(res,400,{error:'chat_id and text required'});
     const s=[...sessions.values()].find(x=>x.id===body.session_id)||sessions.get(activeId);
-    await tgSend(chat_id,`[${label||(s?.label)||'mercury'}] ${text}`); return json(res,200,{ok:true});
+    await tgSend(chat_id,`[${htmlEsc(label||(s?.label)||'mercury')}] ${htmlEsc(text)}`);return json(res,200,{ok:true});
   }
-  if (m==='POST' && url==='/permission-request') {
-    let body; try{body=await bodyOf(req)}catch{return json(res,400,{error:'bad json'});}
-    const {session_id,tool_name='',description='',input_preview='',prefixed_request_id=''}=body;
+  if (m==='POST'&&url==='/permission-request'){
+    let body;try{body=await bodyOf(req)}catch{return json(res,400,{error:'bad json'});}
+    const {tool_name='',description='',prefixed_request_id=''}=body;
     const chatId=lastChatId||(process.env.MERCURY_TELEGRAM_CHAT_ID?Number(process.env.MERCURY_TELEGRAM_CHAT_ID):null);
-    if (chatId) await tgSend(chatId,`Claude wants to run ${tool_name}: ${description}\n\nReply 'yes ${prefixed_request_id}' or 'no ${prefixed_request_id}'`);
+    if (chatId) await tgSend(chatId,`Claude wants to run ${htmlEsc(tool_name)}: ${htmlEsc(description)}\n\nReply 'yes ${htmlEsc(prefixed_request_id)}' or 'no ${htmlEsc(prefixed_request_id)}'`);
     return json(res,200,{ok:true});
   }
   json(res,404,{error:'not found'});
 });
 
-acquireLock();
-server.listen(PORT,'127.0.0.1',()=>process.stderr.write(`${TAG} IPC server listening on 127.0.0.1:${PORT}\n`));
-server.on('error',e=>{process.stderr.write(`${TAG} server error: ${e.message}\n`);releaseLock();process.exit(1);});
-process.on('SIGTERM',()=>{releaseLock();process.exit(0);});
-process.on('SIGINT', ()=>{releaseLock();process.exit(0);});
+// Startup: listen first, then acquire lock + write token (avoids holding lock if port busy)
+server.listen(PORT,'127.0.0.1',()=>{
+  process.stderr.write(`${TAG} IPC server listening on 127.0.0.1:${PORT}\n`);
+  acquireLock(); writeToken();
+});
+server.on('error',e=>{process.stderr.write(`${TAG} server error: ${e.message}\n`);process.exit(1);});
+// do NOT releaseLock on server error — lock may not have been acquired yet
+
+const cleanup=()=>{releaseLock();cleanupToken();};
+process.on('SIGTERM',()=>{cleanup();process.exit(0);});
+process.on('SIGINT', ()=>{cleanup();process.exit(0);});

--- a/adapters/mercury-channel-router/router.cjs
+++ b/adapters/mercury-channel-router/router.cjs
@@ -102,7 +102,12 @@ async function routeMessage(msg) {
   const cmdM = text.match(/^\/(\w+)(?:\s+(.*))?$/s);
   if (cmdM) { await handleCmd(chatId, cmdM[1], cmdM[2]?.trim()); return; }
   const vM = text.match(/^\s*(y|yes|n|no)\s+([\w-]+)\s*$/i);
-  if (vM) { const v = /^y/i.test(vM[1])?'yes':'no'; for (const s of sessions.values()) sendToInbox(s.id, {type:'verdict',verdict:v,request_id:vM[2]}); return; }
+  if (vM) {
+    const v = /^y/i.test(vM[1])?'yes':'no', rid = vM[2];
+    const pm = rid.match(/^([a-z0-9]{6})-([a-km-z]{5})$/);
+    if (pm) { const t=[...sessions.values()].find(s=>s.shortId===pm[1]); if(t) sendToInbox(t.id,{type:'verdict',verdict:v,request_id:pm[2]}); return; }
+    for (const s of sessions.values()) sendToInbox(s.id, {type:'verdict',verdict:v,request_id:rid}); return;
+  }
   const pM = text.match(/^@([\w-]+)\s+(.+)$/s);
   if (pM) { const t=[...sessions.values()].find(s=>s.label.startsWith(pM[1])); t?sendToInbox(t.id,{type:'message',content:pM[2],from_chat:chatId}):await tgSend(chatId,`No session matching @${pM[1]}`); return; }
   if (!activeId || !sessions.has(activeId)) { await tgSend(chatId, 'No active session. Use /list.'); return; }
@@ -127,10 +132,10 @@ const server = http.createServer(async (req, res) => {
   if (m==='POST' && url==='/register') {
     let body; try{body=await bodyOf(req)}catch{return json(res,400,{error:'bad json'});}
     if (sessions.size>=MAX_SESS) return json(res,429,{error:'session limit reached',max:MAX_SESS});
-    const {session_id,project_path,branch,pid}=body;
+    const {session_id,project_path,branch,pid,short_id}=body;
     if (!session_id) return json(res,400,{error:'session_id required'});
     const label=body.label||deriveLabel({project_path,branch});
-    sessions.set(session_id,{id:session_id,label,project_path,branch,pid,sseClients:[]});
+    sessions.set(session_id,{id:session_id,label,project_path,branch,pid,shortId:short_id||session_id.slice(0,6),sseClients:[]});
     if (!activeId) activeId=session_id; clearTimeout(shutdownTimer); shutdownTimer=null;
     process.stderr.write(`${TAG} registered ${session_id} [${label}]\n`);
     return json(res,200,{ok:true,label,active:activeId===session_id});
@@ -157,6 +162,13 @@ const server = http.createServer(async (req, res) => {
     const {chat_id,text,label}=body; if(!chat_id||!text) return json(res,400,{error:'chat_id and text required'});
     const s=[...sessions.values()].find(x=>x.id===body.session_id)||sessions.get(activeId);
     await tgSend(chat_id,`[${label||(s?.label)||'mercury'}] ${text}`); return json(res,200,{ok:true});
+  }
+  if (m==='POST' && url==='/permission-request') {
+    let body; try{body=await bodyOf(req)}catch{return json(res,400,{error:'bad json'});}
+    const {session_id,tool_name='',description='',input_preview='',prefixed_request_id=''}=body;
+    const chatId=lastChatId||(process.env.MERCURY_TELEGRAM_CHAT_ID?Number(process.env.MERCURY_TELEGRAM_CHAT_ID):null);
+    if (chatId) await tgSend(chatId,`Claude wants to run ${tool_name}: ${description}\n\nReply 'yes ${prefixed_request_id}' or 'no ${prefixed_request_id}'`);
+    return json(res,200,{ok:true});
   }
   json(res,404,{error:'not found'});
 });

--- a/adapters/mercury-channel-router/router.cjs
+++ b/adapters/mercury-channel-router/router.cjs
@@ -32,7 +32,7 @@ function acquireLock() {
         const pid = parseInt(fs.readFileSync(LOCK_FILE,'utf8').trim(),10);
         if (pid && pid !== process.pid) {
           try { process.kill(pid,0); process.stderr.write(`${TAG} already running (pid ${pid})\n`); process.exit(1); }
-          catch { fs.unlinkSync(LOCK_FILE); } // stale — retry
+          catch (e2) { if (e2.code === 'EPERM') { process.stderr.write(`${TAG} pid ${pid} exists (no permission); aborting\n`); process.exit(1); } fs.unlinkSync(LOCK_FILE); } // ESRCH/other → stale, retry
         } else { fs.unlinkSync(LOCK_FILE); }
       } catch { fs.unlinkSync(LOCK_FILE); }
     }
@@ -188,7 +188,7 @@ const server = http.createServer(async (req,res)=>{
     const {severity='info',title='',body:mb='',label:fl}=body;
     const lbl=fl||(sessions.get(activeId)?.label)||'mercury';
     const chatId=lastChatId||(process.env.MERCURY_TELEGRAM_CHAT_ID?Number(process.env.MERCURY_TELEGRAM_CHAT_ID):null);
-    if (chatId) await tgSend(chatId,`[${htmlEsc(lbl)}] <b>${htmlEsc(severity.toUpperCase())}: ${htmlEsc(title)}</b>\n${htmlEsc(mb)}`);
+    if (chatId) await tgSend(chatId,`[${htmlEsc(lbl)}] <b>${htmlEsc(String(severity).toUpperCase())}: ${htmlEsc(title)}</b>\n${htmlEsc(mb)}`);
     return json(res,200,{ok:true});
   }
   if (m==='POST'&&url==='/reply'){

--- a/adapters/mercury-channel-router/router.cjs
+++ b/adapters/mercury-channel-router/router.cjs
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+'use strict';
+
+// Mercury Channel Router — long-running Telegram bot + IPC server.
+// One instance per machine; spawned by mercury-channel-client on first session.
+
+const http = require('http');
+const fs   = require('fs');
+const os   = require('os');
+const path = require('path');
+
+const PORT      = Number(process.env.MERCURY_ROUTER_PORT) || 8788;
+const LOCK_FILE = path.join(os.homedir(), '.mercury', 'router.lock');
+const MAX_SESS  = 3;
+const TAG       = '[mercury-channel-router]';
+
+function acquireLock() {
+  try {
+    fs.mkdirSync(path.dirname(LOCK_FILE), { recursive: true });
+    if (fs.existsSync(LOCK_FILE)) {
+      const pid = parseInt(fs.readFileSync(LOCK_FILE, 'utf8').trim(), 10);
+      if (pid && pid !== process.pid) {
+        try { process.kill(pid, 0); process.stderr.write(`${TAG} already running (pid ${pid})\n`); process.exit(1); }
+        catch { /* stale lock */ }
+      }
+    }
+    fs.writeFileSync(LOCK_FILE, String(process.pid));
+  } catch (e) { process.stderr.write(`${TAG} lock error: ${e.message}\n`); }
+}
+const releaseLock = () => { try { fs.unlinkSync(LOCK_FILE); } catch {} };
+
+let bot = null;
+const BOT_TOKEN = process.env.MERCURY_TELEGRAM_BOT_TOKEN;
+if (!process.env.MERCURY_NOTIFY_DISABLED && BOT_TOKEN) {
+  try {
+    const TelegramBot = require('node-telegram-bot-api');
+    bot = new TelegramBot(BOT_TOKEN, { polling: true });
+    bot.on('polling_error', e => process.stderr.write(`${TAG} polling error: ${e.message}\n`));
+    process.stderr.write(`${TAG} Telegram polling started\n`);
+  } catch (e) { process.stderr.write(`${TAG} Telegram init failed: ${e.message}\n`); }
+} else if (!BOT_TOKEN) {
+  process.stderr.write(`${TAG} WARNING: MERCURY_TELEGRAM_BOT_TOKEN not set; Telegram disabled\n`);
+}
+
+const ALLOWED   = new Set((process.env.MERCURY_TELEGRAM_ALLOWED_USER_IDS || '').split(',').map(s => s.trim()).filter(Boolean));
+const isAllowed = id => ALLOWED.size === 0 || ALLOWED.has(String(id));
+
+const sessions = new Map();
+let activeId = null, shutdownTimer = null;
+const startTs = Date.now();
+let lastChatId = null;
+
+function deriveLabel({ project_path = '', branch = '' }) {
+  const m1 = branch.match(/^feature\/(?:lane-[\w-]+\/)?TASK-(\d+)-([\w-]+)/);
+  if (m1) return `#${m1[1]} ${m1[2]}`.slice(0, 30);
+  const m2 = branch.match(/^feature\/([\w-]+)/);
+  return (m2 ? m2[1] : path.basename(project_path || process.cwd())).slice(0, 30);
+}
+
+function sendToInbox(sid, event) {
+  const s = sessions.get(sid); if (!s) return;
+  const data = `data: ${JSON.stringify(event)}\n\n`;
+  s.sseClients = (s.sseClients || []).filter(r => { try { r.write(data); return true; } catch { return false; } });
+}
+
+function scheduleShutdown() {
+  if (sessions.size > 0) { clearTimeout(shutdownTimer); shutdownTimer = null; return; }
+  if (shutdownTimer) return;
+  process.stderr.write(`${TAG} all sessions gone; shutting down in 30s\n`);
+  shutdownTimer = setTimeout(() => { releaseLock(); process.exit(0); }, 30000);
+}
+
+async function tgSend(chatId, text) {
+  if (!bot) return;
+  try { await bot.sendMessage(chatId, text.length > 4096 ? text.slice(0, 4090) + '…' : text, { parse_mode: 'HTML' }); }
+  catch (e) { process.stderr.write(`${TAG} sendMessage error: ${e.message}\n`); }
+}
+
+async function handleCmd(chatId, cmd, args) {
+  lastChatId = chatId;
+  if (cmd === 'status') {
+    const a = sessions.get(activeId);
+    return tgSend(chatId, `<b>Mercury Router</b>\nUptime: ${Math.round((Date.now()-startTs)/1000)}s\nSessions: ${sessions.size}/${MAX_SESS}\nActive: ${a ? a.label : 'none'}`);
+  }
+  if (cmd === 'list') {
+    if (!sessions.size) return tgSend(chatId, 'No sessions registered.');
+    return tgSend(chatId, [...sessions.values()].map(s => `[${s.label}]${s.id===activeId?' <b>active</b>':''}`).join('\n'));
+  }
+  if (cmd === 'help') return tgSend(chatId, '/status /list /cancel /continue /help\n@label text — route\nyes/no &lt;id&gt; — verdict');
+  if (cmd === 'cancel' || cmd === 'continue') {
+    const t = args ? [...sessions.values()].find(s => s.label.includes(args)) : sessions.get(activeId);
+    if (!t) return tgSend(chatId, 'No matching session.');
+    sendToInbox(t.id, { type: 'command', cmd, from_chat: chatId });
+    return tgSend(chatId, `Sent /${cmd} to [${t.label}]`);
+  }
+}
+
+async function routeMessage(msg) {
+  const chatId = msg.chat.id; lastChatId = chatId;
+  if (!isAllowed(msg.from?.id)) return;
+  const text = (msg.text || '').trim(); if (!text) return;
+  const cmdM = text.match(/^\/(\w+)(?:\s+(.*))?$/s);
+  if (cmdM) { await handleCmd(chatId, cmdM[1], cmdM[2]?.trim()); return; }
+  const vM = text.match(/^\s*(y|yes|n|no)\s+([\w-]+)\s*$/i);
+  if (vM) { const v = /^y/i.test(vM[1])?'yes':'no'; for (const s of sessions.values()) sendToInbox(s.id, {type:'verdict',verdict:v,request_id:vM[2]}); return; }
+  const pM = text.match(/^@([\w-]+)\s+(.+)$/s);
+  if (pM) { const t=[...sessions.values()].find(s=>s.label.startsWith(pM[1])); t?sendToInbox(t.id,{type:'message',content:pM[2],from_chat:chatId}):await tgSend(chatId,`No session matching @${pM[1]}`); return; }
+  if (!activeId || !sessions.has(activeId)) { await tgSend(chatId, 'No active session. Use /list.'); return; }
+  sendToInbox(activeId, { type: 'message', content: text, from_chat: chatId });
+}
+if (bot) bot.on('message', routeMessage);
+
+const json  = (res, code, obj) => { res.writeHead(code, {'Content-Type':'application/json'}); res.end(JSON.stringify(obj)); };
+const bodyOf = req => new Promise((ok, fail) => { let b=''; req.on('data',c=>b+=c); req.on('end',()=>{try{ok(JSON.parse(b||'{}'))}catch(e){fail(e)}}); req.on('error',fail); });
+
+const server = http.createServer(async (req, res) => {
+  const url = req.url||'/', m = req.method||'GET';
+  if (m==='GET'  && url==='/health')      return json(res,200,{ok:true,sessions:sessions.size,uptime:Date.now()-startTs});
+  if (m==='GET'  && url==='/sessions')    return json(res,200,[...sessions.values()].map(({id,label,branch,pid,sseClients})=>({id,label,branch,pid,active:id===activeId,subscribers:(sseClients||[]).length})));
+  if (m==='GET'  && url.startsWith('/inbox/')) {
+    const sid=url.slice(7); if (!sessions.has(sid)) return json(res,404,{error:'session not found'});
+    res.writeHead(200,{'Content-Type':'text/event-stream','Cache-Control':'no-cache',Connection:'keep-alive'});
+    res.write('data: {"type":"connected"}\n\n');
+    const s=sessions.get(sid); s.sseClients=s.sseClients||[]; s.sseClients.push(res);
+    req.on('close',()=>{ s.sseClients=(s.sseClients||[]).filter(r=>r!==res); }); return;
+  }
+  if (m==='POST' && url==='/register') {
+    let body; try{body=await bodyOf(req)}catch{return json(res,400,{error:'bad json'});}
+    if (sessions.size>=MAX_SESS) return json(res,429,{error:'session limit reached',max:MAX_SESS});
+    const {session_id,project_path,branch,pid}=body;
+    if (!session_id) return json(res,400,{error:'session_id required'});
+    const label=body.label||deriveLabel({project_path,branch});
+    sessions.set(session_id,{id:session_id,label,project_path,branch,pid,sseClients:[]});
+    if (!activeId) activeId=session_id; clearTimeout(shutdownTimer); shutdownTimer=null;
+    process.stderr.write(`${TAG} registered ${session_id} [${label}]\n`);
+    return json(res,200,{ok:true,label,active:activeId===session_id});
+  }
+  if (m==='DELETE' && url.startsWith('/register/')) {
+    const sid=url.slice(10); sessions.delete(sid);
+    if (activeId===sid) activeId=sessions.size>0?sessions.keys().next().value:null;
+    process.stderr.write(`${TAG} deregistered ${sid}\n`); scheduleShutdown(); return json(res,200,{ok:true});
+  }
+  if (m==='POST' && url.startsWith('/take-ownership/')) {
+    const sid=url.slice(16); if(!sessions.has(sid)) return json(res,404,{error:'session not found'});
+    activeId=sid; return json(res,200,{ok:true});
+  }
+  if (m==='POST' && url==='/notify') {
+    let body; try{body=await bodyOf(req)}catch{return json(res,400,{error:'bad json'});}
+    const {severity='info',title='',body:mb='',label:fl}=body;
+    const lbl=fl||(sessions.get(activeId)?.label)||'mercury';
+    const chatId=lastChatId||(process.env.MERCURY_TELEGRAM_CHAT_ID?Number(process.env.MERCURY_TELEGRAM_CHAT_ID):null);
+    if (chatId) await tgSend(chatId,`[${lbl}] <b>${severity.toUpperCase()}: ${title}</b>\n${mb}`);
+    return json(res,200,{ok:true});
+  }
+  if (m==='POST' && url==='/reply') {
+    let body; try{body=await bodyOf(req)}catch{return json(res,400,{error:'bad json'});}
+    const {chat_id,text,label}=body; if(!chat_id||!text) return json(res,400,{error:'chat_id and text required'});
+    const s=[...sessions.values()].find(x=>x.id===body.session_id)||sessions.get(activeId);
+    await tgSend(chat_id,`[${label||(s?.label)||'mercury'}] ${text}`); return json(res,200,{ok:true});
+  }
+  json(res,404,{error:'not found'});
+});
+
+acquireLock();
+server.listen(PORT,'127.0.0.1',()=>process.stderr.write(`${TAG} IPC server listening on 127.0.0.1:${PORT}\n`));
+server.on('error',e=>{process.stderr.write(`${TAG} server error: ${e.message}\n`);releaseLock();process.exit(1);});
+process.on('SIGTERM',()=>{releaseLock();process.exit(0);});
+process.on('SIGINT', ()=>{releaseLock();process.exit(0);});

--- a/adapters/mercury-channel-router/router.cjs
+++ b/adapters/mercury-channel-router/router.cjs
@@ -90,8 +90,15 @@ function scheduleShutdown() {
 
 async function tgSend(chatId, text) {
   if (!bot) return;
-  try { await bot.sendMessage(chatId, text.length>4096?text.slice(0,4090)+'…':text, {parse_mode:'HTML'}); }
-  catch (e) { process.stderr.write(`${TAG} sendMessage error: ${e.message}\n`); }
+  const payload = text.length>4096?text.slice(0,4090)+'…':text;
+  for (let attempt=0; attempt<2; attempt++) {
+    try { await bot.sendMessage(chatId, payload, {parse_mode:'HTML'}); return; }
+    catch (e) {
+      const ra = Number(e?.response?.body?.parameters?.retry_after);
+      if (attempt===0 && Number.isFinite(ra) && ra>0 && ra<=5) { await new Promise(r=>setTimeout(r,ra*1000)); continue; }
+      process.stderr.write(`${TAG} sendMessage error (attempt ${attempt+1}): ${e.message}\n`); return;
+    }
+  }
 }
 
 async function handleCmd(chatId, cmd, args) {
@@ -105,7 +112,12 @@ async function handleCmd(chatId, cmd, args) {
   }
   if (cmd==='help') return tgSend(chatId,'/status /list /cancel /continue /help\n@label text — route\nyes/no &lt;id&gt; — verdict');
   if (cmd==='cancel'||cmd==='continue') {
-    const t=args?[...sessions.values()].find(s=>s.label.includes(args)):sessions.get(activeId);
+    let t = sessions.get(activeId);
+    if (args) {
+      const m = args.match(/^@([\w-]+)$/);
+      if (!m) return tgSend(chatId,`Usage: /${htmlEsc(cmd)} @&lt;label-prefix&gt;`);
+      t = [...sessions.values()].find(s=>s.label.startsWith(m[1]));
+    }
     if (!t) return tgSend(chatId,'No matching session.');
     sendToInbox(t.id,{type:'command',cmd,from_chat:chatId});
     return tgSend(chatId,`Sent /${htmlEsc(cmd)} to [${htmlEsc(t.label)}]`);

--- a/adapters/mercury-loop-detector/hook.cjs
+++ b/adapters/mercury-loop-detector/hook.cjs
@@ -151,6 +151,7 @@ function main() {
       const fullReason = `Mercury loop detector: ${tr.message}\n(Buffer reset. If this is a false positive, resume your work.)`;
       writeStallReport(cwd, session_id, 'timeout_hard', fullReason, state,
         { name: tool_name, input_hash: ihash, errored, err_sig });
+      try { const { notify } = require('../mercury-notify/notify.cjs'); notify('error', `Mercury stall: timeout_hard`, tr.message).catch(() => {}); } catch { /* notify load failure non-fatal */ }
       Object.assign(state, EMPTY_STATE()); state.session_id = session_id; saveState(statePath, state);
       block(fullReason);
     }
@@ -162,6 +163,7 @@ function main() {
     const fullReason = `Mercury loop detector: ${stall.reason}\n(Buffer reset. If this is a false positive, resume your work.)`;
     writeStallReport(cwd, session_id, stall.type, fullReason, state,
       { name: tool_name, input_hash: ihash, errored, err_sig });
+    try { const { notify } = require('../mercury-notify/notify.cjs'); notify('error', `Mercury stall: ${stall.type}`, stall.reason).catch(() => {}); } catch { /* notify load failure non-fatal */ }
     Object.assign(state, EMPTY_STATE()); state.session_id = session_id; saveState(statePath, state);
     block(fullReason);
   }

--- a/adapters/mercury-notify/README.md
+++ b/adapters/mercury-notify/README.md
@@ -1,0 +1,49 @@
+# mercury-notify
+
+Thin HTTP client for hook scripts to send notifications through the channel router.
+
+## Role
+
+Forwards `notify(severity, title, body)` calls to `mercury-channel-router` via HTTP POST.
+Does not hold Telegram credentials or spawn processes. If the router is not running, fails silently.
+
+## Usage
+
+```js
+const { notify } = require('./adapters/mercury-notify/notify.cjs');
+await notify('error', 'Mercury stall: no_progress', 'details here');
+```
+
+## Startup
+
+No startup needed. `require` directly from any hook or script. The router must be running separately (spawned automatically by `mercury-channel-client` when a Claude Code session starts).
+
+## Environment Variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `MERCURY_ROUTER_PORT` | No | IPC port (default: 8788) |
+| `MERCURY_NOTIFY_DISABLED` | No | Set to any value to skip all notifications silently |
+
+## Setup
+
+Add to `~/.claude/settings.json` env block:
+
+```json
+{
+  "env": {
+    "MERCURY_TELEGRAM_BOT_TOKEN": "your-bot-token",
+    "MERCURY_TELEGRAM_ALLOWED_USER_IDS": "123456789"
+  }
+}
+```
+
+## Error Handling
+
+Never throws. Returns `{ ok: false, error: "transport" }` if router is unreachable.
+Logs to stderr only.
+
+## Notes
+
+- Bun is optional — Node 18+ works fine.
+- This module has no dependencies beyond Node built-ins.

--- a/adapters/mercury-notify/UPSTREAM.md
+++ b/adapters/mercury-notify/UPSTREAM.md
@@ -1,0 +1,18 @@
+# UPSTREAM — mercury-notify
+
+## Origin
+
+Original implementation. No code cherry-picked from any external project.
+
+## Inspiration
+
+Designed as the outbound leg of the Mercury Phase 5 bidirectional Telegram integration.
+Pattern informed by the ADR in `.mercury/docs/research/phase5-mvp-telegram-adr-2026-04-25.md`.
+
+## Dependencies
+
+None (Node built-ins only: `fetch` available in Node 18+).
+
+## License
+
+MIT (Mercury project).

--- a/adapters/mercury-notify/notify.cjs
+++ b/adapters/mercury-notify/notify.cjs
@@ -5,14 +5,25 @@
 // Callers: hook scripts (loop-detector, post-commit, etc.).
 // Never throws; always returns {ok, ...}.
 
-const PORT = process.env.MERCURY_ROUTER_PORT || 8788;
+const fs   = require('fs');
+const os   = require('os');
+const path = require('path');
+
+const PORT       = process.env.MERCURY_ROUTER_PORT || 8788;
+const TOKEN_FILE = path.join(os.homedir(), '.mercury', 'router.token');
+
+function readToken() {
+  try { return fs.readFileSync(TOKEN_FILE, 'utf8').trim(); } catch { return null; }
+}
 
 async function notify(severity, title, body, options = {}) {
   if (process.env.MERCURY_NOTIFY_DISABLED) return { ok: true, skipped: true };
+  const token = readToken();
+  if (!token) return { ok: false, error: 'no_token' };
   try {
     const res = await fetch(`http://127.0.0.1:${PORT}/notify`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
       body: JSON.stringify({ severity, title, body, ...options }),
       signal: AbortSignal.timeout(2000),
     });

--- a/adapters/mercury-notify/notify.cjs
+++ b/adapters/mercury-notify/notify.cjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+'use strict';
+
+// Mercury Notify — thin HTTP client forwarding notifications to mercury-channel-router.
+// Callers: hook scripts (loop-detector, post-commit, etc.).
+// Never throws; always returns {ok, ...}.
+
+const PORT = process.env.MERCURY_ROUTER_PORT || 8788;
+
+async function notify(severity, title, body, options = {}) {
+  if (process.env.MERCURY_NOTIFY_DISABLED) return { ok: true, skipped: true };
+  try {
+    const res = await fetch(`http://127.0.0.1:${PORT}/notify`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ severity, title, body, ...options }),
+      signal: AbortSignal.timeout(2000),
+    });
+    if (!res.ok) return { ok: false, error: `router_${res.status}` };
+    return { ok: true };
+  } catch (e) {
+    process.stderr.write(`[mercury-notify] ${e.message}\n`);
+    return { ok: false, error: 'transport' };
+  }
+}
+
+module.exports = { notify };

--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
     "@types/node": "^25.5.0",
     "typescript": "^5.9.3"
   },
-  "dependencies": {},
+  "dependencies": {
+    "node-telegram-bot-api": "^0.67.0",
+    "@modelcontextprotocol/sdk": "^1.29.0"
+  },
   "pnpm": {
     "onlyBuiltDependencies": ["better-sqlite3"]
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,13 @@ settings:
 importers:
 
   .:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.3.6)
+      node-telegram-bot-api:
+        specifier: ^0.67.0
+        version: 0.67.0(request@2.88.2)
     devDependencies:
       '@types/node':
         specifier: ^25.5.0
@@ -19,23 +26,2161 @@ importers:
 
 packages:
 
+  '@cypress/request-promise@5.0.0':
+    resolution: {integrity: sha512-eKdYVpa9cBEw2kTBlHeu1PP16Blwtum6QHg/u9s/MoHkZfuo1pRGka1VlUHXF5kdew82BvOJVVGk0x8X0nbp+w==}
+    engines: {node: '>=0.10.0'}
+    peerDependencies:
+      '@cypress/request': ^3.0.0
+
+  '@cypress/request@3.0.10':
+    resolution: {integrity: sha512-hauBrOdvu08vOsagkZ/Aju5XuiZx6ldsLfByg1htFeldhex+PeMrYauANzFsMJeAA0+dyPLbDoX2OYuvVoLDkQ==}
+    engines: {node: '>= 6'}
+
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
+
   '@types/node@25.5.0':
     resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
+
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
+  array-buffer-byte-length@1.0.2:
+    resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
+    engines: {node: '>= 0.4'}
+
+  array.prototype.findindex@2.2.4:
+    resolution: {integrity: sha512-LLm4mhxa9v8j0A/RPnpQAP4svXToJFh+Hp1pNYl5ZD5qpB4zdx/D4YjpVcETkhFbUKWO3iGMVLvrOnnmkAJT6A==}
+    engines: {node: '>= 0.4'}
+
+  arraybuffer.prototype.slice@1.0.4:
+    resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
+    engines: {node: '>= 0.4'}
+
+  asn1@0.2.6:
+    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
+
+  assert-plus@1.0.0:
+    resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
+    engines: {node: '>=0.8'}
+
+  async-function@1.0.0:
+    resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
+    engines: {node: '>= 0.4'}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  available-typed-arrays@1.0.7:
+    resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
+    engines: {node: '>= 0.4'}
+
+  aws-sign2@0.7.0:
+    resolution: {integrity: sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==}
+
+  aws4@1.13.2:
+    resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
+
+  bcrypt-pbkdf@1.0.2:
+    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
+
+  bl@1.2.3:
+    resolution: {integrity: sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==}
+
+  bluebird@3.7.2:
+    resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
+
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bind@1.0.9:
+    resolution: {integrity: sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
+  caseless@0.12.0:
+    resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  core-util-is@1.0.2:
+    resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
+
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  dashdash@1.14.1:
+    resolution: {integrity: sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==}
+    engines: {node: '>=0.10'}
+
+  data-view-buffer@1.0.2:
+    resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
+    engines: {node: '>= 0.4'}
+
+  data-view-byte-length@1.0.2:
+    resolution: {integrity: sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==}
+    engines: {node: '>= 0.4'}
+
+  data-view-byte-offset@1.0.1:
+    resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
+    engines: {node: '>= 0.4'}
+
+  debug@3.2.7:
+    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
+
+  define-properties@1.2.1:
+    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
+    engines: {node: '>= 0.4'}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ecc-jsbn@0.1.2:
+    resolution: {integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  es-abstract@1.24.2:
+    resolution: {integrity: sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==}
+    engines: {node: '>= 0.4'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
+  es-shim-unscopables@1.1.0:
+    resolution: {integrity: sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==}
+    engines: {node: '>= 0.4'}
+
+  es-to-primitive@1.3.0:
+    resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
+    engines: {node: '>= 0.4'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  eventemitter3@3.1.2:
+    resolution: {integrity: sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==}
+
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
+  express-rate-limit@8.4.1:
+    resolution: {integrity: sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  extsprintf@1.3.0:
+    resolution: {integrity: sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==}
+    engines: {'0': node >=0.6.0}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  file-type@3.9.0:
+    resolution: {integrity: sha512-RLoqTXE8/vPmMuTI88DAzhMYC99I8BWv7zYP4A1puo5HIjEJ5EX48ighy4ZyKMG9EDXxBgW6e++cn7d1xuFghA==}
+    engines: {node: '>=0.10.0'}
+
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
+  for-each@0.3.5:
+    resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
+    engines: {node: '>= 0.4'}
+
+  forever-agent@0.6.1:
+    resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
+
+  form-data@2.3.3:
+    resolution: {integrity: sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==}
+    engines: {node: '>= 0.12'}
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  function.prototype.name@1.1.8:
+    resolution: {integrity: sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==}
+    engines: {node: '>= 0.4'}
+
+  functions-have-names@1.2.3:
+    resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
+  generator-function@2.0.1:
+    resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
+    engines: {node: '>= 0.4'}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  get-symbol-description@1.1.0:
+    resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
+    engines: {node: '>= 0.4'}
+
+  getpass@0.1.7:
+    resolution: {integrity: sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==}
+
+  globalthis@1.0.4:
+    resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
+    engines: {node: '>= 0.4'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  har-schema@2.0.0:
+    resolution: {integrity: sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==}
+    engines: {node: '>=4'}
+
+  har-validator@5.1.5:
+    resolution: {integrity: sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==}
+    engines: {node: '>=6'}
+    deprecated: this library is no longer supported
+
+  has-bigints@1.1.0:
+    resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
+    engines: {node: '>= 0.4'}
+
+  has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
+
+  has-proto@1.2.0:
+    resolution: {integrity: sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==}
+    engines: {node: '>= 0.4'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
+  hono@4.12.15:
+    resolution: {integrity: sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==}
+    engines: {node: '>=16.9.0'}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
+  http-signature@1.2.0:
+    resolution: {integrity: sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==}
+    engines: {node: '>=0.8', npm: '>=1.3.7'}
+
+  http-signature@1.4.0:
+    resolution: {integrity: sha512-G5akfn7eKbpDN+8nPS/cb57YeA1jLTVxjpCj7tmm3QKPdyDy7T+qSC40e9ptydSWvkwjSXw1VbkpyEm39ukeAg==}
+    engines: {node: '>=0.10'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  internal-slot@1.1.0:
+    resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
+    engines: {node: '>= 0.4'}
+
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
+  is-array-buffer@3.0.5:
+    resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
+    engines: {node: '>= 0.4'}
+
+  is-async-function@2.1.1:
+    resolution: {integrity: sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==}
+    engines: {node: '>= 0.4'}
+
+  is-bigint@1.1.0:
+    resolution: {integrity: sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==}
+    engines: {node: '>= 0.4'}
+
+  is-boolean-object@1.2.2:
+    resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
+    engines: {node: '>= 0.4'}
+
+  is-callable@1.2.7:
+    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
+    engines: {node: '>= 0.4'}
+
+  is-data-view@1.0.2:
+    resolution: {integrity: sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==}
+    engines: {node: '>= 0.4'}
+
+  is-date-object@1.1.0:
+    resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
+    engines: {node: '>= 0.4'}
+
+  is-finalizationregistry@1.1.1:
+    resolution: {integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==}
+    engines: {node: '>= 0.4'}
+
+  is-generator-function@1.1.2:
+    resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
+    engines: {node: '>= 0.4'}
+
+  is-map@2.0.3:
+    resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
+    engines: {node: '>= 0.4'}
+
+  is-negative-zero@2.0.3:
+    resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
+    engines: {node: '>= 0.4'}
+
+  is-number-object@1.1.1:
+    resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
+    engines: {node: '>= 0.4'}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
+  is-regex@1.2.1:
+    resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
+    engines: {node: '>= 0.4'}
+
+  is-set@2.0.3:
+    resolution: {integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==}
+    engines: {node: '>= 0.4'}
+
+  is-shared-array-buffer@1.0.4:
+    resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
+    engines: {node: '>= 0.4'}
+
+  is-string@1.1.1:
+    resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
+    engines: {node: '>= 0.4'}
+
+  is-symbol@1.1.1:
+    resolution: {integrity: sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==}
+    engines: {node: '>= 0.4'}
+
+  is-typed-array@1.1.15:
+    resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
+    engines: {node: '>= 0.4'}
+
+  is-typedarray@1.0.0:
+    resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
+
+  is-weakmap@2.0.2:
+    resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
+    engines: {node: '>= 0.4'}
+
+  is-weakref@1.1.1:
+    resolution: {integrity: sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==}
+    engines: {node: '>= 0.4'}
+
+  is-weakset@2.0.4:
+    resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
+    engines: {node: '>= 0.4'}
+
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
+  isarray@2.0.5:
+    resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isstream@0.1.2:
+    resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
+
+  jose@6.2.2:
+    resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
+
+  jsbn@0.1.1:
+    resolution: {integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
+
+  json-stringify-safe@5.0.1:
+    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
+
+  jsprim@1.4.2:
+    resolution: {integrity: sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==}
+    engines: {node: '>=0.6.0'}
+
+  jsprim@2.0.2:
+    resolution: {integrity: sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==}
+    engines: {'0': node >=0.6.0}
+
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+
+  mime@1.6.0:
+    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
+  node-telegram-bot-api@0.67.0:
+    resolution: {integrity: sha512-gO7o/dPcdFSUuFuPiAYBxV7bcN+vQL3pfaHN8P4z8fPtFstN05xVmhMFOth57DANGDKBpzW3rMRo7debOlUI1w==}
+    engines: {node: '>=0.12'}
+
+  oauth-sign@0.9.0:
+    resolution: {integrity: sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  object-keys@1.1.1:
+    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
+    engines: {node: '>= 0.4'}
+
+  object.assign@4.1.7:
+    resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
+    engines: {node: '>= 0.4'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  own-keys@1.0.1:
+    resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
+    engines: {node: '>= 0.4'}
+
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+
+  performance-now@2.1.0:
+    resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+
+  possible-typed-array-names@1.1.0:
+    resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
+    engines: {node: '>= 0.4'}
+
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
+  psl@1.15.0:
+    resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
+
+  pump@2.0.1:
+    resolution: {integrity: sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  qs@6.14.2:
+    resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
+    engines: {node: '>=0.6'}
+
+  qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+    engines: {node: '>=0.6'}
+
+  qs@6.5.5:
+    resolution: {integrity: sha512-mzR4sElr1bfCaPJe7m8ilJ6ZXdDaGoObcYR0ZHSsktM/Lt21MVHj5De30GQH2eiZ1qGRTO7LCAzQsUeXTNexWQ==}
+    engines: {node: '>=0.6'}
+
+  querystringify@2.2.0:
+    resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
+
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
+  reflect.getprototypeof@1.0.10:
+    resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
+    engines: {node: '>= 0.4'}
+
+  regexp.prototype.flags@1.5.4:
+    resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
+    engines: {node: '>= 0.4'}
+
+  request-promise-core@1.1.3:
+    resolution: {integrity: sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==}
+    engines: {node: '>=0.10.0'}
+    peerDependencies:
+      request: ^2.34
+
+  request@2.88.2:
+    resolution: {integrity: sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==}
+    engines: {node: '>= 6'}
+    deprecated: request has been deprecated, see https://github.com/request/request/issues/3142
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  requires-port@1.0.0:
+    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
+
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
+  safe-array-concat@1.1.4:
+    resolution: {integrity: sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==}
+    engines: {node: '>=0.4'}
+
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safe-push-apply@1.0.0:
+    resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
+    engines: {node: '>= 0.4'}
+
+  safe-regex-test@1.1.0:
+    resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
+    engines: {node: '>= 0.4'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
+  set-function-length@1.2.2:
+    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
+    engines: {node: '>= 0.4'}
+
+  set-function-name@2.0.2:
+    resolution: {integrity: sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==}
+    engines: {node: '>= 0.4'}
+
+  set-proto@1.0.0:
+    resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
+    engines: {node: '>= 0.4'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
+  sshpk@1.18.0:
+    resolution: {integrity: sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==}
+    engines: {node: '>=0.10.0'}
+    hasBin: true
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
+  stealthy-require@1.1.1:
+    resolution: {integrity: sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g==}
+    engines: {node: '>=0.10.0'}
+
+  stop-iteration-iterator@1.1.0:
+    resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.trim@1.2.10:
+    resolution: {integrity: sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.trimend@1.0.9:
+    resolution: {integrity: sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.trimstart@1.0.8:
+    resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
+    engines: {node: '>= 0.4'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
+
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
+  tough-cookie@2.5.0:
+    resolution: {integrity: sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==}
+    engines: {node: '>=0.8'}
+
+  tough-cookie@4.1.4:
+    resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
+    engines: {node: '>=6'}
+
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
+  tweetnacl@0.14.5:
+    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
+
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
+
+  typed-array-buffer@1.0.3:
+    resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
+    engines: {node: '>= 0.4'}
+
+  typed-array-byte-length@1.0.3:
+    resolution: {integrity: sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==}
+    engines: {node: '>= 0.4'}
+
+  typed-array-byte-offset@1.0.4:
+    resolution: {integrity: sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==}
+    engines: {node: '>= 0.4'}
+
+  typed-array-length@1.0.7:
+    resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
+    engines: {node: '>= 0.4'}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
+  unbox-primitive@1.1.0:
+    resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
+    engines: {node: '>= 0.4'}
+
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
+  universalify@0.2.0:
+    resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
+    engines: {node: '>= 4.0.0'}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  url-parse@1.5.10:
+    resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@3.4.0:
+    resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
+    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
+    hasBin: true
+
+  uuid@8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    hasBin: true
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
+
+  verror@1.10.0:
+    resolution: {integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==}
+    engines: {'0': node >=0.6.0}
+
+  which-boxed-primitive@1.1.1:
+    resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
+    engines: {node: '>= 0.4'}
+
+  which-builtin-type@1.2.1:
+    resolution: {integrity: sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==}
+    engines: {node: '>= 0.4'}
+
+  which-collection@1.0.2:
+    resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
+    engines: {node: '>= 0.4'}
+
+  which-typed-array@1.1.20:
+    resolution: {integrity: sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==}
+    engines: {node: '>= 0.4'}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
 snapshots:
+
+  '@cypress/request-promise@5.0.0(@cypress/request@3.0.10)(request@2.88.2)':
+    dependencies:
+      '@cypress/request': 3.0.10
+      bluebird: 3.7.2
+      request-promise-core: 1.1.3(request@2.88.2)
+      stealthy-require: 1.1.1
+      tough-cookie: 4.1.4
+    transitivePeerDependencies:
+      - request
+
+  '@cypress/request@3.0.10':
+    dependencies:
+      aws-sign2: 0.7.0
+      aws4: 1.13.2
+      caseless: 0.12.0
+      combined-stream: 1.0.8
+      extend: 3.0.2
+      forever-agent: 0.6.1
+      form-data: 4.0.5
+      http-signature: 1.4.0
+      is-typedarray: 1.0.0
+      isstream: 0.1.2
+      json-stringify-safe: 5.0.1
+      mime-types: 2.1.35
+      performance-now: 2.1.0
+      qs: 6.14.2
+      safe-buffer: 5.2.1
+      tough-cookie: 5.1.2
+      tunnel-agent: 0.6.0
+      uuid: 8.3.2
+
+  '@hono/node-server@1.19.14(hono@4.12.15)':
+    dependencies:
+      hono: 4.12.15
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.15)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.8
+      express: 5.2.1
+      express-rate-limit: 8.4.1(express@5.2.1)
+      hono: 4.12.15
+      jose: 6.2.2
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    transitivePeerDependencies:
+      - supports-color
 
   '@types/node@25.5.0':
     dependencies:
       undici-types: 7.18.2
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv@6.15.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  array-buffer-byte-length@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      is-array-buffer: 3.0.5
+
+  array.prototype.findindex@2.2.4:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-object-atoms: 1.1.1
+      es-shim-unscopables: 1.1.0
+
+  arraybuffer.prototype.slice@1.0.4:
+    dependencies:
+      array-buffer-byte-length: 1.0.2
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      is-array-buffer: 3.0.5
+
+  asn1@0.2.6:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  assert-plus@1.0.0: {}
+
+  async-function@1.0.0: {}
+
+  asynckit@0.4.0: {}
+
+  available-typed-arrays@1.0.7:
+    dependencies:
+      possible-typed-array-names: 1.1.0
+
+  aws-sign2@0.7.0: {}
+
+  aws4@1.13.2: {}
+
+  bcrypt-pbkdf@1.0.2:
+    dependencies:
+      tweetnacl: 0.14.5
+
+  bl@1.2.3:
+    dependencies:
+      readable-stream: 2.3.8
+      safe-buffer: 5.2.1
+
+  bluebird@3.7.2: {}
+
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.1
+      raw-body: 3.0.2
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  bytes@3.1.2: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bind@1.0.9:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      get-intrinsic: 1.3.0
+      set-function-length: 1.2.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
+  caseless@0.12.0: {}
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
+  core-util-is@1.0.2: {}
+
+  core-util-is@1.0.3: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  dashdash@1.14.1:
+    dependencies:
+      assert-plus: 1.0.0
+
+  data-view-buffer@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-data-view: 1.0.2
+
+  data-view-byte-length@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-data-view: 1.0.2
+
+  data-view-byte-offset@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-data-view: 1.0.2
+
+  debug@3.2.7:
+    dependencies:
+      ms: 2.1.3
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  define-properties@1.2.1:
+    dependencies:
+      define-data-property: 1.1.4
+      has-property-descriptors: 1.0.2
+      object-keys: 1.1.1
+
+  delayed-stream@1.0.0: {}
+
+  depd@2.0.0: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  ecc-jsbn@0.1.2:
+    dependencies:
+      jsbn: 0.1.1
+      safer-buffer: 2.1.2
+
+  ee-first@1.1.1: {}
+
+  encodeurl@2.0.0: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
+
+  es-abstract@1.24.2:
+    dependencies:
+      array-buffer-byte-length: 1.0.2
+      arraybuffer.prototype.slice: 1.0.4
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      data-view-buffer: 1.0.2
+      data-view-byte-length: 1.0.2
+      data-view-byte-offset: 1.0.1
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      es-set-tostringtag: 2.1.0
+      es-to-primitive: 1.3.0
+      function.prototype.name: 1.1.8
+      get-intrinsic: 1.3.0
+      get-proto: 1.0.1
+      get-symbol-description: 1.1.0
+      globalthis: 1.0.4
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+      has-proto: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      internal-slot: 1.1.0
+      is-array-buffer: 3.0.5
+      is-callable: 1.2.7
+      is-data-view: 1.0.2
+      is-negative-zero: 2.0.3
+      is-regex: 1.2.1
+      is-set: 2.0.3
+      is-shared-array-buffer: 1.0.4
+      is-string: 1.1.1
+      is-typed-array: 1.1.15
+      is-weakref: 1.1.1
+      math-intrinsics: 1.1.0
+      object-inspect: 1.13.4
+      object-keys: 1.1.1
+      object.assign: 4.1.7
+      own-keys: 1.0.1
+      regexp.prototype.flags: 1.5.4
+      safe-array-concat: 1.1.4
+      safe-push-apply: 1.0.0
+      safe-regex-test: 1.1.0
+      set-proto: 1.0.0
+      stop-iteration-iterator: 1.1.0
+      string.prototype.trim: 1.2.10
+      string.prototype.trimend: 1.0.9
+      string.prototype.trimstart: 1.0.8
+      typed-array-buffer: 1.0.3
+      typed-array-byte-length: 1.0.3
+      typed-array-byte-offset: 1.0.4
+      typed-array-length: 1.0.7
+      unbox-primitive: 1.1.0
+      which-typed-array: 1.1.20
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.3
+
+  es-shim-unscopables@1.1.0:
+    dependencies:
+      hasown: 2.0.3
+
+  es-to-primitive@1.3.0:
+    dependencies:
+      is-callable: 1.2.7
+      is-date-object: 1.1.0
+      is-symbol: 1.1.1
+
+  escape-html@1.0.3: {}
+
+  etag@1.8.1: {}
+
+  eventemitter3@3.1.2: {}
+
+  eventsource-parser@3.0.8: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.8
+
+  express-rate-limit@8.4.1(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.1.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.1
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  extend@3.0.2: {}
+
+  extsprintf@1.3.0: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-uri@3.1.0: {}
+
+  file-type@3.9.0: {}
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  for-each@0.3.5:
+    dependencies:
+      is-callable: 1.2.7
+
+  forever-agent@0.6.1: {}
+
+  form-data@2.3.3:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.3
+      mime-types: 2.1.35
+
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
+
+  function-bind@1.1.2: {}
+
+  function.prototype.name@1.1.8:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      functions-have-names: 1.2.3
+      hasown: 2.0.3
+      is-callable: 1.2.7
+
+  functions-have-names@1.2.3: {}
+
+  generator-function@2.0.1: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+
+  get-symbol-description@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+
+  getpass@0.1.7:
+    dependencies:
+      assert-plus: 1.0.0
+
+  globalthis@1.0.4:
+    dependencies:
+      define-properties: 1.2.1
+      gopd: 1.2.0
+
+  gopd@1.2.0: {}
+
+  har-schema@2.0.0: {}
+
+  har-validator@5.1.5:
+    dependencies:
+      ajv: 6.15.0
+      har-schema: 2.0.0
+
+  has-bigints@1.1.0: {}
+
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.1
+
+  has-proto@1.2.0:
+    dependencies:
+      dunder-proto: 1.0.1
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+
+  hono@4.12.15: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
+  http-signature@1.2.0:
+    dependencies:
+      assert-plus: 1.0.0
+      jsprim: 1.4.2
+      sshpk: 1.18.0
+
+  http-signature@1.4.0:
+    dependencies:
+      assert-plus: 1.0.0
+      jsprim: 2.0.2
+      sshpk: 1.18.0
+
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  inherits@2.0.4: {}
+
+  internal-slot@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      hasown: 2.0.3
+      side-channel: 1.1.0
+
+  ip-address@10.1.0: {}
+
+  ipaddr.js@1.9.1: {}
+
+  is-array-buffer@3.0.5:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+
+  is-async-function@2.1.1:
+    dependencies:
+      async-function: 1.0.0
+      call-bound: 1.0.4
+      get-proto: 1.0.1
+      has-tostringtag: 1.0.2
+      safe-regex-test: 1.1.0
+
+  is-bigint@1.1.0:
+    dependencies:
+      has-bigints: 1.1.0
+
+  is-boolean-object@1.2.2:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-callable@1.2.7: {}
+
+  is-data-view@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+      is-typed-array: 1.1.15
+
+  is-date-object@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-finalizationregistry@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+
+  is-generator-function@1.1.2:
+    dependencies:
+      call-bound: 1.0.4
+      generator-function: 2.0.1
+      get-proto: 1.0.1
+      has-tostringtag: 1.0.2
+      safe-regex-test: 1.1.0
+
+  is-map@2.0.3: {}
+
+  is-negative-zero@2.0.3: {}
+
+  is-number-object@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-promise@4.0.0: {}
+
+  is-regex@1.2.1:
+    dependencies:
+      call-bound: 1.0.4
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.3
+
+  is-set@2.0.3: {}
+
+  is-shared-array-buffer@1.0.4:
+    dependencies:
+      call-bound: 1.0.4
+
+  is-string@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-symbol@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-symbols: 1.1.0
+      safe-regex-test: 1.1.0
+
+  is-typed-array@1.1.15:
+    dependencies:
+      which-typed-array: 1.1.20
+
+  is-typedarray@1.0.0: {}
+
+  is-weakmap@2.0.2: {}
+
+  is-weakref@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+
+  is-weakset@2.0.4:
+    dependencies:
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+
+  isarray@1.0.0: {}
+
+  isarray@2.0.5: {}
+
+  isexe@2.0.0: {}
+
+  isstream@0.1.2: {}
+
+  jose@6.2.2: {}
+
+  jsbn@0.1.1: {}
+
+  json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
+
+  json-schema@0.4.0: {}
+
+  json-stringify-safe@5.0.1: {}
+
+  jsprim@1.4.2:
+    dependencies:
+      assert-plus: 1.0.0
+      extsprintf: 1.3.0
+      json-schema: 0.4.0
+      verror: 1.10.0
+
+  jsprim@2.0.2:
+    dependencies:
+      assert-plus: 1.0.0
+      extsprintf: 1.3.0
+      json-schema: 0.4.0
+      verror: 1.10.0
+
+  lodash@4.18.1: {}
+
+  math-intrinsics@1.1.0: {}
+
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
+  mime-db@1.52.0: {}
+
+  mime-db@1.54.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
+  mime@1.6.0: {}
+
+  ms@2.1.3: {}
+
+  negotiator@1.0.0: {}
+
+  node-telegram-bot-api@0.67.0(request@2.88.2):
+    dependencies:
+      '@cypress/request': 3.0.10
+      '@cypress/request-promise': 5.0.0(@cypress/request@3.0.10)(request@2.88.2)
+      array.prototype.findindex: 2.2.4
+      bl: 1.2.3
+      debug: 3.2.7
+      eventemitter3: 3.1.2
+      file-type: 3.9.0
+      mime: 1.6.0
+      pump: 2.0.1
+    transitivePeerDependencies:
+      - request
+      - supports-color
+
+  oauth-sign@0.9.0: {}
+
+  object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
+
+  object-keys@1.1.1: {}
+
+  object.assign@4.1.7:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
+      has-symbols: 1.1.0
+      object-keys: 1.1.1
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  own-keys@1.0.1:
+    dependencies:
+      get-intrinsic: 1.3.0
+      object-keys: 1.1.1
+      safe-push-apply: 1.0.0
+
+  parseurl@1.3.3: {}
+
+  path-key@3.1.1: {}
+
+  path-to-regexp@8.4.2: {}
+
+  performance-now@2.1.0: {}
+
+  pkce-challenge@5.0.1: {}
+
+  possible-typed-array-names@1.1.0: {}
+
+  process-nextick-args@2.0.1: {}
+
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
+  psl@1.15.0:
+    dependencies:
+      punycode: 2.3.1
+
+  pump@2.0.1:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
+  punycode@2.3.1: {}
+
+  qs@6.14.2:
+    dependencies:
+      side-channel: 1.1.0
+
+  qs@6.15.1:
+    dependencies:
+      side-channel: 1.1.0
+
+  qs@6.5.5: {}
+
+  querystringify@2.2.0: {}
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
+
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+
+  reflect.getprototypeof@1.0.10:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      get-intrinsic: 1.3.0
+      get-proto: 1.0.1
+      which-builtin-type: 1.2.1
+
+  regexp.prototype.flags@1.5.4:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-errors: 1.3.0
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      set-function-name: 2.0.2
+
+  request-promise-core@1.1.3(request@2.88.2):
+    dependencies:
+      lodash: 4.18.1
+      request: 2.88.2
+
+  request@2.88.2:
+    dependencies:
+      aws-sign2: 0.7.0
+      aws4: 1.13.2
+      caseless: 0.12.0
+      combined-stream: 1.0.8
+      extend: 3.0.2
+      forever-agent: 0.6.1
+      form-data: 2.3.3
+      har-validator: 5.1.5
+      http-signature: 1.2.0
+      is-typedarray: 1.0.0
+      isstream: 0.1.2
+      json-stringify-safe: 5.0.1
+      mime-types: 2.1.35
+      oauth-sign: 0.9.0
+      performance-now: 2.1.0
+      qs: 6.5.5
+      safe-buffer: 5.2.1
+      tough-cookie: 2.5.0
+      tunnel-agent: 0.6.0
+      uuid: 3.4.0
+
+  require-from-string@2.0.2: {}
+
+  requires-port@1.0.0: {}
+
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
+  safe-array-concat@1.1.4:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+      has-symbols: 1.1.0
+      isarray: 2.0.5
+
+  safe-buffer@5.1.2: {}
+
+  safe-buffer@5.2.1: {}
+
+  safe-push-apply@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      isarray: 2.0.5
+
+  safe-regex-test@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-regex: 1.2.1
+
+  safer-buffer@2.1.2: {}
+
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  set-function-length@1.2.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.3.0
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+
+  set-function-name@2.0.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      functions-have-names: 1.2.3
+      has-property-descriptors: 1.0.2
+
+  set-proto@1.0.0:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+
+  setprototypeof@1.2.0: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
+  sshpk@1.18.0:
+    dependencies:
+      asn1: 0.2.6
+      assert-plus: 1.0.0
+      bcrypt-pbkdf: 1.0.2
+      dashdash: 1.14.1
+      ecc-jsbn: 0.1.2
+      getpass: 0.1.7
+      jsbn: 0.1.1
+      safer-buffer: 2.1.2
+      tweetnacl: 0.14.5
+
+  statuses@2.0.2: {}
+
+  stealthy-require@1.1.1: {}
+
+  stop-iteration-iterator@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      internal-slot: 1.1.0
+
+  string.prototype.trim@1.2.10:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-data-property: 1.1.4
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-object-atoms: 1.1.1
+      has-property-descriptors: 1.0.2
+
+  string.prototype.trimend@1.0.9:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
+
+  string.prototype.trimstart@1.0.8:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
+
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
+  toidentifier@1.0.1: {}
+
+  tough-cookie@2.5.0:
+    dependencies:
+      psl: 1.15.0
+      punycode: 2.3.1
+
+  tough-cookie@4.1.4:
+    dependencies:
+      psl: 1.15.0
+      punycode: 2.3.1
+      universalify: 0.2.0
+      url-parse: 1.5.10
+
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  tweetnacl@0.14.5: {}
+
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
+  typed-array-buffer@1.0.3:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-typed-array: 1.1.15
+
+  typed-array-byte-length@1.0.3:
+    dependencies:
+      call-bind: 1.0.9
+      for-each: 0.3.5
+      gopd: 1.2.0
+      has-proto: 1.2.0
+      is-typed-array: 1.1.15
+
+  typed-array-byte-offset@1.0.4:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.9
+      for-each: 0.3.5
+      gopd: 1.2.0
+      has-proto: 1.2.0
+      is-typed-array: 1.1.15
+      reflect.getprototypeof: 1.0.10
+
+  typed-array-length@1.0.7:
+    dependencies:
+      call-bind: 1.0.9
+      for-each: 0.3.5
+      gopd: 1.2.0
+      is-typed-array: 1.1.15
+      possible-typed-array-names: 1.1.0
+      reflect.getprototypeof: 1.0.10
+
   typescript@5.9.3: {}
 
+  unbox-primitive@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-bigints: 1.1.0
+      has-symbols: 1.1.0
+      which-boxed-primitive: 1.1.1
+
   undici-types@7.18.2: {}
+
+  universalify@0.2.0: {}
+
+  unpipe@1.0.0: {}
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
+
+  url-parse@1.5.10:
+    dependencies:
+      querystringify: 2.2.0
+      requires-port: 1.0.0
+
+  util-deprecate@1.0.2: {}
+
+  uuid@3.4.0: {}
+
+  uuid@8.3.2: {}
+
+  vary@1.1.2: {}
+
+  verror@1.10.0:
+    dependencies:
+      assert-plus: 1.0.0
+      core-util-is: 1.0.2
+      extsprintf: 1.3.0
+
+  which-boxed-primitive@1.1.1:
+    dependencies:
+      is-bigint: 1.1.0
+      is-boolean-object: 1.2.2
+      is-number-object: 1.1.1
+      is-string: 1.1.1
+      is-symbol: 1.1.1
+
+  which-builtin-type@1.2.1:
+    dependencies:
+      call-bound: 1.0.4
+      function.prototype.name: 1.1.8
+      has-tostringtag: 1.0.2
+      is-async-function: 2.1.1
+      is-date-object: 1.1.0
+      is-finalizationregistry: 1.1.1
+      is-generator-function: 1.1.2
+      is-regex: 1.2.1
+      is-weakref: 1.1.1
+      isarray: 2.0.5
+      which-boxed-primitive: 1.1.1
+      which-collection: 1.0.2
+      which-typed-array: 1.1.20
+
+  which-collection@1.0.2:
+    dependencies:
+      is-map: 2.0.3
+      is-set: 2.0.3
+      is-weakmap: 2.0.2
+      is-weakset: 2.0.4
+
+  which-typed-array@1.1.20:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      for-each: 0.3.5
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  wrappy@1.0.2: {}
+
+  zod-to-json-schema@3.25.2(zod@4.3.6):
+    dependencies:
+      zod: 4.3.6
+
+  zod@4.3.6: {}


### PR DESCRIPTION
Closes #293.

## Summary

Phase 5 MVP — full bidirectional Telegram integration. Users can:
- Receive Mercury stall alerts on phone (loop-detector → notify → router → Telegram)
- Send messages to Telegram bot, get them as `<channel>` events into the active Claude Code session (Telegram → router → channel-client MCP → Claude)
- Approve/deny tool permissions remotely (Channels permission relay protocol)
- Run up to 3 sessions in parallel with explicit `@<label>` routing

Per ADR v2 ([`.mercury/docs/research/phase5-mvp-telegram-adr-2026-04-25.md`](https://github.com/392fyc/Mercury/blob/develop/.mercury/docs/research/phase5-mvp-telegram-adr-2026-04-25.md)).

## Architecture (3 adapters)

| Adapter | LOC | Role |
|---|---|---|
| `mercury-channel-router/router.cjs` | 208 / 220 | Long-lived process per machine. Owns Telegram polling token + IPC server + ownership election + label resolution + 0-LLM regex routing |
| `mercury-channel-client/channel.cjs` | 223 / 230\* | MCP server, one per Claude Code session. Spawned by Claude via `.mcp.json`. Bridges router IPC ↔ MCP `notifications/claude/channel` + reply tool + permission relay |
| `mercury-notify/notify.cjs` | 38 / 80 | Thin HTTP client for hook scripts (loop-detector, etc.) to POST `/notify` to router |

\*Client LOC exceeds the original 200 target by 23 LOC due to IPC token auth retry/cleanup logic added in iter 3 security hardening — net positive trade-off; LOC amnesty extended to 230.

IPC: localhost HTTP + SSE (router → client). Bearer token auth on all endpoints except `/health`. Token written to `~/.mercury/router.token` mode 0600 at router startup.

Routing: 0 LLM. Regex + commands only (`@label text` / `/cmd args` / `yes <prefixed-id>`). LLM intent parsing deferred to Phase 5-3.

## Iteration history (multi-round dual-verify)

| # | Commit | Scope | Acceptance |
|---|--------|-------|-----------|
| 1 | `bb8a458` | Initial 3-adapter implementation + loop-detector wire + 4 research docs bundle | partial — ADR §7.6 ID rewriting + §5.2 step 6 outbound permission relay missing |
| 2 | `3a1324d` | ADR §7.6 prefix-based ID rewriting + §5.2 step 6 outbound permission_request handler | pass — 18/18 architecture criteria |
| 3 | `38b68cb` | Dual-verify security hardening: 7 fixes (3 Critical + 4 High + 1 Medium) | pass — 17/17 criteria, 0 regressions |

## Security hardening (iter 3 — 7 fixes)

| ID | Severity | Fix | Why |
|---|---|---|---|
| C1 | Critical | Allowlist fail-CLOSED (router.cjs:59) | Was fail-open: missing env var = any Telegram user could inject prompts |
| C2 | Critical | `htmlEsc` helper applied to all 8 `parse_mode:'HTML'` interpolations | Was: `<` in stall reason → Telegram 400 → notification silently dropped |
| C3 | Critical | IPC Bearer token auth on all endpoints except `/health`; `~/.mercury/router.token` mode 0600 | Localhost is not a trust boundary on workstations (DNS rebinding, malicious npm postinstall) |
| H1 | High | `msg.from` null guard + `chat.type === 'private'` guard before allowlist | Channel posts / group chats / anonymous admins could bypass sender check |
| H2 | High | Atomic `fs.openSync('wx')` lock + PID-validating release + listen-before-lock order | Race + EADDRINUSE handler used to delete winner's lock → spawn loop |
| H3 | High | Removed `process.on('exit')` execSync shell-injection vector | `CLAUDE_SESSION_ID` env var (user-controlled) string-interpolated into shell command |
| H4 | High | Removed `AbortSignal.timeout(60000)` from SSE fetch — connection now indefinite-lived | Forced reconnect every 60s caused listener accumulation + duplicate event delivery |
| H5 | High | Non-prefixed verdict rejected with helpful message instead of broadcasting to all sessions | Defeated the entire ADR §7.6 prefix mitigation |
| H6 | High | README prerequisite warnings: project-root launch + `MERCURY_TELEGRAM_ALLOWED_USER_IDS` REQUIRED | `.mcp.json` relative paths + allowlist requirement weren't loud enough |
| M5 | Medium | `lastChatId` mutation moved AFTER allowlist gate | Attacker-sent (rejected) messages used to leak chat_id into outbound notify target |

## User-level setup (NOT committed; documented in adapter READMEs)

Add to `~/.claude/settings.json` env block:

```json
"env": {
  "MERCURY_TELEGRAM_BOT_TOKEN": "<bot-token-from-BotFather>",
  "MERCURY_TELEGRAM_ALLOWED_USER_IDS": "<your-numeric-telegram-user-id>",
  "CLAUDE_HANDOFF_AUTO_LAUNCH_FLAGS": "--channels server:mercury-telegram --dangerously-load-development-channels"
}
```

Then launch Claude with: `claude --channels server:mercury-telegram --dangerously-load-development-channels`

Bun is **NOT required**. Node 20+ (already in `package.json` engines) is sufficient. Bun is mentioned only as an optional alternative runtime in adapter READMEs.

`CLAUDE_HANDOFF_AUTO_LAUNCH_FLAGS` env var support is being added to `392fyc/claude-handoff` plugin in a separate cross-repo PR (cross-repo work for handoff session continuity in bidirectional mode).

## Research docs bundled in this PR

- `phase5-mvp-telegram-adr-2026-04-25.md` (632 LOC) — v2 ADR (authoritative spec)
- `phase5-bidirectional-feasibility-2026-04-25.md` (242 LOC) — Channels API feasibility + multi-session blocker analysis
- `router-llm-backend-2026-04-25.md` (168 LOC) — Codex CLI vs Claude API vs OpenAI direct vs No-LLM (decision: 0 LLM MVP)
- `phase5-sizing-2026-04-25.md` (275 LOC) — Routines does NOT shrink Phase 5 (orthogonal layer)

## MVP limitations (acknowledged, not blockers)

- **Localhost trust model**: any local process can hit IPC endpoints with the token (`~/.mercury/router.token` is readable by user-level processes). Mitigated by 0600 mode but not bulletproof on multi-user systems.
- **No LLM intent parsing**: free-text "cancel that thing" requires explicit `@label` or `/cancel` command. Phase 5-3 adds optional intent parsing.
- **Hard 3-session limit**: 4th `/register` returns HTTP 429; channel-client logs warning but Claude Code starts normally (Telegram inactive for that session).
- **MVP private chats only**: group chats refused (`chat.type !== 'private'` early return) to avoid shared chat_id ambiguity.
- **handoff plugin integration**: requires cross-repo PR to `392fyc/claude-handoff` for `CLAUDE_HANDOFF_AUTO_LAUNCH_FLAGS` env var. Tracking separately.

## MVP follow-ups (deferred — should be Issues filed post-merge)

- M1 `git branch --show-current` blocks MCP startup; defer to async with override env var
- M2 `MERCURY_NOTIFY_DISABLED="0"` truthy bug — strict `=== '1' || === 'true'` check
- M3 SSE reconnect needs exponential backoff (currently fixed 2s)
- M4 `text.slice(4090)` may split UTF-16 surrogate pairs at boundary
- L1-L5 minor (`input_preview` unused, magic numbers, variable shadowing, polling/lock ordering)

## Test plan

- [x] Iter 1 smoke: 5/5 (router /health 5s, no-token graceful, notify no-router, notify with-router, loop-detector wire non-breaking)
- [x] Iter 2 smoke: 5/5 (SESSION_SHORT format, verdict regex 5 cases, /permission-request POST 200)
- [x] Iter 3 smoke: 8/8 (token auth: noauth→401, wrong→401, correct→200, /health no-auth→200, regression on existing endpoints)
- [x] Acceptance iter 1: partial (architecture: 19/20)
- [x] Acceptance iter 2: pass (18/18 criteria including ADR §7.6 + §5.2 step 6)
- [x] Acceptance iter 3: pass (17/17 criteria, 0 regressions)
- [x] Dual-verify: NEEDS-CHANGES (3 Critical + 6 High + 5 Medium + 5 Low) → all 7 must-fix addressed in iter 3
- [ ] Argus review (this PR)
- [ ] End-to-end manual: deploy + Telegram bot integration test (post-merge user task)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
