### PR TITLE
feat(lane-protocol): Rule 1.1 probe-after-write — scripts/lane-claim.sh (#309)

### DIFF
--- a/.mercury/docs/guides/lane-claim.md
+++ b/.mercury/docs/guides/lane-claim.md
@@ -1,0 +1,104 @@
+# Lane Claim Wrapper — `scripts/lane-claim.sh`
+
+Implements **Rule 1.1 probe-after-write Issue claim verification** of the multi-lane protocol
+(v0.1 Delta 1, Issue [#309](https://github.com/392fyc/Mercury/issues/309)).
+
+## Why
+
+Mercury Rule 1 (v0) requires every lane to claim an Issue with `lane:<name>` label before working
+on it. The raw command was:
+
+```bash
+gh issue edit <N> --add-assignee @me --add-label "lane:<name>"
+```
+
+But the GitHub REST API is **not atomic** for label edits. If two lanes claim the same Issue
+within milliseconds (concurrent CI runs, parallel session starts, two operators), both writes
+succeed and both lanes silently believe they own the Issue. v0's first-timestamp-wins resolution
+is post-hoc only — neither lane learns of the conflict until a human notices.
+
+Rule 1.1 closes the gap: after every claim write, immediately re-query the Issue's labels and
+verify exactly one `lane:*` prefix is present. Conflict → abort + comment + non-zero exit.
+
+## Usage
+
+```bash
+scripts/lane-claim.sh <lane-name> <issue-number> [--dry-run] [--no-assignee]
+```
+
+| Flag | Effect |
+|------|--------|
+| `--dry-run` | Print the intended actions without calling `gh`. Useful for CI validation. |
+| `--no-assignee` | Skip `--add-assignee @me`. Use when the wrapper runs in CI/bot context where `@me` resolves to the bot account. |
+| `-h`, `--help` | Print usage from this script's header. |
+
+### Exit codes
+
+| Exit | Meaning |
+|------|---------|
+| `0` | Clean claim — exactly one `lane:*` label present after probe |
+| `1` | Conflict — multiple `lane:*` labels OR zero `lane:*` labels post-write; conflict comment posted on the Issue |
+| `2` | Invalid args, `gh` or `jq` missing, or `gh` API error |
+
+### Examples
+
+```bash
+# Standard claim — current user becomes assignee
+scripts/lane-claim.sh side-multi-lane 309
+
+# CI/bot context — skip @me assignment
+scripts/lane-claim.sh side-multi-lane 309 --no-assignee
+
+# Validate without calling GitHub
+scripts/lane-claim.sh side-multi-lane 309 --dry-run
+```
+
+## Conflict resolution
+
+When the wrapper detects a conflict (exit code `1`), it posts a comment on the Issue listing the
+detected `lane:*` labels and asking for human arbitration. The comment template:
+
+> :rotating_light: Lane claim conflict detected by `scripts/lane-claim.sh` (Rule 1.1
+> probe-after-write).
+>
+> Post-write label set contains N `lane:*` labels:
+> - `lane:main`
+> - `lane:other`
+>
+> Latest claim: `lane:other` by `@user`.
+>
+> GitHub REST API non-atomic — concurrent claims both succeeded silently. Manual arbitration
+> required:
+>
+> 1. Decide which lane owns Issue #N
+> 2. Other lane(s): `gh issue edit N --remove-label lane:<other>`
+> 3. Loser lanes close their session and fall back to non-conflicting work
+
+The wrapper does **not** auto-remove either label — that decision belongs to the user, since
+"first claim should win" is a heuristic that breaks when the first claim came from a stale
+process or a misconfigured agent.
+
+## Tests
+
+```bash
+scripts/test-lane-claim.sh
+```
+
+Stubs `gh` via PATH manipulation and exercises:
+
+- Argument validation (missing args, invalid lane name, non-numeric Issue)
+- `--help` and `--dry-run` paths (no API calls)
+- Happy path (single `lane:*` label) → exit `0`
+- Race detection (two `lane:*` labels) → exit `1`
+- Zero-label edge case (silent edit failure) → exit `1`
+- `gh issue edit` failure → exit `2`
+
+Tests do not touch real GitHub — safe to run in CI on every commit.
+
+## Source references
+
+- Issue [#309](https://github.com/392fyc/Mercury/issues/309) — acceptance criteria
+- [`feedback_lane_protocol.md`](https://github.com/392fyc/Mercury/blob/develop/.mercury/docs/research/multi-lane-protocol-2026-04-25.md) (user-memory, repo mirror in research doc)
+- [v0.1 Delta companion](../lane-protocol-v0.1-deltas.md#delta-1--rule-11-probe-after-write-p1)
+- [GitHub Releases API race condition (devactivity.com)](https://devactivity.com/insights/mastering-github-releases-avoiding-race-conditions-for-enhanced-engineering-productivity/)
+- [GitHub community discussion #9252 — concurrency group bug](https://github.com/orgs/community/discussions/9252)

--- a/.mercury/docs/guides/lane-claim.md
+++ b/.mercury/docs/guides/lane-claim.md
@@ -48,6 +48,19 @@ call as `--repo <owner>/<repo>`. This defends against:
 If the wrapper cannot resolve the repo (no git repo + no `GH_REPO`), it exits with code `2`
 before any GitHub API call.
 
+### Known limitation: residual race window
+
+Rule 1.1 reduces but does not eliminate the GitHub REST non-atomic race. There is a small
+residual window between the probe-pass and the follow-up `--add-assignee` call (step 3) during
+which a different lane could add a competing `lane:*` label. If that happens, the assignee will
+still be added before this wrapper returns, even though the Issue effectively has a conflict.
+
+This is accepted residual risk. Adding a second probe would only shift the window — there is no
+atomic compare-and-swap on the GitHub Issues label API. The probe-after-write design is "best
+effort post-hoc detection at the closest point to the write," and the second-write (assignee) is
+a follow-up that should be treated as a non-binding side-effect (assignees can be removed by any
+lane during conflict arbitration without affecting label ownership).
+
 ### Exit codes
 
 | Exit | Meaning |

--- a/.mercury/docs/guides/lane-claim.md
+++ b/.mercury/docs/guides/lane-claim.md
@@ -52,8 +52,8 @@ before any GitHub API call.
 
 | Exit | Meaning |
 |------|---------|
-| `0` | Clean claim — exactly one `lane:*` label present after probe |
-| `1` | Either multiple `lane:*` labels (conflict — Issue comment posted) OR zero `lane:*` labels (silent edit failure — warn only, no comment) |
+| `0` | Clean claim — exactly one `lane:*` label after probe AND it matches the requested lane (assignee added in a follow-up call after the probe) |
+| `1` | Verification failed — multiple `lane:*` labels (conflict — Issue comment posted), OR zero `lane:*` labels (silent edit failure — warn only), OR exactly one `lane:*` label that belongs to a different lane (existing owner — warn only) |
 | `2` | Invalid args, `gh`/`jq` missing, cannot resolve target repo, or `gh` API error |
 
 ### Examples

--- a/.mercury/docs/guides/lane-claim.md
+++ b/.mercury/docs/guides/lane-claim.md
@@ -26,15 +26,12 @@ verify exactly one `lane:*` prefix is present. Conflict → abort + comment + no
 scripts/lane-claim.sh <lane-name> <issue-number> [--dry-run] [--no-assignee]
 ```
 
-| Flag | Effect |
-|------|--------|
-| `--dry-run` | Print the intended actions without calling `gh`. Useful for CI validation. |
+| Flag / Env var | Effect |
+|----------------|--------|
+| `--dry-run` | Print the intended actions without calling `gh`/`jq`. Strict offline — works without `gh` installed. |
 | `--no-assignee` | Skip `--add-assignee @me`. Use when the wrapper runs in CI/bot context where `@me` resolves to the bot account. |
 | `-h`, `--help` | Print usage from this script's header. |
-
-| Env var | Effect |
-|---------|--------|
-| `GH_REPO=<owner>/<repo>` | Override repo target. Without this, the wrapper resolves the repo from the current cwd via `gh repo view`. Set this in CI / off-cwd contexts to prevent accidentally writing to the wrong repo. |
+| `GH_REPO=<owner>/<repo>` (env) | Override repo target. Without this, the wrapper resolves the repo from the current cwd via `gh repo view`. Set this in CI / off-cwd contexts to prevent accidentally writing to the wrong repo. |
 
 ### Repo target pinning
 
@@ -56,8 +53,8 @@ before any GitHub API call.
 | Exit | Meaning |
 |------|---------|
 | `0` | Clean claim — exactly one `lane:*` label present after probe |
-| `1` | Conflict — multiple `lane:*` labels OR zero `lane:*` labels post-write; conflict comment posted on the Issue |
-| `2` | Invalid args, `gh` or `jq` missing, or `gh` API error |
+| `1` | Either multiple `lane:*` labels (conflict — Issue comment posted) OR zero `lane:*` labels (silent edit failure — warn only, no comment) |
+| `2` | Invalid args, `gh`/`jq` missing, cannot resolve target repo, or `gh` API error |
 
 ### Examples
 

--- a/.mercury/docs/guides/lane-claim.md
+++ b/.mercury/docs/guides/lane-claim.md
@@ -46,7 +46,8 @@ call as `--repo <owner>/<repo>`. This defends against:
   unless `GH_REPO` is set.
 
 If the wrapper cannot resolve the repo (no git repo + no `GH_REPO`), it exits with code `2`
-before any GitHub API call.
+before any issue edit/comment is attempted (`gh repo view` itself may hit the API during
+resolution; only the issue write/probe/comment paths are gated by successful resolution).
 
 ### Known limitation: residual race window
 
@@ -94,13 +95,14 @@ detected `lane:*` labels and asking for human arbitration. The comment template:
 > - `lane:main`
 > - `lane:other`
 >
-> Latest claim: `lane:other` by `@user`.
+> This invocation attempted to add `lane:other` as `@user` (ordering of past claims is not
+> knowable from this side — multiple lane labels are simply present after the probe).
 >
 > GitHub REST API non-atomic — concurrent claims both succeeded silently. Manual arbitration
 > required:
 >
 > 1. Decide which lane owns Issue #N
-> 2. Other lane(s): `gh issue edit N --remove-label lane:<other>`
+> 2. Other lane(s): `gh issue edit N --repo $REPO --remove-label lane:<other>`
 > 3. Loser lanes close their session and fall back to non-conflicting work
 
 The wrapper does **not** auto-remove either label — that decision belongs to the user, since
@@ -127,7 +129,7 @@ Tests do not touch real GitHub — safe to run in CI on every commit.
 ## Source references
 
 - Issue [#309](https://github.com/392fyc/Mercury/issues/309) — acceptance criteria
-- [Multi-lane protocol research design doc](https://github.com/392fyc/Mercury/blob/develop/.mercury/docs/research/multi-lane-protocol-2026-04-25.md) — repo-side authority for the v0 7 rules (the protocol is also mirrored in user-memory `feedback_lane_protocol.md`, which is per-machine and not web-accessible)
+- [Multi-lane protocol research design doc](../research/multi-lane-protocol-2026-04-25.md) — repo-side authority for the v0 7 rules (the protocol is also mirrored in user-memory `feedback_lane_protocol.md`, which is per-machine and not web-accessible)
 - [v0.1 Delta companion](../lane-protocol-v0.1-deltas.md#delta-1--rule-11-probe-after-write-p1)
 - [GitHub Releases API race condition (devactivity.com)](https://devactivity.com/insights/mastering-github-releases-avoiding-race-conditions-for-enhanced-engineering-productivity/)
 - [GitHub community discussion #9252 — concurrency group bug](https://github.com/orgs/community/discussions/9252)

--- a/.mercury/docs/guides/lane-claim.md
+++ b/.mercury/docs/guides/lane-claim.md
@@ -32,6 +32,25 @@ scripts/lane-claim.sh <lane-name> <issue-number> [--dry-run] [--no-assignee]
 | `--no-assignee` | Skip `--add-assignee @me`. Use when the wrapper runs in CI/bot context where `@me` resolves to the bot account. |
 | `-h`, `--help` | Print usage from this script's header. |
 
+| Env var | Effect |
+|---------|--------|
+| `GH_REPO=<owner>/<repo>` | Override repo target. Without this, the wrapper resolves the repo from the current cwd via `gh repo view`. Set this in CI / off-cwd contexts to prevent accidentally writing to the wrong repo. |
+
+### Repo target pinning
+
+The repo is resolved **once** at script start and passed explicitly to every subsequent `gh issue *`
+call as `--repo <owner>/<repo>`. This defends against:
+
+- **Cross-repo writes**: a `cd` mid-script (impossible in this single-file script, but a future
+  refactor could introduce one) cannot redirect writes to a different repo.
+- **CI / fork contexts**: where `gh` may auto-resolve to an unexpected repo because of
+  `git remote` configuration. CI should always set `GH_REPO` explicitly.
+- **Wrong-cwd execution**: running the script from a sibling repo silently writes to that repo
+  unless `GH_REPO` is set.
+
+If the wrapper cannot resolve the repo (no git repo + no `GH_REPO`), it exits with code `2`
+before any GitHub API call.
+
 ### Exit codes
 
 | Exit | Meaning |
@@ -98,7 +117,7 @@ Tests do not touch real GitHub — safe to run in CI on every commit.
 ## Source references
 
 - Issue [#309](https://github.com/392fyc/Mercury/issues/309) — acceptance criteria
-- [`feedback_lane_protocol.md`](https://github.com/392fyc/Mercury/blob/develop/.mercury/docs/research/multi-lane-protocol-2026-04-25.md) (user-memory, repo mirror in research doc)
+- [Multi-lane protocol research design doc](https://github.com/392fyc/Mercury/blob/develop/.mercury/docs/research/multi-lane-protocol-2026-04-25.md) — repo-side authority for the v0 7 rules (the protocol is also mirrored in user-memory `feedback_lane_protocol.md`, which is per-machine and not web-accessible)
 - [v0.1 Delta companion](../lane-protocol-v0.1-deltas.md#delta-1--rule-11-probe-after-write-p1)
 - [GitHub Releases API race condition (devactivity.com)](https://devactivity.com/insights/mastering-github-releases-avoiding-race-conditions-for-enhanced-engineering-productivity/)
 - [GitHub community discussion #9252 — concurrency group bug](https://github.com/orgs/community/discussions/9252)

--- a/scripts/lane-claim.sh
+++ b/scripts/lane-claim.sh
@@ -157,8 +157,21 @@ GitHub REST API non-atomic — concurrent claims both succeeded silently. Manual
 Source: [Mercury lane-claim.md (Rule 1.1 in-repo guide)](https://github.com/$REPO/blob/HEAD/.mercury/docs/guides/lane-claim.md).
 EOF
 )
-  if ! gh issue comment "$ISSUE" --repo "$REPO" --body "$COMMENT_BODY" >/dev/null 2>&1; then
-    warn "failed to post conflict comment — please post manually"
+  # Conflict comment is a side-effect. Detection + non-zero exit are the hard
+  # requirements; the comment is best-effort. Retry once on transient gh/API
+  # failure; surface a loud warn if both attempts fail so the operator knows
+  # the conflict needs manual posting (the conflict itself is still signaled
+  # via stderr CONFLICT line above + exit 1 below).
+  COMMENT_OK=0
+  for attempt in 1 2; do
+    if gh issue comment "$ISSUE" --repo "$REPO" --body "$COMMENT_BODY" >/dev/null 2>&1; then
+      COMMENT_OK=1
+      break
+    fi
+    [ "$attempt" -lt 2 ] && sleep 1
+  done
+  if [ "$COMMENT_OK" -eq 0 ]; then
+    warn "FAILED to post conflict comment after 2 attempts — conflict is still signaled via the CONFLICT line above + exit 1; post the comment manually so the other lane sees the conflict"
   fi
   exit 1
 fi

--- a/scripts/lane-claim.sh
+++ b/scripts/lane-claim.sh
@@ -68,6 +68,25 @@ case "$ISSUE" in
   ''|*[!0-9]*|0) die "issue must be a positive integer: '$ISSUE'" ;;
 esac
 
+LABEL="lane:$LANE"
+
+EDIT_ARGS=(--add-label "$LABEL")
+if [ "$NO_ASSIGNEE" -eq 0 ]; then
+  EDIT_ARGS+=(--add-assignee "@me")
+fi
+
+# Dry-run gate: print intent and exit without any external command (no gh / jq /
+# git invocations). Strict offline semantics — useful for CI validation in
+# minimal containers that may not even have gh installed yet.
+if [ "$DRY_RUN" -eq 1 ]; then
+  REPO_PREVIEW="${GH_REPO:-<resolved at runtime via gh repo view>}"
+  printf '[dry-run] target repo: %s\n' "$REPO_PREVIEW"
+  printf '[dry-run] gh issue edit %s --repo %s %s\n' "$ISSUE" "$REPO_PREVIEW" "${EDIT_ARGS[*]}"
+  printf '[dry-run] probe + verdict skipped (no gh/jq calls in dry-run)\n'
+  exit 0
+fi
+
+# Live-mode pre-flight: tools + repo target.
 command -v gh >/dev/null 2>&1 || die "gh CLI not installed or not on PATH"
 command -v jq >/dev/null 2>&1 || die "jq not installed or not on PATH"
 
@@ -86,21 +105,7 @@ case "$REPO" in
   *) die "invalid repo format '$REPO' (expected owner/repo)" ;;
 esac
 
-LABEL="lane:$LANE"
-
-EDIT_ARGS=(--add-label "$LABEL")
-if [ "$NO_ASSIGNEE" -eq 0 ]; then
-  EDIT_ARGS+=(--add-assignee "@me")
-fi
-
 # Step 1: write — add the lane label (+ @me assignee unless suppressed)
-if [ "$DRY_RUN" -eq 1 ]; then
-  printf '[dry-run] target repo: %s\n' "$REPO"
-  printf '[dry-run] gh issue edit %s --repo %s %s\n' "$ISSUE" "$REPO" "${EDIT_ARGS[*]}"
-  printf '[dry-run] probe + verdict skipped\n'
-  exit 0
-fi
-
 if ! gh issue edit "$ISSUE" --repo "$REPO" "${EDIT_ARGS[@]}" >/dev/null; then
   die "gh issue edit #$ISSUE failed"
 fi

--- a/scripts/lane-claim.sh
+++ b/scripts/lane-claim.sh
@@ -70,18 +70,18 @@ esac
 
 LABEL="lane:$LANE"
 
-EDIT_ARGS=(--add-label "$LABEL")
-if [ "$NO_ASSIGNEE" -eq 0 ]; then
-  EDIT_ARGS+=(--add-assignee "@me")
-fi
-
 # Dry-run gate: print intent and exit without any external command (no gh / jq /
 # git invocations). Strict offline semantics — useful for CI validation in
 # minimal containers that may not even have gh installed yet.
 if [ "$DRY_RUN" -eq 1 ]; then
   REPO_PREVIEW="${GH_REPO:-<resolved at runtime via gh repo view>}"
   printf '[dry-run] target repo: %s\n' "$REPO_PREVIEW"
-  printf '[dry-run] gh issue edit %s --repo %s %s\n' "$ISSUE" "$REPO_PREVIEW" "${EDIT_ARGS[*]}"
+  printf '[dry-run] step 1: gh issue edit %s --repo %s --add-label %s\n' \
+    "$ISSUE" "$REPO_PREVIEW" "$LABEL"
+  if [ "$NO_ASSIGNEE" -eq 0 ]; then
+    printf '[dry-run] step 3 (only if probe is clean): gh issue edit %s --repo %s --add-assignee @me\n' \
+      "$ISSUE" "$REPO_PREVIEW"
+  fi
   printf '[dry-run] probe + verdict skipped (no gh/jq calls in dry-run)\n'
   exit 0
 fi
@@ -110,9 +110,11 @@ case "$REPO" in
   *) die "invalid repo format '$REPO' (expected owner/repo)" ;;
 esac
 
-# Step 1: write — add the lane label (+ @me assignee unless suppressed)
-if ! gh issue edit "$ISSUE" --repo "$REPO" "${EDIT_ARGS[@]}" >/dev/null; then
-  die "gh issue edit #$ISSUE failed"
+# Step 1: write LABEL only — assignee deferred until the probe verifies a clean
+# claim (Copilot iter 2 #317: a losing concurrent claimant should not modify
+# assignees on an Issue another lane already owns).
+if ! gh issue edit "$ISSUE" --repo "$REPO" --add-label "$LABEL" >/dev/null; then
+  die "gh issue edit #$ISSUE failed (add-label)"
 fi
 
 # Step 2: probe — re-query labels and count lane:* prefix
@@ -142,12 +144,12 @@ Post-write label set contains $LANE_COUNT \`lane:*\` labels:
 
 $LABEL_LIST
 
-Latest claim: \`$LABEL\` by \`@$ACTOR\`.
+This invocation attempted to add \`$LABEL\` as \`@$ACTOR\` (ordering of past claims is not knowable from this side — multiple lane labels are simply present after the probe).
 
 GitHub REST API non-atomic — concurrent claims both succeeded silently. Manual arbitration required:
 
 1. Decide which lane owns Issue #$ISSUE
-2. Other lane(s): \`gh issue edit $ISSUE --remove-label lane:<other>\`
+2. Other lane(s): \`gh issue edit $ISSUE --repo $REPO --remove-label lane:<other>\`
 3. Loser lanes close their session and fall back to non-conflicting work
 
 Source: [Mercury lane-claim.md (Rule 1.1 in-repo guide)](https://github.com/392fyc/Mercury/blob/develop/.mercury/docs/guides/lane-claim.md).
@@ -172,6 +174,14 @@ if ! printf '%s\n' "$LANE_LABELS" | grep -qxF "$LABEL"; then
   EXISTING=$(printf '%s' "$LANE_LABELS" | tr '\n' ' ' | sed 's/[[:space:]]*$//')
   warn "single lane:* label is '$EXISTING', not requested '$LABEL' — claim did not take effect (existing owner)"
   exit 1
+fi
+
+# Step 3: probe verified clean ownership — now safe to set assignee.
+# Failure here is non-fatal; the label claim is already recorded.
+if [ "$NO_ASSIGNEE" -eq 0 ]; then
+  if ! gh issue edit "$ISSUE" --repo "$REPO" --add-assignee "@me" >/dev/null 2>&1; then
+    warn "label claimed but --add-assignee @me failed — non-fatal, set assignee manually if needed"
+  fi
 fi
 
 printf 'lane-claim: issue #%s claimed by %s (probe verified single lane label)\n' \

--- a/scripts/lane-claim.sh
+++ b/scripts/lane-claim.sh
@@ -97,8 +97,13 @@ command -v jq >/dev/null 2>&1 || die "jq not installed or not on PATH"
 # or env mutation cannot redirect writes.
 REPO="${GH_REPO:-}"
 if [ -z "$REPO" ]; then
+  # gh repo view can fail for several reasons: not in a git repo, no `origin`
+  # remote, gh auth missing, network/API outage. Don't claim "not in a git repo"
+  # specifically — the actual stderr is suppressed for cleanliness so the
+  # caller cannot distinguish reasons. Suggest GH_REPO as the deterministic
+  # override path.
   REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null) \
-    || die "cannot determine target repo: not in a git repo and GH_REPO not set"
+    || die "cannot determine target repo via GH_REPO or gh repo view (no git repo, no origin remote, gh auth missing, or API/network error)"
 fi
 case "$REPO" in
   */*) ;;
@@ -145,7 +150,7 @@ GitHub REST API non-atomic — concurrent claims both succeeded silently. Manual
 2. Other lane(s): \`gh issue edit $ISSUE --remove-label lane:<other>\`
 3. Loser lanes close their session and fall back to non-conflicting work
 
-Source: [Mercury feedback_lane_protocol.md Rule 1.1](https://github.com/392fyc/Mercury/blob/develop/.mercury/docs/guides/lane-claim.md).
+Source: [Mercury lane-claim.md (Rule 1.1 in-repo guide)](https://github.com/392fyc/Mercury/blob/develop/.mercury/docs/guides/lane-claim.md).
 EOF
 )
   if ! gh issue comment "$ISSUE" --repo "$REPO" --body "$COMMENT_BODY" >/dev/null 2>&1; then

--- a/scripts/lane-claim.sh
+++ b/scripts/lane-claim.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# scripts/lane-claim.sh — Mercury multi-lane Issue claim with probe-after-write.
+# Implements Rule 1.1 of feedback_lane_protocol.md (v0.1 Delta 1, Issue #309).
+#
+# Adds `lane:<lane>` label (+ @me assignee) to <issue-number>, then re-queries
+# Issue labels. If post-write count of `lane:*` labels > 1, aborts non-zero
+# and posts an Issue comment so the user can resolve the conflict.
+#
+# GitHub REST API non-atomic: two concurrent claims can both succeed silently.
+# This wrapper detects the race post-hoc but immediately after the write —
+# closer than v0 first-timestamp-wins (which never detects).
+#
+# Usage:
+#   scripts/lane-claim.sh <lane-name> <issue-number> [--dry-run] [--no-assignee]
+#
+# Exit codes:
+#   0  clean claim (exactly 1 lane:* label after probe)
+#   1  conflict detected (>1 lane:* labels) or zero labels post-write
+#   2  invalid args / gh|jq not available / API error
+
+set -u
+
+die()  { printf 'lane-claim: %s\n' "$1" >&2; exit 2; }
+warn() { printf 'lane-claim WARN: %s\n' "$1" >&2; }
+
+LANE=""
+ISSUE=""
+DRY_RUN=0
+NO_ASSIGNEE=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run) DRY_RUN=1; shift ;;
+    --no-assignee) NO_ASSIGNEE=1; shift ;;
+    -h|--help)
+      sed -n '2,19p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    --) shift; break ;;
+    -*) die "unknown flag: $1" ;;
+    *)
+      if [ -z "$LANE" ]; then
+        LANE="$1"
+      elif [ -z "$ISSUE" ]; then
+        ISSUE="$1"
+      else
+        die "too many positional arguments; got: $1"
+      fi
+      shift
+      ;;
+  esac
+done
+
+[ -n "$LANE" ]  || die "missing <lane-name> argument (try --help)"
+[ -n "$ISSUE" ] || die "missing <issue-number> argument (try --help)"
+
+# Lane name validation: alnum + hyphen + underscore only. Protects label content
+# from injection into shell expansions / JSON later in the comment payload.
+case "$LANE" in
+  -*) die "lane name must not start with hyphen: '$LANE'" ;;
+  *[!A-Za-z0-9_-]*) die "lane name must be [A-Za-z0-9_-]: '$LANE'" ;;
+esac
+case "$ISSUE" in
+  ''|*[!0-9]*) die "issue must be a positive integer: '$ISSUE'" ;;
+esac
+
+command -v gh >/dev/null 2>&1 || die "gh CLI not installed or not on PATH"
+command -v jq >/dev/null 2>&1 || die "jq not installed or not on PATH"
+
+LABEL="lane:$LANE"
+
+EDIT_ARGS=(--add-label "$LABEL")
+if [ "$NO_ASSIGNEE" -eq 0 ]; then
+  EDIT_ARGS+=(--add-assignee "@me")
+fi
+
+# Step 1: write — add the lane label (+ @me assignee unless suppressed)
+if [ "$DRY_RUN" -eq 1 ]; then
+  printf '[dry-run] gh issue edit %s %s\n' "$ISSUE" "${EDIT_ARGS[*]}"
+  printf '[dry-run] probe + verdict skipped\n'
+  exit 0
+fi
+
+if ! gh issue edit "$ISSUE" "${EDIT_ARGS[@]}" >/dev/null; then
+  die "gh issue edit #$ISSUE failed"
+fi
+
+# Step 2: probe — re-query labels and count lane:* prefix
+LABELS_JSON=$(gh issue view "$ISSUE" --json labels 2>/dev/null) \
+  || die "gh issue view #$ISSUE failed (post-write probe)"
+
+LANE_LABELS=$(printf '%s' "$LABELS_JSON" \
+  | jq -r '.labels[].name | select(startswith("lane:"))' 2>/dev/null) \
+  || die "jq parse failed on gh issue view output"
+
+if [ -z "$LANE_LABELS" ]; then
+  LANE_COUNT=0
+else
+  LANE_COUNT=$(printf '%s\n' "$LANE_LABELS" | grep -c '^lane:')
+fi
+
+if [ "$LANE_COUNT" -gt 1 ]; then
+  printf 'lane-claim CONFLICT: issue #%s has %d lane:* labels: %s\n' \
+    "$ISSUE" "$LANE_COUNT" "$(printf '%s' "$LANE_LABELS" | tr '\n' ' ')" >&2
+
+  ACTOR=$(gh api user --jq .login 2>/dev/null || echo unknown)
+  LABEL_LIST=$(printf '%s' "$LANE_LABELS" | sed 's/^/- `/' | sed 's/$/`/')
+  COMMENT_BODY=$(cat <<EOF
+:rotating_light: Lane claim conflict detected by \`scripts/lane-claim.sh\` (Rule 1.1 probe-after-write).
+
+Post-write label set contains $LANE_COUNT \`lane:*\` labels:
+
+$LABEL_LIST
+
+Latest claim: \`$LABEL\` by \`@$ACTOR\`.
+
+GitHub REST API non-atomic — concurrent claims both succeeded silently. Manual arbitration required:
+
+1. Decide which lane owns Issue #$ISSUE
+2. Other lane(s): \`gh issue edit $ISSUE --remove-label lane:<other>\`
+3. Loser lanes close their session and fall back to non-conflicting work
+
+Source: [Mercury feedback_lane_protocol.md Rule 1.1](https://github.com/392fyc/Mercury/blob/develop/.mercury/docs/guides/lane-claim.md).
+EOF
+)
+  if ! gh issue comment "$ISSUE" --body "$COMMENT_BODY" >/dev/null 2>&1; then
+    warn "failed to post conflict comment — please post manually"
+  fi
+  exit 1
+fi
+
+if [ "$LANE_COUNT" -eq 0 ]; then
+  warn "no lane:* labels detected post-write — the edit may have silently failed"
+  exit 1
+fi
+
+printf 'lane-claim: issue #%s claimed by %s (probe verified single lane label)\n' \
+  "$ISSUE" "$LABEL"
+exit 0

--- a/scripts/lane-claim.sh
+++ b/scripts/lane-claim.sh
@@ -13,10 +13,14 @@
 # Usage:
 #   scripts/lane-claim.sh <lane-name> <issue-number> [--dry-run] [--no-assignee]
 #
+# Repo target: pinned at script start. Defaults to current cwd's git repo
+# (via `gh repo view`); override with GH_REPO=owner/repo for CI / off-cwd use.
+# All gh issue calls receive --repo $REPO explicitly to prevent cwd drift mid-run.
+#
 # Exit codes:
 #   0  clean claim (exactly 1 lane:* label after probe)
 #   1  conflict detected (>1 lane:* labels) or zero labels post-write
-#   2  invalid args / gh|jq not available / API error
+#   2  invalid args / gh|jq not available / API error / cannot resolve repo
 
 set -u
 
@@ -33,7 +37,7 @@ while [ $# -gt 0 ]; do
     --dry-run) DRY_RUN=1; shift ;;
     --no-assignee) NO_ASSIGNEE=1; shift ;;
     -h|--help)
-      sed -n '2,19p' "$0" | sed 's/^# \{0,1\}//'
+      sed -n '2,23p' "$0" | sed 's/^# \{0,1\}//'
       exit 0
       ;;
     --) shift; break ;;
@@ -61,11 +65,26 @@ case "$LANE" in
   *[!A-Za-z0-9_-]*) die "lane name must be [A-Za-z0-9_-]: '$LANE'" ;;
 esac
 case "$ISSUE" in
-  ''|*[!0-9]*) die "issue must be a positive integer: '$ISSUE'" ;;
+  ''|*[!0-9]*|0) die "issue must be a positive integer: '$ISSUE'" ;;
 esac
 
 command -v gh >/dev/null 2>&1 || die "gh CLI not installed or not on PATH"
 command -v jq >/dev/null 2>&1 || die "jq not installed or not on PATH"
+
+# Pin the target repo at script start. Defense against CI / fork / wrong-cwd
+# execution silently writing to the wrong repo. Order: GH_REPO env override →
+# `gh repo view` (current cwd's git repo via gh's resolution). All subsequent
+# `gh issue *` calls get `--repo $REPO` explicitly so a mid-script cwd change
+# or env mutation cannot redirect writes.
+REPO="${GH_REPO:-}"
+if [ -z "$REPO" ]; then
+  REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null) \
+    || die "cannot determine target repo: not in a git repo and GH_REPO not set"
+fi
+case "$REPO" in
+  */*) ;;
+  *) die "invalid repo format '$REPO' (expected owner/repo)" ;;
+esac
 
 LABEL="lane:$LANE"
 
@@ -76,17 +95,18 @@ fi
 
 # Step 1: write — add the lane label (+ @me assignee unless suppressed)
 if [ "$DRY_RUN" -eq 1 ]; then
-  printf '[dry-run] gh issue edit %s %s\n' "$ISSUE" "${EDIT_ARGS[*]}"
+  printf '[dry-run] target repo: %s\n' "$REPO"
+  printf '[dry-run] gh issue edit %s --repo %s %s\n' "$ISSUE" "$REPO" "${EDIT_ARGS[*]}"
   printf '[dry-run] probe + verdict skipped\n'
   exit 0
 fi
 
-if ! gh issue edit "$ISSUE" "${EDIT_ARGS[@]}" >/dev/null; then
+if ! gh issue edit "$ISSUE" --repo "$REPO" "${EDIT_ARGS[@]}" >/dev/null; then
   die "gh issue edit #$ISSUE failed"
 fi
 
 # Step 2: probe — re-query labels and count lane:* prefix
-LABELS_JSON=$(gh issue view "$ISSUE" --json labels 2>/dev/null) \
+LABELS_JSON=$(gh issue view "$ISSUE" --repo "$REPO" --json labels 2>/dev/null) \
   || die "gh issue view #$ISSUE failed (post-write probe)"
 
 LANE_LABELS=$(printf '%s' "$LABELS_JSON" \
@@ -123,7 +143,7 @@ GitHub REST API non-atomic — concurrent claims both succeeded silently. Manual
 Source: [Mercury feedback_lane_protocol.md Rule 1.1](https://github.com/392fyc/Mercury/blob/develop/.mercury/docs/guides/lane-claim.md).
 EOF
 )
-  if ! gh issue comment "$ISSUE" --body "$COMMENT_BODY" >/dev/null 2>&1; then
+  if ! gh issue comment "$ISSUE" --repo "$REPO" --body "$COMMENT_BODY" >/dev/null 2>&1; then
     warn "failed to post conflict comment — please post manually"
   fi
   exit 1

--- a/scripts/lane-claim.sh
+++ b/scripts/lane-claim.sh
@@ -164,6 +164,16 @@ if [ "$LANE_COUNT" -eq 0 ]; then
   exit 1
 fi
 
+# Final invariant: the single lane:* label MUST be the one we tried to claim.
+# A mismatch here means the edit silently failed AND a different lane already
+# owns the Issue — exit 1 (treat as ownership conflict, not a clean claim).
+# grep -F (literal) + -x (full-line) avoids regex surprises in $LABEL.
+if ! printf '%s\n' "$LANE_LABELS" | grep -qxF "$LABEL"; then
+  EXISTING=$(printf '%s' "$LANE_LABELS" | tr '\n' ' ' | sed 's/[[:space:]]*$//')
+  warn "single lane:* label is '$EXISTING', not requested '$LABEL' — claim did not take effect (existing owner)"
+  exit 1
+fi
+
 printf 'lane-claim: issue #%s claimed by %s (probe verified single lane label)\n' \
   "$ISSUE" "$LABEL"
 exit 0

--- a/scripts/lane-claim.sh
+++ b/scripts/lane-claim.sh
@@ -78,11 +78,13 @@ if [ "$DRY_RUN" -eq 1 ]; then
   printf '[dry-run] target repo: %s\n' "$REPO_PREVIEW"
   printf '[dry-run] step 1: gh issue edit %s --repo %s --add-label %s\n' \
     "$ISSUE" "$REPO_PREVIEW" "$LABEL"
+  printf '[dry-run] step 2: gh issue view %s --repo %s --json labels (probe + count lane:* labels + ownership-invariant check)\n' \
+    "$ISSUE" "$REPO_PREVIEW"
   if [ "$NO_ASSIGNEE" -eq 0 ]; then
     printf '[dry-run] step 3 (only if probe is clean): gh issue edit %s --repo %s --add-assignee @me\n' \
       "$ISSUE" "$REPO_PREVIEW"
   fi
-  printf '[dry-run] probe + verdict skipped (no gh/jq calls in dry-run)\n'
+  printf '[dry-run] no gh/jq calls executed in dry-run mode\n'
   exit 0
 fi
 
@@ -152,7 +154,7 @@ GitHub REST API non-atomic — concurrent claims both succeeded silently. Manual
 2. Other lane(s): \`gh issue edit $ISSUE --repo $REPO --remove-label lane:<other>\`
 3. Loser lanes close their session and fall back to non-conflicting work
 
-Source: [Mercury lane-claim.md (Rule 1.1 in-repo guide)](https://github.com/392fyc/Mercury/blob/develop/.mercury/docs/guides/lane-claim.md).
+Source: [Mercury lane-claim.md (Rule 1.1 in-repo guide)](https://github.com/$REPO/blob/HEAD/.mercury/docs/guides/lane-claim.md).
 EOF
 )
   if ! gh issue comment "$ISSUE" --repo "$REPO" --body "$COMMENT_BODY" >/dev/null 2>&1; then

--- a/scripts/lane-claim.sh
+++ b/scripts/lane-claim.sh
@@ -37,10 +37,15 @@ while [ $# -gt 0 ]; do
     --dry-run) DRY_RUN=1; shift ;;
     --no-assignee) NO_ASSIGNEE=1; shift ;;
     -h|--help)
-      sed -n '2,23p' "$0" | sed 's/^# \{0,1\}//'
+      sed -n '2,23p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
       exit 0
       ;;
-    --) shift; break ;;
+    --) shift; while [ $# -gt 0 ]; do
+          if [ -z "$LANE" ]; then LANE="$1"
+          elif [ -z "$ISSUE" ]; then ISSUE="$1"
+          else die "too many positional arguments after --: $1"; fi
+          shift
+        done; break ;;
     -*) die "unknown flag: $1" ;;
     *)
       if [ -z "$LANE" ]; then
@@ -138,7 +143,11 @@ if [ "$LANE_COUNT" -gt 1 ]; then
     "$ISSUE" "$LANE_COUNT" "$(printf '%s' "$LANE_LABELS" | tr '\n' ' ')" >&2
 
   ACTOR=$(gh api user --jq .login 2>/dev/null || echo unknown)
-  LABEL_LIST=$(printf '%s' "$LANE_LABELS" | sed 's/^/- `/' | sed 's/$/`/')
+  # Strip backticks from label names before embedding in the markdown bullet
+  # list. Lane names produced by this script are alnum + hyphen + underscore
+  # (validated above), but other tools could create lane:* labels containing
+  # backticks; embedding raw would break out of inline-code formatting.
+  LABEL_LIST=$(printf '%s' "$LANE_LABELS" | tr -d '`' | sed 's/^/- `/' | sed 's/$/`/')
   COMMENT_BODY=$(cat <<EOF
 :rotating_light: Lane claim conflict detected by \`scripts/lane-claim.sh\` (Rule 1.1 probe-after-write).
 

--- a/scripts/test-lane-claim.sh
+++ b/scripts/test-lane-claim.sh
@@ -19,6 +19,15 @@ SCRIPT="$REPO_ROOT/scripts/lane-claim.sh"
   exit 2
 }
 
+# The harness stubs `gh` via PATH but does NOT stub `jq` — `lane-claim.sh`
+# pipes the (stubbed) gh JSON output through real `jq`. Slim CI images may
+# omit jq; fail fast with a clear message instead of producing confusing
+# stub-related failures.
+command -v jq >/dev/null 2>&1 || {
+  echo "test-lane-claim: jq not installed — required by lane-claim.sh, not stubbed by the harness" >&2
+  exit 2
+}
+
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
 

--- a/scripts/test-lane-claim.sh
+++ b/scripts/test-lane-claim.sh
@@ -158,7 +158,8 @@ stub gh-edit-fail
 PATH="$TMP/bin:$PATH" assert_exit 2 "gh edit failure → exit 2" \
   "$SCRIPT" --no-assignee test 309
 
-# --dry-run path: doesn't even call gh — should succeed without stub
+# --dry-run path: strict offline (no gh / jq / git invocations) since iter 2 fix.
+# Verified separately at the CLI with PATH=/usr/bin:/bin (no gh, no jq) → exit 0.
 PATH="$TMP/bin:$PATH" assert_exit 0 "--dry-run skips API → exit 0" \
   "$SCRIPT" --dry-run --no-assignee test 309
 

--- a/scripts/test-lane-claim.sh
+++ b/scripts/test-lane-claim.sh
@@ -134,6 +134,28 @@ esac
 EOF
 chmod +x "$TMP/bin/gh-other-lane"
 
+# gh-race-comment-fail: race scenario (2 lane:* labels) where `issue comment`
+# always returns non-zero. Verifies the wrapper retries 2x then warns + still
+# exits 1 (conflict detection is the hard requirement; comment posting is
+# best-effort).
+cat > "$TMP/bin/gh-race-comment-fail" <<'EOF'
+#!/usr/bin/env bash
+case "$1 $2" in
+  "issue edit")    exit 0 ;;
+  "issue view")    echo '{"labels":[{"name":"lane:main"},{"name":"lane:other"}]}' ; exit 0 ;;
+  "api user")      echo 'testuser' ; exit 0 ;;
+  "issue comment")
+    if [ -n "${LANE_CLAIM_TEST_COMMENT_FAIL_LOG:-}" ]; then
+      printf 'attempt\n' >> "$LANE_CLAIM_TEST_COMMENT_FAIL_LOG"
+    fi
+    echo "fake gh issue comment failure" >&2
+    exit 1
+    ;;
+  *) echo "stub-race-fail: unhandled $*" >&2 ; exit 99 ;;
+esac
+EOF
+chmod +x "$TMP/bin/gh-race-comment-fail"
+
 stub() {
   ln -sf "$TMP/bin/$1" "$TMP/bin/gh"
 }
@@ -171,6 +193,21 @@ PATH="$TMP/bin:$PATH" assert_exit 1 "zero lane labels post-write → exit 1" \
 stub gh-other-lane
 PATH="$TMP/bin:$PATH" assert_exit 1 "single lane:* label belongs to other lane → exit 1" \
   "$SCRIPT" --no-assignee test 309
+
+stub gh-race-comment-fail
+COMMENT_FAIL_LOG="$TMP/comment-fail-log"
+rm -f "$COMMENT_FAIL_LOG"
+LANE_CLAIM_TEST_COMMENT_FAIL_LOG="$COMMENT_FAIL_LOG" PATH="$TMP/bin:$PATH" \
+  assert_exit 1 "race + comment-failure → exit 1 (conflict still signaled)" \
+  "$SCRIPT" --no-assignee main 309
+
+# Side-effect: wrapper must retry 2x on comment failure
+ATTEMPTS=$(wc -l < "$COMMENT_FAIL_LOG" 2>/dev/null | tr -d ' ')
+if [ "$ATTEMPTS" = "2" ]; then
+  pass "comment-failure path retries exactly 2 times before warn"
+else
+  fail "comment-failure path attempt count = $ATTEMPTS (expected 2)"
+fi
 
 stub gh-edit-fail
 PATH="$TMP/bin:$PATH" assert_exit 2 "gh edit failure → exit 2" \

--- a/scripts/test-lane-claim.sh
+++ b/scripts/test-lane-claim.sh
@@ -120,6 +120,20 @@ esac
 EOF
 chmod +x "$TMP/bin/gh-edit-fail"
 
+# gh-other-lane: edit silently no-ops; view returns ONE lane:* label, but it's
+# `lane:other` — not the lane the script was asked to claim. Verifies the
+# ownership-mismatch invariant (single label present yet wrong owner).
+cat > "$TMP/bin/gh-other-lane" <<'EOF'
+#!/usr/bin/env bash
+case "$1 $2" in
+  "issue edit")    exit 0 ;;
+  "issue view")    echo '{"labels":[{"name":"lane:other"},{"name":"P2"}]}' ; exit 0 ;;
+  "api user")      echo 'testuser' ; exit 0 ;;
+  *) echo "stub-other-lane: unhandled $*" >&2 ; exit 99 ;;
+esac
+EOF
+chmod +x "$TMP/bin/gh-other-lane"
+
 stub() {
   ln -sf "$TMP/bin/$1" "$TMP/bin/gh"
 }
@@ -152,6 +166,10 @@ fi
 
 stub gh-zero
 PATH="$TMP/bin:$PATH" assert_exit 1 "zero lane labels post-write → exit 1" \
+  "$SCRIPT" --no-assignee test 309
+
+stub gh-other-lane
+PATH="$TMP/bin:$PATH" assert_exit 1 "single lane:* label belongs to other lane → exit 1" \
   "$SCRIPT" --no-assignee test 309
 
 stub gh-edit-fail

--- a/scripts/test-lane-claim.sh
+++ b/scripts/test-lane-claim.sh
@@ -53,6 +53,7 @@ assert_exit 2 "lane starting with hyphen rejected" "$SCRIPT" -bad 309
 assert_exit 2 "non-numeric issue rejected"         "$SCRIPT" good 0xFF
 assert_exit 2 "unknown flag rejected"              "$SCRIPT" --bogus good 309
 assert_exit 2 "empty issue rejected"               "$SCRIPT" good ""
+assert_exit 2 "issue=0 rejected (positive integer)" "$SCRIPT" good 0
 
 # ---------------------------------------------------------------------------
 # gh stubs for happy path + race + zero-label edge case
@@ -73,11 +74,18 @@ chmod +x "$TMP/bin/gh-happy"
 
 cat > "$TMP/bin/gh-race" <<'EOF'
 #!/usr/bin/env bash
+# When the wrapper invokes `issue comment`, record the call by appending to
+# the marker file so tests can assert the side-effect — not just exit code.
 case "$1 $2" in
   "issue edit")    exit 0 ;;
   "issue view")    echo '{"labels":[{"name":"lane:main"},{"name":"lane:other"}]}' ; exit 0 ;;
   "api user")      echo 'testuser' ; exit 0 ;;
-  "issue comment") exit 0 ;;
+  "issue comment")
+    if [ -n "${LANE_CLAIM_TEST_COMMENT_MARKER:-}" ]; then
+      printf 'comment-called %s\n' "$*" >> "$LANE_CLAIM_TEST_COMMENT_MARKER"
+    fi
+    exit 0
+    ;;
   *) echo "stub-race: unhandled $*" >&2 ; exit 99 ;;
 esac
 EOF
@@ -110,13 +118,28 @@ stub() {
 echo
 echo "[scenarios]"
 
+# All scenarios pin GH_REPO so stubs don't need to mock `gh repo view`. This
+# also exercises the production code path that resolves repo from env.
+export GH_REPO="test-owner/test-repo"
+
 stub gh-happy
 PATH="$TMP/bin:$PATH" assert_exit 0 "happy path (1 lane label) → exit 0" \
   "$SCRIPT" --no-assignee test 309
 
 stub gh-race
-PATH="$TMP/bin:$PATH" assert_exit 1 "race detected (2 lane labels) → exit 1" \
+COMMENT_MARKER="$TMP/comment-called"
+rm -f "$COMMENT_MARKER"
+LANE_CLAIM_TEST_COMMENT_MARKER="$COMMENT_MARKER" PATH="$TMP/bin:$PATH" \
+  assert_exit 1 "race detected (2 lane labels) → exit 1" \
   "$SCRIPT" --no-assignee main 309
+
+# Side-effect assertion: the wrapper MUST post a conflict comment in race scenario
+# (acceptance criterion from #309 — exit code alone is insufficient evidence).
+if [ -s "$COMMENT_MARKER" ] && grep -q 'comment-called' "$COMMENT_MARKER"; then
+  pass "race scenario triggered gh issue comment side-effect"
+else
+  fail "race scenario did NOT trigger gh issue comment (marker: $COMMENT_MARKER)"
+fi
 
 stub gh-zero
 PATH="$TMP/bin:$PATH" assert_exit 1 "zero lane labels post-write → exit 1" \

--- a/scripts/test-lane-claim.sh
+++ b/scripts/test-lane-claim.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# scripts/test-lane-claim.sh — smoke + race tests for lane-claim.sh
+#
+# Stubs `gh` via PATH-prepended fakes to avoid real GitHub API calls.
+# Verifies: arg validation, --help, --dry-run, happy path, race detection.
+#
+# Run from repo root (or anywhere — auto-discovers via git rev-parse).
+# Exit 0 if all tests pass; non-zero if any test fails.
+
+set -u
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
+  echo "test-lane-claim: not inside a git repo" >&2
+  exit 2
+}
+SCRIPT="$REPO_ROOT/scripts/lane-claim.sh"
+[ -x "$SCRIPT" ] || {
+  echo "test-lane-claim: $SCRIPT missing or not executable" >&2
+  exit 2
+}
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+PASS=0
+FAIL=0
+pass() { printf '  PASS: %s\n' "$1"; PASS=$((PASS+1)); }
+fail() { printf '  FAIL: %s\n' "$1"; FAIL=$((FAIL+1)); }
+
+assert_exit() {
+  local expected=$1
+  local desc=$2
+  shift 2
+  "$@" >/dev/null 2>&1
+  local actual=$?
+  if [ "$actual" = "$expected" ]; then
+    pass "$desc (exit=$actual)"
+  else
+    fail "$desc (expected exit=$expected got=$actual)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Arg validation tests (no gh stub needed — validation runs before any API call)
+# ---------------------------------------------------------------------------
+
+echo "[arg-validation]"
+assert_exit 0 "--help prints usage"               "$SCRIPT" --help
+assert_exit 2 "missing both args"                  "$SCRIPT"
+assert_exit 2 "missing issue arg"                  "$SCRIPT" only-lane
+assert_exit 2 "lane with space rejected"           "$SCRIPT" "bad lane" 309
+assert_exit 2 "lane starting with hyphen rejected" "$SCRIPT" -bad 309
+assert_exit 2 "non-numeric issue rejected"         "$SCRIPT" good 0xFF
+assert_exit 2 "unknown flag rejected"              "$SCRIPT" --bogus good 309
+assert_exit 2 "empty issue rejected"               "$SCRIPT" good ""
+
+# ---------------------------------------------------------------------------
+# gh stubs for happy path + race + zero-label edge case
+# ---------------------------------------------------------------------------
+
+mkdir -p "$TMP/bin"
+
+cat > "$TMP/bin/gh-happy" <<'EOF'
+#!/usr/bin/env bash
+case "$1 $2" in
+  "issue edit")    exit 0 ;;
+  "issue view")    echo '{"labels":[{"name":"lane:test"},{"name":"P1"}]}' ; exit 0 ;;
+  "api user")      echo 'testuser' ; exit 0 ;;
+  *) echo "stub-happy: unhandled $*" >&2 ; exit 99 ;;
+esac
+EOF
+chmod +x "$TMP/bin/gh-happy"
+
+cat > "$TMP/bin/gh-race" <<'EOF'
+#!/usr/bin/env bash
+case "$1 $2" in
+  "issue edit")    exit 0 ;;
+  "issue view")    echo '{"labels":[{"name":"lane:main"},{"name":"lane:other"}]}' ; exit 0 ;;
+  "api user")      echo 'testuser' ; exit 0 ;;
+  "issue comment") exit 0 ;;
+  *) echo "stub-race: unhandled $*" >&2 ; exit 99 ;;
+esac
+EOF
+chmod +x "$TMP/bin/gh-race"
+
+cat > "$TMP/bin/gh-zero" <<'EOF'
+#!/usr/bin/env bash
+case "$1 $2" in
+  "issue edit")    exit 0 ;;
+  "issue view")    echo '{"labels":[{"name":"P1"}]}' ; exit 0 ;;
+  "api user")      echo 'testuser' ; exit 0 ;;
+  *) echo "stub-zero: unhandled $*" >&2 ; exit 99 ;;
+esac
+EOF
+chmod +x "$TMP/bin/gh-zero"
+
+cat > "$TMP/bin/gh-edit-fail" <<'EOF'
+#!/usr/bin/env bash
+case "$1 $2" in
+  "issue edit") echo "fake edit failure" >&2 ; exit 1 ;;
+  *) echo "stub-edit-fail: unhandled $*" >&2 ; exit 99 ;;
+esac
+EOF
+chmod +x "$TMP/bin/gh-edit-fail"
+
+stub() {
+  ln -sf "$TMP/bin/$1" "$TMP/bin/gh"
+}
+
+echo
+echo "[scenarios]"
+
+stub gh-happy
+PATH="$TMP/bin:$PATH" assert_exit 0 "happy path (1 lane label) → exit 0" \
+  "$SCRIPT" --no-assignee test 309
+
+stub gh-race
+PATH="$TMP/bin:$PATH" assert_exit 1 "race detected (2 lane labels) → exit 1" \
+  "$SCRIPT" --no-assignee main 309
+
+stub gh-zero
+PATH="$TMP/bin:$PATH" assert_exit 1 "zero lane labels post-write → exit 1" \
+  "$SCRIPT" --no-assignee test 309
+
+stub gh-edit-fail
+PATH="$TMP/bin:$PATH" assert_exit 2 "gh edit failure → exit 2" \
+  "$SCRIPT" --no-assignee test 309
+
+# --dry-run path: doesn't even call gh — should succeed without stub
+PATH="$TMP/bin:$PATH" assert_exit 0 "--dry-run skips API → exit 0" \
+  "$SCRIPT" --dry-run --no-assignee test 309
+
+echo
+printf '%d pass / %d fail\n' "$PASS" "$FAIL"
+[ "$FAIL" = "0" ]


### PR DESCRIPTION
## Summary

- Implements `scripts/lane-claim.sh` per Rule 1.1 probe-after-write (#309 / parent #292)
- Wrapper detects concurrent lane claims via post-write label re-query
- Tests: 13/13 PASS via PATH-stubbed `gh` — no real GitHub API contact
- Docs: `.mercury/docs/guides/lane-claim.md` covers usage, exit codes, conflict resolution

## Why

GitHub REST API is non-atomic for label edits. Two lanes claiming the same Issue within milliseconds (concurrent CI runs, parallel session starts, two operators) both succeed silently. v0 Rule 1's first-timestamp-wins resolution is post-hoc only — neither lane learns of the conflict until human intervention.

Rule 1.1 closes the gap by re-querying labels immediately after the write and aborting (with comment) if more than one `lane:*` prefix label is present.

## Scope

Closes #309. Self-contained per Rule 8 (lane lifecycle autonomy, v0.2). No cross-lane coordination required — side-multi-lane owns implementation end-to-end.

## Test plan

- [x] `scripts/test-lane-claim.sh` — 13/13 PASS (arg validation × 8 + scenarios × 5)
- [x] `scripts/lane-claim.sh --help` — clean usage output (no `set -u` leak after MEDIUM-1 fix)
- [x] `scripts/lane-claim.sh side-multi-lane 309 --dry-run` — prints intended `gh` command, no API calls
- [x] Claude Code deep-review — PASS (1 MEDIUM fixed in-session, 2 LOW acceptable, 0 critical/high)
- [x] **dual-verify partial** — Codex code-audit attempted but Codex CLI hung >8 minutes (no terminal output, similar to S71 timeout pattern). Per Mercury dual-verify §Fallback this is a low-risk change (pure additive, 3 new files, no integration with existing paths) so Claude-only review is acceptable. Argus + Copilot will provide additional review coverage post-PR.

## Source references

- Issue [#309](https://github.com/392fyc/Mercury/issues/309) — acceptance criteria
- [v0.1 Delta companion](https://github.com/392fyc/Mercury/blob/develop/.mercury/docs/lane-protocol-v0.1-deltas.md#delta-1--rule-11-probe-after-write-p1)
- Research doc `.mercury/docs/research/multi-lane-protocol-2026-04-25.md` (PR #305)