### PR TITLE
feat(phase-a): 5h observability + lane status aggregator (#322)

### DIFF
--- a/.mercury/docs/guides/phase-a-install.md
+++ b/.mercury/docs/guides/phase-a-install.md
@@ -70,12 +70,13 @@ After restarting Claude Code, the status bar should display:
 Manual smoke test (no Claude Code session needed):
 
 ```bash
-echo '{"rate_limits":{"five_hour":{"used_percentage":96},"seven_day":{"used_percentage":20}},"model":{"display_name":"Opus 4.7"},"context_window":{"used_percentage":30}}' \
+# Use a far-future resets_at so the marker stores a realistic epoch (not 0).
+echo '{"rate_limits":{"five_hour":{"used_percentage":96,"resets_at":9999999999},"seven_day":{"used_percentage":20}},"model":{"display_name":"Opus 4.7"},"context_window":{"used_percentage":30}}' \
   | bash scripts/statusline-mercury.sh
 # → red-colored "5h: 96% | 7d: 20% | ctx: 30% | Opus 4.7"
 # → .mercury/state/auto-run-paused file created
 cat .mercury/state/auto-run-paused
-# → 0  (resets_at from test JSON)
+# → 9999999999  (resets_at echoed from input JSON)
 rm -f .mercury/state/auto-run-paused
 ```
 
@@ -144,7 +145,7 @@ rm -f .mercury/state/auto-run-paused
 | # | Criterion (Issue #322 + #320) | Verification command |
 |---|-------------------------------|----------------------|
 | 1 | statusline shows 5h%, 7d%, ctx%, model | `echo '{"rate_limits":{"five_hour":{"used_percentage":50},"seven_day":{"used_percentage":10}},"model":{"display_name":"Test"},"context_window":{"used_percentage":5}}' \| bash scripts/statusline-mercury.sh` → output contains `5h: 50%` |
-| 2 | marker created when `used_percentage >= 95`, deleted when window resets | `echo '{"rate_limits":{"five_hour":{"used_percentage":96},"seven_day":{}}}' \| bash scripts/statusline-mercury.sh && ls -la .mercury/state/auto-run-paused` |
+| 2 | marker created when `used_percentage >= 95`, deleted when window resets | `echo '{"rate_limits":{"five_hour":{"used_percentage":96,"resets_at":9999999999},"seven_day":{}}}' \| bash scripts/statusline-mercury.sh && ls -la .mercury/state/auto-run-paused` |
 | 3 | corrupted marker (non-numeric) self-heals without crash | `echo "bad" > .mercury/state/auto-run-paused && echo '{"rate_limits":{"five_hour":{"used_percentage":50}}}' \| bash scripts/statusline-mercury.sh 2>&1 \| grep corrupted` |
 | 4 | `lane-status.json` updates with `last_checked_at` ISO timestamp | `bash scripts/lane-status.sh && jq .last_checked_at .mercury/state/lane-status.json` |
 | 5 | durable cron registered (survives session restart) | After `CronCreate durable:true`, restart Claude Code session, then verify cron still listed |

--- a/.mercury/docs/guides/phase-a-install.md
+++ b/.mercury/docs/guides/phase-a-install.md
@@ -52,10 +52,13 @@ existing JSON object — do **not** overwrite the whole file.
 }
 ```
 
-Validate JSON after merging:
+Validate JSON after merging (compute the path in shell so bash `${VAR:-default}`
+expansion happens BEFORE Python sees it — Python's `os.path.expandvars` does NOT
+understand `${VAR:-default}` syntax):
 
 ```bash
-python -c "import json,os; json.load(open(os.path.expandvars('${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json')))" \
+SETTINGS="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json"
+python -c "import json, sys; json.load(open(sys.argv[1]))" "$SETTINGS" \
   && echo "JSON valid"
 ```
 
@@ -117,11 +120,19 @@ CronCreate:
 > `durable: true` is **mandatory** — without it the cron silently disappears after session restart,
 > opening quota-tracking gaps (per Issue #320 acceptance criterion 5).
 
-Verify registration survived a session restart:
+Verify registration survived a session restart by listing crons inside Claude Code
+itself — the GitHub API does not expose Claude Code's local cron registry:
+
+> Inside the new Claude Code session, ask the agent to run `CronList` (built-in
+> tool) and confirm the lane-status entry appears. If it is missing, the
+> previous registration was not durable; re-register with `durable: true`.
+
+A separate way to indirectly observe the cron is firing: `lane-status.json`'s
+`last_checked_at` timestamp should be within the configured cron interval:
 
 ```bash
-gh api /repos/392fyc/Mercury/actions/variables 2>/dev/null || \
-  echo "(verify via Claude Code: list active crons)"
+STATE_FILE="${MERCURY_TEST_REPO_ROOT:-$(git rev-parse --show-toplevel)}/.mercury/state/lane-status.json"
+jq -r '.last_checked_at' "$STATE_FILE"
 ```
 
 ---

--- a/.mercury/docs/guides/phase-a-install.md
+++ b/.mercury/docs/guides/phase-a-install.md
@@ -1,0 +1,162 @@
+# Phase A Install Guide — 5h Observability + Cross-Lane Aggregator
+
+Issue #322 / #320 · Phase A · `scripts/statusline-mercury.sh` + `scripts/lane-status.sh`
+
+---
+
+## Prerequisites
+
+- `jq` installed and on PATH
+- `gh` CLI authenticated (`gh auth status`)
+- Claude Code CLI installed
+- Mercury repo cloned, working tree clean
+
+---
+
+## A1 — Install statusline-mercury.sh
+
+### Step 1 — Symlink into Claude config dir (idempotent)
+
+```bash
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+ln -sf "$REPO_ROOT/scripts/statusline-mercury.sh" "$CLAUDE_DIR/statusline-mercury.sh"
+```
+
+Verify the symlink:
+
+```bash
+ls -la "$CLAUDE_DIR/statusline-mercury.sh"
+# → should point to scripts/statusline-mercury.sh inside the repo
+```
+
+### Step 2 — Merge settings.json snippet
+
+> **WARNING — back up first** (per Mercury user-level change governance in CLAUDE.md):
+
+```bash
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+cp "$CLAUDE_DIR/settings.json" "$CLAUDE_DIR/settings.json.backup-pre-322"
+```
+
+Add the following `statusLine` block to `$CLAUDE_DIR/settings.json`. Merge manually into the
+existing JSON object — do **not** overwrite the whole file.
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/statusline-mercury.sh",
+    "refreshInterval": 60
+  }
+}
+```
+
+Validate JSON after merging:
+
+```bash
+python -c "import json,os; json.load(open(os.path.expandvars('${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json')))" \
+  && echo "JSON valid"
+```
+
+### Step 3 — Verify
+
+After restarting Claude Code, the status bar should display:
+
+```
+5h: 42% | 7d: 18% | ctx: 12% | Opus 4.7
+```
+
+Manual smoke test (no Claude Code session needed):
+
+```bash
+echo '{"rate_limits":{"five_hour":{"used_percentage":96},"seven_day":{"used_percentage":20}},"model":{"display_name":"Opus 4.7"},"context_window":{"used_percentage":30}}' \
+  | bash scripts/statusline-mercury.sh
+# → red-colored "5h: 96% | 7d: 20% | ctx: 30% | Opus 4.7"
+# → .mercury/state/auto-run-paused file created
+cat .mercury/state/auto-run-paused
+# → 0  (resets_at from test JSON)
+rm -f .mercury/state/auto-run-paused
+```
+
+---
+
+## A2 — Install lane-status.sh
+
+No symlink needed — runs from repo root via cron or manually.
+
+### Manual run
+
+```bash
+bash scripts/lane-status.sh --print
+# Compact summary table printed to stdout.
+# .mercury/state/lane-status.json written.
+```
+
+Inspect output:
+
+```bash
+jq '.' .mercury/state/lane-status.json
+```
+
+### Cron registration (via Claude Code `CronCreate` tool)
+
+**Do NOT register from the script** — registration is user-driven via Claude Code:
+
+```text
+CronCreate:
+  cron: "*/5 * * * *"
+  durable: true
+  prompt: |
+    Run scripts/lane-status.sh from the Mercury repo root ($REPO_ROOT).
+    If lane-status.json shows any is_stale: true lanes, append a line to
+    .mercury/state/stale-lanes.log with ISO timestamp and lane name.
+```
+
+> `durable: true` is **mandatory** — without it the cron silently disappears after session restart,
+> opening quota-tracking gaps (per Issue #320 acceptance criterion 5).
+
+Verify registration survived a session restart:
+
+```bash
+gh api /repos/392fyc/Mercury/actions/variables 2>/dev/null || \
+  echo "(verify via Claude Code: list active crons)"
+```
+
+---
+
+## Rollback
+
+```bash
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+# Remove symlink
+rm -f "$CLAUDE_DIR/statusline-mercury.sh"
+# Restore settings.json
+mv "$CLAUDE_DIR/settings.json.backup-pre-322" "$CLAUDE_DIR/settings.json"
+# Remove any pause marker
+rm -f .mercury/state/auto-run-paused
+```
+
+---
+
+## Acceptance Verification Matrix
+
+| # | Criterion (Issue #322 + #320) | Verification command |
+|---|-------------------------------|----------------------|
+| 1 | statusline shows 5h%, 7d%, ctx%, model | `echo '{"rate_limits":{"five_hour":{"used_percentage":50},"seven_day":{"used_percentage":10}},"model":{"display_name":"Test"},"context_window":{"used_percentage":5}}' \| bash scripts/statusline-mercury.sh` → output contains `5h: 50%` |
+| 2 | marker created when `used_percentage >= 95`, deleted when window resets | `echo '{"rate_limits":{"five_hour":{"used_percentage":96},"seven_day":{}}}' \| bash scripts/statusline-mercury.sh && ls -la .mercury/state/auto-run-paused` |
+| 3 | corrupted marker (non-numeric) self-heals without crash | `echo "bad" > .mercury/state/auto-run-paused && echo '{"rate_limits":{"five_hour":{"used_percentage":50}}}' \| bash scripts/statusline-mercury.sh 2>&1 \| grep corrupted` |
+| 4 | `lane-status.json` updates with `last_checked_at` ISO timestamp | `bash scripts/lane-status.sh && jq .last_checked_at .mercury/state/lane-status.json` |
+| 5 | durable cron registered (survives session restart) | After `CronCreate durable:true`, restart Claude Code session, then verify cron still listed |
+
+---
+
+## Environment Variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `MERCURY_PAUSE_THRESHOLD` | `95` | 5h usage % at which auto-run pauses |
+| `MERCURY_WARN_THRESHOLD` | `85` | 5h usage % at which display turns yellow |
+| `MERCURY_LANE_STALE_MIN` | `15` | Minutes after which a lane is considered stale |
+| `CLAUDE_PROJECT_DIR` | (injected by Claude Code) | Repo root override for statusline |
+| `MERCURY_TEST_REPO_ROOT` | (unset) | Test isolation override for both scripts |

--- a/scripts/lane-status.sh
+++ b/scripts/lane-status.sh
@@ -2,39 +2,22 @@
 # Mercury cross-lane status aggregator (Issue #322, Phase A).
 # Polls GitHub Issues with lane:* labels + last-commit timestamps on lane branches.
 # Writes .mercury/state/lane-status.json with 15-min staleness gate.
-# Atomic write via tmp file + mv to avoid mid-write read corruption.
+# Atomic write via mktemp + mv to avoid mid-write read corruption.
 #
 # Usage: bash scripts/lane-status.sh [--print]
-#   --print    Also emit compact summary table to stdout (default: silent for cron)
-#
-# ## Cron registration (via Claude Code CronCreate tool — do NOT run from script)
-#
-#   CronCreate:
-#     cron: "*/5 * * * *"
-#     durable: true   # MANDATORY — survives session restart (per Issue #320 acceptance)
-#     prompt: |
-#       Run scripts/lane-status.sh --print from the Mercury repo root.
-#       If lane-status.json shows any is_stale: true, append a line to
-#       .mercury/state/stale-lanes.log with ISO timestamp + lane name.
-#
-# Note: durable: true is required so the cron survives claude session restarts.
-# Verify registration post-restart with: gh api ... | jq '.cron_jobs'
+# Cron registration (via Claude Code CronCreate, durable: true): see
+# .mercury/docs/guides/phase-a-install.md §A2.
 
 set -euo pipefail
 
-# ---------------------------------------------------------------------------
 # Config
-# ---------------------------------------------------------------------------
 STALE_MIN=${MERCURY_LANE_STALE_MIN:-15}
 PRINT_SUMMARY=false
 for arg in "$@"; do
   [ "$arg" = "--print" ] && PRINT_SUMMARY=true
 done
 
-# ---------------------------------------------------------------------------
-# Resolve REPO_ROOT
-# Same pattern as statusline-mercury.sh; supports MERCURY_TEST_REPO_ROOT override.
-# ---------------------------------------------------------------------------
+# Resolve REPO_ROOT (same pattern as statusline-mercury.sh; MERCURY_TEST_REPO_ROOT override).
 if [ -n "${MERCURY_TEST_REPO_ROOT:-}" ]; then
   REPO_ROOT="$MERCURY_TEST_REPO_ROOT"
 elif [ -n "${CLAUDE_PROJECT_DIR:-}" ] && [ -d "$CLAUDE_PROJECT_DIR/.git" ]; then
@@ -49,55 +32,56 @@ if [ -z "${REPO_ROOT:-}" ]; then
 fi
 
 STATE_DIR="$REPO_ROOT/.mercury/state"
-OUTPUT_FILE="$STATE_DIR/lane-status.json"
-TMP_FILE="$STATE_DIR/lane-status.json.tmp"
 
 mkdir -p "$STATE_DIR"
 
-# ---------------------------------------------------------------------------
-# Discover lane labels
-# Mercury convention: labels named "lane:*" (e.g. lane:main, lane:side-multi-lane).
-# `gh issue list --label` requires exact label name; we enumerate via `gh label list`.
-# Note: GitHub API --label filter matches exact strings only, no wildcard support.
-# ---------------------------------------------------------------------------
-lane_labels=$(gh label list --limit 100 --json name --jq '[.[] | select(.name | startswith("lane:")) | .name]')
-lane_label_count=$(echo "$lane_labels" | jq 'length')
+# m1: mktemp for unique tmp file — avoids fixed-name collision under concurrent cron.
+TMP_FILE="$(mktemp "$STATE_DIR/lane-status.json.XXXXXX")"
+trap 'rm -f "$TMP_FILE"' EXIT
+
+# Source portable date helpers (M1 fix: BSD/macOS date portability).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/date-utils.sh
+source "$SCRIPT_DIR/lib/date-utils.sh"
+
+# Discover lane labels (convention: lane:* — e.g. lane:main, lane:side-multi-lane).
+# M2: tolerate gh + jq failure so script never aborts on transient network issues.
+labels_raw="$(gh label list --limit 100 --json name 2>/dev/null || echo '[]')"
+# Strip \r to handle Windows CRLF in gh output under MINGW.
+lane_labels="$(echo "$labels_raw" | jq -r '[.[] | select(.name | startswith("lane:")) | .name] // []' 2>/dev/null | tr -d '\r' || echo '[]')"
+
+lane_label_count=$(echo "$lane_labels" | jq 'length' 2>/dev/null || echo 0)
 
 if [ "$lane_label_count" -eq 0 ]; then
-  echo "[lane-status] WARNING: No lane:* labels found. Writing empty lanes array." >&2
+  echo "[lane-status] WARN: no lane:* labels detected (gh failure or empty result)" >&2
+  # Still write valid lane-status.json with empty lanes array below.
 fi
 
-# ---------------------------------------------------------------------------
-# Enumerate live lane branches from remote
-# Pattern: refs/heads/feature/lane-<name>/...
-# ---------------------------------------------------------------------------
-remote_refs=$(git -C "$REPO_ROOT" ls-remote origin 'refs/heads/feature/lane-*' 2>/dev/null || true)
+# Enumerate live lane branches from remote (refs/heads/feature/lane-<name>/...).
+# M2: tolerate git ls-remote failure; tr -d '\r' for MINGW CRLF.
+remote_refs="$(git -C "$REPO_ROOT" ls-remote origin 'refs/heads/feature/lane-*' 2>/dev/null | tr -d '\r' || true)"
 
-# ---------------------------------------------------------------------------
-# Compute staleness threshold timestamp (seconds since epoch)
-# ---------------------------------------------------------------------------
 now=$(date +%s)
 stale_cutoff=$(( now - STALE_MIN * 60 ))
 
-# ---------------------------------------------------------------------------
-# Build lanes JSON array
-# ---------------------------------------------------------------------------
 lanes_json="[]"
 
 # Iterate over each lane label
 while IFS= read -r label_name; do
+  [ -z "$label_name" ] && continue
+
   # Strip "lane:" prefix to get the lane id
   lane_id="${label_name#lane:}"
 
-  # Fetch open Issues with this label
-  issues_json=$(gh issue list \
+  # M2: tolerate gh issue list failure — fall back to empty array
+  issues_json="$(gh issue list \
     --label "$label_name" \
     --state open \
     --json number,title,labels,updatedAt \
-    --limit 50 2>/dev/null || echo "[]")
+    --limit 50 2>/dev/null || echo '[]')"
 
   # Normalize: extract relevant fields only
-  issues_normalized=$(echo "$issues_json" | jq '[.[] | {number: .number, title: .title, updated_at: .updatedAt}]')
+  issues_normalized="$(echo "$issues_json" | jq '[.[] | {number: .number, title: .title, updated_at: .updatedAt}]' 2>/dev/null || echo '[]')"
 
   # Find matching branches: feature/lane-<lane_id>/...
   # lane_id may contain hyphens; branch prefix is feature/lane-<lane_id>/
@@ -107,37 +91,44 @@ while IFS= read -r label_name; do
   while IFS= read -r ref_line; do
     [ -z "$ref_line" ] && continue
     # ref_line format: "<sha>\trefs/heads/<branch>"
-    ref_branch=$(echo "$ref_line" | awk '{print $2}' | sed 's|refs/heads/||')
-    # Get last commit timestamp for this branch (ISO 8601)
-    last_commit_at=$(git -C "$REPO_ROOT" log -1 --format=%cI "origin/${ref_branch}" 2>/dev/null || true)
+    ref_branch=$(echo "$ref_line" | awk '{print $2}' | sed 's|refs/heads/||' | tr -d '\r')
+    # M1: use TZ=UTC --date format to get UTC timestamp directly, avoiding
+    # %cI's +HH:MM form which BSD date -j cannot parse.
+    last_commit_at=$(git -C "$REPO_ROOT" log -1 \
+      --date=format-local:'%Y-%m-%dT%H:%M:%SZ' \
+      --format=%cd \
+      "origin/${ref_branch}" 2>/dev/null | tr -d '\r' || true)
+    # Fallback: if format-local unsupported, use %cI and let parse_epoch normalize
+    if [ -z "$last_commit_at" ]; then
+      last_commit_at=$(git -C "$REPO_ROOT" log -1 --format=%cI "origin/${ref_branch}" 2>/dev/null | tr -d '\r' || true)
+    fi
     if [ -n "$last_commit_at" ]; then
       branches_json=$(echo "$branches_json" | jq \
         --arg ref "$ref_branch" \
         --arg ts "$last_commit_at" \
         '. + [{"ref": $ref, "last_commit_at": $ts}]')
     fi
-  done < <(echo "$remote_refs" | grep "refs/heads/${branch_prefix}" || true)
+  # m2: use grep -F for fixed-string lane_id lookup — prevents regex metachars in
+  # lane_id (e.g. "." or "+") from causing mis-matches.
+  done < <(echo "$remote_refs" | grep -F "refs/heads/${branch_prefix}" || true)
 
   # Compute is_stale:
   # A lane is stale if its most-recent issue update AND most-recent branch commit
   # are both older than STALE_MIN minutes (or if there are no issues AND no branches).
   most_recent_issue_epoch=0
   if [ "$(echo "$issues_normalized" | jq 'length')" -gt 0 ]; then
-    most_recent_issue_ts=$(echo "$issues_normalized" | jq -r '[.[].updated_at] | max')
+    # tr -d '\r': jq on Windows MINGW emits CRLF; strip before date parsing.
+    most_recent_issue_ts=$(echo "$issues_normalized" | jq -r '[.[].updated_at] | max' | tr -d '\r')
     if [ -n "$most_recent_issue_ts" ] && [ "$most_recent_issue_ts" != "null" ]; then
-      most_recent_issue_epoch=$(date -d "$most_recent_issue_ts" +%s 2>/dev/null || \
-                                date -j -f "%Y-%m-%dT%H:%M:%SZ" "$most_recent_issue_ts" +%s 2>/dev/null || \
-                                echo 0)
+      most_recent_issue_epoch=$(parse_epoch "$most_recent_issue_ts")
     fi
   fi
 
   most_recent_branch_epoch=0
   if [ "$(echo "$branches_json" | jq 'length')" -gt 0 ]; then
-    most_recent_branch_ts=$(echo "$branches_json" | jq -r '[.[].last_commit_at] | max')
+    most_recent_branch_ts=$(echo "$branches_json" | jq -r '[.[].last_commit_at] | max' | tr -d '\r')
     if [ -n "$most_recent_branch_ts" ] && [ "$most_recent_branch_ts" != "null" ]; then
-      most_recent_branch_epoch=$(date -d "$most_recent_branch_ts" +%s 2>/dev/null || \
-                                 date -j -f "%Y-%m-%dT%H:%M:%SZ" "$most_recent_branch_ts" +%s 2>/dev/null || \
-                                 echo 0)
+      most_recent_branch_epoch=$(parse_epoch "$most_recent_branch_ts")
     fi
   fi
 
@@ -160,11 +151,10 @@ while IFS= read -r label_name; do
     --argjson stale "$is_stale" \
     '. + [{"name": $name, "issues": $issues, "branches": $branches, "is_stale": $stale}]')
 
-done < <(echo "$lane_labels" | jq -r '.[]')
+# tr -d '\r': jq on Windows MINGW emits CRLF line endings; strip before read.
+done < <(echo "$lane_labels" | jq -r '.[]' 2>/dev/null | tr -d '\r' || true)
 
-# ---------------------------------------------------------------------------
-# Build final JSON and write atomically
-# ---------------------------------------------------------------------------
+# Build final JSON and write atomically.
 last_checked_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 final_json=$(jq -n \
@@ -177,12 +167,13 @@ final_json=$(jq -n \
     lanes: $lanes
   }')
 
+OUTPUT_FILE="$STATE_DIR/lane-status.json"
 echo "$final_json" > "$TMP_FILE"
+# Atomic rename; disarm the EXIT trap first so we don't delete the file we just wrote.
+trap - EXIT
 mv "$TMP_FILE" "$OUTPUT_FILE"
 
-# ---------------------------------------------------------------------------
-# Optional --print summary table
-# ---------------------------------------------------------------------------
+# Optional --print summary table.
 if [ "$PRINT_SUMMARY" = "true" ]; then
   echo "Lane Status — $(date -u '+%Y-%m-%dT%H:%M:%SZ') (stale > ${STALE_MIN}m)"
   echo "---------------------------------------------------------------"

--- a/scripts/lane-status.sh
+++ b/scripts/lane-status.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+# Mercury cross-lane status aggregator (Issue #322, Phase A).
+# Polls GitHub Issues with lane:* labels + last-commit timestamps on lane branches.
+# Writes .mercury/state/lane-status.json with 15-min staleness gate.
+# Atomic write via tmp file + mv to avoid mid-write read corruption.
+#
+# Usage: bash scripts/lane-status.sh [--print]
+#   --print    Also emit compact summary table to stdout (default: silent for cron)
+#
+# ## Cron registration (via Claude Code CronCreate tool — do NOT run from script)
+#
+#   CronCreate:
+#     cron: "*/5 * * * *"
+#     durable: true   # MANDATORY — survives session restart (per Issue #320 acceptance)
+#     prompt: |
+#       Run scripts/lane-status.sh --print from the Mercury repo root.
+#       If lane-status.json shows any is_stale: true, append a line to
+#       .mercury/state/stale-lanes.log with ISO timestamp + lane name.
+#
+# Note: durable: true is required so the cron survives claude session restarts.
+# Verify registration post-restart with: gh api ... | jq '.cron_jobs'
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+STALE_MIN=${MERCURY_LANE_STALE_MIN:-15}
+PRINT_SUMMARY=false
+for arg in "$@"; do
+  [ "$arg" = "--print" ] && PRINT_SUMMARY=true
+done
+
+# ---------------------------------------------------------------------------
+# Resolve REPO_ROOT
+# Same pattern as statusline-mercury.sh; supports MERCURY_TEST_REPO_ROOT override.
+# ---------------------------------------------------------------------------
+if [ -n "${MERCURY_TEST_REPO_ROOT:-}" ]; then
+  REPO_ROOT="$MERCURY_TEST_REPO_ROOT"
+elif [ -n "${CLAUDE_PROJECT_DIR:-}" ] && [ -d "$CLAUDE_PROJECT_DIR/.git" ]; then
+  REPO_ROOT="$CLAUDE_PROJECT_DIR"
+else
+  REPO_ROOT="$(git -C "$(pwd)" rev-parse --show-toplevel 2>/dev/null)"
+fi
+
+if [ -z "${REPO_ROOT:-}" ]; then
+  echo "[lane-status] ERROR: Cannot resolve repo root. Run from inside the Mercury repo." >&2
+  exit 1
+fi
+
+STATE_DIR="$REPO_ROOT/.mercury/state"
+OUTPUT_FILE="$STATE_DIR/lane-status.json"
+TMP_FILE="$STATE_DIR/lane-status.json.tmp"
+
+mkdir -p "$STATE_DIR"
+
+# ---------------------------------------------------------------------------
+# Discover lane labels
+# Mercury convention: labels named "lane:*" (e.g. lane:main, lane:side-multi-lane).
+# `gh issue list --label` requires exact label name; we enumerate via `gh label list`.
+# Note: GitHub API --label filter matches exact strings only, no wildcard support.
+# ---------------------------------------------------------------------------
+lane_labels=$(gh label list --limit 100 --json name --jq '[.[] | select(.name | startswith("lane:")) | .name]')
+lane_label_count=$(echo "$lane_labels" | jq 'length')
+
+if [ "$lane_label_count" -eq 0 ]; then
+  echo "[lane-status] WARNING: No lane:* labels found. Writing empty lanes array." >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Enumerate live lane branches from remote
+# Pattern: refs/heads/feature/lane-<name>/...
+# ---------------------------------------------------------------------------
+remote_refs=$(git -C "$REPO_ROOT" ls-remote origin 'refs/heads/feature/lane-*' 2>/dev/null || true)
+
+# ---------------------------------------------------------------------------
+# Compute staleness threshold timestamp (seconds since epoch)
+# ---------------------------------------------------------------------------
+now=$(date +%s)
+stale_cutoff=$(( now - STALE_MIN * 60 ))
+
+# ---------------------------------------------------------------------------
+# Build lanes JSON array
+# ---------------------------------------------------------------------------
+lanes_json="[]"
+
+# Iterate over each lane label
+while IFS= read -r label_name; do
+  # Strip "lane:" prefix to get the lane id
+  lane_id="${label_name#lane:}"
+
+  # Fetch open Issues with this label
+  issues_json=$(gh issue list \
+    --label "$label_name" \
+    --state open \
+    --json number,title,labels,updatedAt \
+    --limit 50 2>/dev/null || echo "[]")
+
+  # Normalize: extract relevant fields only
+  issues_normalized=$(echo "$issues_json" | jq '[.[] | {number: .number, title: .title, updated_at: .updatedAt}]')
+
+  # Find matching branches: feature/lane-<lane_id>/...
+  # lane_id may contain hyphens; branch prefix is feature/lane-<lane_id>/
+  branch_prefix="feature/lane-${lane_id}/"
+  branches_json="[]"
+
+  while IFS= read -r ref_line; do
+    [ -z "$ref_line" ] && continue
+    # ref_line format: "<sha>\trefs/heads/<branch>"
+    ref_branch=$(echo "$ref_line" | awk '{print $2}' | sed 's|refs/heads/||')
+    # Get last commit timestamp for this branch (ISO 8601)
+    last_commit_at=$(git -C "$REPO_ROOT" log -1 --format=%cI "origin/${ref_branch}" 2>/dev/null || true)
+    if [ -n "$last_commit_at" ]; then
+      branches_json=$(echo "$branches_json" | jq \
+        --arg ref "$ref_branch" \
+        --arg ts "$last_commit_at" \
+        '. + [{"ref": $ref, "last_commit_at": $ts}]')
+    fi
+  done < <(echo "$remote_refs" | grep "refs/heads/${branch_prefix}" || true)
+
+  # Compute is_stale:
+  # A lane is stale if its most-recent issue update AND most-recent branch commit
+  # are both older than STALE_MIN minutes (or if there are no issues AND no branches).
+  most_recent_issue_epoch=0
+  if [ "$(echo "$issues_normalized" | jq 'length')" -gt 0 ]; then
+    most_recent_issue_ts=$(echo "$issues_normalized" | jq -r '[.[].updated_at] | max')
+    if [ -n "$most_recent_issue_ts" ] && [ "$most_recent_issue_ts" != "null" ]; then
+      most_recent_issue_epoch=$(date -d "$most_recent_issue_ts" +%s 2>/dev/null || \
+                                date -j -f "%Y-%m-%dT%H:%M:%SZ" "$most_recent_issue_ts" +%s 2>/dev/null || \
+                                echo 0)
+    fi
+  fi
+
+  most_recent_branch_epoch=0
+  if [ "$(echo "$branches_json" | jq 'length')" -gt 0 ]; then
+    most_recent_branch_ts=$(echo "$branches_json" | jq -r '[.[].last_commit_at] | max')
+    if [ -n "$most_recent_branch_ts" ] && [ "$most_recent_branch_ts" != "null" ]; then
+      most_recent_branch_epoch=$(date -d "$most_recent_branch_ts" +%s 2>/dev/null || \
+                                 date -j -f "%Y-%m-%dT%H:%M:%SZ" "$most_recent_branch_ts" +%s 2>/dev/null || \
+                                 echo 0)
+    fi
+  fi
+
+  # Most recent activity across both sources
+  most_recent_epoch=$most_recent_issue_epoch
+  if [ "$most_recent_branch_epoch" -gt "$most_recent_epoch" ]; then
+    most_recent_epoch=$most_recent_branch_epoch
+  fi
+
+  is_stale=false
+  if [ "$most_recent_epoch" -eq 0 ] || [ "$most_recent_epoch" -lt "$stale_cutoff" ]; then
+    is_stale=true
+  fi
+
+  # Append this lane to the lanes array
+  lanes_json=$(echo "$lanes_json" | jq \
+    --arg name "$lane_id" \
+    --argjson issues "$issues_normalized" \
+    --argjson branches "$branches_json" \
+    --argjson stale "$is_stale" \
+    '. + [{"name": $name, "issues": $issues, "branches": $branches, "is_stale": $stale}]')
+
+done < <(echo "$lane_labels" | jq -r '.[]')
+
+# ---------------------------------------------------------------------------
+# Build final JSON and write atomically
+# ---------------------------------------------------------------------------
+last_checked_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+final_json=$(jq -n \
+  --arg ts "$last_checked_at" \
+  --argjson stale_min "$STALE_MIN" \
+  --argjson lanes "$lanes_json" \
+  '{
+    last_checked_at: $ts,
+    stale_threshold_minutes: $stale_min,
+    lanes: $lanes
+  }')
+
+echo "$final_json" > "$TMP_FILE"
+mv "$TMP_FILE" "$OUTPUT_FILE"
+
+# ---------------------------------------------------------------------------
+# Optional --print summary table
+# ---------------------------------------------------------------------------
+if [ "$PRINT_SUMMARY" = "true" ]; then
+  echo "Lane Status — $(date -u '+%Y-%m-%dT%H:%M:%SZ') (stale > ${STALE_MIN}m)"
+  echo "---------------------------------------------------------------"
+  echo "$final_json" | jq -r '.lanes[] | "\(.name)\t issues:\((.issues | length))\t branches:\((.branches | length))\t stale:\(.is_stale)"'
+  echo "---------------------------------------------------------------"
+  echo "Written: $OUTPUT_FILE"
+fi

--- a/scripts/lane-status.sh
+++ b/scripts/lane-status.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Mercury cross-lane status aggregator (Issue #322, Phase A).
 # Polls GitHub Issues with lane:* labels + last-commit timestamps on lane branches.
 # Writes .mercury/state/lane-status.json with 15-min staleness gate.
@@ -92,9 +92,10 @@ while IFS= read -r label_name; do
     [ -z "$ref_line" ] && continue
     # ref_line format: "<sha>\trefs/heads/<branch>"
     ref_branch=$(echo "$ref_line" | awk '{print $2}' | sed 's|refs/heads/||' | tr -d '\r')
-    # M1: use TZ=UTC --date format to get UTC timestamp directly, avoiding
-    # %cI's +HH:MM form which BSD date -j cannot parse.
-    last_commit_at=$(git -C "$REPO_ROOT" log -1 \
+    # M1: TZ=UTC + --date=format-local emits the timestamp in UTC, then the
+    # literal Z suffix is honest. Without TZ=UTC, format-local would format in
+    # the local zone but still tack on Z, mislabeling the value (Copilot finding).
+    last_commit_at=$(TZ=UTC git -C "$REPO_ROOT" log -1 \
       --date=format-local:'%Y-%m-%dT%H:%M:%SZ' \
       --format=%cd \
       "origin/${ref_branch}" 2>/dev/null | tr -d '\r' || true)
@@ -169,9 +170,10 @@ final_json=$(jq -n \
 
 OUTPUT_FILE="$STATE_DIR/lane-status.json"
 echo "$final_json" > "$TMP_FILE"
-# Atomic rename; disarm the EXIT trap first so we don't delete the file we just wrote.
-trap - EXIT
-mv "$TMP_FILE" "$OUTPUT_FILE"
+# Atomic rename. Disarm the EXIT trap only AFTER mv succeeds so a failed mv
+# (permission denied, ENOSPC, …) still triggers the cleanup trap and removes
+# the orphaned temp file.
+mv "$TMP_FILE" "$OUTPUT_FILE" && trap - EXIT
 
 # Optional --print summary table.
 if [ "$PRINT_SUMMARY" = "true" ]; then

--- a/scripts/lane-status.sh
+++ b/scripts/lane-status.sh
@@ -10,8 +10,12 @@
 
 set -euo pipefail
 
-# Config
+# Config — numeric-guard MERCURY_LANE_STALE_MIN so a malformed env var (e.g. "abc")
+# doesn't crash arithmetic eval downstream or inject garbage into jq --argjson.
 STALE_MIN=${MERCURY_LANE_STALE_MIN:-15}
+case "$STALE_MIN" in
+  ''|*[!0-9]*) STALE_MIN=15 ;;
+esac
 PRINT_SUMMARY=false
 for arg in "$@"; do
   [ "$arg" = "--print" ] && PRINT_SUMMARY=true

--- a/scripts/lib/date-utils.sh
+++ b/scripts/lib/date-utils.sh
@@ -9,45 +9,43 @@
 #   normalize_iso <iso_timestamp> — strips +HH:MM / -HH:MM timezone suffix to Z-form
 #                                   so BSD date -j can parse it.
 
-# normalize_iso: convert "2026-04-26T12:34:56+00:00" → "2026-04-26T12:34:56Z"
-# Works for any +HH:MM or -HH:MM offset by stripping the offset (treating as UTC
-# for staleness purposes — sub-hour TZ differences are irrelevant for a 15-min gate).
+# normalize_iso: strip a +HH:MM / -HH:MM offset suffix to a literal "Z" so that BSD
+# `date -j -f "%Y-%m-%dT%H:%M:%SZ"` can parse it. The offset is DROPPED, not converted —
+# this is lossy and only safe when the BSD fallback path is reached. GNU `date -d` and
+# `gdate -d` parse offsets natively, so they MUST receive the original timestamp (not
+# the normalized form) to avoid silent UTC drift on inputs like "2026-04-26T12:00:00+08:00".
 normalize_iso() {
   local ts="$1"
-  # Already Z-suffixed: return as-is
   if [[ "$ts" == *Z ]]; then
     echo "$ts"
     return
   fi
-  # Strip trailing +HH:MM or -HH:MM (including +00:00 and -00:00 forms)
   echo "$ts" | sed 's/[+-][0-9][0-9]:[0-9][0-9]$/Z/'
 }
 
 # parse_epoch: convert ISO 8601 timestamp to Unix epoch integer.
 # Strategy (in order):
-#   1. TZ=UTC date -d   (GNU/Linux)
-#   2. gdate -d         (GNU coreutils on macOS via brew)
-#   3. BSD date -j -f   (macOS built-in, requires Z-normalized input)
+#   1. TZ=UTC date -d   (GNU/Linux, parses offset natively — pass raw $ts)
+#   2. gdate -d         (GNU coreutils on macOS via brew, parses offset natively — raw $ts)
+#   3. BSD date -j -f   (macOS built-in, requires Z-form — uses normalize_iso, drops offset)
 #   4. Fallback: 0
+# Mercury sources (git --date=format-local Z, gh API Z) all emit Z-form, so the BSD path's
+# offset-drop is a no-op in practice. This ordering preserves correctness if a non-Z source
+# is ever introduced.
 parse_epoch() {
   local ts="$1"
   [ -z "$ts" ] && echo 0 && return
 
-  local norm
-  norm="$(normalize_iso "$ts")"
-
-  # Try GNU date -d (Linux)
   local epoch
-  epoch="$(TZ=UTC date -d "$norm" +%s 2>/dev/null)" && echo "$epoch" && return
+  epoch="$(TZ=UTC date -d "$ts" +%s 2>/dev/null)" && echo "$epoch" && return
 
-  # Try gdate (GNU coreutils on macOS via brew)
   if command -v gdate > /dev/null 2>&1; then
-    epoch="$(TZ=UTC gdate -d "$norm" +%s 2>/dev/null)" && echo "$epoch" && return
+    epoch="$(TZ=UTC gdate -d "$ts" +%s 2>/dev/null)" && echo "$epoch" && return
   fi
 
-  # Try BSD date -j (macOS built-in); requires Z-normalized input
+  local norm
+  norm="$(normalize_iso "$ts")"
   epoch="$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$norm" +%s 2>/dev/null)" && echo "$epoch" && return
 
-  # All parsers failed — return 0
   echo 0
 }

--- a/scripts/lib/date-utils.sh
+++ b/scripts/lib/date-utils.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# scripts/lib/date-utils.sh — portable date parsing helpers for Mercury scripts.
+# Source this file; do not execute directly.
+#
+# Provides:
+#   parse_epoch <iso_timestamp>  — converts ISO 8601 string to Unix epoch (seconds).
+#                                   Handles both Linux `date -d` and BSD `date -j`.
+#                                   Falls back to 0 on parse failure.
+#   normalize_iso <iso_timestamp> — strips +HH:MM / -HH:MM timezone suffix to Z-form
+#                                   so BSD date -j can parse it.
+
+# normalize_iso: convert "2026-04-26T12:34:56+00:00" → "2026-04-26T12:34:56Z"
+# Works for any +HH:MM or -HH:MM offset by stripping the offset (treating as UTC
+# for staleness purposes — sub-hour TZ differences are irrelevant for a 15-min gate).
+normalize_iso() {
+  local ts="$1"
+  # Already Z-suffixed: return as-is
+  if [[ "$ts" == *Z ]]; then
+    echo "$ts"
+    return
+  fi
+  # Strip trailing +HH:MM or -HH:MM (including +00:00 and -00:00 forms)
+  echo "$ts" | sed 's/[+-][0-9][0-9]:[0-9][0-9]$/Z/'
+}
+
+# parse_epoch: convert ISO 8601 timestamp to Unix epoch integer.
+# Strategy (in order):
+#   1. TZ=UTC date -d   (GNU/Linux)
+#   2. gdate -d         (GNU coreutils on macOS via brew)
+#   3. BSD date -j -f   (macOS built-in, requires Z-normalized input)
+#   4. Fallback: 0
+parse_epoch() {
+  local ts="$1"
+  [ -z "$ts" ] && echo 0 && return
+
+  local norm
+  norm="$(normalize_iso "$ts")"
+
+  # Try GNU date -d (Linux)
+  local epoch
+  epoch="$(TZ=UTC date -d "$norm" +%s 2>/dev/null)" && echo "$epoch" && return
+
+  # Try gdate (GNU coreutils on macOS via brew)
+  if command -v gdate > /dev/null 2>&1; then
+    epoch="$(TZ=UTC gdate -d "$norm" +%s 2>/dev/null)" && echo "$epoch" && return
+  fi
+
+  # Try BSD date -j (macOS built-in); requires Z-normalized input
+  epoch="$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$norm" +%s 2>/dev/null)" && echo "$epoch" && return
+
+  # All parsers failed — return 0
+  echo 0
+}

--- a/scripts/lib/date-utils.sh
+++ b/scripts/lib/date-utils.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # scripts/lib/date-utils.sh — portable date parsing helpers for Mercury scripts.
 # Source this file; do not execute directly.
 #

--- a/scripts/statusline-mercury.sh
+++ b/scripts/statusline-mercury.sh
@@ -42,8 +42,11 @@ now=$(date +%s)
 
 # FLOOR (not round) for threshold comparison — avoid early false-trigger when 94.6% rounds to 95.
 # Rationale: pause should fire at "definitely >=95", not "rounds to >=95".
+# Numeric-guard: any non-digit input (NaN, empty, "soon", malformed JSON) coerces to 0.
 pct_floor=$(echo "$five_hour_pct" | cut -d. -f1)
-[ -z "$pct_floor" ] && pct_floor=0
+case "$pct_floor" in
+  ''|*[!0-9]*) pct_floor=0 ;;
+esac
 
 # Pause logic: write marker if FLOORED threshold exceeded (only when in a git repo)
 if [ -n "$MARKER" ]; then

--- a/scripts/statusline-mercury.sh
+++ b/scripts/statusline-mercury.sh
@@ -49,6 +49,12 @@ pct_floor=$(echo "$five_hour_pct" | cut -d. -f1)
 if [ -n "$MARKER" ]; then
   if [ "$pct_floor" -ge "$PAUSE_THRESHOLD" ]; then
     mkdir -p "$STATE_DIR"
+    # m3: coerce non-numeric resets_at to 0 before writing marker (defense-in-depth).
+    if ! [[ "$resets_at" =~ ^[0-9]+$ ]]; then
+      resets_at=0
+    fi
+    # Note: marker write is non-atomic (no flock for Windows MINGW portability).
+    # Concurrent statusline refreshes converge within one refresh cycle.
     echo "$resets_at" > "$MARKER"
   # Resume logic: delete marker only after BOTH (a) stored window passed AND (b) current usage
   # also below threshold. Two-source confirmation reduces false-positive resume risk.

--- a/scripts/statusline-mercury.sh
+++ b/scripts/statusline-mercury.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Mercury 5h-quota statusline (Issue #322 / #320, PR #321 §Dim 4.4 spec).
+# Reads Claude Code statusline JSON via stdin; writes .mercury/state/auto-run-paused
+# when 5h usage >= PAUSE_THRESHOLD (default 95). Two-source resume confirmation.
+# REPO_ROOT via $CLAUDE_PROJECT_DIR (preferred) or git rev-parse fallback.
+# See PR #321 research doc for full rationale on FLOOR-not-round + non-strict semantics.
+
+# Note: NOT using `set -euo pipefail` here because statusline runs frequently in arbitrary cwds
+# (any user shell prompt). A non-zero exit from `set -e` would break the Claude Code UI display
+# in non-repo directories. Instead, every external command is wrapped with `|| true` and explicit
+# null-checks below.
+
+PAUSE_THRESHOLD=${MERCURY_PAUSE_THRESHOLD:-95}  # per Issue #320 acceptance >=95%
+WARN_THRESHOLD=${MERCURY_WARN_THRESHOLD:-85}    # early-warning color only
+
+# Resolve repo root via $CLAUDE_PROJECT_DIR (Claude Code-injected env var, set in any session
+# attached to a project) FIRST; fall back to git rev-parse for non-Claude shells.
+# Support MERCURY_TEST_REPO_ROOT override for test isolation.
+if [ -n "${MERCURY_TEST_REPO_ROOT:-}" ]; then
+  REPO_ROOT="$MERCURY_TEST_REPO_ROOT"
+elif [ -n "${CLAUDE_PROJECT_DIR:-}" ] && [ -d "$CLAUDE_PROJECT_DIR/.git" ]; then
+  REPO_ROOT="$CLAUDE_PROJECT_DIR"
+else
+  REPO_ROOT="$(git -C "$(pwd)" rev-parse --show-toplevel 2>/dev/null || true)"
+fi
+
+if [ -z "$REPO_ROOT" ]; then
+  # Outside any git repo / Mercury project: still display usage but skip marker writes.
+  STATE_DIR=""
+  MARKER=""
+else
+  STATE_DIR="$REPO_ROOT/.mercury/state"
+  MARKER="$STATE_DIR/auto-run-paused"
+fi
+
+input=$(cat)
+
+# Extract rate_limits fields (null-safe with // 0 / // "")
+five_hour_pct=$(echo "$input" | jq -r '.rate_limits.five_hour.used_percentage // 0')
+resets_at=$(echo "$input" | jq -r '.rate_limits.five_hour.resets_at // 0')
+now=$(date +%s)
+
+# FLOOR (not round) for threshold comparison — avoid early false-trigger when 94.6% rounds to 95.
+# Rationale: pause should fire at "definitely >=95", not "rounds to >=95".
+pct_floor=$(echo "$five_hour_pct" | cut -d. -f1)
+[ -z "$pct_floor" ] && pct_floor=0
+
+# Pause logic: write marker if FLOORED threshold exceeded (only when in a git repo)
+if [ -n "$MARKER" ]; then
+  if [ "$pct_floor" -ge "$PAUSE_THRESHOLD" ]; then
+    mkdir -p "$STATE_DIR"
+    echo "$resets_at" > "$MARKER"
+  # Resume logic: delete marker only after BOTH (a) stored window passed AND (b) current usage
+  # also below threshold. Two-source confirmation reduces false-positive resume risk.
+  elif [ -f "$MARKER" ]; then
+    stored_reset=$(cat "$MARKER" 2>/dev/null || echo 0)
+    if ! [[ "$stored_reset" =~ ^[0-9]+$ ]]; then
+      echo "[statusline-mercury] Invalid pause marker; removing corrupted file." >&2
+      rm -f "$MARKER"
+    elif [ "$now" -ge "$stored_reset" ] && [ "$pct_floor" -lt "$PAUSE_THRESHOLD" ]; then
+      # Both signals agree usage has cleared: stored window expired AND current % < threshold.
+      rm -f "$MARKER"
+    fi
+    # If only one signal clears, leave marker in place — next refresh re-evaluates.
+  fi
+fi
+
+# Display output (display rounds for readability, but pause logic uses floor)
+pct_bar=$(printf '%.0f' "$five_hour_pct" 2>/dev/null || echo "?")
+seven_pct=$(echo "$input" | jq -r '.rate_limits.seven_day.used_percentage // "?"')
+model=$(echo "$input" | jq -r '.model.display_name // "?"')
+ctx=$(echo "$input" | jq -r '.context_window.used_percentage // 0' | cut -d. -f1)
+
+# Color code: green < 70%, yellow at 70 or WARN_THRESHOLD (default 85), red at PAUSE_THRESHOLD (default 95)
+if [ "$pct_floor" -ge "$PAUSE_THRESHOLD" ]; then color='\033[31m'  # red — pause point
+elif [ "$pct_floor" -ge "$WARN_THRESHOLD" ]; then color='\033[33m' # yellow — early warn
+elif [ "$pct_floor" -ge 70 ]; then color='\033[33m'                 # yellow — soft warn
+else color='\033[32m'                                                # green
+fi
+reset='\033[0m'
+
+echo -e "${color}5h: ${pct_bar}%${reset} | 7d: ${seven_pct}% | ctx: ${ctx}% | ${model}"

--- a/scripts/statusline-mercury.sh
+++ b/scripts/statusline-mercury.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Mercury 5h-quota statusline (Issue #322 / #320, PR #321 §Dim 4.4 spec).
 # Reads Claude Code statusline JSON via stdin; writes .mercury/state/auto-run-paused
 # when 5h usage >= PAUSE_THRESHOLD (default 95). Two-source resume confirmation.
@@ -35,9 +35,10 @@ fi
 
 input=$(cat)
 
-# Extract rate_limits fields (null-safe with // 0 / // "")
-five_hour_pct=$(echo "$input" | jq -r '.rate_limits.five_hour.used_percentage // 0')
-resets_at=$(echo "$input" | jq -r '.rate_limits.five_hour.resets_at // 0')
+# Extract rate_limits fields (null-safe with // 0 / // ""). jq stderr suppressed +
+# fallback to 0/"?" so missing-jq or invalid-stdin can't pollute the statusline UI.
+five_hour_pct=$(echo "$input" | jq -r '.rate_limits.five_hour.used_percentage // 0' 2>/dev/null || echo 0)
+resets_at=$(echo "$input" | jq -r '.rate_limits.five_hour.resets_at // 0' 2>/dev/null || echo 0)
 now=$(date +%s)
 
 # FLOOR (not round) for threshold comparison — avoid early false-trigger when 94.6% rounds to 95.
@@ -74,11 +75,15 @@ if [ -n "$MARKER" ]; then
   fi
 fi
 
-# Display output (display rounds for readability, but pause logic uses floor)
+# Display output (display rounds for readability, but pause logic uses floor).
+# jq stderr suppressed + fallback so a missing jq doesn't pollute the prompt UI.
 pct_bar=$(printf '%.0f' "$five_hour_pct" 2>/dev/null || echo "?")
-seven_pct=$(echo "$input" | jq -r '.rate_limits.seven_day.used_percentage // "?"')
-model=$(echo "$input" | jq -r '.model.display_name // "?"')
-ctx=$(echo "$input" | jq -r '.context_window.used_percentage // 0' | cut -d. -f1)
+seven_pct=$(echo "$input" | jq -r '.rate_limits.seven_day.used_percentage // "?"' 2>/dev/null || echo "?")
+model=$(echo "$input" | jq -r '.model.display_name // "?"' 2>/dev/null || echo "?")
+ctx=$(echo "$input" | jq -r '.context_window.used_percentage // 0' 2>/dev/null | cut -d. -f1)
+case "$ctx" in
+  ''|*[!0-9]*) ctx=0 ;;
+esac
 
 # Color code: green < 70%, yellow at 70 or WARN_THRESHOLD (default 85), red at PAUSE_THRESHOLD (default 95)
 if [ "$pct_floor" -ge "$PAUSE_THRESHOLD" ]; then color='\033[31m'  # red — pause point

--- a/scripts/statusline-mercury.sh
+++ b/scripts/statusline-mercury.sh
@@ -12,6 +12,10 @@
 
 PAUSE_THRESHOLD=${MERCURY_PAUSE_THRESHOLD:-95}  # per Issue #320 acceptance >=95%
 WARN_THRESHOLD=${MERCURY_WARN_THRESHOLD:-85}    # early-warning color only
+# Numeric-guard env overrides — a malformed value (e.g. "abc") would otherwise
+# crash the integer comparisons below with "[: integer expression expected".
+case "$PAUSE_THRESHOLD" in ''|*[!0-9]*) PAUSE_THRESHOLD=95 ;; esac
+case "$WARN_THRESHOLD" in ''|*[!0-9]*) WARN_THRESHOLD=85 ;; esac
 
 # Resolve repo root via $CLAUDE_PROJECT_DIR (Claude Code-injected env var, set in any session
 # attached to a project) FIRST; fall back to git rev-parse for non-Claude shells.

--- a/scripts/test-lane-status.sh
+++ b/scripts/test-lane-status.sh
@@ -68,19 +68,20 @@ cat > "$STUB_BIN/git" << 'GITSTUB'
 #!/bin/bash
 # Stub git for lane-status.sh tests
 
-if [[ "$*" == *"ls-remote"*"feature/lane-*"* ]]; then
-  echo "abc123def456	refs/heads/feature/lane-main/TASK-001"
-  echo "789xyz000111	refs/heads/feature/lane-side-multi-lane/TASK-309"
+if [[ "$*" == *"ls-remote"* ]]; then
+  printf '%s\t%s\n' 'abc123def456' 'refs/heads/feature/lane-main/TASK-001'
+  printf '%s\t%s\n' '789xyz000111' 'refs/heads/feature/lane-side-multi-lane/TASK-309'
   exit 0
 fi
 
-if [[ "$*" == *"log"*"-1"*"--format=%cI"* ]]; then
-  echo "2026-04-26T10:00:00+00:00"
+if [[ "$*" == *"log"* ]]; then
+  echo "2026-04-26T10:00:00Z"
   exit 0
 fi
 
-# Pass through all other git commands to the real git
-exec "$(which git)" "$@"
+# Pass through all other git commands to the real git (hardcoded to avoid
+# infinite recursion when this stub directory is first on PATH).
+exec '/mingw64/bin/git' "$@"
 GITSTUB
 chmod +x "$STUB_BIN/git"
 
@@ -167,6 +168,129 @@ if echo "$PRINT_OUT" | grep -q "Lane Status"; then
 else
   fail "T3 --print produces summary header" "stdout: $PRINT_OUT"
 fi
+
+# ---------------------------------------------------------------------------
+# T_DATE — staleness / date-parsing test (validates M1 fix)
+# Stubs git log to return a controlled timestamp; asserts is_stale accordingly.
+# Uses a fresh STUB_DATE bin prepended to PATH for each subtest.
+# Real git binary resolved once at test-script start to avoid infinite recursion.
+# ---------------------------------------------------------------------------
+
+REAL_GIT="$(command -v git)"
+# In case our own STUB_BIN/git is on PATH, walk PATH to find the real one
+for _p in $(echo "$PATH" | tr ':' '\n'); do
+  _g="$_p/git"
+  if [ -x "$_g" ] && [ "$_p" != "$STUB_BIN" ]; then
+    REAL_GIT="$_g"
+    break
+  fi
+done
+
+# T_DATE.1: branch committed 30 seconds ago → is_stale: false
+# Issue updatedAt is set far in the future so it never triggers stale alone;
+# branch timestamp is the controlling signal.
+FRESH_TS="$(date -u -d '30 seconds ago' '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || \
+            date -u -v-30S '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || \
+            date -u '+%Y-%m-%dT%H:%M:%SZ')"
+
+STUB_DATE1="/tmp/mercury-lane-status-stubs-date1-$$"
+mkdir -p "$STUB_DATE1"
+
+# Write gh stub: single lane:main, issue updated far in future (never stale)
+printf '%s\n' '#!/bin/bash' \
+  'if [[ "$*" == *"label list"* ]]; then' \
+  '  echo '"'"'[{"name":"lane:main"}]'"'"'; exit 0; fi' \
+  'if [[ "$*" == *"issue list"* ]]; then' \
+  '  echo '"'"'[{"number":1,"title":"Fresh issue","labels":[{"name":"lane:main"}],"updatedAt":"2099-01-01T00:00:00Z"}]'"'"'; exit 0; fi' \
+  'echo '"'"'[]'"'"'; exit 0' > "$STUB_DATE1/gh"
+chmod +x "$STUB_DATE1/gh"
+
+# Write git stub: returns FRESH_TS for log; real git for everything else
+printf '%s\n' '#!/bin/bash' \
+  'if [[ "$*" == *"ls-remote"* ]]; then' \
+  "  printf '%s\t%s\n' 'aaabbbccc111' 'refs/heads/feature/lane-main/TASK-DATE'; exit 0; fi" \
+  'if [[ "$*" == *"log"* ]]; then' \
+  "  echo '$FRESH_TS'; exit 0; fi" \
+  "exec '$REAL_GIT' \"\$@\"" > "$STUB_DATE1/git"
+chmod +x "$STUB_DATE1/git"
+
+export PATH="$STUB_DATE1:$(echo "$PATH" | sed "s|${STUB_BIN}:||g")"
+
+rm -f "$REPO_ROOT/.mercury/state/lane-status.json"
+set +e
+bash "$LANE_STATUS" 2>/dev/null
+EXIT_D1=$?
+set -e
+
+if [ "$EXIT_D1" -ne 0 ]; then
+  fail "T_DATE.1 script exits 0 (fresh branch)" "exit code: $EXIT_D1"
+elif [ ! -f "$REPO_ROOT/.mercury/state/lane-status.json" ]; then
+  fail "T_DATE.1 output file created" "missing lane-status.json"
+else
+  # Use index 0 — T_DATE stubs emit exactly one lane
+  D1_STALE=$(jq -r '.lanes[0].is_stale' "$REPO_ROOT/.mercury/state/lane-status.json" 2>/dev/null || echo "missing")
+  D1_TS=$(jq -r '.lanes[0].branches[0].last_commit_at // ""' "$REPO_ROOT/.mercury/state/lane-status.json" 2>/dev/null || echo "")
+  if [ "$D1_STALE" = "false" ]; then
+    pass "T_DATE.1 is_stale=false for branch committed 30s ago"
+  else
+    fail "T_DATE.1 is_stale=false for branch committed 30s ago" "got is_stale=$D1_STALE ts=$D1_TS"
+  fi
+  if [ -n "$D1_TS" ] && [ "$D1_TS" != "null" ]; then
+    pass "T_DATE.1 last_commit_at is non-empty: $D1_TS"
+  else
+    fail "T_DATE.1 last_commit_at is non-empty" "got: $D1_TS (full json: $(cat "$REPO_ROOT/.mercury/state/lane-status.json"))"
+  fi
+fi
+
+rm -rf "$STUB_DATE1"
+
+# T_DATE.2: branch committed 1 hour ago → is_stale: true
+# Both issue and branch timestamps are stale so both signals agree.
+STALE_TS="$(date -u -d '1 hour ago' '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || \
+            date -u -v-1H '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || \
+            echo '2000-01-01T00:00:00Z')"
+
+STUB_DATE2="/tmp/mercury-lane-status-stubs-date2-$$"
+mkdir -p "$STUB_DATE2"
+
+printf '%s\n' '#!/bin/bash' \
+  'if [[ "$*" == *"label list"* ]]; then' \
+  '  echo '"'"'[{"name":"lane:main"}]'"'"'; exit 0; fi' \
+  'if [[ "$*" == *"issue list"* ]]; then' \
+  "  echo '[{\"number\":1,\"title\":\"Old\",\"labels\":[{\"name\":\"lane:main\"}],\"updatedAt\":\"$STALE_TS\"}]'; exit 0; fi" \
+  'echo '"'"'[]'"'"'; exit 0' > "$STUB_DATE2/gh"
+chmod +x "$STUB_DATE2/gh"
+
+printf '%s\n' '#!/bin/bash' \
+  'if [[ "$*" == *"ls-remote"* ]]; then' \
+  "  printf '%s\t%s\n' 'aaabbbccc222' 'refs/heads/feature/lane-main/TASK-DATE'; exit 0; fi" \
+  'if [[ "$*" == *"log"* ]]; then' \
+  "  echo '$STALE_TS'; exit 0; fi" \
+  "exec '$REAL_GIT' \"\$@\"" > "$STUB_DATE2/git"
+chmod +x "$STUB_DATE2/git"
+
+export PATH="$STUB_DATE2:$(echo "$PATH" | sed "s|${STUB_DATE1}:||g")"
+
+rm -f "$REPO_ROOT/.mercury/state/lane-status.json"
+set +e
+bash "$LANE_STATUS" 2>/dev/null
+EXIT_D2=$?
+set -e
+
+if [ "$EXIT_D2" -ne 0 ]; then
+  fail "T_DATE.2 script exits 0 (stale branch)" "exit code: $EXIT_D2"
+elif [ ! -f "$REPO_ROOT/.mercury/state/lane-status.json" ]; then
+  fail "T_DATE.2 output file created" "missing lane-status.json"
+else
+  D2_STALE=$(jq -r '.lanes[0].is_stale' "$REPO_ROOT/.mercury/state/lane-status.json" 2>/dev/null || echo "missing")
+  if [ "$D2_STALE" = "true" ]; then
+    pass "T_DATE.2 is_stale=true for branch committed 1h ago"
+  else
+    fail "T_DATE.2 is_stale=true for branch committed 1h ago" "got is_stale=$D2_STALE"
+  fi
+fi
+
+rm -rf "$STUB_DATE2"
 
 # ---------------------------------------------------------------------------
 # Results

--- a/scripts/test-lane-status.sh
+++ b/scripts/test-lane-status.sh
@@ -1,0 +1,179 @@
+#!/bin/bash
+# scripts/test-lane-status.sh — smoke test for lane-status.sh (Issue #322)
+# Stubs `gh` and `git` network calls to avoid hitting real GitHub.
+# Asserts output JSON is valid and contains required top-level keys.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LANE_STATUS="$SCRIPT_DIR/lane-status.sh"
+
+PASS=0
+FAIL=0
+
+pass() { echo "PASS: $1"; PASS=$(( PASS + 1 )); }
+fail() { echo "FAIL: $1 — $2"; FAIL=$(( FAIL + 1 )); }
+
+# ---------------------------------------------------------------------------
+# Setup: temp repo root + stub bin directory prepended to PATH
+# ---------------------------------------------------------------------------
+REPO_ROOT="/tmp/mercury-lane-status-test-$$"
+export MERCURY_TEST_REPO_ROOT="$REPO_ROOT"
+mkdir -p "$REPO_ROOT/.git"
+mkdir -p "$REPO_ROOT/.mercury/state"
+
+STUB_BIN="/tmp/mercury-lane-status-stubs-$$"
+mkdir -p "$STUB_BIN"
+
+cleanup() {
+  rm -rf "$REPO_ROOT" "$STUB_BIN"
+}
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Stub `gh` — emits canned responses
+# ---------------------------------------------------------------------------
+cat > "$STUB_BIN/gh" << 'GHSTUB'
+#!/bin/bash
+# Stub gh for lane-status.sh tests
+
+# gh label list --limit 100 --json name
+if [[ "$*" == *"label list"* ]]; then
+  echo '[{"name":"lane:main"},{"name":"lane:side-multi-lane"}]'
+  exit 0
+fi
+
+# gh issue list --label "lane:main" ...
+if [[ "$*" == *"lane:main"* ]]; then
+  echo '[{"number":301,"title":"Main lane test issue","labels":[{"name":"lane:main"}],"updatedAt":"2026-04-26T10:00:00Z"}]'
+  exit 0
+fi
+
+# gh issue list --label "lane:side-multi-lane" ...
+if [[ "$*" == *"lane:side-multi-lane"* ]]; then
+  echo '[{"number":309,"title":"Side lane test issue","labels":[{"name":"lane:side-multi-lane"}],"updatedAt":"2026-04-26T10:05:00Z"}]'
+  exit 0
+fi
+
+# Default: empty list
+echo '[]'
+exit 0
+GHSTUB
+chmod +x "$STUB_BIN/gh"
+
+# ---------------------------------------------------------------------------
+# Stub `git` — intercepts ls-remote and log; passes other git commands through
+# ---------------------------------------------------------------------------
+cat > "$STUB_BIN/git" << 'GITSTUB'
+#!/bin/bash
+# Stub git for lane-status.sh tests
+
+if [[ "$*" == *"ls-remote"*"feature/lane-*"* ]]; then
+  echo "abc123def456	refs/heads/feature/lane-main/TASK-001"
+  echo "789xyz000111	refs/heads/feature/lane-side-multi-lane/TASK-309"
+  exit 0
+fi
+
+if [[ "$*" == *"log"*"-1"*"--format=%cI"* ]]; then
+  echo "2026-04-26T10:00:00+00:00"
+  exit 0
+fi
+
+# Pass through all other git commands to the real git
+exec "$(which git)" "$@"
+GITSTUB
+chmod +x "$STUB_BIN/git"
+
+# Prepend stub bin to PATH
+export PATH="$STUB_BIN:$PATH"
+
+# ---------------------------------------------------------------------------
+# Test 1 — valid JSON output with required top-level keys
+# ---------------------------------------------------------------------------
+OUTPUT_FILE="$REPO_ROOT/.mercury/state/lane-status.json"
+
+set +e
+bash "$LANE_STATUS" 2>/dev/null
+EXIT_CODE=$?
+set -e
+
+if [ "$EXIT_CODE" -ne 0 ]; then
+  fail "T1 script exited non-zero" "exit code: $EXIT_CODE"
+else
+  pass "T1 script exits 0"
+fi
+
+if [ ! -f "$OUTPUT_FILE" ]; then
+  fail "T1 output file exists" "lane-status.json not created"
+else
+  pass "T1 output file created"
+fi
+
+# Validate JSON structure
+if jq -e 'has("last_checked_at") and has("lanes") and has("stale_threshold_minutes")' \
+       "$OUTPUT_FILE" > /dev/null 2>&1; then
+  pass "T1 JSON has required top-level keys"
+else
+  fail "T1 JSON has required top-level keys" "$(cat "$OUTPUT_FILE" 2>/dev/null | head -3)"
+fi
+
+# Validate lanes is an array
+if jq -e '.lanes | type == "array"' "$OUTPUT_FILE" > /dev/null 2>&1; then
+  pass "T1 lanes is an array"
+else
+  fail "T1 lanes is an array" "$(jq '.lanes' "$OUTPUT_FILE" 2>/dev/null)"
+fi
+
+# Validate last_checked_at is a non-empty string
+LAST_CHECKED=$(jq -r '.last_checked_at' "$OUTPUT_FILE" 2>/dev/null)
+if [ -n "$LAST_CHECKED" ] && [ "$LAST_CHECKED" != "null" ]; then
+  pass "T1 last_checked_at is set: $LAST_CHECKED"
+else
+  fail "T1 last_checked_at is set" "got: $LAST_CHECKED"
+fi
+
+# Validate stale_threshold_minutes is numeric
+STALE_MIN=$(jq -r '.stale_threshold_minutes' "$OUTPUT_FILE" 2>/dev/null)
+if [[ "$STALE_MIN" =~ ^[0-9]+$ ]]; then
+  pass "T1 stale_threshold_minutes is numeric: $STALE_MIN"
+else
+  fail "T1 stale_threshold_minutes is numeric" "got: $STALE_MIN"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2 — each lane entry has required fields
+# ---------------------------------------------------------------------------
+LANE_COUNT=$(jq '.lanes | length' "$OUTPUT_FILE" 2>/dev/null)
+if [ "$LANE_COUNT" -ge 1 ]; then
+  pass "T2 at least one lane in output (got $LANE_COUNT)"
+else
+  fail "T2 at least one lane in output" "got $LANE_COUNT"
+fi
+
+if jq -e '.lanes[] | has("name") and has("issues") and has("branches") and has("is_stale")' \
+       "$OUTPUT_FILE" > /dev/null 2>&1; then
+  pass "T2 each lane has name/issues/branches/is_stale"
+else
+  fail "T2 each lane has name/issues/branches/is_stale" \
+       "$(jq '.lanes[0]' "$OUTPUT_FILE" 2>/dev/null)"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3 — --print flag produces human-readable stdout
+# ---------------------------------------------------------------------------
+PRINT_OUT=$(bash "$LANE_STATUS" --print 2>/dev/null)
+if echo "$PRINT_OUT" | grep -q "Lane Status"; then
+  pass "T3 --print produces summary header"
+else
+  fail "T3 --print produces summary header" "stdout: $PRINT_OUT"
+fi
+
+# ---------------------------------------------------------------------------
+# Results
+# ---------------------------------------------------------------------------
+echo ""
+echo "Results: $PASS passed, $FAIL failed (total $(( PASS + FAIL )))"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/scripts/test-lane-status.sh
+++ b/scripts/test-lane-status.sh
@@ -30,6 +30,18 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Resolve the real git binary BEFORE prepending STUB_BIN to PATH so stubs can
+# delegate without infinite recursion. Walk PATH and skip STUB_BIN entries.
+REAL_GIT=""
+for _p in $(echo "$PATH" | tr ':' '\n'); do
+  _g="$_p/git"
+  if [ -x "$_g" ] && [ "$_p" != "$STUB_BIN" ]; then
+    REAL_GIT="$_g"
+    break
+  fi
+done
+[ -z "$REAL_GIT" ] && { echo "FAIL: real git not found on PATH" >&2; exit 1; }
+
 # ---------------------------------------------------------------------------
 # Stub `gh` — emits canned responses
 # ---------------------------------------------------------------------------
@@ -61,28 +73,15 @@ exit 0
 GHSTUB
 chmod +x "$STUB_BIN/gh"
 
-# ---------------------------------------------------------------------------
-# Stub `git` — intercepts ls-remote and log; passes other git commands through
-# ---------------------------------------------------------------------------
-cat > "$STUB_BIN/git" << 'GITSTUB'
-#!/bin/bash
-# Stub git for lane-status.sh tests
-
-if [[ "$*" == *"ls-remote"* ]]; then
-  printf '%s\t%s\n' 'abc123def456' 'refs/heads/feature/lane-main/TASK-001'
-  printf '%s\t%s\n' '789xyz000111' 'refs/heads/feature/lane-side-multi-lane/TASK-309'
-  exit 0
-fi
-
-if [[ "$*" == *"log"* ]]; then
-  echo "2026-04-26T10:00:00Z"
-  exit 0
-fi
-
-# Pass through all other git commands to the real git (hardcoded to avoid
-# infinite recursion when this stub directory is first on PATH).
-exec '/mingw64/bin/git' "$@"
-GITSTUB
+# Stub `git` — intercepts ls-remote and log; delegates other git commands to REAL_GIT.
+printf '%s\n' '#!/bin/bash' \
+  'if [[ "$*" == *"ls-remote"* ]]; then' \
+  "  printf '%s\t%s\n' 'abc123def456' 'refs/heads/feature/lane-main/TASK-001'" \
+  "  printf '%s\t%s\n' '789xyz000111' 'refs/heads/feature/lane-side-multi-lane/TASK-309'" \
+  '  exit 0; fi' \
+  'if [[ "$*" == *"log"* ]]; then' \
+  '  echo "2026-04-26T10:00:00Z"; exit 0; fi' \
+  "exec '$REAL_GIT' \"\$@\"" > "$STUB_BIN/git"
 chmod +x "$STUB_BIN/git"
 
 # Prepend stub bin to PATH
@@ -169,22 +168,9 @@ else
   fail "T3 --print produces summary header" "stdout: $PRINT_OUT"
 fi
 
-# ---------------------------------------------------------------------------
-# T_DATE — staleness / date-parsing test (validates M1 fix)
+# T_DATE — staleness / date-parsing test (validates M1 fix).
 # Stubs git log to return a controlled timestamp; asserts is_stale accordingly.
-# Uses a fresh STUB_DATE bin prepended to PATH for each subtest.
-# Real git binary resolved once at test-script start to avoid infinite recursion.
-# ---------------------------------------------------------------------------
-
-REAL_GIT="$(command -v git)"
-# In case our own STUB_BIN/git is on PATH, walk PATH to find the real one
-for _p in $(echo "$PATH" | tr ':' '\n'); do
-  _g="$_p/git"
-  if [ -x "$_g" ] && [ "$_p" != "$STUB_BIN" ]; then
-    REAL_GIT="$_g"
-    break
-  fi
-done
+# REAL_GIT was resolved at test-script start (above) so subtest stubs reuse it.
 
 # T_DATE.1: branch committed 30 seconds ago → is_stale: false
 # Issue updatedAt is set far in the future so it never triggers stale alone;

--- a/scripts/test-lane-status.sh
+++ b/scripts/test-lane-status.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # scripts/test-lane-status.sh — smoke test for lane-status.sh (Issue #322)
 # Stubs `gh` and `git` network calls to avoid hitting real GitHub.
 # Asserts output JSON is valid and contains required top-level keys.

--- a/scripts/test-statusline-mercury.sh
+++ b/scripts/test-statusline-mercury.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+# scripts/test-statusline-mercury.sh — smoke tests for statusline-mercury.sh (Issue #322)
+# Tests: display output, pause trigger, FLOOR-not-round, boundary 95.0,
+#        corrupted marker self-heal, two-source resume, partial resume guard.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STATUSLINE="$SCRIPT_DIR/statusline-mercury.sh"
+
+PASS=0
+FAIL=0
+
+# ---------------------------------------------------------------------------
+# Test harness helpers
+# ---------------------------------------------------------------------------
+pass() { echo "PASS: $1"; PASS=$(( PASS + 1 )); }
+fail() { echo "FAIL: $1"; FAIL=$(( FAIL + 1 )); }
+
+assert_contains() {
+  local label="$1" output="$2" needle="$3"
+  if echo "$output" | grep -qF "$needle"; then
+    pass "$label"
+  else
+    fail "$label — expected to find '$needle' in: $output"
+  fi
+}
+
+assert_not_contains() {
+  local label="$1" output="$2" needle="$3"
+  if ! echo "$output" | grep -qF "$needle"; then
+    pass "$label"
+  else
+    fail "$label — expected NOT to find '$needle' in: $output"
+  fi
+}
+
+assert_file_exists() {
+  local label="$1" path="$2"
+  if [ -f "$path" ]; then
+    pass "$label"
+  else
+    fail "$label — file not found: $path"
+  fi
+}
+
+assert_file_not_exists() {
+  local label="$1" path="$2"
+  if [ ! -f "$path" ]; then
+    pass "$label"
+  else
+    fail "$label — file unexpectedly exists: $path"
+  fi
+}
+
+assert_file_content() {
+  local label="$1" path="$2" expected="$3"
+  local actual
+  actual=$(cat "$path" 2>/dev/null || echo "")
+  if [ "$actual" = "$expected" ]; then
+    pass "$label"
+  else
+    fail "$label — expected '$expected', got '$actual'"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Setup: temp repo root (shared across tests, reset per test)
+# ---------------------------------------------------------------------------
+CLAUDE_PROJECT_DIR="/tmp/mercury-statusline-test-$$"
+export CLAUDE_PROJECT_DIR
+# statusline-mercury.sh checks $CLAUDE_PROJECT_DIR/.git to validate repo root
+mkdir -p "$CLAUDE_PROJECT_DIR/.git"
+mkdir -p "$CLAUDE_PROJECT_DIR/.mercury/state"
+MARKER="$CLAUDE_PROJECT_DIR/.mercury/state/auto-run-paused"
+
+cleanup() { rm -rf "$CLAUDE_PROJECT_DIR"; }
+trap cleanup EXIT
+
+reset_marker() { rm -f "$MARKER"; }
+
+BASE_JSON_TEMPLATE='{"rate_limits":{"five_hour":{"used_percentage":PCT,"resets_at":9999999999},"seven_day":{"used_percentage":18.3}},"model":{"display_name":"Opus 4.7"},"context_window":{"used_percentage":12}}'
+
+make_json() {
+  local pct="$1"
+  echo "${BASE_JSON_TEMPLATE//PCT/$pct}"
+}
+
+# ---------------------------------------------------------------------------
+# Test 1 — display only (42% usage, no pause)
+# ---------------------------------------------------------------------------
+reset_marker
+OUTPUT=$(make_json 42.0 | bash "$STATUSLINE" 2>/dev/null)
+assert_contains "T1 stdout contains '5h: 42%'" "$OUTPUT" "5h: 42%"
+assert_file_not_exists "T1 no marker created" "$MARKER"
+
+# ---------------------------------------------------------------------------
+# Test 2 — pause trigger (96.5% usage)
+# ---------------------------------------------------------------------------
+reset_marker
+make_json 96.5 | bash "$STATUSLINE" 2>/dev/null
+assert_file_exists "T2 marker created at 96.5%" "$MARKER"
+assert_file_content "T2 marker contains resets_at" "$MARKER" "9999999999"
+
+# ---------------------------------------------------------------------------
+# Test 3 — FLOOR-not-round: 94.6 floors to 94, must NOT trigger pause
+# ---------------------------------------------------------------------------
+reset_marker
+make_json 94.6 | bash "$STATUSLINE" 2>/dev/null
+assert_file_not_exists "T3 no marker at 94.6% (floors to 94)" "$MARKER"
+
+# ---------------------------------------------------------------------------
+# Test 4 — boundary 95.0: must trigger pause
+# ---------------------------------------------------------------------------
+reset_marker
+make_json 95.0 | bash "$STATUSLINE" 2>/dev/null
+assert_file_exists "T4 marker created at exactly 95.0%" "$MARKER"
+
+# ---------------------------------------------------------------------------
+# Test 5 — corrupted marker self-heal
+# Pre-create marker with non-numeric content; feed 50% usage.
+# Expect: marker deleted AND stderr contains corruption message.
+# ---------------------------------------------------------------------------
+reset_marker
+echo "not-a-number" > "$MARKER"
+STDERR_OUT=$(make_json 50.0 | bash "$STATUSLINE" 2>&1 >/dev/null)
+assert_file_not_exists "T5 corrupted marker deleted" "$MARKER"
+assert_contains "T5 stderr mentions corruption" "$STDERR_OUT" "corrupted"
+
+# ---------------------------------------------------------------------------
+# Test 6 — two-source resume: marker has expired timestamp (0), usage 50%
+# Both signals (stored_reset=0 <= now, pct < threshold) → marker removed.
+# ---------------------------------------------------------------------------
+reset_marker
+echo "0" > "$MARKER"
+make_json 50.0 | bash "$STATUSLINE" 2>/dev/null
+assert_file_not_exists "T6 expired marker removed when usage low" "$MARKER"
+
+# ---------------------------------------------------------------------------
+# Test 7 — partial resume: marker has expired timestamp (0), usage still 96%
+# Only one signal clears (timestamp expired) but usage still high → marker stays.
+# ---------------------------------------------------------------------------
+reset_marker
+echo "0" > "$MARKER"
+make_json 96.0 | bash "$STATUSLINE" 2>/dev/null
+assert_file_exists "T7 marker preserved when usage still high despite expired ts" "$MARKER"
+
+# ---------------------------------------------------------------------------
+# Results
+# ---------------------------------------------------------------------------
+echo ""
+echo "Results: $PASS passed, $FAIL failed (total $(( PASS + FAIL )))"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/scripts/test-statusline-mercury.sh
+++ b/scripts/test-statusline-mercury.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # scripts/test-statusline-mercury.sh — smoke tests for statusline-mercury.sh (Issue #322)
 # Tests: display output, pause trigger, FLOOR-not-round, boundary 95.0,
 #        corrupted marker self-heal, two-source resume, partial resume guard.

--- a/scripts/test-statusline-mercury.sh
+++ b/scripts/test-statusline-mercury.sh
@@ -146,6 +146,18 @@ make_json 96.0 | bash "$STATUSLINE" 2>/dev/null
 assert_file_exists "T7 marker preserved when usage still high despite expired ts" "$MARKER"
 
 # ---------------------------------------------------------------------------
+# Test 8 — m3: non-numeric resets_at is coerced to 0 in marker
+# Feed 96% usage with a non-numeric resets_at ("soon"). Expect:
+#   - marker created (pause triggered)
+#   - marker content is "0" (coerced), not "soon"
+# ---------------------------------------------------------------------------
+reset_marker
+NON_NUMERIC_JSON='{"rate_limits":{"five_hour":{"used_percentage":96.5,"resets_at":"soon"},"seven_day":{"used_percentage":18.3}},"model":{"display_name":"Opus 4.7"},"context_window":{"used_percentage":12}}'
+echo "$NON_NUMERIC_JSON" | bash "$STATUSLINE" 2>/dev/null
+assert_file_exists "T8 marker created with non-numeric resets_at" "$MARKER"
+assert_file_content "T8 marker coerced to 0 (not 'soon')" "$MARKER" "0"
+
+# ---------------------------------------------------------------------------
 # Results
 # ---------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
## Summary

Phase A of the agent-team-orchestration reframe (#318) — implements the
two CONDITIONAL_GO promotion gates from PR #321 research:

1. **A1 `scripts/statusline-mercury.sh`** (88 LOC) — Claude Code statusline
   reading `rate_limits.five_hour.used_percentage`, writing
   `.mercury/state/auto-run-paused` marker at ≥95%, two-source resume
   (timestamp expired AND current % below threshold), corrupted-marker
   self-heal, FLOOR-not-round semantics.

2. **A2 `scripts/lane-status.sh`** (183 LOC) — cross-lane aggregator
   polling `lane:*` GitHub Issues + `feature/lane-*` branch tips, writing
   `.mercury/state/lane-status.json` with `last_checked_at` ISO timestamp
   and 15-minute staleness gate. Atomic write via mktemp+mv.

3. **`scripts/lib/date-utils.sh`** (54 LOC) — portable `parse_epoch` /
   `normalize_iso` helpers (GNU `date -d` + BSD `date -j` + gdate
   fallback) sourced by lane-status.

4. **`.mercury/docs/guides/phase-a-install.md`** — install guide:
   symlink statusline-mercury.sh into `${CLAUDE_CONFIG_DIR}`,
   merge `settings.json` statusLine block (with backup), durable
   CronCreate registration for lane-status.sh, rollback steps,
   acceptance verification matrix.

## Phase A acceptance criteria (from PR #321 research §Phased PR Plan)

- [x] statusline displays 5h%, 7d%, ctx%, model
- [x] auto-run-paused marker created at ≥95%, deleted on window reset
- [x] corrupted marker self-heals without crash
- [x] lane-status.json updates with `last_checked_at` ISO
- [x] durable cron registration documented (manual step — Claude Code
      CronCreate `durable: true`)

## Test plan

- [x] `bash scripts/test-statusline-mercury.sh` → 12/12 PASS (display,
      pause-trigger 96.5%, FLOOR @ 94.6%, boundary @ 95.0%, corrupted
      marker self-heal, two-source resume, partial-resume guard,
      non-numeric resets_at coerce)
- [x] `bash scripts/test-lane-status.sh` → 12/12 PASS (JSON shape,
      lane fields, --print flag, T_DATE.1 fresh branch is_stale=false,
      T_DATE.2 stale branch is_stale=true)
- [x] Manual smoke from install guide (5h: 96% pause marker create + remove)
- [x] LOC cap compliance: lane-status.sh 183 ≤ 200 (Mercury CLAUDE.md
      adapter cap)

## Codex audit followup

Commit `b565f49` addresses 2 Major + 3 minor findings from parallel
Codex code-audit on the initial implementation (`806380e`):

- M1: BSD/macOS `date -j` portability (extracted to `lib/date-utils.sh`;
  `git log --date=format-local` for direct UTC ISO emit)
- M2: tolerate `gh` + `git ls-remote` network failure with `||` fallbacks
- m1: `mktemp` for unique tmp filename (concurrent cron safety)
- m2: `grep -F` for fixed-string lane id matching (regex-metachar safety)
- m5: realistic far-future `resets_at` (9999999999) in install guide mock

## References

Closes #322
Refs #320 (5h tooling)
Refs #318 (architecture reframe parent)

Generated with Claude Code