### PR TITLE
feat(lane-protocol): Phase B v0.1 deltas — Rule 3.1/3.2/4.1 (#310 #311 #312)

### DIFF
--- a/.mercury/docs/guides/lane-close.md
+++ b/.mercury/docs/guides/lane-close.md
@@ -1,0 +1,132 @@
+# Lane Close Ceremony — `scripts/lane-close.sh`
+
+Implements **Rule 3.2 tmp dir auto-prune on close** of the multi-lane protocol
+(v0.1 Delta 3, Issue [#311](https://github.com/392fyc/Mercury/issues/311)).
+
+## Why
+
+When a lane finishes its scope, two cleanup steps must happen in lock-step:
+
+1. The lane's `**Status**:` line in `LANES.md` flips from `active` to `closed`
+   so future sessions know not to claim work against it.
+2. The lane's `.tmp/lane-<lane>/` directory is removed so the repo's working
+   tree doesn't accumulate orphan scratch dirs.
+
+v0 had no script for either step, so operators did them by hand — and the
+"flip the wrong line" failure mode was easy to hit (the registry has multiple
+`**Status**:` lines, one per lane). This script makes the two-step ceremony
+atomic and bounded to the owning lane's section.
+
+## Usage
+
+```bash
+scripts/lane-close.sh <lane-name>
+                      [--lanes-file PATH] [--memory-dir PATH]
+                      [--tmp-dir PATH] [--repo-root PATH]
+                      [--yes] [--force-cross-lane] [--dry-run]
+```
+
+| Flag / Env var | Effect |
+|----------------|--------|
+| `--yes` | Skip the interactive confirm prompt. Required in non-interactive contexts (CI, autorun). |
+| `--force-cross-lane` | Suppress the warning emitted when the current branch does not match `feature/lane-<lane>/*`. Useful when closing from `develop` after a PR merge. |
+| `--dry-run` | Print intended actions without modifying `LANES.md` or removing the tmp dir. |
+| `--lanes-file PATH` | Override LANES.md location. Defaults to `<memory-dir>/LANES.md`. |
+| `--memory-dir PATH` | Override memory dir. Defaults to `MERCURY_MEMORY_DIR` env, then `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/D--Mercury-Mercury/memory`. |
+| `--tmp-dir PATH` | Override the tmp dir to remove. Defaults to `<repo-root>/.tmp/lane-<lane>`. |
+| `--repo-root PATH` | Override repo root. Defaults to `git rev-parse --show-toplevel`. |
+| `MERCURY_MEMORY_DIR` (env) | Same effect as `--memory-dir`. |
+
+### Section-bounded edit (Rule 6 compliance)
+
+The Status rewrite is bounded to the **target lane's section only**. The script
+walks `LANES.md` line-by-line and:
+
+1. Detects the lane heading (`### \`<lane>\``).
+2. Sets an in-section flag.
+3. Rewrites the **first** `- **Status**:` line encountered while the flag is on.
+4. Resets the flag at the next `## ` or `### ` heading.
+
+Other lanes' `Status` lines are **never** touched, even if they appear nearby
+in the file. The test harness verifies this explicitly (a fixture with three
+active lanes — `main`, `side-target`, `side-other` — confirms only the named
+lane flips).
+
+### Owning-lane heuristic
+
+Per Rule 6, only the owning lane should close itself. The script can't
+cryptographically prove ownership from inside a single repo checkout, so it
+uses a heuristic: if the current branch starts with `feature/lane-<lane>/`,
+the run is presumed in-scope and proceeds silently. Otherwise it emits a
+`WARN` (not a hard error). Pass `--force-cross-lane` to silence the warning
+when you legitimately need to close from another branch — e.g., after the
+lane's last PR was merged and you switched back to `develop`.
+
+### Tmp-dir safety guards
+
+Before removing `.tmp/lane-<lane>/`, the script refuses to proceed if it
+contains either:
+
+- Any file matching `*.uncommitted` — the documented Mercury convention for
+  "save me first" markers attached to scratch work.
+- A `.git` directory — indicates a nested checkout that the operator likely
+  doesn't want destroyed.
+
+In either case the script exits `1` **without** flipping the Status line, so
+the registry is never left in a half-closed state. Resolve the unsafe content
+manually (move it to a real branch, delete after inspection, etc.) then
+re-run.
+
+### Exit codes
+
+| Exit | Meaning |
+|------|---------|
+| `0` | Lane closed cleanly — Status flipped AND tmp dir removed (or did not exist). Also returned for successful `--dry-run`. |
+| `1` | Validation failed: lane not in LANES.md / already closed / unsafe tmp content / user aborted at confirm prompt / non-interactive without `--yes`. |
+| `2` | Invalid args, lanes-file not found, cannot resolve repo root. |
+
+## Examples
+
+```bash
+# Standard close from the lane's own working branch
+scripts/lane-close.sh side-multi-lane
+
+# Close from develop (after PR merged) — silence cross-lane warning
+git checkout develop
+scripts/lane-close.sh side-multi-lane --yes --force-cross-lane
+
+# Preview without mutating anything
+scripts/lane-close.sh side-multi-lane --dry-run
+
+# Custom paths for testing
+scripts/lane-close.sh side-multi-lane --yes --force-cross-lane \
+  --lanes-file ./test-fixtures/LANES.md \
+  --memory-dir ./test-fixtures \
+  --repo-root ./test-fixtures \
+  --tmp-dir ./test-fixtures/.tmp/lane-side-multi-lane
+```
+
+## Tests
+
+```bash
+scripts/test-lane-close.sh
+```
+
+Builds a 4-lane synthetic LANES.md (3 active + 1 already-closed) and exercises:
+
+- Argument validation (missing lane, invalid lane name, missing lanes-file)
+- Happy path: target lane flipped, OTHER lanes' Status untouched, tmp dir removed
+- Already-closed lane → exit 1
+- Unknown lane → exit 1
+- `*.uncommitted` file in tmp dir → exit 1, Status preserved (no partial state)
+- `.git` artifact in tmp dir → exit 1
+- `--dry-run` exits 0 without mutating LANES.md
+- Non-interactive context without `--yes` → exit 1
+
+Tests use synthetic fixtures only — no GitHub or live LANES.md interaction.
+
+## Source references
+
+- Issue [#311](https://github.com/392fyc/Mercury/issues/311) — acceptance criteria
+- [v0.1 Delta companion](../lane-protocol-v0.1-deltas.md#delta-3--rule-32-tmp-dir-auto-prune-p2) — full rationale
+- `feedback_lane_protocol.md` Rule 6 (LANES.md section ownership)

--- a/.mercury/docs/guides/lane-emergency-escalation.md
+++ b/.mercury/docs/guides/lane-emergency-escalation.md
@@ -125,8 +125,8 @@ the review window.
 
 ```bash
 scripts/check-main-idle.sh [--hours N] [--memory-dir PATH]
-                           [--repo OWNER/REPO] [--no-issue-check]
-                           [--format text|json]
+                           [--repo OWNER/REPO] [--repo-root PATH]
+                           [--no-issue-check] [--format text|json]
 ```
 
 | Flag | Effect |
@@ -134,6 +134,7 @@ scripts/check-main-idle.sh [--hours N] [--memory-dir PATH]
 | `--hours N` | Idleness threshold in hours (default 48). |
 | `--memory-dir PATH` | Override memory dir. Defaults to `MERCURY_MEMORY_DIR` env, then `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/D--Mercury-Mercury/memory`. |
 | `--repo OWNER/REPO` | Pin the GitHub repo. Defaults to `gh repo view` resolution. |
+| `--repo-root PATH` | Pin the local checkout for `git for-each-ref` branch-activity probing. Defaults to `git rev-parse --show-toplevel` from cwd; pass explicitly when invoking outside the Mercury checkout. |
 | `--no-issue-check` | Skip GitHub Issue probe. Useful in CI without `gh` auth. Note: skipping this signal makes the verdict less reliable — issue activity is one of three signals, and absence is treated as "stale" for that signal. |
 | `--format text\|json` | Output format. |
 

--- a/.mercury/docs/guides/lane-emergency-escalation.md
+++ b/.mercury/docs/guides/lane-emergency-escalation.md
@@ -1,0 +1,157 @@
+# Lane Emergency Spec-Change Escalation — Rule 4.1
+
+Implements **Rule 4.1 emergency spec-change escalation** of the multi-lane
+protocol (v0.1 Delta 4, Issue [#312](https://github.com/392fyc/Mercury/issues/312)).
+
+This is a **doc-only protocol delta** plus an optional helper script
+(`scripts/check-main-idle.sh`). No mandatory code path.
+
+## Why
+
+Rule 4 grants the main lane exclusive edit rights over `.mercury/docs/DIRECTION.md`
+and `.mercury/docs/EXECUTION-PLAN.md`. Side lanes that need a spec change must
+file an Issue and wait for main to act on it.
+
+This works fine when main is responsive. It fails when main is unresponsive
+for an extended period — the side lane is then deadlocked: it cannot proceed
+without the spec change, cannot make the change itself (Rule 4 red line), and
+has no escalation path. The Spotify model documented this exact failure mode
+in 2018 (see Sources below); without an explicit escape hatch, lanes either
+stall indefinitely or quietly violate Rule 4.
+
+Rule 4.1 closes the gap with a **user-arbitrated** escalation: side lane
+opens a clearly-flagged PR, the user (not the side lane) decides whether to
+merge.
+
+## When the rule applies
+
+All of:
+
+1. Side lane needs a change to `DIRECTION.md` or `EXECUTION-PLAN.md` to make
+   forward progress on its claimed Issues.
+2. The blocking concern was filed on a coordination Issue (`lane:main` +
+   `coordination` labels) at least 48 hours before the escalation PR is opened.
+3. Main lane has been idle for 48+ hours — defined objectively as **all three**
+   of:
+   - No commits to `feature/lane-main/*` or legacy `feature/TASK-*` branches
+   - No edits to `<memory-dir>/session-handoff.md`
+   - No `updatedAt` change on any Issue carrying the `lane:main` label
+
+The optional helper `scripts/check-main-idle.sh` checks all three signals and
+returns exit `0` (idle) or exit `1` (active). Use it to verify the
+precondition before opening the escalation PR; do not skip the check based on
+intuition.
+
+## Procedure
+
+1. **Verify the 48h precondition** (do not skip):
+
+   ```bash
+   scripts/check-main-idle.sh --hours 48
+   # exit 0 → precondition met
+   # exit 1 → main has activity within 48h, escalation NOT permitted
+   ```
+
+2. **Open the PR with the emergency prefix**. Title format:
+
+   ```
+   [EMERGENCY-<lane>] <short summary>
+   ```
+
+   Example: `[EMERGENCY-side-multi-lane] DIRECTION.md §3 cap-5 bypass for #292 close`
+
+3. **PR body MUST include**:
+   - Reference to this rule: `Per Rule 4.1 (lane-emergency-escalation.md)`.
+   - Reference to the coordination Issue filed ≥48h earlier.
+   - Output of `scripts/check-main-idle.sh --format json` as evidence the
+     precondition was met at the moment the PR was opened (paste verbatim).
+   - Explicit ping to the user — escalation is **opt-in**; the user decides
+     whether to merge, not the bot.
+   - A rollback statement: what to revert if the spec change turns out to be
+     wrong.
+
+4. **Do NOT** auto-merge or admin-merge. The user is the arbitrator. If
+   review bots block the PR, that is a feature, not a bug — the user can
+   bypass after reviewing.
+
+5. **If main lane resumes activity** during the PR's review window, **close
+   the PR without merging**, hand the change request back to main lane via
+   the original coordination Issue, and proceed without the spec change. The
+   precondition (48h idle) was the entire justification; once main is active,
+   it is no longer met.
+
+## What this rule is NOT
+
+- **Not** a way for side lanes to bypass main on substantive disagreements.
+  Rule 4 still applies; this is purely a deadlock breaker for absent owners.
+- **Not** auto-merge. The user must explicitly approve.
+- **Not** retroactive. Once main resumes activity the escalation lapses.
+- **Not** a license to claim Issues outside the side lane's scope. The
+  spec-change PR must be the minimum viable change to unblock the lane's
+  existing claimed work.
+
+## Suggested PR body template
+
+```markdown
+## Emergency spec-change escalation (Rule 4.1)
+
+**Lane**: <lane-name>
+**Coordination Issue**: #NNN (filed YYYY-MM-DD, >=48h before this PR)
+**Blocked work**: #MMM (claimed by `lane:<lane-name>`)
+
+### Idleness evidence
+
+`scripts/check-main-idle.sh --format json` output at PR open:
+\`\`\`json
+{...paste verbatim...}
+\`\`\`
+
+### Spec change
+
+<diff summary>
+
+### Rollback
+
+<one-line description of what to revert>
+
+### Arbitration
+
+@<user> — Rule 4.1 opt-in escalation. Merge only if you accept the change
+on main lane's behalf; close without merge if main resumes activity during
+the review window.
+```
+
+## `scripts/check-main-idle.sh` reference
+
+```bash
+scripts/check-main-idle.sh [--hours N] [--memory-dir PATH]
+                           [--repo OWNER/REPO] [--no-issue-check]
+                           [--format text|json]
+```
+
+| Flag | Effect |
+|------|--------|
+| `--hours N` | Idleness threshold in hours (default 48). |
+| `--memory-dir PATH` | Override memory dir. Defaults to `MERCURY_MEMORY_DIR` env, then `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/D--Mercury-Mercury/memory`. |
+| `--repo OWNER/REPO` | Pin the GitHub repo. Defaults to `gh repo view` resolution. |
+| `--no-issue-check` | Skip GitHub Issue probe. Useful in CI without `gh` auth. Note: skipping this signal makes the verdict less reliable — issue activity is one of three signals, and absence is treated as "stale" for that signal. |
+| `--format text\|json` | Output format. |
+
+Exit `0` if all three signals are stale past the threshold (idle); exit `1`
+otherwise (active); exit `2` on argument or environment errors.
+
+## Tests
+
+```bash
+scripts/test-check-main-idle.sh
+```
+
+Verifies arg validation, fresh-handoff verdict (exit 1), 60d-old-handoff
+fixture report fields, and JSON output structure.
+
+## Source references
+
+- Issue [#312](https://github.com/392fyc/Mercury/issues/312) — acceptance criteria
+- [v0.1 Delta companion](../lane-protocol-v0.1-deltas.md#delta-4--rule-41-emergency-spec-change-escalation-p2)
+- [Overcoming the Pitfalls of the Spotify Model](https://medium.com/@ss-tech/overcoming-the-pitfalls-of-the-spotify-model-8e09edc9583b)
+- `feedback_lane_protocol.md` Rule 4 (DIRECTION/EXECUTION-PLAN exclusivity)

--- a/.mercury/docs/guides/lane-sweep.md
+++ b/.mercury/docs/guides/lane-sweep.md
@@ -35,7 +35,7 @@ or `--days 7` to mirror Claude Code's worktree threshold.
 
 ```bash
 scripts/lane-sweep.sh [--lanes-file PATH] [--memory-dir PATH]
-                      [--days N] [--repo OWNER/REPO]
+                      [--days N] [--repo OWNER/REPO] [--repo-root PATH]
                       [--format text|json] [--no-issue-check]
 ```
 
@@ -46,6 +46,7 @@ scripts/lane-sweep.sh [--lanes-file PATH] [--memory-dir PATH]
 | `--lanes-file PATH` | Override LANES.md location. Defaults to `<memory-dir>/LANES.md`. |
 | `--memory-dir PATH` | Override memory dir. Defaults to `MERCURY_MEMORY_DIR` env, then `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/D--Mercury-Mercury/memory`. |
 | `--repo OWNER/REPO` | Pin the GitHub repo for Issue activity probe. Defaults to `gh repo view` resolution. |
+| `--repo-root PATH` | Pin the local checkout for `git for-each-ref` branch-activity probing. Defaults to `git rev-parse --show-toplevel` from cwd; pass explicitly when invoking the script outside the Mercury checkout (CI, cron from a different cwd). |
 | `--no-issue-check` | Skip the GitHub Issue probe (offline mode / fast tests). |
 | `MERCURY_MEMORY_DIR` (env) | Same effect as `--memory-dir`. |
 | `GH_REPO` (env) | Same effect as `--repo`. |

--- a/.mercury/docs/guides/lane-sweep.md
+++ b/.mercury/docs/guides/lane-sweep.md
@@ -114,8 +114,9 @@ unattended sweeping can install a scheduled job manually:
 ```
 
 ```powershell
-# Windows: register a Scheduled Task
-schtasks /Create /SC MONTHLY /MO 1 /D 1 /TN "MercuryLaneSweep" /TR "bash D:\Mercury\Mercury\scripts\lane-sweep.sh"
+# Windows: register a Scheduled Task. Substitute <REPO_ROOT> with your local
+# Mercury checkout (the script must be invoked via bash on Windows).
+schtasks /Create /SC MONTHLY /MO 1 /D 1 /TN "MercuryLaneSweep" /TR "bash <REPO_ROOT>\scripts\lane-sweep.sh"
 ```
 
 The cron is intentionally not pre-baked because lane operators self-host on

--- a/.mercury/docs/guides/lane-sweep.md
+++ b/.mercury/docs/guides/lane-sweep.md
@@ -1,0 +1,148 @@
+# Lane Stale Sweep — `scripts/lane-sweep.sh`
+
+Implements **Rule 3.1 14-day stale lane sweep** of the multi-lane protocol
+(v0.1 Delta 2, Issue [#310](https://github.com/392fyc/Mercury/issues/310)).
+
+## Why
+
+Lanes can quietly stop progressing — owner moved on, scope was descoped, or
+the work blocked on an external dependency that never resolved. v0 had no
+mechanism to detect this; orphaned lanes accumulate in `LANES.md` and confuse
+new sessions about which work is live.
+
+Claude Code 2.1.76 added native stale worktree detection (7+ day threshold)
+after the 222-workspace + 8-agent same-file-write incidents. Mercury Rule 3.1
+gives us an analogous signal at the lane layer.
+
+## What "stale" means
+
+A lane is **stale** if and only if **all three** of the following are true at
+the same time (default threshold: 14 days):
+
+| Signal | Source | Stale criterion |
+|--------|--------|-----------------|
+| Branch activity | `git for-each-ref` on `feature/lane-<lane>/*` (and legacy `feature/TASK-*` for main) | newest committerdate > 14d ago, or no matching refs |
+| Handoff activity | mtime of `<memory-dir>/session-handoff[-<lane>].md` | mtime > 14d ago, or file missing |
+| Issue activity | `gh issue list --label "lane:<lane>" --state all` newest `updatedAt` | > 14d ago, or no matching Issues |
+
+Each signal is independently classified `fresh` or `stale`. Lane verdict is
+`stale` only when **all three signals are stale simultaneously**.
+
+The 14d threshold is a default. Use `--days 30` for a more conservative sweep,
+or `--days 7` to mirror Claude Code's worktree threshold.
+
+## Usage
+
+```bash
+scripts/lane-sweep.sh [--lanes-file PATH] [--memory-dir PATH]
+                      [--days N] [--repo OWNER/REPO]
+                      [--format text|json] [--no-issue-check]
+```
+
+| Flag / Env var | Effect |
+|----------------|--------|
+| `--days N` | Override the staleness threshold (default 14). |
+| `--format text\|json` | Output format (default `text` — table). |
+| `--lanes-file PATH` | Override LANES.md location. Defaults to `<memory-dir>/LANES.md`. |
+| `--memory-dir PATH` | Override memory dir. Defaults to `MERCURY_MEMORY_DIR` env, then `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/D--Mercury-Mercury/memory`. |
+| `--repo OWNER/REPO` | Pin the GitHub repo for Issue activity probe. Defaults to `gh repo view` resolution. |
+| `--no-issue-check` | Skip the GitHub Issue probe (offline mode / fast tests). |
+| `MERCURY_MEMORY_DIR` (env) | Same effect as `--memory-dir`. |
+| `GH_REPO` (env) | Same effect as `--repo`. |
+
+### Report-only — Rule 6 compliance
+
+The script **never mutates `LANES.md`**. Status flips remain the responsibility
+of the owning lane (Rule 6 ownership). The script's contract is:
+
+> Here are the lanes that meet the stale criteria. The owning lane should
+> decide whether to flip its own section to `closed`.
+
+This matches the `feedback_lane_protocol.md` constraint that "only the owning
+lane edits its own section". Auto-edit would create a backdoor for one lane
+to modify another lane's metadata.
+
+### Exit codes
+
+| Exit | Meaning |
+|------|---------|
+| `0` | Report emitted successfully, regardless of whether any lanes were stale. |
+| `2` | Invalid args, missing `gh`/`jq`, cannot resolve memory dir or repo target. |
+
+The exit code does NOT signal "any lane is stale" — that would conflate
+report success with editorial verdict. To act on the verdict, parse the
+output (`--format json` is recommended for machine consumption).
+
+## Examples
+
+```bash
+# Default: 14-day threshold, text table, live Issue probe
+scripts/lane-sweep.sh
+
+# Conservative 30-day threshold, JSON for piping
+scripts/lane-sweep.sh --days 30 --format json | jq '.lanes[] | select(.verdict == "stale")'
+
+# Offline run — no GitHub probe, useful in CI without gh auth
+scripts/lane-sweep.sh --no-issue-check
+
+# Custom memory dir for testing
+scripts/lane-sweep.sh --memory-dir ./test-fixtures/memory --days 7 --no-issue-check
+```
+
+### Sample text output
+
+```
+LANE                   BRANCH_AGE   HANDOFF_AGE   ISSUE_AGE   VERDICT
+main                   0d           0d            0d          fresh
+side-multi-lane        0d           0d            0d          fresh
+side-experiment        45d          38d           52d         stale
+```
+
+## Recommended cadence
+
+- **Manual**: run before opening a new lane to confirm capacity (Rule 7 cap-5).
+- **Cron**: monthly is sufficient for v0.1 — the threshold is 14d, the cap is 5
+  lanes, and the worst-case cost of a missed sweep is operator confusion (not
+  data loss).
+
+A cron registration is **not** committed by default. Operators who want
+unattended sweeping can install a scheduled job manually:
+
+```bash
+# Linux: crontab -e (1st of every month, 9am UTC)
+0 9 1 * * cd "$HOME/Mercury" && bash scripts/lane-sweep.sh --format json > /var/log/mercury-lane-sweep.json
+```
+
+```powershell
+# Windows: register a Scheduled Task
+schtasks /Create /SC MONTHLY /MO 1 /D 1 /TN "MercuryLaneSweep" /TR "bash D:\Mercury\Mercury\scripts\lane-sweep.sh"
+```
+
+The cron is intentionally not pre-baked because lane operators self-host on
+heterogeneous environments (Mercury runs on Windows + Linux + macOS). A repo
+script that picks a host-specific scheduler would violate the Mercury
+"don't hardcode deployment-specific tools" feedback rule.
+
+## Tests
+
+```bash
+scripts/test-lane-sweep.sh
+```
+
+Builds a synthetic memory dir + LANES.md fixture and exercises:
+
+- Argument validation (missing values, invalid `--days`, invalid `--format`)
+- Active-lane parsing (3 active + 1 closed → only active appear)
+- Fresh handoff → `fresh` verdict (one signal defeats the all-three rule)
+- Stale handoff (60d-old mtime) → `stale` verdict (all signals satisfied)
+- JSON format produces parseable output with required fields
+- Empty Active Lanes section → exit 0 with WARN
+
+Tests run offline (use `--no-issue-check`); safe in CI.
+
+## Source references
+
+- Issue [#310](https://github.com/392fyc/Mercury/issues/310) — acceptance criteria
+- [v0.1 Delta companion](../lane-protocol-v0.1-deltas.md#delta-2--rule-31-stale-lane-sweep-p1) — full rationale
+- [DOCS Worktree cleanup recovery (claude-code#34282)](https://github.com/anthropics/claude-code/issues/34282)
+- [Stale worktrees never cleaned up (claude-code#26725)](https://github.com/anthropics/claude-code/issues/26725)

--- a/scripts/check-main-idle.sh
+++ b/scripts/check-main-idle.sh
@@ -98,14 +98,20 @@ else
 fi
 
 # 3. Issue activity — `lane:main` label.
+# Distinguish "no Issues with this label" (legitimate empty) from "probe
+# failed" (gh/jq/date error). Failure must NOT silently produce a "main is
+# idle" verdict — that would directly trigger spurious Rule 4.1 emergency
+# escalation PRs (importance 8/10 per Argus #327 review). Die on probe
+# failure; only an empty Issue list is treated as a missing-data signal.
 issue_ts=""
 if [ "$NO_ISSUE_CHECK" -eq 0 ]; then
-  out=$(gh issue list --repo "$REPO" --label "lane:main" --state all --limit 200 --json updatedAt 2>/dev/null) || out=""
-  if [ -n "$out" ]; then
-    iso=$(printf '%s' "$out" | jq -r 'if length == 0 then "" else (max_by(.updatedAt).updatedAt) end' 2>/dev/null)
-    if [ -n "$iso" ]; then
-      issue_ts=$(date -d "$iso" +%s 2>/dev/null || date -j -f '%Y-%m-%dT%H:%M:%SZ' "$iso" +%s 2>/dev/null || echo "")
-    fi
+  out=$(gh issue list --repo "$REPO" --label "lane:main" --state all --limit 200 --json updatedAt 2>/dev/null) \
+    || die "gh issue list failed (Issue activity probe — refusing to verdict 'idle' on tool failure; pass --no-issue-check to bypass)"
+  iso=$(printf '%s' "$out" | jq -r 'if length == 0 then "" else (max_by(.updatedAt).updatedAt) end' 2>/dev/null) \
+    || die "jq parse failed on gh output (Issue activity probe — refusing to verdict on parse error)"
+  if [ -n "$iso" ]; then
+    issue_ts=$(date -d "$iso" +%s 2>/dev/null || date -j -f '%Y-%m-%dT%H:%M:%SZ' "$iso" +%s) \
+      || die "date parse failed for ISO timestamp '$iso' (refusing to verdict on parse error)"
   fi
 fi
 

--- a/scripts/check-main-idle.sh
+++ b/scripts/check-main-idle.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# scripts/check-main-idle.sh — detect main-lane idleness for Rule 4.1
+# emergency spec-change escalation (v0.1 Delta 4, Issue #312).
+#
+# Returns the maximum age across THREE main-lane activity signals and
+# compares it to the threshold (default 48h):
+#   1. Newest commit on `feature/lane-main/*` or legacy `feature/TASK-*` refs
+#   2. mtime of `<memory-dir>/session-handoff.md`
+#   3. Newest `updatedAt` of any Issue carrying the `lane:main` label
+#
+# main is "idle" only if ALL THREE are simultaneously older than the threshold.
+# This script is a HELPER — it answers "is the threshold met?", not "should we
+# escalate?". Escalation is always opt-in and arbitrated by the user per
+# Rule 4.1.
+#
+# Usage:
+#   scripts/check-main-idle.sh [--hours N] [--memory-dir PATH]
+#                              [--repo OWNER/REPO] [--no-issue-check]
+#                              [--format text|json]
+#
+# Defaults:
+#   --hours        48
+#   --memory-dir   ${MERCURY_MEMORY_DIR:-${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/D--Mercury-Mercury/memory}
+#   --repo         resolved at runtime via `gh repo view` (or GH_REPO env)
+#   --format       text
+#
+# Exit codes:
+#   0  main is idle past the threshold (escalation precondition met)
+#   1  main is NOT idle (recent activity within window) — also returned for
+#      report-only success cases
+#   2  invalid args / missing required tools / cannot resolve memory or repo
+
+set -u
+
+die() { printf 'check-main-idle: %s\n' "$1" >&2; exit 2; }
+
+HOURS=48
+FORMAT=text
+MEMORY_DIR=""
+REPO=""
+NO_ISSUE_CHECK=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --hours)        shift; [ $# -gt 0 ] || die "--hours needs a value"; HOURS="$1"; shift ;;
+    --memory-dir)   shift; [ $# -gt 0 ] || die "--memory-dir needs a value"; MEMORY_DIR="$1"; shift ;;
+    --repo)         shift; [ $# -gt 0 ] || die "--repo needs a value"; REPO="$1"; shift ;;
+    --format)       shift; [ $# -gt 0 ] || die "--format needs a value"; FORMAT="$1"; shift ;;
+    --no-issue-check) NO_ISSUE_CHECK=1; shift ;;
+    -h|--help)
+      sed -n '2,32p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    -*) die "unknown flag: $1" ;;
+    *)  die "unexpected positional argument: $1" ;;
+  esac
+done
+
+case "$HOURS" in
+  ''|*[!0-9]*|0) die "--hours must be a positive integer: '$HOURS'" ;;
+esac
+case "$FORMAT" in
+  text|json) ;;
+  *) die "--format must be text or json (got '$FORMAT')" ;;
+esac
+
+if [ -z "$MEMORY_DIR" ]; then
+  MEMORY_DIR="${MERCURY_MEMORY_DIR:-${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/D--Mercury-Mercury/memory}"
+fi
+[ -d "$MEMORY_DIR" ] || die "memory dir not found: $MEMORY_DIR"
+
+if [ "$NO_ISSUE_CHECK" -eq 0 ]; then
+  command -v gh >/dev/null 2>&1 || die "gh CLI required (or pass --no-issue-check)"
+  command -v jq >/dev/null 2>&1 || die "jq required (or pass --no-issue-check)"
+  if [ -z "$REPO" ]; then REPO="${GH_REPO:-}"; fi
+  if [ -z "$REPO" ]; then
+    REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null) \
+      || die "cannot determine target repo (pass --repo or set GH_REPO)"
+  fi
+fi
+
+NOW=$(date +%s)
+THRESHOLD_SECS=$((HOURS * 3600))
+
+# 1. Branch activity — main lane ref glob.
+branch_ts=$(git for-each-ref --sort=-committerdate --format='%(committerdate:unix)' \
+  'refs/heads/feature/lane-main/*' \
+  'refs/remotes/*/feature/lane-main/*' \
+  'refs/heads/feature/TASK-*' \
+  'refs/remotes/*/feature/TASK-*' \
+  2>/dev/null | head -n1)
+
+# 2. Handoff mtime — main file is unsuffixed.
+handoff_file="$MEMORY_DIR/session-handoff.md"
+if [ -f "$handoff_file" ]; then
+  handoff_ts=$(stat -c %Y "$handoff_file" 2>/dev/null || stat -f %m "$handoff_file" 2>/dev/null || echo "")
+else
+  handoff_ts=""
+fi
+
+# 3. Issue activity — `lane:main` label.
+issue_ts=""
+if [ "$NO_ISSUE_CHECK" -eq 0 ]; then
+  out=$(gh issue list --repo "$REPO" --label "lane:main" --state all --limit 200 --json updatedAt 2>/dev/null) || out=""
+  if [ -n "$out" ]; then
+    iso=$(printf '%s' "$out" | jq -r 'if length == 0 then "" else (max_by(.updatedAt).updatedAt) end' 2>/dev/null)
+    if [ -n "$iso" ]; then
+      issue_ts=$(date -d "$iso" +%s 2>/dev/null || date -j -f '%Y-%m-%dT%H:%M:%SZ' "$iso" +%s 2>/dev/null || echo "")
+    fi
+  fi
+fi
+
+age_hours() {
+  local ts="$1"
+  if [ -z "$ts" ]; then echo "inf"; else echo $(( (NOW - ts) / 3600 )); fi
+}
+
+is_idle_signal() {
+  local ts="$1"
+  if [ -z "$ts" ]; then return 0; fi
+  [ $((NOW - ts)) -gt "$THRESHOLD_SECS" ]
+}
+
+bage=$(age_hours "$branch_ts")
+hage=$(age_hours "$handoff_ts")
+iage=$(age_hours "$issue_ts")
+
+verdict=active
+if is_idle_signal "$branch_ts" && is_idle_signal "$handoff_ts" && is_idle_signal "$issue_ts"; then
+  verdict=idle
+fi
+
+if [ "$FORMAT" = "json" ]; then
+  printf '{"threshold_hours":%d,"branch_age_hours":"%s","handoff_age_hours":"%s","issue_age_hours":"%s","verdict":"%s"}\n' \
+    "$HOURS" "$bage" "$hage" "$iage" "$verdict"
+else
+  printf 'main lane idleness check (threshold %dh)\n' "$HOURS"
+  printf '  branch_age:  %sh\n' "$bage"
+  printf '  handoff_age: %sh\n' "$hage"
+  printf '  issue_age:   %sh\n' "$iage"
+  printf '  verdict:     %s\n' "$verdict"
+fi
+
+[ "$verdict" = "idle" ] && exit 0 || exit 1

--- a/scripts/check-main-idle.sh
+++ b/scripts/check-main-idle.sh
@@ -2,26 +2,30 @@
 # scripts/check-main-idle.sh — detect main-lane idleness for Rule 4.1
 # emergency spec-change escalation (v0.1 Delta 4, Issue #312).
 #
-# Returns the maximum age across THREE main-lane activity signals and
-# compares it to the threshold (default 48h):
+# Evaluates THREE main-lane activity signals against the threshold
+# (default 48h) and returns "idle" only when ALL THREE are simultaneously
+# older than the threshold (logical AND, not maximum):
 #   1. Newest commit on `feature/lane-main/*` or legacy `feature/TASK-*` refs
 #   2. mtime of `<memory-dir>/session-handoff.md`
 #   3. Newest `updatedAt` of any Issue carrying the `lane:main` label
 #
-# main is "idle" only if ALL THREE are simultaneously older than the threshold.
+# AND-gate prevents a single missing-data signal from producing a false
+# "idle" verdict; all three must converge before the precondition is met.
 # This script is a HELPER — it answers "is the threshold met?", not "should we
 # escalate?". Escalation is always opt-in and arbitrated by the user per
 # Rule 4.1.
 #
 # Usage:
 #   scripts/check-main-idle.sh [--hours N] [--memory-dir PATH]
-#                              [--repo OWNER/REPO] [--no-issue-check]
-#                              [--format text|json]
+#                              [--repo OWNER/REPO] [--repo-root PATH]
+#                              [--no-issue-check] [--format text|json]
 #
 # Defaults:
 #   --hours        48
 #   --memory-dir   ${MERCURY_MEMORY_DIR:-${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/D--Mercury-Mercury/memory}
 #   --repo         resolved at runtime via `gh repo view` (or GH_REPO env)
+#   --repo-root    `git rev-parse --show-toplevel` from cwd; pin explicitly
+#                  when running outside the Mercury checkout
 #   --format       text
 #
 # Exit codes:
@@ -38,6 +42,7 @@ HOURS=48
 FORMAT=text
 MEMORY_DIR=""
 REPO=""
+REPO_ROOT=""
 NO_ISSUE_CHECK=0
 
 while [ $# -gt 0 ]; do
@@ -45,15 +50,26 @@ while [ $# -gt 0 ]; do
     --hours)        shift; [ $# -gt 0 ] || die "--hours needs a value"; HOURS="$1"; shift ;;
     --memory-dir)   shift; [ $# -gt 0 ] || die "--memory-dir needs a value"; MEMORY_DIR="$1"; shift ;;
     --repo)         shift; [ $# -gt 0 ] || die "--repo needs a value"; REPO="$1"; shift ;;
+    --repo-root)    shift; [ $# -gt 0 ] || die "--repo-root needs a value"; REPO_ROOT="$1"; shift ;;
     --format)       shift; [ $# -gt 0 ] || die "--format needs a value"; FORMAT="$1"; shift ;;
     --no-issue-check) NO_ISSUE_CHECK=1; shift ;;
     -h|--help)
-      sed -n '2,32p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      sed -n '2,33p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
       exit 0 ;;
     -*) die "unknown flag: $1" ;;
     *)  die "unexpected positional argument: $1" ;;
   esac
 done
+
+# Repo-root for branch-activity probe. Same rationale as lane-sweep.sh —
+# without an explicit pin, `git for-each-ref` silently returns empty in
+# non-git contexts and masks operator error as branch_age=inf.
+if [ -z "$REPO_ROOT" ]; then
+  REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) \
+    || die "cannot resolve repo root (cwd is not inside a git checkout — pass --repo-root explicitly)"
+fi
+[ -d "$REPO_ROOT/.git" ] || [ -f "$REPO_ROOT/.git" ] \
+  || die "--repo-root is not a git checkout: $REPO_ROOT"
 
 case "$HOURS" in
   ''|*[!0-9]*|0) die "--hours must be a positive integer: '$HOURS'" ;;
@@ -82,7 +98,8 @@ NOW=$(date +%s)
 THRESHOLD_SECS=$((HOURS * 3600))
 
 # 1. Branch activity — main lane ref glob.
-branch_ts=$(git for-each-ref --sort=-committerdate --format='%(committerdate:unix)' \
+# Pinned via `git -C "$REPO_ROOT"` so cwd doesn't silently hijack the result.
+branch_ts=$(git -C "$REPO_ROOT" for-each-ref --sort=-committerdate --format='%(committerdate:unix)' \
   'refs/heads/feature/lane-main/*' \
   'refs/remotes/*/feature/lane-main/*' \
   'refs/heads/feature/TASK-*' \

--- a/scripts/check-main-idle.sh
+++ b/scripts/check-main-idle.sh
@@ -92,6 +92,11 @@ if [ "$NO_ISSUE_CHECK" -eq 0 ]; then
     REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null) \
       || die "cannot determine target repo (pass --repo or set GH_REPO)"
   fi
+  # Validate repo shape (owner/repo). Mirrors lane-sweep.sh + lane-claim.sh.
+  case "$REPO" in
+    */*) ;;
+    *) die "invalid repo format '$REPO' (expected owner/repo)" ;;
+  esac
 fi
 
 NOW=$(date +%s)

--- a/scripts/lane-close.sh
+++ b/scripts/lane-close.sh
@@ -4,8 +4,11 @@
 #
 # Atomically:
 #   1. Validate <lane> exists in LANES.md, status != closed
-#   2. Refuse if `.tmp/lane-<lane>/` contains uncommitted/dangerous content
-#      (untracked content the user may want to inspect first)
+#   2. Refuse if `.tmp/lane-<lane>/` contains specific dangerous markers:
+#      any file matching `*.uncommitted` (the documented Mercury "save me
+#      first" suffix) OR a `.git` directory/file (nested checkout artifact).
+#      Other untracked content does NOT block close — operators are expected
+#      to use the `.uncommitted` suffix to flag inspect-first content.
 #   3. Flip the lane's `**Status**: ...` line to `closed` (only that lane's
 #      section — Rule 6 ownership)
 #   4. Remove `.tmp/lane-<lane>/`

--- a/scripts/lane-close.sh
+++ b/scripts/lane-close.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# scripts/lane-close.sh — Mercury multi-lane close ceremony.
+# Implements Rule 3.2 of feedback_lane_protocol.md (v0.1 Delta 3, Issue #311).
+#
+# Atomically:
+#   1. Validate <lane> exists in LANES.md, status != closed
+#   2. Refuse if `.tmp/lane-<lane>/` contains uncommitted/dangerous content
+#      (untracked content the user may want to inspect first)
+#   3. Flip the lane's `**Status**: ...` line to `closed` (only that lane's
+#      section — Rule 6 ownership)
+#   4. Remove `.tmp/lane-<lane>/`
+#
+# Per Rule 6 only the OWNING lane should run this. The script issues a soft
+# warning when the current git branch does not match `feature/lane-<lane>/*`
+# (heuristic — not enforced; pass --force-cross-lane to silence).
+#
+# Usage:
+#   scripts/lane-close.sh <lane-name>
+#                         [--lanes-file PATH] [--memory-dir PATH]
+#                         [--tmp-dir PATH] [--repo-root PATH]
+#                         [--yes] [--force-cross-lane] [--dry-run]
+#
+# Defaults:
+#   --memory-dir   ${MERCURY_MEMORY_DIR:-${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/D--Mercury-Mercury/memory}
+#   --lanes-file   <memory-dir>/LANES.md
+#   --repo-root    `git rev-parse --show-toplevel`
+#   --tmp-dir      <repo-root>/.tmp/lane-<lane>
+#
+# Exit codes:
+#   0  lane closed cleanly (or --dry-run path completed)
+#   1  validation failed (lane missing / already closed / unsafe tmp dir / aborted)
+#   2  invalid args / missing lanes-file / cannot resolve repo root
+
+set -u
+
+die()  { printf 'lane-close: %s\n' "$1" >&2; exit 2; }
+warn() { printf 'lane-close WARN: %s\n' "$1" >&2; }
+fail() { printf 'lane-close: %s\n' "$1" >&2; exit 1; }
+
+LANE=""
+LANES_FILE=""
+MEMORY_DIR=""
+TMP_DIR=""
+REPO_ROOT=""
+YES=0
+FORCE_CROSS_LANE=0
+DRY_RUN=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --lanes-file)        shift; [ $# -gt 0 ] || die "--lanes-file needs a value"; LANES_FILE="$1"; shift ;;
+    --memory-dir)        shift; [ $# -gt 0 ] || die "--memory-dir needs a value"; MEMORY_DIR="$1"; shift ;;
+    --tmp-dir)           shift; [ $# -gt 0 ] || die "--tmp-dir needs a value"; TMP_DIR="$1"; shift ;;
+    --repo-root)         shift; [ $# -gt 0 ] || die "--repo-root needs a value"; REPO_ROOT="$1"; shift ;;
+    --yes)               YES=1; shift ;;
+    --force-cross-lane)  FORCE_CROSS_LANE=1; shift ;;
+    --dry-run)           DRY_RUN=1; shift ;;
+    -h|--help)
+      sed -n '2,32p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    --) shift; while [ $# -gt 0 ]; do
+          [ -z "$LANE" ] || die "too many positional args after --: $1"
+          LANE="$1"; shift
+        done; break ;;
+    -*) die "unknown flag: $1" ;;
+    *)
+      [ -z "$LANE" ] || die "too many positional args; got: $1"
+      LANE="$1"; shift ;;
+  esac
+done
+
+[ -n "$LANE" ] || die "missing <lane-name> argument (try --help)"
+case "$LANE" in
+  -*) die "lane name must not start with hyphen: '$LANE'" ;;
+  *[!A-Za-z0-9_-]*) die "lane name must be [A-Za-z0-9_-]: '$LANE'" ;;
+esac
+
+if [ -z "$MEMORY_DIR" ]; then
+  MEMORY_DIR="${MERCURY_MEMORY_DIR:-${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/D--Mercury-Mercury/memory}"
+fi
+if [ -z "$LANES_FILE" ]; then LANES_FILE="$MEMORY_DIR/LANES.md"; fi
+[ -f "$LANES_FILE" ] || die "LANES.md not found: $LANES_FILE"
+
+if [ -z "$REPO_ROOT" ]; then
+  REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || die "cannot resolve repo root (pass --repo-root)"
+fi
+[ -d "$REPO_ROOT" ] || die "repo root not a directory: $REPO_ROOT"
+
+if [ -z "$TMP_DIR" ]; then TMP_DIR="$REPO_ROOT/.tmp/lane-$LANE"; fi
+
+# Validate lane is registered in LANES.md and detect current status.
+# The `### \`<lane>\`` heading anchors the section; the next line containing
+# `**Status**:` (potentially several lines later) is the lane's status line.
+LANE_HEADING_RE="^### \`${LANE}\`"
+if ! grep -q "$LANE_HEADING_RE" "$LANES_FILE"; then
+  fail "lane '$LANE' not found in $LANES_FILE"
+fi
+
+# Extract the lane's section (heading line through to the next heading or EOF).
+LANE_SECTION=$(awk -v re="$LANE_HEADING_RE" '
+  $0 ~ re { in_section = 1; print; next }
+  /^### / && in_section { exit }
+  /^## / && in_section { exit }
+  in_section { print }
+' "$LANES_FILE")
+
+CUR_STATUS=$(printf '%s\n' "$LANE_SECTION" \
+  | grep -m1 '^- \*\*Status\*\*:' \
+  | sed -E 's/^- \*\*Status\*\*: `?([A-Za-z_-]+)`?.*/\1/' \
+  || true)
+
+if [ -z "$CUR_STATUS" ]; then
+  fail "could not parse current Status for lane '$LANE' (expected line: '- **Status**: \`active\`' or similar)"
+fi
+
+if [ "$CUR_STATUS" = "closed" ]; then
+  fail "lane '$LANE' is already closed (Status=$CUR_STATUS)"
+fi
+
+# Owning-lane heuristic: warn if current branch doesn't match lane prefix.
+# Skipped under --force-cross-lane and silently in non-git contexts.
+if [ "$FORCE_CROSS_LANE" -eq 0 ]; then
+  CUR_BRANCH=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+  if [ -n "$CUR_BRANCH" ] && [ "$CUR_BRANCH" != "HEAD" ]; then
+    case "$CUR_BRANCH" in
+      "feature/lane-${LANE}/"*) ;;
+      *) warn "current branch '$CUR_BRANCH' does not match owning-lane prefix 'feature/lane-${LANE}/*' — pass --force-cross-lane to silence this warning" ;;
+    esac
+  fi
+fi
+
+# Tmp dir safety check: refuse close if the tmp dir exists AND contains files
+# matching dangerous patterns. The ".uncommitted" suffix is the documented
+# Mercury convention for "save me first" markers; ".git" artifacts indicate
+# a nested checkout (likely accidental).
+if [ -d "$TMP_DIR" ]; then
+  UNSAFE=$(find "$TMP_DIR" \( -name '*.uncommitted' -o -name '.git' \) -print 2>/dev/null | head -n5)
+  if [ -n "$UNSAFE" ]; then
+    fail "refusing to remove $TMP_DIR — found unsafe entries (resolve manually first):
+$UNSAFE"
+  fi
+fi
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  printf '[dry-run] would flip Status of lane %s from %s to closed in %s\n' "$LANE" "$CUR_STATUS" "$LANES_FILE"
+  if [ -d "$TMP_DIR" ]; then
+    printf '[dry-run] would rm -rf %s\n' "$TMP_DIR"
+  else
+    printf '[dry-run] no tmp dir at %s (skip rm)\n' "$TMP_DIR"
+  fi
+  exit 0
+fi
+
+# Confirm before destructive action unless --yes.
+if [ "$YES" -eq 0 ]; then
+  if [ -t 0 ]; then
+    printf 'Close lane %s? Will flip Status to `closed` and rm -rf %s [y/N] ' "$LANE" "$TMP_DIR"
+    read -r ans
+    case "${ans:-}" in
+      y|Y|yes|YES) ;;
+      *) fail "aborted by user" ;;
+    esac
+  else
+    fail "refusing destructive action without --yes in non-interactive context"
+  fi
+fi
+
+# Edit LANES.md: replace the Status line within the lane's own section ONLY.
+# Strategy: stream through file, toggle in-section flag on heading match,
+# turn off on next heading; rewrite the first matching Status line inside
+# the section, then exit-flag to prevent further edits to other sections.
+TMP_LANES=$(mktemp)
+awk -v re="$LANE_HEADING_RE" '
+  BEGIN { in_section = 0; replaced = 0 }
+  $0 ~ re { in_section = 1; print; next }
+  in_section && (/^### / || /^## /) { in_section = 0; print; next }
+  in_section && !replaced && /^- \*\*Status\*\*:/ {
+    sub(/`[A-Za-z_-]+`/, "`closed`")
+    sub(/\*\*Status\*\*: [A-Za-z_-]+/, "**Status**: `closed`")
+    print
+    replaced = 1
+    next
+  }
+  { print }
+  END { if (!replaced) exit 7 }
+' "$LANES_FILE" > "$TMP_LANES" || {
+  rm -f "$TMP_LANES"
+  fail "failed to rewrite Status line — Status pattern not matched in lane section"
+}
+
+mv "$TMP_LANES" "$LANES_FILE"
+
+# Remove tmp dir if present.
+if [ -d "$TMP_DIR" ]; then
+  rm -rf "$TMP_DIR" || fail "rm -rf $TMP_DIR failed"
+  printf 'lane-close: removed %s\n' "$TMP_DIR"
+else
+  printf 'lane-close: no tmp dir at %s (nothing to remove)\n' "$TMP_DIR"
+fi
+
+printf 'lane-close: lane %s flipped to `closed` in %s\n' "$LANE" "$LANES_FILE"
+exit 0

--- a/scripts/lane-close.sh
+++ b/scripts/lane-close.sh
@@ -123,6 +123,17 @@ case "$TMP_DIR_REAL" in
     case "$LEAF" in
       ..|*/..|../*|*/../*) die "refusing --tmp-dir with '..' segment: '$TMP_DIR' → '$TMP_DIR_REAL'" ;;
     esac
+    # Lane-name consistency check (Argus #327 iter 4/5 finding #3): the
+    # leaf's first segment MUST be `lane-<LANE>` (or equal to it). Without
+    # this guard, `lane-close.sh foo --tmp-dir .tmp/lane-bar` would
+    # silently `rm -rf` the WRONG lane's tmp dir while flipping foo's
+    # Status. The lane name was already validated against [A-Za-z0-9_-]
+    # so direct string equality is safe.
+    EXPECTED_LEAF_PREFIX="lane-${LANE}"
+    case "$LEAF" in
+      "$EXPECTED_LEAF_PREFIX"|"$EXPECTED_LEAF_PREFIX"/*) ;;
+      *) die "refusing --tmp-dir whose leaf does not match 'lane-${LANE}': '$TMP_DIR' → '$TMP_DIR_REAL' (leaf=${LEAF})" ;;
+    esac
     ;;
   *)
     die "refusing --tmp-dir outside ${EXPECTED_PREFIX}*: '$TMP_DIR' → '$TMP_DIR_REAL'" ;;

--- a/scripts/lane-close.sh
+++ b/scripts/lane-close.sh
@@ -50,7 +50,9 @@ while [ $# -gt 0 ]; do
   case "$1" in
     --lanes-file)        shift; [ $# -gt 0 ] || die "--lanes-file needs a value"; LANES_FILE="$1"; shift ;;
     --memory-dir)        shift; [ $# -gt 0 ] || die "--memory-dir needs a value"; MEMORY_DIR="$1"; shift ;;
-    --tmp-dir)           shift; [ $# -gt 0 ] || die "--tmp-dir needs a value"; TMP_DIR="$1"; shift ;;
+    --tmp-dir)           shift; [ $# -gt 0 ] || die "--tmp-dir needs a value"
+                          [ -n "$1" ] || die "--tmp-dir requires a non-empty path (got empty string)"
+                          TMP_DIR="$1"; shift ;;
     --repo-root)         shift; [ $# -gt 0 ] || die "--repo-root needs a value"; REPO_ROOT="$1"; shift ;;
     --yes)               YES=1; shift ;;
     --force-cross-lane)  FORCE_CROSS_LANE=1; shift ;;
@@ -87,6 +89,39 @@ fi
 [ -d "$REPO_ROOT" ] || die "repo root not a directory: $REPO_ROOT"
 
 if [ -z "$TMP_DIR" ]; then TMP_DIR="$REPO_ROOT/.tmp/lane-$LANE"; fi
+
+# Tmp dir safety gate: refuse anything outside the repo's .tmp/ subtree, OR
+# anything that resolves to a root-like / repo-root / parent-of-repo path.
+# This blocks `--tmp-dir /` `--tmp-dir $HOME` `--tmp-dir $REPO_ROOT` etc.
+# from triggering rm -rf later. Rule: TMP_DIR must be REPO_ROOT/.tmp/<something>
+# and the <something> must be non-empty. Empty / root paths refused outright.
+case "$TMP_DIR" in
+  ''|/|/.|/..) die "refusing unsafe --tmp-dir: '$TMP_DIR' (empty or root path)" ;;
+esac
+# Realpath comparison defends against `--tmp-dir $REPO_ROOT/.tmp/lane-foo/..`
+# tricks. realpath is GNU; on systems without it, fall back to readlink -f then
+# raw path comparison (best-effort).
+TMP_DIR_REAL=$(realpath -m "$TMP_DIR" 2>/dev/null \
+            || readlink -f "$TMP_DIR" 2>/dev/null \
+            || printf '%s' "$TMP_DIR")
+REPO_ROOT_REAL=$(realpath -m "$REPO_ROOT" 2>/dev/null \
+              || readlink -f "$REPO_ROOT" 2>/dev/null \
+              || printf '%s' "$REPO_ROOT")
+EXPECTED_PREFIX="${REPO_ROOT_REAL%/}/.tmp/"
+case "$TMP_DIR_REAL" in
+  "$REPO_ROOT_REAL"|"${REPO_ROOT_REAL%/}")
+    die "refusing --tmp-dir that resolves to repo root: '$TMP_DIR' → '$TMP_DIR_REAL'" ;;
+  "$EXPECTED_PREFIX"*)
+    # Resolved path must contain a non-empty leaf beyond .tmp/
+    LEAF="${TMP_DIR_REAL#$EXPECTED_PREFIX}"
+    [ -n "$LEAF" ] || die "refusing --tmp-dir without leaf segment: '$TMP_DIR' → '$TMP_DIR_REAL'"
+    case "$LEAF" in
+      */*/..) die "refusing --tmp-dir traversal: '$TMP_DIR' → '$TMP_DIR_REAL'" ;;
+    esac
+    ;;
+  *)
+    die "refusing --tmp-dir outside ${EXPECTED_PREFIX}*: '$TMP_DIR' → '$TMP_DIR_REAL'" ;;
+esac
 
 # Validate lane is registered in LANES.md and detect current status.
 # The `### \`<lane>\`` heading anchors the section; the next line containing

--- a/scripts/lane-close.sh
+++ b/scripts/lane-close.sh
@@ -115,8 +115,13 @@ case "$TMP_DIR_REAL" in
     # Resolved path must contain a non-empty leaf beyond .tmp/
     LEAF="${TMP_DIR_REAL#$EXPECTED_PREFIX}"
     [ -n "$LEAF" ] || die "refusing --tmp-dir without leaf segment: '$TMP_DIR' → '$TMP_DIR_REAL'"
+    # Reject any `..` segment in the leaf (handles `lane-foo/..`, `..`,
+    # `a/../b`, etc.). Belt-and-braces: realpath/readlink fallback may have
+    # left literal `..` segments unresolved. Match by exact equality OR
+    # bordered by `/` so that names containing `..` as a literal substring
+    # (e.g. `lane-..foo`) are NOT falsely flagged.
     case "$LEAF" in
-      */*/..) die "refusing --tmp-dir traversal: '$TMP_DIR' → '$TMP_DIR_REAL'" ;;
+      ..|*/..|../*|*/../*) die "refusing --tmp-dir with '..' segment: '$TMP_DIR' → '$TMP_DIR_REAL'" ;;
     esac
     ;;
   *)

--- a/scripts/lane-sweep.sh
+++ b/scripts/lane-sweep.sh
@@ -175,14 +175,30 @@ issue_last_ts() {
     return
   fi
   local out iso
-  out=$(gh issue list --repo "$REPO" --label "lane:${lane}" --state all \
-        --limit 200 --json updatedAt 2>/dev/null) || { echo ""; return; }
-  iso=$(printf '%s' "$out" \
-    | jq -r 'if length == 0 then "" else (max_by(.updatedAt).updatedAt) end' 2>/dev/null)
+  # Asymmetric error policy vs check-main-idle.sh: sweep is REPORT-ONLY (no
+  # destructive action gated on its verdict), so a per-lane probe failure
+  # should warn-and-continue rather than abort the entire report. The
+  # AND-gate verdict logic still requires three signals to converge before
+  # declaring stale, so a single missing-data signal can't produce a
+  # false-positive on its own. WARN distinguishes "probe failed" from "no
+  # data" so the operator can investigate (Argus #327 iter 3 finding).
+  if ! out=$(gh issue list --repo "$REPO" --label "lane:${lane}" --state all \
+             --limit 200 --json updatedAt 2>/dev/null); then
+    warn "gh issue probe failed for lane '$lane' — treating as missing data"
+    echo ""; return
+  fi
+  if ! iso=$(printf '%s' "$out" \
+             | jq -r 'if length == 0 then "" else (max_by(.updatedAt).updatedAt) end' 2>/dev/null); then
+    warn "jq parse failed for lane '$lane' Issue probe output — treating as missing data"
+    echo ""; return
+  fi
   if [ -n "$iso" ]; then
-    date -d "$iso" +%s 2>/dev/null \
-      || date -j -f '%Y-%m-%dT%H:%M:%SZ' "$iso" +%s 2>/dev/null \
-      || echo ""
+    if ! ts=$(date -d "$iso" +%s 2>/dev/null) \
+       && ! ts=$(date -j -f '%Y-%m-%dT%H:%M:%SZ' "$iso" +%s 2>/dev/null); then
+      warn "date parse failed for ISO '$iso' (lane '$lane') — treating as missing data"
+      echo ""; return
+    fi
+    echo "$ts"
   else
     echo ""
   fi

--- a/scripts/lane-sweep.sh
+++ b/scripts/lane-sweep.sh
@@ -172,6 +172,21 @@ issue_last_ts() {
   fi
 }
 
+# Defensive JSON-string escaper for fields read from LANES.md (lane names
+# have no validation upstream — a manually-tampered LANES.md could include
+# quote/backslash/newline that break JSON output). Output INCLUDES the
+# surrounding double-quotes. Handles the common metacharacters; control
+# bytes outside \n/\t fall through unescaped, which is acceptable for the
+# defensive use case (Argus #327 finding).
+json_string() {
+  local s=$1
+  s=${s//\\/\\\\}
+  s=${s//\"/\\\"}
+  s=${s//$'\n'/\\n}
+  s=${s//$'\t'/\\t}
+  printf '"%s"' "$s"
+}
+
 # Age in days from a unix ts (empty → "inf"). Stable formatter for both
 # text rows and JSON age fields.
 age_days() {
@@ -224,8 +239,12 @@ while IFS= read -r lane; do
   else
     [ "$first" -eq 1 ] || printf ','
     first=0
-    printf '{"lane":"%s","branch_age_days":"%s","handoff_age_days":"%s","issue_age_days":"%s","verdict":"%s"}' \
-      "$lane" "$bage" "$hage" "$iage" "$verdict"
+    # Escape lane name (only field that comes from LANES.md text, may contain
+    # arbitrary chars). Other fields are program-generated and constrained
+    # to digits + "inf" + "fresh"/"stale".
+    LANE_J=$(json_string "$lane")
+    printf '{"lane":%s,"branch_age_days":"%s","handoff_age_days":"%s","issue_age_days":"%s","verdict":"%s"}' \
+      "$LANE_J" "$bage" "$hage" "$iage" "$verdict"
   fi
 done <<EOF
 $LANES

--- a/scripts/lane-sweep.sh
+++ b/scripts/lane-sweep.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+# scripts/lane-sweep.sh — Mercury multi-lane stale-lane detection (report only).
+# Implements Rule 3.1 of feedback_lane_protocol.md (v0.1 Delta 2, Issue #310).
+#
+# A lane is "stale" if ALL THREE criteria are simultaneously older than the
+# threshold (default 14 days):
+#   1. Branch activity   — newest committerdate on `feature/lane-<lane>/*` refs
+#                          (main lane also checks legacy `feature/TASK-*`)
+#   2. Handoff activity  — mtime of the lane's `session-handoff[-<lane>].md`
+#                          file in the user-memory directory
+#   3. Issue activity    — newest `updatedAt` of any Issue carrying the
+#                          `lane:<lane>` label (state=all)
+#
+# Per Rule 6 (LANES.md section ownership) this script REPORTS ONLY — it never
+# mutates `LANES.md`. The owning lane is responsible for any status flip.
+#
+# Usage:
+#   scripts/lane-sweep.sh [--lanes-file PATH] [--memory-dir PATH]
+#                         [--days N] [--repo OWNER/REPO]
+#                         [--format text|json] [--no-issue-check]
+#
+# Defaults:
+#   --lanes-file   <memory-dir>/LANES.md
+#   --memory-dir   ${MERCURY_MEMORY_DIR:-${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/D--Mercury-Mercury/memory}
+#   --days         14
+#   --repo         resolved at runtime via `gh repo view` (or GH_REPO env)
+#   --format       text
+#
+# Exit codes:
+#   0  success — report emitted (independent of stale/fresh verdicts)
+#   2  invalid args / missing required tools / cannot resolve repo or memory dir
+
+set -u
+
+die()  { printf 'lane-sweep: %s\n' "$1" >&2; exit 2; }
+warn() { printf 'lane-sweep WARN: %s\n' "$1" >&2; }
+
+DAYS=14
+FORMAT=text
+LANES_FILE=""
+MEMORY_DIR=""
+REPO=""
+NO_ISSUE_CHECK=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --days)         shift; [ $# -gt 0 ] || die "--days needs a value"; DAYS="$1"; shift ;;
+    --format)       shift; [ $# -gt 0 ] || die "--format needs a value"; FORMAT="$1"; shift ;;
+    --lanes-file)   shift; [ $# -gt 0 ] || die "--lanes-file needs a value"; LANES_FILE="$1"; shift ;;
+    --memory-dir)   shift; [ $# -gt 0 ] || die "--memory-dir needs a value"; MEMORY_DIR="$1"; shift ;;
+    --repo)         shift; [ $# -gt 0 ] || die "--repo needs a value"; REPO="$1"; shift ;;
+    --no-issue-check) NO_ISSUE_CHECK=1; shift ;;
+    -h|--help)
+      sed -n '2,33p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    -*) die "unknown flag: $1" ;;
+    *)  die "unexpected positional argument: $1" ;;
+  esac
+done
+
+case "$DAYS" in
+  ''|*[!0-9]*|0) die "--days must be a positive integer: '$DAYS'" ;;
+esac
+case "$FORMAT" in
+  text|json) ;;
+  *) die "--format must be text or json (got '$FORMAT')" ;;
+esac
+
+# Memory dir resolution. Caller may pass --memory-dir to point at a synthetic
+# directory (used by the test harness); otherwise honor MERCURY_MEMORY_DIR env
+# override; otherwise fall back to the canonical Claude Code path.
+if [ -z "$MEMORY_DIR" ]; then
+  MEMORY_DIR="${MERCURY_MEMORY_DIR:-${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/D--Mercury-Mercury/memory}"
+fi
+[ -d "$MEMORY_DIR" ] || die "memory dir not found: $MEMORY_DIR (set --memory-dir or MERCURY_MEMORY_DIR)"
+
+if [ -z "$LANES_FILE" ]; then
+  LANES_FILE="$MEMORY_DIR/LANES.md"
+fi
+[ -f "$LANES_FILE" ] || die "LANES.md not found: $LANES_FILE"
+
+# Repo resolution for Issue activity probe. Skip if --no-issue-check set
+# (useful for offline runs / fast tests). Mirrors lane-claim.sh resolution.
+if [ "$NO_ISSUE_CHECK" -eq 0 ]; then
+  command -v gh >/dev/null 2>&1 || die "gh CLI required for Issue activity probe (or pass --no-issue-check)"
+  command -v jq >/dev/null 2>&1 || die "jq required for Issue activity probe (or pass --no-issue-check)"
+  if [ -z "$REPO" ]; then
+    REPO="${GH_REPO:-}"
+  fi
+  if [ -z "$REPO" ]; then
+    REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null) \
+      || die "cannot determine target repo (pass --repo or set GH_REPO)"
+  fi
+  case "$REPO" in
+    */*) ;;
+    *) die "invalid repo format '$REPO' (expected owner/repo)" ;;
+  esac
+fi
+
+NOW=$(date +%s)
+THRESHOLD_SECS=$((DAYS * 86400))
+
+# Parse active lane names from LANES.md. Active Lanes section is delimited by
+# the "## Active Lanes" header and the next "## " header (Closed / Governance /
+# Rollback). Inside, lane name appears as: ### `<name>` (default lane)?
+parse_active_lanes() {
+  awk '
+    /^## Active Lanes/ { in_active = 1; next }
+    /^## / && in_active { in_active = 0 }
+    in_active && /^### `[^`]+`/ {
+      match($0, /`[^`]+`/)
+      name = substr($0, RSTART + 1, RLENGTH - 2)
+      print name
+    }
+  ' "$1"
+}
+
+# Newest committerdate (unix ts) across refs matching the lane's branch glob.
+# main lane also includes legacy `feature/TASK-*`. Empty output = no refs.
+branch_last_ts() {
+  local lane="$1"
+  local patterns=(
+    "refs/heads/feature/lane-${lane}/*"
+    "refs/remotes/*/feature/lane-${lane}/*"
+  )
+  if [ "$lane" = "main" ]; then
+    patterns+=(
+      "refs/heads/feature/TASK-*"
+      "refs/remotes/*/feature/TASK-*"
+    )
+  fi
+  git for-each-ref --sort=-committerdate --format='%(committerdate:unix)' \
+    "${patterns[@]}" 2>/dev/null | head -n1
+}
+
+# mtime of session-handoff[-<lane>].md. main lane file has no suffix.
+handoff_last_ts() {
+  local lane="$1"
+  local file
+  if [ "$lane" = "main" ]; then
+    file="$MEMORY_DIR/session-handoff.md"
+  else
+    file="$MEMORY_DIR/session-handoff-${lane}.md"
+  fi
+  if [ -f "$file" ]; then
+    # Portable mtime: try GNU stat then BSD stat.
+    stat -c %Y "$file" 2>/dev/null || stat -f %m "$file" 2>/dev/null || echo ""
+  else
+    echo ""
+  fi
+}
+
+# Newest Issue updatedAt for label lane:<lane>. Empty if no matching Issues
+# or --no-issue-check set.
+issue_last_ts() {
+  local lane="$1"
+  if [ "$NO_ISSUE_CHECK" -eq 1 ]; then
+    echo ""
+    return
+  fi
+  local out iso
+  out=$(gh issue list --repo "$REPO" --label "lane:${lane}" --state all \
+        --limit 200 --json updatedAt 2>/dev/null) || { echo ""; return; }
+  iso=$(printf '%s' "$out" \
+    | jq -r 'if length == 0 then "" else (max_by(.updatedAt).updatedAt) end' 2>/dev/null)
+  if [ -n "$iso" ]; then
+    date -d "$iso" +%s 2>/dev/null \
+      || date -j -f '%Y-%m-%dT%H:%M:%SZ' "$iso" +%s 2>/dev/null \
+      || echo ""
+  else
+    echo ""
+  fi
+}
+
+# Age in days from a unix ts (empty → "inf"). Stable formatter for both
+# text rows and JSON age fields.
+age_days() {
+  local ts="$1"
+  if [ -z "$ts" ]; then
+    echo "inf"
+  else
+    echo $(( (NOW - ts) / 86400 ))
+  fi
+}
+
+is_stale_criterion() {
+  local ts="$1"
+  if [ -z "$ts" ]; then return 0; fi
+  local age=$(( NOW - ts ))
+  [ "$age" -gt "$THRESHOLD_SECS" ]
+}
+
+LANES=$(parse_active_lanes "$LANES_FILE")
+if [ -z "$LANES" ]; then
+  warn "no active lanes parsed from $LANES_FILE — empty report"
+fi
+
+if [ "$FORMAT" = "json" ]; then
+  printf '{"threshold_days":%d,"generated_at":%d,"lanes":[' "$DAYS" "$NOW"
+  first=1
+fi
+
+if [ "$FORMAT" = "text" ]; then
+  printf '%-22s %-12s %-13s %-11s %s\n' "LANE" "BRANCH_AGE" "HANDOFF_AGE" "ISSUE_AGE" "VERDICT"
+fi
+
+while IFS= read -r lane; do
+  [ -z "$lane" ] && continue
+  bts=$(branch_last_ts "$lane")
+  hts=$(handoff_last_ts "$lane")
+  its=$(issue_last_ts "$lane")
+
+  bage=$(age_days "$bts")
+  hage=$(age_days "$hts")
+  iage=$(age_days "$its")
+
+  verdict=fresh
+  if is_stale_criterion "$bts" && is_stale_criterion "$hts" && is_stale_criterion "$its"; then
+    verdict=stale
+  fi
+
+  if [ "$FORMAT" = "text" ]; then
+    printf '%-22s %-12s %-13s %-11s %s\n' "$lane" "${bage}d" "${hage}d" "${iage}d" "$verdict"
+  else
+    [ "$first" -eq 1 ] || printf ','
+    first=0
+    printf '{"lane":"%s","branch_age_days":"%s","handoff_age_days":"%s","issue_age_days":"%s","verdict":"%s"}' \
+      "$lane" "$bage" "$hage" "$iage" "$verdict"
+  fi
+done <<EOF
+$LANES
+EOF
+
+if [ "$FORMAT" = "json" ]; then
+  printf ']}\n'
+fi
+
+exit 0

--- a/scripts/lane-sweep.sh
+++ b/scripts/lane-sweep.sh
@@ -174,7 +174,7 @@ issue_last_ts() {
     echo ""
     return
   fi
-  local out iso
+  local out iso ts
   # Asymmetric error policy vs check-main-idle.sh: sweep is REPORT-ONLY (no
   # destructive action gated on its verdict), so a per-lane probe failure
   # should warn-and-continue rather than abort the entire report. The
@@ -211,7 +211,7 @@ issue_last_ts() {
 # bytes outside \n/\t fall through unescaped, which is acceptable for the
 # defensive use case (Argus #327 finding).
 json_string() {
-  local s=$1
+  local s="$1"
   s=${s//\\/\\\\}
   s=${s//\"/\\\"}
   s=${s//$'\n'/\\n}

--- a/scripts/lane-sweep.sh
+++ b/scripts/lane-sweep.sh
@@ -16,7 +16,7 @@
 #
 # Usage:
 #   scripts/lane-sweep.sh [--lanes-file PATH] [--memory-dir PATH]
-#                         [--days N] [--repo OWNER/REPO]
+#                         [--days N] [--repo OWNER/REPO] [--repo-root PATH]
 #                         [--format text|json] [--no-issue-check]
 #
 # Defaults:
@@ -24,6 +24,8 @@
 #   --memory-dir   ${MERCURY_MEMORY_DIR:-${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/D--Mercury-Mercury/memory}
 #   --days         14
 #   --repo         resolved at runtime via `gh repo view` (or GH_REPO env)
+#   --repo-root    `git rev-parse --show-toplevel` from cwd; pin explicitly
+#                  when running outside the Mercury checkout
 #   --format       text
 #
 # Exit codes:
@@ -40,6 +42,7 @@ FORMAT=text
 LANES_FILE=""
 MEMORY_DIR=""
 REPO=""
+REPO_ROOT=""
 NO_ISSUE_CHECK=0
 
 while [ $# -gt 0 ]; do
@@ -49,14 +52,26 @@ while [ $# -gt 0 ]; do
     --lanes-file)   shift; [ $# -gt 0 ] || die "--lanes-file needs a value"; LANES_FILE="$1"; shift ;;
     --memory-dir)   shift; [ $# -gt 0 ] || die "--memory-dir needs a value"; MEMORY_DIR="$1"; shift ;;
     --repo)         shift; [ $# -gt 0 ] || die "--repo needs a value"; REPO="$1"; shift ;;
+    --repo-root)    shift; [ $# -gt 0 ] || die "--repo-root needs a value"; REPO_ROOT="$1"; shift ;;
     --no-issue-check) NO_ISSUE_CHECK=1; shift ;;
     -h|--help)
-      sed -n '2,33p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      sed -n '2,35p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
       exit 0 ;;
     -*) die "unknown flag: $1" ;;
     *)  die "unexpected positional argument: $1" ;;
   esac
 done
+
+# Repo-root resolution for branch-activity probe. Without an explicit pin,
+# `git for-each-ref` would silently return empty in non-git contexts, masking
+# operator error (e.g. running the sweep from the wrong directory) as
+# branch_age=inf. Pinning a verified repo root makes the failure mode obvious.
+if [ -z "$REPO_ROOT" ]; then
+  REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) \
+    || die "cannot resolve repo root (cwd is not inside a git checkout — pass --repo-root explicitly)"
+fi
+[ -d "$REPO_ROOT/.git" ] || [ -f "$REPO_ROOT/.git" ] \
+  || die "--repo-root is not a git checkout: $REPO_ROOT"
 
 case "$DAYS" in
   ''|*[!0-9]*|0) die "--days must be a positive integer: '$DAYS'" ;;
@@ -117,6 +132,7 @@ parse_active_lanes() {
 
 # Newest committerdate (unix ts) across refs matching the lane's branch glob.
 # main lane also includes legacy `feature/TASK-*`. Empty output = no refs.
+# Pinned via `git -C "$REPO_ROOT"` so cwd doesn't silently hijack the result.
 branch_last_ts() {
   local lane="$1"
   local patterns=(
@@ -129,7 +145,7 @@ branch_last_ts() {
       "refs/remotes/*/feature/TASK-*"
     )
   fi
-  git for-each-ref --sort=-committerdate --format='%(committerdate:unix)' \
+  git -C "$REPO_ROOT" for-each-ref --sort=-committerdate --format='%(committerdate:unix)' \
     "${patterns[@]}" 2>/dev/null | head -n1
 }
 

--- a/scripts/test-check-main-idle.sh
+++ b/scripts/test-check-main-idle.sh
@@ -83,6 +83,15 @@ OUT_JSON=$("$SCRIPT" --hours 48 --memory-dir "$MEM_FRESH" --no-issue-check --for
 assert_contains "json has threshold_hours" '"threshold_hours":48' "$OUT_JSON"
 assert_contains "json has verdict"          '"verdict":"'         "$OUT_JSON"
 
+# ---- repo format validation (Argus #327 iter 4 Copilot fix) ----
+echo
+echo "[repo-format-validation]"
+# GH_REPO without slash → die exit 2 (mirrors lane-sweep.sh + lane-claim.sh)
+RC_BAD=0
+GH_REPO="not-owner-slash-repo" "$SCRIPT" --hours 48 --memory-dir "$MEM_FRESH" >/dev/null 2>&1 || RC_BAD=$?
+[ "$RC_BAD" = "2" ] && pass "invalid GH_REPO format → die exit=2" \
+  || fail "invalid GH_REPO exit=$RC_BAD (expected 2)"
+
 # ---- die-on-tool-failure (Argus #327 finding #5 fix) ----
 # When gh issue list fails (network/auth), check-main-idle.sh MUST exit 2
 # (not silently treat as "no Issue activity" → "idle"). A false "idle"

--- a/scripts/test-check-main-idle.sh
+++ b/scripts/test-check-main-idle.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# scripts/test-check-main-idle.sh — smoke tests for check-main-idle.sh
+#
+# Uses --no-issue-check to avoid live GitHub calls. Builds synthetic
+# memory with a fresh / stale `session-handoff.md` and verifies exit code
+# semantics + report fields. Branch activity is tested implicitly via the
+# real repo (no synthetic git refs).
+
+set -u
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
+  echo "test-check-main-idle: not inside a git repo" >&2; exit 2; }
+SCRIPT="$REPO_ROOT/scripts/check-main-idle.sh"
+[ -x "$SCRIPT" ] || { echo "test-check-main-idle: $SCRIPT missing or not executable" >&2; exit 2; }
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+PASS=0; FAIL=0
+pass() { printf '  PASS: %s\n' "$1"; PASS=$((PASS+1)); }
+fail() { printf '  FAIL: %s\n' "$1"; FAIL=$((FAIL+1)); }
+
+assert_exit() {
+  local expected=$1 desc=$2; shift 2
+  "$@" >/dev/null 2>&1; local actual=$?
+  if [ "$actual" = "$expected" ]; then pass "$desc (exit=$actual)"
+  else fail "$desc (expected=$expected got=$actual)"; fi
+}
+
+assert_contains() {
+  local desc=$1 needle=$2 actual=$3
+  if printf '%s' "$actual" | grep -q -- "$needle"; then pass "$desc"
+  else fail "$desc — needle '$needle' not in: $(printf '%s' "$actual" | head -c200)"; fi
+}
+
+# ---- arg validation ----
+echo "[arg-validation]"
+assert_exit 0 "--help"                       "$SCRIPT" --help
+assert_exit 2 "unknown flag"                  "$SCRIPT" --bogus
+assert_exit 2 "--hours zero"                  "$SCRIPT" --hours 0 --no-issue-check --memory-dir "$TMP"
+assert_exit 2 "--hours non-numeric"           "$SCRIPT" --hours abc --no-issue-check --memory-dir "$TMP"
+assert_exit 2 "--format invalid"              "$SCRIPT" --format yaml --no-issue-check --memory-dir "$TMP"
+assert_exit 2 "missing memory dir"            "$SCRIPT" --memory-dir "$TMP/nope" --no-issue-check
+
+# ---- fresh handoff → not idle (exit 1) ----
+echo
+echo "[scenarios]"
+MEM_FRESH="$TMP/fresh"; mkdir -p "$MEM_FRESH"
+touch "$MEM_FRESH/session-handoff.md"
+
+OUT_FRESH=$("$SCRIPT" --hours 48 --memory-dir "$MEM_FRESH" --no-issue-check --format text 2>&1)
+RC=$?
+[ "$RC" = "1" ] && pass "fresh handoff → exit 1 (not idle)" \
+  || fail "fresh handoff exit=$RC out=$OUT_FRESH"
+assert_contains "report has branch_age"  "branch_age"  "$OUT_FRESH"
+assert_contains "report has handoff_age" "handoff_age" "$OUT_FRESH"
+assert_contains "report has issue_age"   "issue_age"   "$OUT_FRESH"
+assert_contains "verdict line present"   "verdict:"    "$OUT_FRESH"
+
+# ---- stale handoff (60d) + main lane has no current branches/Issues
+# (--no-issue-check suppresses signal 3; signal 1 only if NO main-lane
+# branches exist locally — depends on environment, so we don't assert
+# verdict=idle for this case to keep tests deterministic).
+MEM_STALE="$TMP/stale"; mkdir -p "$MEM_STALE"
+touch "$MEM_STALE/session-handoff.md"
+STALE_DATE=$(date -d '60 days ago' '+%Y%m%d%H%M' 2>/dev/null || date -v-60d '+%Y%m%d%H%M' 2>/dev/null)
+if [ -n "$STALE_DATE" ]; then
+  touch -t "$STALE_DATE" "$MEM_STALE/session-handoff.md" 2>/dev/null \
+    && pass "stale fixture mtime set" \
+    || fail "could not set stale fixture mtime"
+  OUT_STALE=$("$SCRIPT" --hours 48 --memory-dir "$MEM_STALE" --no-issue-check --format json 2>&1) || true
+  assert_contains "json verdict field present" '"verdict":"' "$OUT_STALE"
+  # Verify the handoff_age field shows a large number (>48h), not "0h".
+  if printf '%s' "$OUT_STALE" | grep -qE '"handoff_age_hours":"[0-9]{3,}"|"handoff_age_hours":"inf"'; then
+    pass "stale handoff_age reflects 60d-old mtime (>=100h)"
+  else
+    fail "stale handoff_age unexpectedly small in: $OUT_STALE"
+  fi
+fi
+
+# ---- json format ----
+OUT_JSON=$("$SCRIPT" --hours 48 --memory-dir "$MEM_FRESH" --no-issue-check --format json 2>&1) || true
+assert_contains "json has threshold_hours" '"threshold_hours":48' "$OUT_JSON"
+assert_contains "json has verdict"          '"verdict":"'         "$OUT_JSON"
+
+echo
+printf '%d pass / %d fail\n' "$PASS" "$FAIL"
+[ "$FAIL" = "0" ]

--- a/scripts/test-check-main-idle.sh
+++ b/scripts/test-check-main-idle.sh
@@ -83,6 +83,33 @@ OUT_JSON=$("$SCRIPT" --hours 48 --memory-dir "$MEM_FRESH" --no-issue-check --for
 assert_contains "json has threshold_hours" '"threshold_hours":48' "$OUT_JSON"
 assert_contains "json has verdict"          '"verdict":"'         "$OUT_JSON"
 
+# ---- die-on-tool-failure (Argus #327 finding #5 fix) ----
+# When gh issue list fails (network/auth), check-main-idle.sh MUST exit 2
+# (not silently treat as "no Issue activity" → "idle"). A false "idle"
+# verdict directly enables spurious Rule 4.1 emergency escalation PRs.
+echo
+echo "[die-on-tool-failure]"
+mkdir -p "$TMP/bin-fail"
+cat > "$TMP/bin-fail/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "fake gh failure" >&2
+exit 1
+EOF
+chmod +x "$TMP/bin-fail/gh"
+
+OUT_FAIL=$(PATH="$TMP/bin-fail:$PATH" GH_REPO="test-owner/test-repo" \
+  "$SCRIPT" --hours 48 --memory-dir "$MEM_FRESH" --format text 2>&1) || RC_FAIL=$?
+RC_FAIL=${RC_FAIL:-0}
+[ "$RC_FAIL" = "2" ] && pass "gh failure → die exit=2 (no spurious idle verdict)" \
+  || fail "gh failure exit=$RC_FAIL out=$OUT_FAIL (expected 2)"
+
+# Verify the die message points to the right escape hatch.
+if printf '%s' "$OUT_FAIL" | grep -q -- "--no-issue-check"; then
+  pass "die message mentions --no-issue-check escape hatch"
+else
+  fail "die message missing escape hatch hint: $OUT_FAIL"
+fi
+
 echo
 printf '%d pass / %d fail\n' "$PASS" "$FAIL"
 [ "$FAIL" = "0" ]

--- a/scripts/test-lane-close.sh
+++ b/scripts/test-lane-close.sh
@@ -226,6 +226,23 @@ assert_exit 2 "--tmp-dir with trailing /.. refused" \
 # if realpath is unavailable, the literal `..`-segment guard catches them.
 # Both paths exit 2 — the literal-segment guard is the belt-and-braces fallback.
 
+# Lane-name consistency (Argus #327 iter 4/5 finding #3 fix) — refuse
+# --tmp-dir whose leaf doesn't match `lane-<LANE>`. Without this, closing
+# lane=foo with --tmp-dir=.tmp/lane-bar would silently delete bar's data.
+mkdir -p "$TMP/case8-repo/.tmp/lane-other"
+assert_exit 2 "--tmp-dir for OTHER lane refused (leaf doesn't match)" \
+  "$SCRIPT" side-target --yes --force-cross-lane \
+    --lanes-file "$MEM8/LANES.md" --memory-dir "$MEM8" \
+    --repo-root "$TMP/case8-repo" --tmp-dir "$TMP/case8-repo/.tmp/lane-other"
+# Subdirectory under matching lane name accepted.
+mkdir -p "$TMP/case8-repo/.tmp/lane-side-target/sub"
+OUT_SUB=$("$SCRIPT" side-target --yes --force-cross-lane \
+        --lanes-file "$MEM8/LANES.md" --memory-dir "$MEM8" \
+        --repo-root "$TMP/case8-repo" --tmp-dir "$TMP/case8-repo/.tmp/lane-side-target/sub" 2>&1)
+RC_SUB=$?
+[ "$RC_SUB" = "0" ] && pass "--tmp-dir under lane-<LANE>/sub accepted" \
+  || fail "--tmp-dir under matching lane subdir rejected: exit=$RC_SUB out=$OUT_SUB"
+
 # Valid path under .tmp/ accepted (regression — prior happy-path covers this
 # but explicit assertion documents the safe shape). Use a fresh fixture +
 # repo root because the previous safety sub-tests share state and any

--- a/scripts/test-lane-close.sh
+++ b/scripts/test-lane-close.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# scripts/test-lane-close.sh — smoke tests for lane-close.sh
+#
+# Builds synthetic LANES.md + .tmp/lane-X/ and exercises validation, status
+# rewrite (only target lane's section), tmp-dir removal, safety guards, and
+# dry-run path. Exit 0 if all pass.
+
+set -u
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
+  echo "test-lane-close: not inside a git repo" >&2; exit 2; }
+SCRIPT="$REPO_ROOT/scripts/lane-close.sh"
+[ -x "$SCRIPT" ] || { echo "test-lane-close: $SCRIPT missing or not executable" >&2; exit 2; }
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+PASS=0; FAIL=0
+pass() { printf '  PASS: %s\n' "$1"; PASS=$((PASS+1)); }
+fail() { printf '  FAIL: %s\n' "$1"; FAIL=$((FAIL+1)); }
+
+assert_exit() {
+  local expected=$1 desc=$2; shift 2
+  "$@" >/dev/null 2>&1; local actual=$?
+  if [ "$actual" = "$expected" ]; then pass "$desc (exit=$actual)"
+  else fail "$desc (expected=$expected got=$actual)"; fi
+}
+
+write_fixture_lanes() {
+  local path="$1"
+  cat > "$path" <<'EOF'
+# Mercury Lanes Registry
+
+## Active Lanes
+
+### `main` (default lane)
+
+- **Handoff file**: `session-handoff.md`
+- **Status**: `active`
+
+### `side-target`
+
+- **Handoff file**: `session-handoff-side-target.md`
+- **Status**: `active`
+
+### `side-other`
+
+- **Handoff file**: `session-handoff-side-other.md`
+- **Status**: `active`
+
+### `side-already-closed`
+
+- **Handoff file**: `session-handoff-side-already-closed.md`
+- **Status**: `closed`
+
+## Closed Lanes
+
+(none)
+EOF
+}
+
+# ---- arg validation ----
+echo "[arg-validation]"
+assert_exit 0 "--help"                              "$SCRIPT" --help
+assert_exit 2 "missing lane arg"                     "$SCRIPT" --yes --memory-dir "$TMP"
+assert_exit 2 "lane name with space rejected"        "$SCRIPT" "bad lane" --yes --memory-dir "$TMP"
+assert_exit 2 "lane name starting with hyphen rejected" "$SCRIPT" -bad --yes --memory-dir "$TMP"
+assert_exit 2 "missing lanes-file rejected"          "$SCRIPT" target --yes --memory-dir "$TMP/nope"
+
+# ---- happy path ----
+echo
+echo "[happy-path]"
+MEM1="$TMP/case1"; mkdir -p "$MEM1"; write_fixture_lanes "$MEM1/LANES.md"
+TMPDIR1="$TMP/case1-repo/.tmp/lane-side-target"; mkdir -p "$TMPDIR1"
+echo "scratch" > "$TMPDIR1/note.txt"
+mkdir -p "$TMP/case1-repo"
+
+OUT=$("$SCRIPT" side-target --yes --force-cross-lane \
+        --lanes-file "$MEM1/LANES.md" --memory-dir "$MEM1" \
+        --repo-root "$TMP/case1-repo" --tmp-dir "$TMPDIR1" 2>&1)
+RC=$?
+[ "$RC" = "0" ] && pass "happy path exits 0" || fail "happy path exit=$RC: $OUT"
+
+# Verify side-target Status flipped to closed; OTHER lanes untouched.
+TARGET_STATUS=$(awk '/^### `side-target`/{s=1; next} /^### / && s {exit} s && /^- \*\*Status\*\*:/ {print; exit}' "$MEM1/LANES.md")
+case "$TARGET_STATUS" in
+  *closed*) pass "side-target Status flipped to closed" ;;
+  *) fail "side-target Status not flipped: '$TARGET_STATUS'" ;;
+esac
+
+OTHER_STATUS=$(awk '/^### `side-other`/{s=1; next} /^### / && s {exit} s && /^- \*\*Status\*\*:/ {print; exit}' "$MEM1/LANES.md")
+case "$OTHER_STATUS" in
+  *active*) pass "side-other Status untouched (still active)" ;;
+  *) fail "side-other Status accidentally modified: '$OTHER_STATUS'" ;;
+esac
+
+MAIN_STATUS=$(awk '/^### `main`/{s=1; next} /^### / && s {exit} s && /^- \*\*Status\*\*:/ {print; exit}' "$MEM1/LANES.md")
+case "$MAIN_STATUS" in
+  *active*) pass "main Status untouched (still active)" ;;
+  *) fail "main Status accidentally modified: '$MAIN_STATUS'" ;;
+esac
+
+# Verify tmp dir removed.
+[ ! -d "$TMPDIR1" ] && pass "tmp dir removed" || fail "tmp dir still exists: $TMPDIR1"
+
+# ---- already-closed lane rejected ----
+echo
+echo "[validation]"
+MEM2="$TMP/case2"; mkdir -p "$MEM2"; write_fixture_lanes "$MEM2/LANES.md"
+mkdir -p "$TMP/case2-repo"
+OUT2=$("$SCRIPT" side-already-closed --yes --force-cross-lane \
+        --lanes-file "$MEM2/LANES.md" --memory-dir "$MEM2" \
+        --repo-root "$TMP/case2-repo" 2>&1)
+RC2=$?
+[ "$RC2" = "1" ] && pass "already-closed lane rejected (exit=1)" || fail "already-closed exit=$RC2: $OUT2"
+
+# Lane not in LANES.md → exit 1
+MEM3="$TMP/case3"; mkdir -p "$MEM3"; write_fixture_lanes "$MEM3/LANES.md"
+mkdir -p "$TMP/case3-repo"
+assert_exit 1 "unknown lane rejected" \
+  "$SCRIPT" no-such-lane --yes --force-cross-lane \
+    --lanes-file "$MEM3/LANES.md" --memory-dir "$MEM3" \
+    --repo-root "$TMP/case3-repo"
+
+# ---- safety guard: refuse if .uncommitted file present ----
+echo
+echo "[safety-guards]"
+MEM4="$TMP/case4"; mkdir -p "$MEM4"; write_fixture_lanes "$MEM4/LANES.md"
+TMPDIR4="$TMP/case4-repo/.tmp/lane-side-target"; mkdir -p "$TMPDIR4"
+echo "danger" > "$TMPDIR4/work.uncommitted"
+mkdir -p "$TMP/case4-repo"
+OUT4=$("$SCRIPT" side-target --yes --force-cross-lane \
+        --lanes-file "$MEM4/LANES.md" --memory-dir "$MEM4" \
+        --repo-root "$TMP/case4-repo" --tmp-dir "$TMPDIR4" 2>&1)
+RC4=$?
+[ "$RC4" = "1" ] && pass "uncommitted file blocks close (exit=1)" \
+  || fail "uncommitted file did not block: exit=$RC4 out=$OUT4"
+# Status MUST still be active in this case (no partial state).
+TARGET_STATUS4=$(awk '/^### `side-target`/{s=1; next} /^### / && s {exit} s && /^- \*\*Status\*\*:/ {print; exit}' "$MEM4/LANES.md")
+case "$TARGET_STATUS4" in
+  *active*) pass "side-target Status preserved (no partial flip on safety abort)" ;;
+  *) fail "side-target Status partially flipped: '$TARGET_STATUS4'" ;;
+esac
+
+# Refuse if .git directory present (nested checkout indicator).
+MEM5="$TMP/case5"; mkdir -p "$MEM5"; write_fixture_lanes "$MEM5/LANES.md"
+TMPDIR5="$TMP/case5-repo/.tmp/lane-side-target"; mkdir -p "$TMPDIR5/.git"
+mkdir -p "$TMP/case5-repo"
+assert_exit 1 ".git artifact blocks close" \
+  "$SCRIPT" side-target --yes --force-cross-lane \
+    --lanes-file "$MEM5/LANES.md" --memory-dir "$MEM5" \
+    --repo-root "$TMP/case5-repo" --tmp-dir "$TMPDIR5"
+
+# ---- dry-run path ----
+echo
+echo "[dry-run]"
+MEM6="$TMP/case6"; mkdir -p "$MEM6"; write_fixture_lanes "$MEM6/LANES.md"
+mkdir -p "$TMP/case6-repo"
+OUT6=$("$SCRIPT" side-target --dry-run --force-cross-lane \
+        --lanes-file "$MEM6/LANES.md" --memory-dir "$MEM6" \
+        --repo-root "$TMP/case6-repo" 2>&1)
+RC6=$?
+[ "$RC6" = "0" ] && pass "dry-run exits 0" || fail "dry-run exit=$RC6: $OUT6"
+TARGET6=$(awk '/^### `side-target`/{s=1; next} /^### / && s {exit} s && /^- \*\*Status\*\*:/ {print; exit}' "$MEM6/LANES.md")
+case "$TARGET6" in
+  *active*) pass "dry-run did not mutate LANES.md" ;;
+  *) fail "dry-run mutated LANES.md: '$TARGET6'" ;;
+esac
+
+# ---- non-interactive without --yes refuses ----
+echo
+echo "[interactive-guard]"
+MEM7="$TMP/case7"; mkdir -p "$MEM7"; write_fixture_lanes "$MEM7/LANES.md"
+mkdir -p "$TMP/case7-repo"
+# stdin redirected from /dev/null → not a tty; without --yes script must abort 1.
+"$SCRIPT" side-target --force-cross-lane \
+  --lanes-file "$MEM7/LANES.md" --memory-dir "$MEM7" \
+  --repo-root "$TMP/case7-repo" </dev/null >/dev/null 2>&1
+RC7=$?
+[ "$RC7" = "1" ] && pass "non-interactive without --yes refuses" \
+  || fail "non-interactive exit=$RC7 (expected 1)"
+
+echo
+printf '%d pass / %d fail\n' "$PASS" "$FAIL"
+[ "$FAIL" = "0" ]

--- a/scripts/test-lane-close.sh
+++ b/scripts/test-lane-close.sh
@@ -215,6 +215,17 @@ assert_exit 2 "--tmp-dir outside repo refused" \
     --lanes-file "$MEM8/LANES.md" --memory-dir "$MEM8" \
     --repo-root "$TMP/case8-repo" --tmp-dir "$TMP/elsewhere/lane-x"
 
+# Traversal segments (Argus #327 iter 4 Copilot fix — `..` patterns)
+mkdir -p "$TMP/case8-repo/.tmp"
+assert_exit 2 "--tmp-dir with trailing /.. refused" \
+  "$SCRIPT" side-target --yes --force-cross-lane \
+    --lanes-file "$MEM8/LANES.md" --memory-dir "$MEM8" \
+    --repo-root "$TMP/case8-repo" --tmp-dir "$TMP/case8-repo/.tmp/lane-x/.."
+# Note: `..` and `../*` patterns under .tmp/ are typically resolved by realpath
+# to a path outside .tmp/ and caught by the "outside subtree" branch instead;
+# if realpath is unavailable, the literal `..`-segment guard catches them.
+# Both paths exit 2 — the literal-segment guard is the belt-and-braces fallback.
+
 # Valid path under .tmp/ accepted (regression — prior happy-path covers this
 # but explicit assertion documents the safe shape). Use a fresh fixture +
 # repo root because the previous safety sub-tests share state and any

--- a/scripts/test-lane-close.sh
+++ b/scripts/test-lane-close.sh
@@ -180,6 +180,54 @@ RC7=$?
 [ "$RC7" = "1" ] && pass "non-interactive without --yes refuses" \
   || fail "non-interactive exit=$RC7 (expected 1)"
 
+# ---- tmp-dir safety gate (Argus #327 finding #2 fix) ----
+echo
+echo "[tmp-dir-safety]"
+MEM8="$TMP/case8"; mkdir -p "$MEM8"; write_fixture_lanes "$MEM8/LANES.md"
+mkdir -p "$TMP/case8-repo"
+
+# Empty / root paths
+assert_exit 2 "--tmp-dir empty refused" \
+  "$SCRIPT" side-target --yes --force-cross-lane \
+    --lanes-file "$MEM8/LANES.md" --memory-dir "$MEM8" \
+    --repo-root "$TMP/case8-repo" --tmp-dir ""
+assert_exit 2 "--tmp-dir / refused" \
+  "$SCRIPT" side-target --yes --force-cross-lane \
+    --lanes-file "$MEM8/LANES.md" --memory-dir "$MEM8" \
+    --repo-root "$TMP/case8-repo" --tmp-dir "/"
+
+# Repo root itself
+assert_exit 2 "--tmp-dir == repo-root refused" \
+  "$SCRIPT" side-target --yes --force-cross-lane \
+    --lanes-file "$MEM8/LANES.md" --memory-dir "$MEM8" \
+    --repo-root "$TMP/case8-repo" --tmp-dir "$TMP/case8-repo"
+
+# Outside .tmp/ subtree (e.g., HOME-like path under repo)
+mkdir -p "$TMP/case8-repo/some-other-dir"
+assert_exit 2 "--tmp-dir outside .tmp/ subtree refused" \
+  "$SCRIPT" side-target --yes --force-cross-lane \
+    --lanes-file "$MEM8/LANES.md" --memory-dir "$MEM8" \
+    --repo-root "$TMP/case8-repo" --tmp-dir "$TMP/case8-repo/some-other-dir"
+
+# Outside repo entirely
+assert_exit 2 "--tmp-dir outside repo refused" \
+  "$SCRIPT" side-target --yes --force-cross-lane \
+    --lanes-file "$MEM8/LANES.md" --memory-dir "$MEM8" \
+    --repo-root "$TMP/case8-repo" --tmp-dir "$TMP/elsewhere/lane-x"
+
+# Valid path under .tmp/ accepted (regression — prior happy-path covers this
+# but explicit assertion documents the safe shape). Use a fresh fixture +
+# repo root because the previous safety sub-tests share state and any
+# accidental Status flip would poison this assertion.
+MEM8B="$TMP/case8b"; mkdir -p "$MEM8B"; write_fixture_lanes "$MEM8B/LANES.md"
+mkdir -p "$TMP/case8b-repo/.tmp/lane-side-target"
+OUT_OK=$("$SCRIPT" side-target --yes --force-cross-lane \
+        --lanes-file "$MEM8B/LANES.md" --memory-dir "$MEM8B" \
+        --repo-root "$TMP/case8b-repo" --tmp-dir "$TMP/case8b-repo/.tmp/lane-side-target" 2>&1)
+RC_OK=$?
+[ "$RC_OK" = "0" ] && pass "valid --tmp-dir under .tmp/ accepted" \
+  || fail "valid --tmp-dir rejected: exit=$RC_OK out=$OUT_OK"
+
 echo
 printf '%d pass / %d fail\n' "$PASS" "$FAIL"
 [ "$FAIL" = "0" ]

--- a/scripts/test-lane-sweep.sh
+++ b/scripts/test-lane-sweep.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# scripts/test-lane-sweep.sh — smoke tests for lane-sweep.sh
+#
+# Builds synthetic memory dir + LANES.md + handoff files; uses --no-issue-check
+# to skip live GitHub calls; verifies arg validation, parsing, age computation,
+# and stale verdicts. Exit 0 if all pass.
+
+set -u
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
+  echo "test-lane-sweep: not inside a git repo" >&2; exit 2; }
+SCRIPT="$REPO_ROOT/scripts/lane-sweep.sh"
+[ -x "$SCRIPT" ] || { echo "test-lane-sweep: $SCRIPT missing or not executable" >&2; exit 2; }
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+PASS=0; FAIL=0
+pass() { printf '  PASS: %s\n' "$1"; PASS=$((PASS+1)); }
+fail() { printf '  FAIL: %s\n' "$1"; FAIL=$((FAIL+1)); }
+
+assert_exit() {
+  local expected=$1 desc=$2; shift 2
+  "$@" >/dev/null 2>&1; local actual=$?
+  if [ "$actual" = "$expected" ]; then pass "$desc (exit=$actual)"
+  else fail "$desc (expected=$expected got=$actual)"; fi
+}
+
+assert_contains() {
+  local desc=$1 needle=$2 actual=$3
+  if printf '%s' "$actual" | grep -q -- "$needle"; then pass "$desc"
+  else fail "$desc — needle '$needle' not in: $(printf '%s' "$actual" | head -c200)"; fi
+}
+
+assert_not_contains() {
+  local desc=$1 needle=$2 actual=$3
+  if printf '%s' "$actual" | grep -q -- "$needle"; then
+    fail "$desc — unexpected '$needle' in: $(printf '%s' "$actual" | head -c200)"
+  else pass "$desc"; fi
+}
+
+# ---- arg validation (no synthetic memory needed) ----
+echo "[arg-validation]"
+assert_exit 0 "--help"                      "$SCRIPT" --help
+assert_exit 2 "unknown flag rejected"       "$SCRIPT" --bogus
+assert_exit 2 "--days zero rejected"        "$SCRIPT" --days 0 --no-issue-check
+assert_exit 2 "--days non-numeric rejected" "$SCRIPT" --days abc --no-issue-check
+assert_exit 2 "--format invalid rejected"   "$SCRIPT" --format xml --no-issue-check
+assert_exit 2 "missing memory dir rejected" "$SCRIPT" --memory-dir "$TMP/nope" --no-issue-check
+
+# ---- synthetic memory + LANES.md fixture ----
+MEM="$TMP/memory"
+mkdir -p "$MEM"
+cat > "$MEM/LANES.md" <<'EOF'
+---
+name: LANES
+---
+# Mercury Lanes Registry
+
+## Active Lanes
+
+### `main` (default lane)
+
+- **Status**: `active`
+
+### `side-fresh`
+
+- **Status**: `active`
+
+### `side-stale`
+
+- **Status**: `active`
+
+## Closed Lanes
+
+### `side-archived`
+
+- **Status**: `closed`
+
+## Governance
+
+something
+EOF
+
+# Fresh handoff (now), stale handoff (60d old), no handoff for one lane.
+touch "$MEM/session-handoff.md"
+touch "$MEM/session-handoff-side-fresh.md"
+# Stale: set mtime 60 days ago via touch -t (portable on GNU; BSD uses different syntax).
+STALE_DATE=$(date -d '60 days ago' '+%Y%m%d%H%M' 2>/dev/null || date -v-60d '+%Y%m%d%H%M' 2>/dev/null)
+if [ -n "$STALE_DATE" ]; then
+  touch -t "$STALE_DATE" "$MEM/session-handoff-side-stale.md" 2>/dev/null \
+    || { echo "test-lane-sweep: cannot set 60d-old mtime — skipping stale verdict assertion" >&2; STALE_DATE=""; }
+else
+  echo "test-lane-sweep: cannot compute 60d-ago date — stale verdict assertion will be skipped" >&2
+fi
+
+echo
+echo "[scenarios]"
+
+OUT=$("$SCRIPT" --memory-dir "$MEM" --days 14 --no-issue-check --format text 2>&1)
+RC=$?
+[ "$RC" = "0" ] && pass "default-text run exits 0" || fail "default-text run exit=$RC: $OUT"
+
+assert_contains "header row present"        "VERDICT"      "$OUT"
+assert_contains "main lane row present"     "main"         "$OUT"
+assert_contains "side-fresh lane present"   "side-fresh"   "$OUT"
+assert_contains "side-stale lane present"   "side-stale"   "$OUT"
+assert_not_contains "closed lane excluded"  "side-archived" "$OUT"
+
+# Fresh handoff → fresh verdict (issue-check off → infinite, but branch missing
+# → infinite too; only handoff_age fresh defeats stale). Three-of-three rule:
+# stale needs ALL THREE old. With issue=inf + branch=inf + handoff=fresh → not stale.
+assert_contains "side-fresh verdict=fresh"  "side-fresh.*fresh"  "$OUT"
+
+if [ -n "$STALE_DATE" ]; then
+  assert_contains "side-stale verdict=stale" "side-stale.*stale" "$OUT"
+fi
+
+OUT_JSON=$("$SCRIPT" --memory-dir "$MEM" --days 14 --no-issue-check --format json 2>&1)
+assert_contains "json output has lanes array"   '"lanes":\['          "$OUT_JSON"
+assert_contains "json output has verdict field" '"verdict":"'         "$OUT_JSON"
+assert_contains "json output has main entry"    '"lane":"main"'       "$OUT_JSON"
+
+# Empty Active Lanes section → empty body but exit 0 with WARN.
+cat > "$TMP/empty-lanes.md" <<'EOF'
+# Mercury Lanes Registry
+
+## Active Lanes
+
+## Closed Lanes
+EOF
+OUT_EMPTY=$("$SCRIPT" --lanes-file "$TMP/empty-lanes.md" --memory-dir "$MEM" --no-issue-check 2>&1)
+RC_EMPTY=$?
+[ "$RC_EMPTY" = "0" ] && pass "empty active section exits 0" || fail "empty active section exit=$RC_EMPTY"
+assert_contains "empty active section warns" "no active lanes" "$OUT_EMPTY"
+
+echo
+printf '%d pass / %d fail\n' "$PASS" "$FAIL"
+[ "$FAIL" = "0" ]

--- a/scripts/test-lane-sweep.sh
+++ b/scripts/test-lane-sweep.sh
@@ -134,6 +134,49 @@ RC_EMPTY=$?
 [ "$RC_EMPTY" = "0" ] && pass "empty active section exits 0" || fail "empty active section exit=$RC_EMPTY"
 assert_contains "empty active section warns" "no active lanes" "$OUT_EMPTY"
 
+# ---- JSON escape (Argus #327 finding #6 fix) ----
+echo
+echo "[json-escape]"
+JSON_FIX_LANES="$TMP/json-fix-lanes.md"
+cat > "$JSON_FIX_LANES" <<'EOF'
+# Mercury Lanes Registry
+
+## Active Lanes
+
+### `weird"name`
+
+- **Status**: `active`
+
+### `back\slash`
+
+- **Status**: `active`
+
+## Closed Lanes
+EOF
+
+OUT_ESC=$("$SCRIPT" --lanes-file "$JSON_FIX_LANES" --memory-dir "$MEM" \
+          --no-issue-check --format json 2>&1)
+RC_ESC=$?
+[ "$RC_ESC" = "0" ] && pass "weird-lane-name run exits 0" \
+  || fail "weird-lane-name exit=$RC_ESC out=$OUT_ESC"
+
+# JSON validity check via python (best-available cross-platform parser).
+if command -v python >/dev/null 2>&1; then
+  if printf '%s' "$OUT_ESC" | python -c 'import sys,json; json.load(sys.stdin)' 2>/dev/null; then
+    pass "JSON output with quote/backslash in lane name is parseable"
+  else
+    fail "JSON output is INVALID: $OUT_ESC"
+  fi
+elif command -v python3 >/dev/null 2>&1; then
+  if printf '%s' "$OUT_ESC" | python3 -c 'import sys,json; json.load(sys.stdin)' 2>/dev/null; then
+    pass "JSON output with quote/backslash in lane name is parseable (python3)"
+  else
+    fail "JSON output is INVALID: $OUT_ESC"
+  fi
+else
+  echo "  SKIP: python not available — cannot validate JSON" >&2
+fi
+
 echo
 printf '%d pass / %d fail\n' "$PASS" "$FAIL"
 [ "$FAIL" = "0" ]

--- a/scripts/test-lane-sweep.sh
+++ b/scripts/test-lane-sweep.sh
@@ -134,6 +134,42 @@ RC_EMPTY=$?
 [ "$RC_EMPTY" = "0" ] && pass "empty active section exits 0" || fail "empty active section exit=$RC_EMPTY"
 assert_contains "empty active section warns" "no active lanes" "$OUT_EMPTY"
 
+# ---- WARN-on-probe-failure (Argus #327 iter 3 finding fix) ----
+# Sweep is report-only, so a per-lane probe failure must NOT crash the run
+# (asymmetric vs check-main-idle.sh which dies). Stub gh that fails for
+# Issue list calls; expect WARN to stderr + report still produced + lane
+# verdict resolves via missing-data semantics (no fatal exit).
+echo
+echo "[probe-warn]"
+mkdir -p "$TMP/bin-warn"
+cat > "$TMP/bin-warn/gh" <<'EOF'
+#!/usr/bin/env bash
+case "$1 $2" in
+  "issue list")  echo "fake gh issue list failure" >&2 ; exit 1 ;;
+  "repo view")   echo '{"nameWithOwner":"test-owner/test-repo"}' ; exit 0 ;;
+  *) echo "stub-warn: unhandled $*" >&2 ; exit 99 ;;
+esac
+EOF
+chmod +x "$TMP/bin-warn/gh"
+
+# Use the synthetic memory dir + LANES.md fixture from earlier (3 active lanes).
+OUT_WARN=$(PATH="$TMP/bin-warn:$PATH" GH_REPO="test-owner/test-repo" \
+  "$SCRIPT" --memory-dir "$MEM" --days 14 --format text 2>&1)
+RC_WARN=$?
+[ "$RC_WARN" = "0" ] && pass "probe failure → exit 0 (sweep continues, asymmetric vs check-main-idle die)" \
+  || fail "probe failure exit=$RC_WARN out=$OUT_WARN"
+if printf '%s' "$OUT_WARN" | grep -q "gh issue probe failed"; then
+  pass "WARN emitted on probe failure"
+else
+  fail "WARN missing in output: $OUT_WARN"
+fi
+# Report still emitted (header + at least one lane row visible).
+if printf '%s' "$OUT_WARN" | grep -q "VERDICT"; then
+  pass "report still emitted despite probe failure"
+else
+  fail "report missing despite WARN: $OUT_WARN"
+fi
+
 # ---- JSON escape (Argus #327 finding #6 fix) ----
 echo
 echo "[json-escape]"


### PR DESCRIPTION
## Summary

Side-multi-lane Phase B implements three v0.1 protocol deltas as a single bundle:

- **#310 (Rule 3.1, P1)** — `scripts/lane-sweep.sh` stale-lane detection (3-criterion check, default 14d threshold, report-only per Rule 6)
- **#311 (Rule 3.2, P2)** — `scripts/lane-close.sh` atomic close ceremony (section-bounded Status flip + tmp dir prune + safety guards)
- **#312 (Rule 4.1, P2)** — `scripts/check-main-idle.sh` helper + `feedback_lane_protocol.md` Rule 4.1 sub-rule documenting emergency spec-change escalation procedure

Bundled per S4 handoff cost analysis: 3 new files, no integration touches, ~1.4k LOC total (scripts + tests + guides). 53/53 tests passing across the bundle + lane-claim Phase A regression 18/18.

## Files

- `scripts/lane-sweep.sh` (~210 LOC) + `scripts/test-lane-sweep.sh` (19 tests)
- `scripts/lane-close.sh` (~190 LOC) + `scripts/test-lane-close.sh` (18 tests)
- `scripts/check-main-idle.sh` (~135 LOC) + `scripts/test-check-main-idle.sh` (16 tests)
- `.mercury/docs/guides/lane-sweep.md` + `lane-close.md` + `lane-emergency-escalation.md`
- `memory/feedback_lane_protocol.md` — Rule 3.1 + 3.2 + 4.1 sub-rules added (in user-memory, not in this diff)

## Dual-verify status

- **Lane 1 (Claude critic)**: READY_TO_COMMIT — 22/22 acceptance items PASS, 0 BLOCKERS, ~9 MINOR/NIT (deferred follow-up).
- **Lane 2 (OMC code-reviewer)**: READY_TO_COMMIT after fixing 1 MAJOR finding — `lane-sweep.sh issue_last_ts()` rewritten to match `check-main-idle.sh:107` pattern (eliminated buggy `&&/||` chain that produced duplicate `date` calls on GNU systems). 3 MINOR + 2 NIT items deferred to follow-up.
- **Codex side**: dispatched 2× during pre-flight; forwarder accepted both tasks but neither audit returned synchronously within session window. Root cause tracked in #326 (codex-rescue async semantics + ~25k token forwarder baseline). For this PR, dual-perspective coverage delivered via critic + OMC code-reviewer.

## Side-effects

Two coordination Issues filed during pre-flight (Rule 8 v0.2 cross-lane impact):

- **#325** — Mercury loop-detector false positives (7 false trips this session — `no_progress` and `hard timeout` triggered during legitimate verification phases). Proposes broadening progress signal to include Bash/Agent/Skill, raising threshold, or rewriting as idle timer.
- **#326** — dual-verify codex-rescue async + token-heavy contract (P1). Proposes Mercury-local sync polling wrapper to retain Codex/GPT-5 second perspective without sacrificing return-time-bound contract.

## Test plan
- [x] `bash scripts/test-lane-sweep.sh` → 19/19 PASS
- [x] `bash scripts/test-lane-close.sh` → 18/18 PASS
- [x] `bash scripts/test-check-main-idle.sh` → 16/16 PASS
- [x] `bash scripts/test-lane-claim.sh` → 18/18 PASS (Phase A regression)
- [x] Real-world smoke: `bash scripts/lane-sweep.sh --no-issue-check` against actual `LANES.md` produces correct fresh/stale verdicts for both registered lanes
- [x] Real-world smoke: `bash scripts/check-main-idle.sh --hours 48 --no-issue-check` returns exit 1 (active) — main lane handoff updated within window
- [ ] Argus review pending after PR open
- [ ] Copilot review pending

## Lane scope compliance (Rule 4 + Rule 6 + Rule 8)

- ✅ DIRECTION.md / EXECUTION-PLAN.md: zero edits
- ✅ Other lane handoffs / state files: zero edits
- ✅ LANES.md: zero edits in this PR (handoff state update is post-merge in S5 entry)
- ✅ Rule 8 v0.2 self-implementation: side-multi-lane scope, no main-lane gating
- ✅ Branch prefix `feature/lane-side-multi-lane/TASK-310-311-312-phase-b`

Closes #310
Closes #311
Closes #312
Refs #292
Refs #325
Refs #326

🤖 Generated with [Claude Code](https://claude.com/claude-code)