### PR TITLE
docs(exec-plan): mark Phase 5-1+5-2 Complete after PR #295 merge

### DIFF
--- a/.mercury/docs/EXECUTION-PLAN.md
+++ b/.mercury/docs/EXECUTION-PLAN.md
@@ -351,11 +351,11 @@ adapters/         # 适配层
 - ✅ Telegram bot via Anthropic Channels API research preview
 - ✅ 三 adapter 架构：`mercury-channel-router` (Telegram polling + IPC + 0-LLM regex routing) + `mercury-channel-client` (MCP server per session) + `mercury-notify` (thin HTTP client for hook scripts)
 - ✅ 限 3 session 同时运行，IPC Bearer token auth，allowlist fail-closed
-- ✅ Issue #91 closed via #293
+- ✅ Addresses Issue #91 ("IM Bot Bridge — LINE/Telegram 托管 Main Agent 远程对话") — closed manually post-merge
 
 ### 5-3. 与其他模块集成 — 🟡 Partial
 - ✅ Quality Gate: loop-detector stall → notify wire 已落地 (PR #295)
-- ⏳ Session Continuity: handoff session 切换时通知 — 待 `CLAUDE_HANDOFF_AUTO_LAUNCH_FLAGS` env var 在 claude-handoff plugin merge 后启用 (跨仓库 PR #11)
+- ⏳ Session Continuity: handoff session 切换时通知 — 待 `CLAUDE_HANDOFF_AUTO_LAUNCH_FLAGS` env var 在 claude-handoff plugin merge 后启用 (跨仓库: [`392fyc/claude-handoff#11`](https://github.com/392fyc/claude-handoff/pull/11))
 - ⏳ Dev Pipeline: dev/acceptance subagent 完成时通知 — 后续接入
 - 🔜 自然语言意图解析（"取消刚才那个"等口语命令）DEFER — MVP 用 deterministic `@<label>` + `/cmd` 已够用；远期 Phase 5-3 加 OpenAI gpt-4o-mini direct intent parser（ADR §11 Phase 5-3 + `router-llm-backend-2026-04-25.md`）
 

--- a/.mercury/docs/EXECUTION-PLAN.md
+++ b/.mercury/docs/EXECUTION-PLAN.md
@@ -342,20 +342,22 @@ adapters/         # 适配层
 **可用开发模式**: 全部 Phase 1-4 能力 + Session Continuity
 **推荐会话模式**: Mode B（标准开发），agent 可以跨 session 持续开发此模块
 
-### 5-1. 通知接口定义
-- 定义标准通知格式（事件类型、severity、内容）
-- 设计确认/拒绝回调机制
+### 5-1. 通知接口定义 — ✅ Complete (PR #295, merged 2026-04-25)
+- ✅ `notify(severity, title, body, options)` interface 落地 (`adapters/mercury-notify/notify.cjs`)
+- ✅ 双向交互机制：Telegram inbound → Claude Code session via `notifications/claude/channel`，Claude reply via MCP reply tool
+- ✅ 远程权限审批 relay：`notifications/claude/channel/permission_request` + `permission` verdict pair (ADR §5.2 step 6 + §7.6 ID rewriting)
 
-### 5-2. 首个通知渠道
-- 优先实现 Telegram 或 LINE bot（Issue #91）
-- 或利用 Claude Code Channels 原生机制
-- agent commit/PR/异常时自动发通知
-- 用户可回复确认或修改方向
+### 5-2. 首个通知渠道 — ✅ Complete (PR #295, merged 2026-04-25)
+- ✅ Telegram bot via Anthropic Channels API research preview
+- ✅ 三 adapter 架构：`mercury-channel-router` (Telegram polling + IPC + 0-LLM regex routing) + `mercury-channel-client` (MCP server per session) + `mercury-notify` (thin HTTP client for hook scripts)
+- ✅ 限 3 session 同时运行，IPC Bearer token auth，allowlist fail-closed
+- ✅ Issue #91 closed via #293
 
-### 5-3. 与其他模块集成
-- Session Continuity: session 切换时通知
-- Quality Gate: stop 被拦截时通知
-- Dev Pipeline: 任务完成时通知
+### 5-3. 与其他模块集成 — 🟡 Partial
+- ✅ Quality Gate: loop-detector stall → notify wire 已落地 (PR #295)
+- ⏳ Session Continuity: handoff session 切换时通知 — 待 `CLAUDE_HANDOFF_AUTO_LAUNCH_FLAGS` env var 在 claude-handoff plugin merge 后启用 (跨仓库 PR #11)
+- ⏳ Dev Pipeline: dev/acceptance subagent 完成时通知 — 后续接入
+- 🔜 自然语言意图解析（"取消刚才那个"等口语命令）DEFER — MVP 用 deterministic `@<label>` + `/cmd` 已够用；远期 Phase 5-3 加 OpenAI gpt-4o-mini direct intent parser（ADR §11 Phase 5-3 + `router-llm-backend-2026-04-25.md`）
 
 **产出**: 统一通知层 + 至少一个 IM 渠道
 **人类干预点**: 通知渠道选择；通知频率调优（避免过度打扰）

--- a/.mercury/state/upstream-manifest.json
+++ b/.mercury/state/upstream-manifest.json
@@ -199,7 +199,7 @@
     "upstream_path": null,
     "upstream_sha_at_import": null,
     "upstream_license": "n/a (no code copied)",
-    "import_pr": null,
+    "import_pr": 295,
     "import_date": "2026-04-25",
     "import_rationale": "Reference-only adapter inspired by Anthropic Channels reference + openclaw + node-telegram-bot-api. No code cherry-picked.",
     "last_drift_check": null
@@ -211,7 +211,7 @@
     "upstream_path": null,
     "upstream_sha_at_import": null,
     "upstream_license": "n/a (no code copied)",
-    "import_pr": null,
+    "import_pr": 295,
     "import_date": "2026-04-25",
     "import_rationale": "Reference-only adapter inspired by Anthropic Channels reference walkthrough + @modelcontextprotocol/sdk. No code cherry-picked.",
     "last_drift_check": null
@@ -223,7 +223,7 @@
     "upstream_path": null,
     "upstream_sha_at_import": null,
     "upstream_license": "n/a (no code copied)",
-    "import_pr": null,
+    "import_pr": 295,
     "import_date": "2026-04-25",
     "import_rationale": "Original implementation. No upstream references — thin HTTP client wrapping fetch().",
     "last_drift_check": null


### PR DESCRIPTION
Post-merge tracking update for PR #295 (Phase 5 MVP bidirectional Telegram).

## Changes
- EXECUTION-PLAN.md Phase 5-1 + 5-2 marked Complete with PR #295 reference
- Phase 5-3 marked Partial (loop-detector wire done; handoff plugin integration pending PR #11; dev-pipeline integration future)
- Natural-language intent parser DEFER note (Phase 5-3 远期, per ADR §11)
- upstream-manifest.json import_pr null → 295 for 3 new adapter UPSTREAM.md entries per cherry-pick protocol

Pure docs/tracking — no code changes. JSON validity verified via jq.

🤖 Generated with [Claude Code](https://claude.com/claude-code)