### PR TITLE
feat(lane-protocol): Phase C v0.1 deltas — Rule 2.1 short prefix + HARD-CAP (#313 #314)

### DIFF
--- a/.mercury/docs/guides/lane-naming.md
+++ b/.mercury/docs/guides/lane-naming.md
@@ -166,10 +166,11 @@ protocol violations from one filter.
 scripts/test-lane-cap-check.sh
 ```
 
-24 cases covering arg validation, within-cap, boundary (count == max),
-exceeded, custom max, closed-lane exclusion, JSON output validity, and empty
-Active Lanes section. Tests do NOT touch real GitHub or LANES.md — synthetic
-fixtures only.
+32 cases covering arg validation, within-cap, boundary (count == max),
+exceeded, custom max, closed-lane exclusion, JSON output validity (including
+quote/backslash hostile lane names), parser robustness (orphan-no-status
+WARN, zombie-in-Closed-section exclusion), and empty Active Lanes section.
+Tests do NOT touch real GitHub or LANES.md — synthetic fixtures only.
 
 ## Source references
 

--- a/.mercury/docs/guides/lane-naming.md
+++ b/.mercury/docs/guides/lane-naming.md
@@ -1,0 +1,184 @@
+# Lane Naming + Capacity — `feedback_lane_protocol.md` Rule 2 & HARD-CAP
+
+Implements the **Rule 2 short branch prefix** delta (v0.1 Delta 6, Issue
+[#313](https://github.com/392fyc/Mercury/issues/313)) and the **HARD-CAP at 5
+active lanes** delta (v0.1 Delta 7, Issue
+[#314](https://github.com/392fyc/Mercury/issues/314)).
+
+## Why two deltas in one guide
+
+Both shape the lane registry: Δ6 controls how branches are named, Δ7 controls
+how many lanes can exist concurrently. Operators reason about "what lane do I
+open / what do I name its branch" in one mental motion; one combined guide is
+shorter than two cross-referenced ones.
+
+## Δ6 — Short branch prefix (`lane/<short>/<N>-<slug>`)
+
+### What changed
+
+- **OLD prefix** (still valid for backward-compat): `feature/lane-<lane>/TASK-<N>-*` — 45-65 chars
+- **NEW prefix** (preferred for new work): `lane/<short>/<N>-<slug>` — ≤40 chars
+
+Example: `feature/lane-side-multi-lane/TASK-313-314-phase-c` (51 chars) →
+`lane/side-mlane/313-phase-c` (27 chars).
+
+### Why short matters
+
+- Community soft cap is ~50 chars (Graphite naming guide); LeanTaaS hard cap is
+  28 chars. 65-char branches push past both, breaking IDE autocomplete + URL
+  pasting + `gh pr` shell expansion in some terminals.
+- Mercury empirically observed in S3-S5 that the legacy 51-char prefix already
+  truncates in `git branch` listing on narrow terminals and forces line wraps
+  in PR titles.
+
+### Short-name convention
+
+Each lane declares a `Short name` field in its own `LANES.md` section. The
+short name MUST be:
+
+- ≤ 8 characters (giving the rest of the branch ≥ 27 chars for `<N>-<slug>`)
+- Match `[a-z0-9-]+` (lowercase + digits + hyphen only)
+- Globally unique across all active + closed lanes (avoid colliding with a
+  closed lane's archived branches)
+
+Default mapping for current Mercury lanes:
+
+| Lane name | Short name | Rationale |
+|-----------|-----------|-----------|
+| `main` | `main` | Already short; canonical default lane |
+| `side-multi-lane` | `side-mlane` | Compress "multi-lane" → "mlane" (8 chars exact) |
+
+For new lanes: pick a short name at lane open time and write it in the lane's
+`LANES.md` section before any branch is created. If two operators independently
+pick the same short name, lane-claim semantics + manual review apply (no
+mechanical enforcement; collision is rare).
+
+### Backward compatibility
+
+- All existing `feature/lane-<lane>/...` branches and `feature/TASK-<N>-*`
+  legacy main-lane branches REMAIN valid until their containing lane closes.
+- New work on existing lanes MAY continue using the legacy prefix to avoid
+  mid-lane branch-naming churn.
+- New lanes opened after Δ6 SHOULD use the short prefix.
+
+### Script support (current state)
+
+`scripts/lane-sweep.sh` and `scripts/check-main-idle.sh` currently glob
+`refs/heads/feature/lane-<lane>/*` for branch-activity probing. These scripts
+will be extended in v0.2 to also glob `refs/heads/lane/<short>/*` once one
+real lane uses the new prefix end-to-end (deferred to avoid speculative code).
+
+If a lane ONLY has new-prefix branches and no legacy `feature/lane-*`
+branches, the sweep's branch-activity signal will report "inf" until v0.2 ref
+glob extension lands. This degrades gracefully — handoff mtime + Issue
+activity remain valid signals, and the AND-gate verdict still requires three
+stale signals before flagging stale.
+
+## Δ7 — HARD-CAP at 5 active lanes
+
+### Cap value
+
+`LANES.md` MUST NOT exceed **5 active lanes** simultaneously. The cap is
+declared in `feedback_lane_protocol.md` and enforced advisorily by
+`scripts/lane-cap-check.sh`.
+
+### Why 5
+
+Three converging research bases:
+
+- **Miller's Law** ([Laws of UX](https://lawsofux.com/millers-law/)): human
+  short-term memory holds 7±2 items reliably. Lanes consume operator working
+  memory (which lane is on what task, what's the latest handoff, what's
+  blocked); the 7±2 lower bound (5) is a defensible ceiling.
+- **Google multi-agent research**
+  ([towards a science of scaling agent systems](https://research.google/blog/towards-a-science-of-scaling-agent-systems-when-and-why-agent-systems-work/)):
+  3-5 agents optimal; 20+ catastrophic; 39-70% reasoning performance drop at
+  scale. Lanes are coordination units, not agents, but the same coordination
+  cost curve applies.
+- **Personal Kanban WIP limits**
+  ([Atlassian Kanban WIP](https://www.atlassian.com/agile/kanban/wip-limits)):
+  3-5 max parallel activities is the conventional sweet spot for sustained
+  throughput vs context-switch cost.
+
+### Resolution when cap is hit
+
+If you want to open lane #6:
+
+1. **Close an existing lane first.** Use `scripts/lane-close.sh <lane>` to
+   flip Status to `closed` + prune `.tmp/lane-<lane>/`.
+2. **OR** open a GitHub Issue with the `protocol-violation` label requesting
+   a temporary cap raise. The Issue body MUST justify the raise (specific
+   work that requires more parallelism, expected duration, plan to return
+   below cap). User arbitrates.
+
+### Advisory enforcement
+
+```bash
+scripts/lane-cap-check.sh [--lanes-file PATH] [--memory-dir PATH]
+                          [--max N] [--format text|json]
+```
+
+| Flag | Effect |
+|------|--------|
+| `--max N` | Override the cap (default 5). |
+| `--format text\|json` | Output format. |
+| `--lanes-file PATH` | Override LANES.md location. |
+| `--memory-dir PATH` | Override memory dir. Defaults to `MERCURY_MEMORY_DIR` env, then `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/D--Mercury-Mercury/memory`. |
+| `MERCURY_MEMORY_DIR` (env) | Same effect as `--memory-dir`. |
+
+Exit `0` if count ≤ max, exit `1` if exceeded, exit `2` on argument or
+environment errors. Verdict is reported as text or JSON; the script never
+mutates LANES.md.
+
+The script is **advisory** — running it before opening a new lane is a
+discipline, not an automated gate. Pre-commit hook enforcement was considered
+and rejected: side lanes cannot easily install or modify shared hooks, and
+the cap is a sociotechnical limit (operator + maintainer review) rather than
+a mechanical one.
+
+### Sample text output
+
+```
+lane-cap-check: 2 active lane(s), cap=5 → within_cap
+  active: main,side-multi-lane
+```
+
+When exceeded:
+
+```
+lane-cap-check: 6 active lane(s), cap=5 → exceeded
+  active: main,side-mlane,side-foo,side-bar,side-baz,side-qux
+  resolution: close an existing lane OR open Issue with `protocol-violation` label requesting cap raise (per feedback_lane_protocol.md HARD-CAP §)
+```
+
+### `protocol-violation` GitHub label
+
+Defined in the Mercury repo at #314 implementation time. Color `#B60205`
+(GitHub red), description: "Multi-lane protocol violation (e.g. >5 active
+lanes, Rule X breach) requiring user arbitration".
+
+Operators opening cap-raise Issues use this label so the user can triage all
+protocol violations from one filter.
+
+## Tests
+
+```bash
+scripts/test-lane-cap-check.sh
+```
+
+24 cases covering arg validation, within-cap, boundary (count == max),
+exceeded, custom max, closed-lane exclusion, JSON output validity, and empty
+Active Lanes section. Tests do NOT touch real GitHub or LANES.md — synthetic
+fixtures only.
+
+## Source references
+
+- Issue [#313](https://github.com/392fyc/Mercury/issues/313) — Δ6 acceptance criteria
+- Issue [#314](https://github.com/392fyc/Mercury/issues/314) — Δ7 acceptance criteria
+- [v0.1 Delta companion §Δ6](../lane-protocol-v0.1-deltas.md#delta-6--rule-2-shorter-branch-prefix-p3)
+- [v0.1 Delta companion §Δ7](../lane-protocol-v0.1-deltas.md#delta-7--hard-cap-at-5-active-lanes-doc-only)
+- [Limiting Git Branch Names to 28 Characters (LeanTaaS)](https://medium.com/leantaas-engineering/why-are-we-limiting-git-branch-name-length-to-28-characters-c49cb5f4ff9a)
+- [Best practices for naming Git branches (Graphite)](https://graphite.com/guides/git-branch-naming-conventions)
+- [Miller's Law (Laws of UX)](https://lawsofux.com/millers-law/)
+- [Towards a science of scaling agent systems (Google research)](https://research.google/blog/towards-a-science-of-scaling-agent-systems-when-and-why-agent-systems-work/)
+- [Working with WIP limits for Kanban (Atlassian)](https://www.atlassian.com/agile/kanban/wip-limits)

--- a/scripts/lane-cap-check.sh
+++ b/scripts/lane-cap-check.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# scripts/lane-cap-check.sh — Mercury multi-lane capacity advisory.
+# Implements Rule 7 HARD-CAP of feedback_lane_protocol.md (v0.1 Delta 7,
+# Issue #314).
+#
+# Counts the number of `Status: active` lanes in LANES.md. The protocol
+# caps active lanes at 5 (Miller's 7±2 working memory + Google multi-agent
+# 3-5 optimal + Personal Kanban WIP limits 3-5). Exceeding the cap requires
+# either closing an existing lane OR opening an Issue with the
+# `protocol-violation` label requesting a cap raise.
+#
+# This script is ADVISORY — it reports the count + verdict, never blocks.
+# Hard enforcement would require a pre-commit hook that side lanes cannot
+# easily bypass; the cap is sociotechnical (operator + maintainer review)
+# rather than mechanical.
+#
+# Usage:
+#   scripts/lane-cap-check.sh [--lanes-file PATH] [--memory-dir PATH]
+#                             [--max N] [--format text|json]
+#
+# Defaults:
+#   --lanes-file   <memory-dir>/LANES.md
+#   --memory-dir   ${MERCURY_MEMORY_DIR:-${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/D--Mercury-Mercury/memory}
+#   --max          5
+#   --format       text
+#
+# Exit codes:
+#   0  count <= max (within cap)
+#   1  count >  max (cap exceeded — requires close-existing OR
+#      protocol-violation Issue per Rule 7)
+#   2  invalid args / lanes-file missing / memory dir missing
+
+set -u
+
+die()  { printf 'lane-cap-check: %s\n' "$1" >&2; exit 2; }
+warn() { printf 'lane-cap-check WARN: %s\n' "$1" >&2; }
+
+# Defensive JSON-string escaper for lane names read from LANES.md (lane names
+# are validated upstream by lane-claim/lane-close but lane-cap-check accepts
+# whatever the file contains — manual edits could include quotes/backslashes
+# that break JSON output). Output INCLUDES the surrounding double-quotes.
+# Mirrors scripts/lane-sweep.sh json_string().
+json_string() {
+  local s="$1"
+  s=${s//\\/\\\\}
+  s=${s//\"/\\\"}
+  s=${s//$'\n'/\\n}
+  s=${s//$'\t'/\\t}
+  printf '"%s"' "$s"
+}
+
+MAX=5
+FORMAT=text
+LANES_FILE=""
+MEMORY_DIR=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --lanes-file)  shift; [ $# -gt 0 ] || die "--lanes-file needs a value"
+                   [ -n "$1" ] || die "--lanes-file requires a non-empty path"
+                   LANES_FILE="$1"; shift ;;
+    --memory-dir)  shift; [ $# -gt 0 ] || die "--memory-dir needs a value"
+                   [ -n "$1" ] || die "--memory-dir requires a non-empty path"
+                   MEMORY_DIR="$1"; shift ;;
+    --max)         shift; [ $# -gt 0 ] || die "--max needs a value"
+                   MAX="$1"; shift ;;
+    --format)      shift; [ $# -gt 0 ] || die "--format needs a value"
+                   FORMAT="$1"; shift ;;
+    -h|--help)
+      sed -n '2,32p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    -*) die "unknown flag: $1" ;;
+    *)  die "unexpected positional argument: $1" ;;
+  esac
+done
+
+case "$MAX" in
+  ''|*[!0-9]*|0) die "--max must be a positive integer: '$MAX'" ;;
+esac
+case "$FORMAT" in
+  text|json) ;;
+  *) die "--format must be text or json (got '$FORMAT')" ;;
+esac
+
+if [ -z "$MEMORY_DIR" ]; then
+  MEMORY_DIR="${MERCURY_MEMORY_DIR:-${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/D--Mercury-Mercury/memory}"
+fi
+[ -d "$MEMORY_DIR" ] || die "memory dir not found: $MEMORY_DIR (set --memory-dir or MERCURY_MEMORY_DIR)"
+
+if [ -z "$LANES_FILE" ]; then LANES_FILE="$MEMORY_DIR/LANES.md"; fi
+[ -f "$LANES_FILE" ] || die "LANES.md not found: $LANES_FILE"
+
+# Parse Active Lanes section + count `Status: active` markers within it.
+# Uses the same Active-Lanes detection logic as scripts/lane-sweep.sh
+# (### `<name>` headings between "## Active Lanes" and the next "## " header).
+# A lane is counted only if its section contains a Status line resolving to
+# `active` (case-sensitive, matching the protocol's literal value).
+# awk emits two stream types:
+#   ACTIVE <lane>          — lane has Status: active
+#   ORPHAN <lane>          — lane heading appeared but next heading came
+#                            without a Status line (malformed LANES.md)
+# Both are reported; ORPHAN counts as a parsing-warning that the operator
+# should fix in LANES.md, but does NOT contribute to the active count.
+PARSE_OUTPUT=$(awk '
+  function flush(   was_orphan) {
+    if (current_lane == "") return
+    # ORPHAN only when no Status line at all was seen for the current lane.
+    # A non-active Status (e.g. `closed` / `paused`) is well-formed — silent skip.
+    if (had_status == 0) print "ORPHAN", current_lane
+    current_lane = ""; had_status = 0
+  }
+  BEGIN { in_active = 0; current_lane = ""; had_status = 0 }
+  /^## Active Lanes/ { in_active = 1; flush(); next }
+  /^## / && in_active { flush(); in_active = 0 }
+  in_active && /^### `[^`]+`/ {
+    flush()
+    match($0, /`[^`]+`/)
+    current_lane = substr($0, RSTART + 1, RLENGTH - 2)
+    next
+  }
+  in_active && current_lane != "" && /^- \*\*Status\*\*:/ {
+    had_status = 1
+    if ($0 ~ /^- \*\*Status\*\*: `?active`?/) { print "ACTIVE", current_lane }
+    # closed / paused / other non-active values: tracked but not counted
+  }
+  END { flush() }
+' "$LANES_FILE")
+
+ACTIVE_LANES=$(printf '%s' "$PARSE_OUTPUT" | awk '/^ACTIVE / { sub(/^ACTIVE /, ""); print }')
+ORPHAN_LANES=$(printf '%s' "$PARSE_OUTPUT" | awk '/^ORPHAN / { sub(/^ORPHAN /, ""); print }')
+
+if [ -n "$ORPHAN_LANES" ]; then
+  while IFS= read -r orphan; do
+    [ -n "$orphan" ] && warn "lane '$orphan' has heading but no Status line — not counted (fix LANES.md)"
+  done <<EOF
+$ORPHAN_LANES
+EOF
+fi
+
+COUNT=0
+if [ -n "$ACTIVE_LANES" ]; then
+  COUNT=$(printf '%s\n' "$ACTIVE_LANES" | grep -c .)
+fi
+
+if [ "$COUNT" -le "$MAX" ]; then
+  VERDICT="within_cap"
+else
+  VERDICT="exceeded"
+fi
+
+if [ "$FORMAT" = "json" ]; then
+  # Build a JSON array of escaped lane names — defensive against quote/
+  # backslash characters in manually-tampered LANES.md (lane-cap-check
+  # reads raw file content; lane-claim/lane-close validate upstream but
+  # this script is the defensive escape layer for hostile inputs).
+  JSON_LANES=""
+  if [ -n "$ACTIVE_LANES" ]; then
+    first=1
+    while IFS= read -r ln; do
+      [ -z "$ln" ] && continue
+      if [ "$first" -eq 1 ]; then first=0; else JSON_LANES="${JSON_LANES},"; fi
+      JSON_LANES="${JSON_LANES}$(json_string "$ln")"
+    done <<EOF
+$ACTIVE_LANES
+EOF
+  fi
+  printf '{"max":%d,"active_count":%d,"verdict":"%s","lanes":[%s]}\n' \
+    "$MAX" "$COUNT" "$VERDICT" "$JSON_LANES"
+else
+  printf 'lane-cap-check: %d active lane(s), cap=%d → %s\n' "$COUNT" "$MAX" "$VERDICT"
+  if [ -n "$ACTIVE_LANES" ]; then
+    printf '  active: %s\n' "$(printf '%s' "$ACTIVE_LANES" | tr '\n' ',' | sed 's/,$//')"
+  fi
+  if [ "$VERDICT" = "exceeded" ]; then
+    printf '  resolution: close an existing lane OR open Issue with `protocol-violation` label requesting cap raise (per feedback_lane_protocol.md HARD-CAP §)\n'
+  fi
+fi
+
+[ "$VERDICT" = "within_cap" ] && exit 0 || exit 1

--- a/scripts/lane-cap-check.sh
+++ b/scripts/lane-cap-check.sh
@@ -9,10 +9,12 @@
 # either closing an existing lane OR opening an Issue with the
 # `protocol-violation` label requesting a cap raise.
 #
-# This script is ADVISORY — it reports the count + verdict, never blocks.
-# Hard enforcement would require a pre-commit hook that side lanes cannot
-# easily bypass; the cap is sociotechnical (operator + maintainer review)
-# rather than mechanical.
+# This script is ADVISORY — it reports the count + verdict and uses exit
+# code 1 to signal "cap exceeded" so callers can opt-in to gating (CI step
+# / pre-commit hook). The script itself never installs hooks or modifies
+# LANES.md. Hard mechanical enforcement is intentionally out of scope: the
+# cap is sociotechnical (operator + maintainer review), and side lanes
+# cannot easily install or modify shared hooks.
 #
 # Usage:
 #   scripts/lane-cap-check.sh [--lanes-file PATH] [--memory-dir PATH]
@@ -120,14 +122,22 @@ PARSE_OUTPUT=$(awk '
   }
   in_active && current_lane != "" && /^- \*\*Status\*\*:/ {
     had_status = 1
-    if ($0 ~ /^- \*\*Status\*\*: `?active`?/) { print "ACTIVE", current_lane }
+    # `active` MUST be the full Status TOKEN — i.e. followed by either
+    # end-of-line OR a non-identifier char (whitespace, punctuation).
+    # Without this guard, `active-foo` / `active123` / `active-ish` would
+    # false-match. The trailing-token requirement permits well-formed
+    # annotations like "active — Phase B complete; ..." which Mercury
+    # convention uses to attach short notes to the Status line.
+    if ($0 ~ /^- \*\*Status\*\*: `?active`?([^A-Za-z0-9_-]|$)/) { print "ACTIVE", current_lane }
     # closed / paused / other non-active values: tracked but not counted
   }
   END { flush() }
-' "$LANES_FILE")
+' "$LANES_FILE") || die "awk parse failed for LANES.md (refusing to verdict on parse error): $LANES_FILE"
 
-ACTIVE_LANES=$(printf '%s' "$PARSE_OUTPUT" | awk '/^ACTIVE / { sub(/^ACTIVE /, ""); print }')
-ORPHAN_LANES=$(printf '%s' "$PARSE_OUTPUT" | awk '/^ORPHAN / { sub(/^ORPHAN /, ""); print }')
+ACTIVE_LANES=$(printf '%s' "$PARSE_OUTPUT" | awk '/^ACTIVE / { sub(/^ACTIVE /, ""); print }') \
+  || die "awk filter (ACTIVE) failed"
+ORPHAN_LANES=$(printf '%s' "$PARSE_OUTPUT" | awk '/^ORPHAN / { sub(/^ORPHAN /, ""); print }') \
+  || die "awk filter (ORPHAN) failed"
 
 if [ -n "$ORPHAN_LANES" ]; then
   while IFS= read -r orphan; do

--- a/scripts/test-lane-cap-check.sh
+++ b/scripts/test-lane-cap-check.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+# scripts/test-lane-cap-check.sh — smoke tests for lane-cap-check.sh
+#
+# Builds synthetic LANES.md fixtures with varying active-lane counts and
+# verifies the advisory verdict + count + exit codes. Exit 0 if all pass.
+
+set -u
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
+  echo "test-lane-cap-check: not inside a git repo" >&2; exit 2; }
+SCRIPT="$REPO_ROOT/scripts/lane-cap-check.sh"
+[ -x "$SCRIPT" ] || { echo "test-lane-cap-check: $SCRIPT missing or not executable" >&2; exit 2; }
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+PASS=0; FAIL=0
+pass() { printf '  PASS: %s\n' "$1"; PASS=$((PASS+1)); }
+fail() { printf '  FAIL: %s\n' "$1"; FAIL=$((FAIL+1)); }
+
+assert_exit() {
+  local expected=$1 desc=$2; shift 2
+  "$@" >/dev/null 2>&1; local actual=$?
+  if [ "$actual" = "$expected" ]; then pass "$desc (exit=$actual)"
+  else fail "$desc (expected=$expected got=$actual)"; fi
+}
+
+assert_contains() {
+  local desc=$1 needle=$2 actual=$3
+  if printf '%s' "$actual" | grep -q -- "$needle"; then pass "$desc"
+  else fail "$desc — needle '$needle' not in: $(printf '%s' "$actual" | head -c200)"; fi
+}
+
+write_fixture_lanes() {
+  local path="$1" count="$2"
+  {
+    cat <<'EOF'
+# Mercury Lanes Registry
+
+## Active Lanes
+
+EOF
+    for i in $(seq 1 "$count"); do
+      printf '### `lane-%d`\n\n- **Status**: `active`\n\n' "$i"
+    done
+    # Also include one closed lane to verify it's NOT counted
+    cat <<'EOF'
+### `lane-closed-x`
+
+- **Status**: `closed`
+
+## Closed Lanes
+
+(none)
+EOF
+  } > "$path"
+}
+
+# ---- arg validation ----
+echo "[arg-validation]"
+assert_exit 0 "--help"                     "$SCRIPT" --help
+assert_exit 2 "unknown flag rejected"      "$SCRIPT" --bogus
+assert_exit 2 "--max zero rejected"        "$SCRIPT" --max 0 --memory-dir "$TMP"
+assert_exit 2 "--max non-numeric rejected" "$SCRIPT" --max abc --memory-dir "$TMP"
+assert_exit 2 "--format invalid rejected"  "$SCRIPT" --format yaml --memory-dir "$TMP"
+assert_exit 2 "missing memory dir rejected" "$SCRIPT" --memory-dir "$TMP/nope"
+assert_exit 2 "missing lanes-file rejected" "$SCRIPT" --lanes-file "$TMP/nope.md" --memory-dir "$TMP"
+
+# ---- within-cap scenarios ----
+MEM="$TMP/mem"; mkdir -p "$MEM"
+echo
+echo "[within-cap]"
+write_fixture_lanes "$MEM/LANES.md" 3
+OUT_3=$("$SCRIPT" --memory-dir "$MEM" --max 5 2>&1)
+RC_3=$?
+[ "$RC_3" = "0" ] && pass "3 active / max 5 → exit 0" || fail "3/5 exit=$RC_3 out=$OUT_3"
+assert_contains "verdict within_cap" "within_cap" "$OUT_3"
+assert_contains "count 3 reported"   "3 active"   "$OUT_3"
+
+# Edge: exactly at cap
+write_fixture_lanes "$MEM/LANES.md" 5
+OUT_5=$("$SCRIPT" --memory-dir "$MEM" --max 5 2>&1)
+RC_5=$?
+[ "$RC_5" = "0" ] && pass "5 active / max 5 → exit 0 (boundary)" || fail "5/5 exit=$RC_5"
+
+# ---- exceeded scenarios ----
+echo
+echo "[exceeded]"
+write_fixture_lanes "$MEM/LANES.md" 6
+OUT_6=$("$SCRIPT" --memory-dir "$MEM" --max 5 2>&1)
+RC_6=$?
+[ "$RC_6" = "1" ] && pass "6 active / max 5 → exit 1" || fail "6/5 exit=$RC_6"
+assert_contains "verdict exceeded"   "exceeded"     "$OUT_6"
+assert_contains "resolution hint"    "protocol-violation" "$OUT_6"
+
+# Custom max
+write_fixture_lanes "$MEM/LANES.md" 4
+OUT_4_3=$("$SCRIPT" --memory-dir "$MEM" --max 3 2>&1)
+RC_4_3=$?
+[ "$RC_4_3" = "1" ] && pass "4 active / max 3 → exit 1 (custom max)" || fail "4/3 exit=$RC_4_3"
+
+# ---- closed lanes excluded from count ----
+echo
+echo "[exclusion]"
+# Fixture above already includes one `closed` lane; verify count = active-only
+write_fixture_lanes "$MEM/LANES.md" 2
+OUT_EXCL=$("$SCRIPT" --memory-dir "$MEM" --max 5 2>&1)
+assert_contains "closed lane excluded from count" "2 active" "$OUT_EXCL"
+
+# ---- json format ----
+echo
+echo "[json]"
+write_fixture_lanes "$MEM/LANES.md" 3
+OUT_JSON=$("$SCRIPT" --memory-dir "$MEM" --max 5 --format json 2>&1)
+RC_JSON=$?
+[ "$RC_JSON" = "0" ] && pass "json within_cap exit 0" || fail "json exit=$RC_JSON"
+assert_contains "json has max"          '"max":5'                "$OUT_JSON"
+assert_contains "json has active_count" '"active_count":3'       "$OUT_JSON"
+assert_contains "json has verdict"      '"verdict":"within_cap"' "$OUT_JSON"
+assert_contains "json has lanes array"   '"lanes":\["lane-1","lane-2","lane-3"\]' "$OUT_JSON"
+
+# Validate JSON parseability
+if command -v python >/dev/null 2>&1; then
+  if printf '%s' "$OUT_JSON" | python -c 'import sys,json; json.load(sys.stdin)' 2>/dev/null; then
+    pass "json output is parseable"
+  else
+    fail "json output is INVALID: $OUT_JSON"
+  fi
+fi
+
+# ---- defensive parser: orphan lane (heading without Status) ----
+# Verifies OMC #327 review MAJOR #1 — lane heading not followed by Status
+# emits WARN to stderr and is NOT counted (fixes overwrite-attribution bug).
+echo
+echo "[parser-orphan]"
+cat > "$MEM/LANES.md" <<'EOF'
+# Mercury Lanes Registry
+
+## Active Lanes
+
+### `lane-orphan`
+
+- **Handoff**: missing-status.md
+
+### `lane-real`
+
+- **Status**: `active`
+
+## Closed Lanes
+EOF
+OUT_O=$("$SCRIPT" --memory-dir "$MEM" --max 5 2>&1)
+RC_O=$?
+[ "$RC_O" = "0" ] && pass "orphan + 1 active → exit 0" || fail "orphan exit=$RC_O out=$OUT_O"
+assert_contains "orphan WARN emitted"     "lane-orphan"            "$OUT_O"
+assert_contains "WARN suggests fix"        "no Status line"         "$OUT_O"
+assert_contains "real lane still counted"  "1 active"               "$OUT_O"
+
+# ---- defensive parser: zombie heading in Closed Lanes section is NOT counted ----
+# Verifies OMC #327 review MINOR #3 — section-boundary logic correctly
+# stops counting at "## Closed Lanes" anchor.
+echo
+echo "[parser-zombie]"
+cat > "$MEM/LANES.md" <<'EOF'
+# Mercury Lanes Registry
+
+## Active Lanes
+
+### `lane-real`
+
+- **Status**: `active`
+
+## Closed Lanes
+
+### `lane-zombie`
+
+- **Status**: `active`
+
+## Governance
+EOF
+OUT_Z=$("$SCRIPT" --memory-dir "$MEM" --max 5 2>&1)
+assert_contains "zombie in Closed not counted" "1 active" "$OUT_Z"
+if printf '%s' "$OUT_Z" | grep -q "lane-zombie"; then
+  fail "zombie lane in Closed Lanes section was incorrectly counted"
+else
+  pass "zombie lane in Closed Lanes section correctly excluded"
+fi
+
+# ---- defensive: JSON escape for hostile lane names ----
+# Verifies OMC #327 review MAJOR #2 — quote/backslash in lane name
+# produce valid JSON via json_string() helper (mirrors lane-sweep.sh pattern).
+echo
+echo "[json-escape]"
+cat > "$MEM/LANES.md" <<'EOF'
+# Mercury Lanes Registry
+
+## Active Lanes
+
+### `weird"name`
+
+- **Status**: `active`
+
+### `back\slash`
+
+- **Status**: `active`
+
+## Closed Lanes
+EOF
+OUT_J=$("$SCRIPT" --memory-dir "$MEM" --max 5 --format json 2>&1)
+RC_J=$?
+[ "$RC_J" = "0" ] && pass "json escape exit 0" || fail "json escape exit=$RC_J out=$OUT_J"
+if command -v python >/dev/null 2>&1; then
+  if printf '%s' "$OUT_J" | python -c 'import sys,json; d=json.load(sys.stdin); assert d["active_count"]==2 and len(d["lanes"])==2' 2>/dev/null; then
+    pass "json with quote/backslash lane names is valid + parses correctly"
+  else
+    fail "json output INVALID under hostile lane names: $OUT_J"
+  fi
+fi
+
+# ---- empty Active Lanes section → 0 count → within cap ----
+echo
+echo "[empty]"
+cat > "$MEM/LANES.md" <<'EOF'
+# Mercury Lanes Registry
+
+## Active Lanes
+
+## Closed Lanes
+EOF
+OUT_E=$("$SCRIPT" --memory-dir "$MEM" --max 5 2>&1)
+RC_E=$?
+[ "$RC_E" = "0" ] && pass "0 active → exit 0" || fail "empty exit=$RC_E"
+assert_contains "0 active reported" "0 active" "$OUT_E"
+
+echo
+printf '%d pass / %d fail\n' "$PASS" "$FAIL"
+[ "$FAIL" = "0" ]

--- a/scripts/test-lane-cap-check.sh
+++ b/scripts/test-lane-cap-check.sh
@@ -216,6 +216,67 @@ if command -v python >/dev/null 2>&1; then
   fi
 fi
 
+# ---- defensive: regex anchored exact match for `active` ----
+# Verifies Argus #328 review iter 1 — `Status: active-foo` / `active123`
+# / `active-ish` MUST NOT be counted as active (only literal `active`).
+echo
+echo "[regex-anchor]"
+cat > "$MEM/LANES.md" <<'EOF'
+# Mercury Lanes Registry
+
+## Active Lanes
+
+### `lane-genuine`
+
+- **Status**: `active`
+
+### `lane-prefix-attack`
+
+- **Status**: `active-foo`
+
+### `lane-suffix-attack`
+
+- **Status**: `activeless`
+
+### `lane-numeric-attack`
+
+- **Status**: active123
+
+## Closed Lanes
+EOF
+OUT_R=$("$SCRIPT" --memory-dir "$MEM" --max 5 2>&1)
+RC_R=$?
+[ "$RC_R" = "0" ] && pass "regex-anchor exit 0" || fail "regex-anchor exit=$RC_R"
+assert_contains "only genuine lane counted (1 active)" "1 active" "$OUT_R"
+if printf '%s' "$OUT_R" | grep -qE "lane-prefix-attack|lane-suffix-attack|lane-numeric-attack"; then
+  fail "non-active prefix/suffix/numeric lane was incorrectly counted"
+else
+  pass "non-active prefix/suffix/numeric lanes correctly excluded"
+fi
+
+# Mercury convention: trailing annotation after Status value (separated by
+# whitespace + dash/punctuation) IS allowed and counts as active. Without
+# this, real LANES.md entries like `Status: \`active\` — Phase B complete`
+# would false-negative (regression caught during S5 smoke test).
+cat > "$MEM/LANES.md" <<'EOF'
+# Mercury Lanes Registry
+
+## Active Lanes
+
+### `lane-with-annotation`
+
+- **Status**: `active` — Phase B complete; Phase C in progress
+
+### `lane-clean`
+
+- **Status**: `active`
+
+## Closed Lanes
+EOF
+OUT_W=$("$SCRIPT" --memory-dir "$MEM" --max 5 2>&1)
+assert_contains "annotated active still counted (Mercury convention)" "2 active" "$OUT_W"
+assert_contains "annotated lane name in active list" "lane-with-annotation" "$OUT_W"
+
 # ---- empty Active Lanes section → 0 count → within cap ----
 echo
 echo "[empty]"


### PR DESCRIPTION
## Summary

Side-multi-lane Phase C bundles two doc-mostly v0.1 protocol deltas:

- **#313 (Δ6 Rule 2.1, P3)** — short branch prefix `lane/<short>/<N>-<slug>` ≤40 char + per-lane Short name field convention
- **#314 (Δ7 HARD-CAP, doc-only)** — 5 active lanes maximum + advisory `scripts/lane-cap-check.sh` + `protocol-violation` GitHub label + Miller's/Google/Kanban-cited rationale

Smaller than Phase B by design (Δ6 is doc-mostly, Δ7 is doc-only with one advisory script). Backward-compat preserved everywhere.

## Files

- `scripts/lane-cap-check.sh` (~155 LOC) + `scripts/test-lane-cap-check.sh` (32 tests)
- `.mercury/docs/guides/lane-naming.md` — combined Δ6 + Δ7 operator guide
- `memory/feedback_lane_protocol.md` — Rule 2.1 + HARD-CAP § landed (in user-memory, not in this diff)
- `memory/LANES.md` — Short name field for side-multi-lane + Governance § Branch naming + Capacity limit (in user-memory, not in this diff)

## Dual-verify status

- **Lane 1 (Claude critic)**: READY_TO_COMMIT — 15/15 acceptance items PASS, 0 BLOCKERS, 3 cosmetic suggestions deferred.
- **Lane 2 (OMC code-reviewer)**: initial NEEDS_FIX → 2 MAJOR fixed pre-commit:
  - Parser miscount on orphan-no-status lane headings → tightened state machine with `flush()` helper + `had_status` flag distinguishing "no Status line" from "non-active Status value"
  - JSON `lanes` field unescaped → imported `json_string()` helper from `lane-sweep.sh`, output schema changed to JSON array of escaped strings
  - 3 MINOR + 1 NIT deferred via doc reframing (v0.2 ref-glob explicit warning) and `warn()` helper addition
  Re-verified: all 32 tests pass + smoke clean.
- **Codex side**: skipped per **#326** (async forwarder broken — 25k token forwarder baseline + no sync return). OMC code-reviewer remains second perspective until #326 sync wrapper lands.

## Side-effects

- GitHub label `protocol-violation` created (color `#B60205`, description "Multi-lane protocol violation requiring user arbitration") via `gh label create`.

## Test plan
- [x] `bash scripts/test-lane-cap-check.sh` → 32/32 PASS
- [x] `bash scripts/test-lane-claim.sh` → 18/18 (Phase A regression)
- [x] `bash scripts/test-lane-sweep.sh` → 24/24 (Phase B regression)
- [x] `bash scripts/test-lane-close.sh` → 27/27 (Phase B regression)
- [x] `bash scripts/test-check-main-idle.sh` → 19/19 (Phase B regression)
- [x] Total: **120/120 PASS**
- [x] Real-world smoke: `bash scripts/lane-cap-check.sh` reports `2 active lane(s), cap=5 → within_cap (main, side-multi-lane)`
- [x] JSON smoke: `bash scripts/lane-cap-check.sh --format json` produces valid parseable JSON with array-typed `lanes` field
- [ ] Argus review pending after PR open
- [ ] Copilot review pending

## Lane scope compliance (Rule 4 + Rule 6 + Rule 8)

- ✅ DIRECTION.md / EXECUTION-PLAN.md: zero edits
- ✅ Other lane handoffs / state files: zero edits
- ✅ LANES.md: only side-multi-lane section + appended Governance subsections (no in-place edit of existing lanes' rows or rules)
- ✅ Rule 8 v0.2 self-implementation: doc-only deltas, no main-lane gating
- ✅ Branch prefix `feature/lane-side-multi-lane/TASK-313-314-phase-c` (legacy — Δ6 takes effect for FUTURE branches; this PR is the LAST one to use legacy prefix per Phase C closure)

Closes #313
Closes #314
Refs #292
Refs #326

🤖 Generated with [Claude Code](https://claude.com/claude-code)