### PR TITLE
feat(phase-b): lane lifecycle scripts — spawn + close --close-issue (#323)

### DIFF
--- a/.mercury/docs/guides/lane-spawn.md
+++ b/.mercury/docs/guides/lane-spawn.md
@@ -1,0 +1,152 @@
+# Lane Spawn Ceremony — `scripts/lane-spawn.sh`
+
+Implements **#323 Phase B B1** (atomic lane creation). Companion to
+[`lane-claim.sh`](./lane-claim.md) (Rule 1.1 / Issue #309) and
+[`lane-close.sh`](./lane-close.md) (Rule 3.2 / Issue #311).
+
+## Why
+
+v0 had no script for opening a lane — the operator manually filed an Issue,
+applied `lane:<name>` label, picked a branch name, wrote a handoff template,
+and edited `LANES.md`. Five steps means five ways to drift, and the
+handoff/LANES.md edit was easy to forget. Phase B makes the four-step
+ceremony atomic from a single command.
+
+## What it does (in order)
+
+| # | Step | Source of truth | Failure semantics |
+|---|------|-----------------|-------------------|
+| 1 | Validate args (`<lane>`, `<issue>`, optional `--short`/`--slug`) | local | exit 2 if invalid; nothing mutated |
+| 2 | Refuse if `<lane>` already in `LANES.md` Active Lanes | `LANES.md` | exit 1; nothing mutated |
+| 3 | Refuse if active count ≥ 5 (Rule 7 Delta 7 / Issue #314) | `LANES.md` | exit 1; nothing mutated |
+| 4 | Refuse if `<short>` already in use by another active lane | `LANES.md` | exit 1; nothing mutated |
+| 5 | Claim Issue via `lane-claim.sh` (Rule 1.1 probe-after-write) | GitHub | exit 1 on conflict; later steps skipped |
+| 6 | Create branch `lane/<short>/<issue>-<slug>` off `origin/develop` | local git | exit 1 on existing branch / missing origin/develop; later steps skipped |
+| 7 | Write per-lane handoff template (refuses to overwrite) | user-memory | exit 1 if file exists; LANES.md NOT touched |
+| 8 | Append new section to `LANES.md` (own section per Rule 6) | `LANES.md` | exit 2 on awk failure; manual edit advised |
+
+Steps 5–8 mutate state. Steps 1–4 are pure validation. The split is
+intentional so a `--dry-run` can fully exercise validation without external
+side-effects.
+
+## Usage
+
+```bash
+scripts/lane-spawn.sh <lane> <issue>
+                      [--short SHORT] [--slug SLUG]
+                      [--memory-dir PATH] [--lanes-file PATH]
+                      [--repo-root PATH] [--repo OWNER/REPO]
+                      [--no-claim] [--no-branch]
+                      [--dry-run] [--yes]
+```
+
+| Flag / Env var | Effect |
+|----------------|--------|
+| `<lane>` (positional) | Lane name. `[A-Za-z0-9_-]+`. |
+| `<issue>` (positional) | GitHub Issue number to claim. Positive integer. |
+| `--short SHORT` | Override short branch prefix (Rule 2.1, ≤8 chars, `[a-z0-9-]+`). Default: lane name lowercased + filtered + truncated. |
+| `--slug SLUG` | Override branch slug. Default: derived from Issue title via `gh issue view`. |
+| `--memory-dir PATH` | Override memory dir. Defaults to `MERCURY_MEMORY_DIR` env, then `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/D--Mercury-Mercury/memory`. |
+| `--lanes-file PATH` | Override LANES.md location (default: `<memory-dir>/LANES.md`). |
+| `--repo-root PATH` | Override repo root (default: `git rev-parse --show-toplevel`). |
+| `--repo OWNER/REPO` | Pin GitHub repo for `gh` calls. Defaults to `gh repo view` / `GH_REPO`. |
+| `--no-claim` | Skip the `lane-claim.sh` step (useful for offline/manual claim). |
+| `--no-branch` | Skip the `git branch` step (useful when branch is created elsewhere). |
+| `--dry-run` | Print intended actions and exit before any state-mutating command. **Note**: `gh repo view` and `gh issue view` may still be invoked *before* the dry-run gate to resolve repo target and derive the slug from the Issue title. To stay fully offline, combine with `--no-claim --slug <slug>` (and `--repo OWNER/REPO` if `gh repo view` is unavailable). |
+| `--yes` | Skip the interactive confirm prompt. Required in non-interactive contexts. |
+| `MERCURY_MEMORY_DIR` (env) | Same as `--memory-dir`. |
+| `GH_REPO` (env) | Same as `--repo`. |
+
+### Branch naming (Rule 2.1)
+
+Default form: `lane/<short>/<issue>-<slug>`, total length capped at **40
+chars**. If the auto-derived slug would overflow, it is truncated and
+trailing hyphens stripped. Example:
+
+```text
+lane=newlane issue=300 short=newl slug="phase-b-lane-lifecycle-cleanup-pass"
+→ lane/newl/300-phase-b-lane-lifecycle  (40 chars after truncation)
+```
+
+If the prefix `lane/<short>/<issue>-` itself exceeds 40 chars (e.g. very
+long short name + 6-digit issue number), the script exits 1 and asks for a
+shorter `--short`.
+
+### Section ownership (Rule 6)
+
+Step 8 only **appends** a new section to `LANES.md`. It never modifies
+existing sections — Rule 6 binds the spawn ceremony exactly as it binds
+`lane-close.sh`. The append-point is "immediately before the next `## `
+header" (typically `## Closed Lanes`); if no such header is found, the
+section is appended at end-of-file.
+
+### Handoff overwrite protection
+
+Step 7 refuses to write if `<memory-dir>/session-handoff-<lane>.md`
+already exists. This protects in-flight session state from being clobbered
+by an accidental re-spawn under the same lane name. To re-spawn, archive
+or delete the prior handoff first.
+
+### Exit codes
+
+| Exit | Meaning |
+|------|---------|
+| `0` | Spawn succeeded, or `--dry-run` path completed. |
+| `1` | Validation failed: lane already exists / cap reached / short collision / Issue not found / handoff exists / aborted at confirm prompt. Local state may be partially mutated when failure occurs **after** step 5 — read the script output to see exact stop point. |
+| `2` | Argument error / missing `gh` or `jq` / cannot resolve repo or memory dir / awk LANES.md edit failure. |
+
+## Examples
+
+```bash
+# Standard spawn — claim Issue, derive slug from title, branch off origin/develop
+scripts/lane-spawn.sh newlane 300
+
+# Pin short name and slug explicitly (bypass Issue title fetch)
+scripts/lane-spawn.sh newlane 300 --short newl --slug "phase-b-test"
+
+# Dry-run preview (no gh / git / FS mutation)
+scripts/lane-spawn.sh newlane 300 --dry-run
+
+# Offline spawn — branch + handoff + LANES.md only, no Issue claim
+scripts/lane-spawn.sh newlane 300 --no-claim --short newl --slug "x"
+
+# Spawn from outside the Mercury checkout (CI)
+scripts/lane-spawn.sh newlane 300 \
+  --repo-root /workspace/Mercury \
+  --memory-dir /workspace/memory \
+  --repo 392fyc/Mercury \
+  --yes
+```
+
+## Tests
+
+```bash
+scripts/test-lane-spawn.sh
+```
+
+Runs offline (no `gh`, no live LANES.md, no live git) and exercises:
+
+- Argument validation (missing args, invalid lane / issue / flag)
+- Dry-run exits 0 + does not mutate LANES.md / handoff file
+- Duplicate-lane refusal (`lane` already in Active Lanes)
+- Short-name collision refusal (cross-lane uniqueness)
+- HARD-CAP=5 enforcement
+- Happy-path with `--no-claim --no-branch`: handoff written, LANES.md
+  appended, other lanes' Status untouched
+- Handoff overwrite guard: refuses + LANES.md NOT mutated
+- Non-interactive without `--yes` → exit 1
+- Auto-derived `--short` from lane name
+- Long slug truncated to keep branch ≤40 chars
+
+## Source references
+
+- Issue [#323](https://github.com/392fyc/Mercury/issues/323) — Phase B
+  acceptance criteria
+- Issue [#309](https://github.com/392fyc/Mercury/issues/309) — Rule 1.1
+  probe-after-write (B1 dependency, merged via PR #317)
+- Issue [#313](https://github.com/392fyc/Mercury/issues/313),
+  [#314](https://github.com/392fyc/Mercury/issues/314) — Rule 2.1 short
+  prefix + HARD-CAP=5 (merged via PR #328)
+- `feedback_lane_protocol.md` — full protocol (v0 + v0.1 + v0.2)
+- [`lane-claim.md`](./lane-claim.md), [`lane-close.md`](./lane-close.md),
+  [`lane-sweep.md`](./lane-sweep.md) — sibling ceremonies

--- a/.mercury/docs/guides/lane-spawn.md
+++ b/.mercury/docs/guides/lane-spawn.md
@@ -104,8 +104,11 @@ scripts/lane-spawn.sh newlane 300
 # Pin short name and slug explicitly (bypass Issue title fetch)
 scripts/lane-spawn.sh newlane 300 --short newl --slug "phase-b-test"
 
-# Dry-run preview (no gh / git / FS mutation)
+# Dry-run preview (no FS / git / Issue mutation; gh repo+issue read-only metadata still queried)
 scripts/lane-spawn.sh newlane 300 --dry-run
+
+# Fully-offline dry-run (no gh at all — pre-pin --slug and --repo)
+scripts/lane-spawn.sh newlane 300 --dry-run --no-claim --slug "phase-b-test" --repo OWNER/REPO
 
 # Offline spawn — branch + handoff + LANES.md only, no Issue claim
 scripts/lane-spawn.sh newlane 300 --no-claim --short newl --slug "x"

--- a/.mercury/docs/guides/phase-b-install.md
+++ b/.mercury/docs/guides/phase-b-install.md
@@ -42,7 +42,10 @@ scripts/lane-spawn.sh side-feature-x 350 --dry-run
 
 After spawn:
 
-- `lane:<name>` label applied + assignee on Issue
+- `lane:<name>` label applied to the Issue (assignee NOT auto-set —
+  `lane-spawn.sh` passes `--no-assignee` to `lane-claim.sh` per Issue
+  #317 Copilot iter 2 contention-avoidance; assign manually if you want
+  GitHub UI ownership)
 - Branch `lane/<short>/<issue>-<slug>` created (off `origin/develop`)
 - Handoff template at `<memory-dir>/session-handoff-<lane>.md`
 - New section appended to `LANES.md` (own section per Rule 6)

--- a/.mercury/docs/guides/phase-b-install.md
+++ b/.mercury/docs/guides/phase-b-install.md
@@ -1,0 +1,181 @@
+# Phase B Install Guide — Lane Lifecycle Scripts
+
+Issue [#323](https://github.com/392fyc/Mercury/issues/323) · Phase B ·
+`scripts/lane-spawn.sh` + `scripts/lane-close.sh` (`--close-issue`) +
+`scripts/lane-sweep.sh` (cron)
+
+This guide is the operator's quick-ref for the three lane-lifecycle
+scripts. Companion to [`phase-a-install.md`](./phase-a-install.md)
+(observability + status aggregator).
+
+## Prerequisites
+
+- `bash` ≥ 4.0 (Git Bash on Windows is fine)
+- `jq` and `gh` on PATH
+- `gh auth status` clean
+- Mercury repo cloned, `origin/develop` reachable
+
+## Module overview
+
+| ID | Script | Purpose | Default exit |
+|----|--------|---------|--------------|
+| B1 | `scripts/lane-spawn.sh`  | Atomic lane creation: claim Issue + branch + handoff + LANES.md row | 0 = spawned |
+| B2 | `scripts/lane-close.sh`  | Atomic lane teardown: Status flip + tmp prune (+ optional Issue close) | 0 = closed |
+| B3 | `scripts/lane-sweep.sh`  | Stale-lane detection (REPORT-ONLY) | 0 = report emitted |
+
+Detailed per-script docs live in
+[`lane-spawn.md`](./lane-spawn.md), [`lane-close.md`](./lane-close.md),
+and [`lane-sweep.md`](./lane-sweep.md).
+
+## B1 — Spawning a new lane
+
+```bash
+# Standard spawn (default short = first 8 chars of lane, slug from Issue title)
+scripts/lane-spawn.sh <lane-name> <issue-number>
+
+# With explicit short + slug
+scripts/lane-spawn.sh side-feature-x 350 --short feat-x --slug "feature-x"
+
+# Dry-run
+scripts/lane-spawn.sh side-feature-x 350 --dry-run
+```
+
+After spawn:
+
+- `lane:<name>` label applied + assignee on Issue
+- Branch `lane/<short>/<issue>-<slug>` created (off `origin/develop`)
+- Handoff template at `<memory-dir>/session-handoff-<lane>.md`
+- New section appended to `LANES.md` (own section per Rule 6)
+
+Switch to the branch and start work:
+
+```bash
+git switch lane/<short>/<issue>-<slug>
+```
+
+## B2 — Closing a lane
+
+Default close (no GitHub Issue mutation):
+
+```bash
+scripts/lane-close.sh <lane-name> --yes
+```
+
+Close with associated Issue closure (#323 spec):
+
+```bash
+scripts/lane-close.sh <lane-name> --yes \
+  --close-issue --issue 350 \
+  --rationale "Phase B B1 + B2 enhancement landed via PR #XYZ. Closing per #323 acceptance."
+```
+
+Behavior:
+
+- Local Status flip + tmp prune always happen first (atomic, rolled back
+  only on safety guard failure).
+- `--close-issue` is best-effort: it posts a closure rationale comment then
+  `gh issue close --reason completed`. Failure here emits `WARN` but does
+  **NOT** flip the exit code — local state is already authoritative.
+- `--rationale` defaults to a generic line if omitted.
+
+## B3 — Detecting stale lanes (cron)
+
+`lane-sweep.sh` is **report-only**: it never mutates `LANES.md`. This is
+intentional per Rule 6 (LANES.md section ownership) — auto-flipping
+another lane's section would be a backdoor. Stale verdicts surface in the
+report; the owning lane decides whether to flip its own section to
+`closed` (using `lane-close.sh`).
+
+> **Note on #323 spec wording:** the original Issue body says "Auto-flip
+> status to `stale` in `LANES.md`". Rule 3.1 (v0.1 Delta 2 / #310, merged
+> via PR #327) supersedes that wording with a REPORT-ONLY contract to
+> respect Rule 6 red line. This Phase B install path follows the merged
+> Rule 3.1 implementation, not the original #323 wording.
+
+### Manual run
+
+```bash
+# Default 14-day threshold, text table
+scripts/lane-sweep.sh
+
+# JSON for piping
+scripts/lane-sweep.sh --format json | jq '.lanes[] | select(.verdict == "stale")'
+```
+
+### Cron registration (via Claude Code `CronCreate`)
+
+Per [`phase-a-install.md`](./phase-a-install.md) §A2 cron pattern:
+
+```text
+CronCreate:
+  cron: "0 9 1 * *"          # 09:00 UTC, 1st of every month
+  durable: true               # MANDATORY — survives session restart
+  prompt: |
+    Run scripts/lane-sweep.sh --format json from the Mercury repo root.
+    Append any verdict=stale lanes (one line per lane, ISO timestamp prefix)
+    to .mercury/state/stale-lanes.log. Do NOT modify LANES.md.
+```
+
+> `durable: true` is **mandatory**. Without it the cron silently disappears
+> after session restart, opening detection gaps.
+
+Verify the cron survived restart by listing crons inside Claude Code:
+
+```text
+CronList → confirm the lane-sweep entry appears.
+```
+
+`stale-lanes.log` is the operator's signal — open the lane's GitHub Issue
+or the lane's handoff for context, then run `lane-close.sh <lane> --yes`
+when ready to retire.
+
+## Verification matrix
+
+| # | Module | Verification command | Expected |
+|---|--------|----------------------|----------|
+| 1 | B1 | `bash scripts/test-lane-spawn.sh` | `31 pass / 0 fail` |
+| 2 | B2 | `bash scripts/test-lane-close.sh` | `42 pass / 0 fail` (includes `--close-issue` cases) |
+| 3 | B3 | `bash scripts/test-lane-sweep.sh` | all green |
+| 4 | B1 dry-run | `scripts/lane-spawn.sh demo 999 --dry-run --no-claim --slug x` | exit 0, prints intent, no FS mutation |
+| 5 | B2 `--close-issue` dry-run | `scripts/lane-close.sh foo --dry-run --close-issue --issue 1` | exit 0, `would gh issue comment` printed |
+| 6 | B3 `--no-issue-check` | `scripts/lane-sweep.sh --no-issue-check --memory-dir <fixture>` | exit 0, table or JSON |
+| 7 | Cron durability | After `CronCreate durable: true`, restart Claude Code, `CronList` | sweep cron still listed |
+
+## Rollback
+
+The Phase B scripts are independent of Phase A. To roll back Phase B:
+
+```bash
+# Remove Phase B scripts
+rm -f scripts/lane-spawn.sh scripts/test-lane-spawn.sh
+
+# Revert lane-close.sh --close-issue enhancement
+git checkout HEAD~1 -- scripts/lane-close.sh scripts/test-lane-close.sh
+
+# Drop B3 cron (inside Claude Code)
+# CronDelete <id>
+```
+
+Operators who installed Phase A can keep it — Phase A and Phase B touch
+different surfaces (statusline + lane-status.json vs lane lifecycle).
+
+## Environment variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `MERCURY_MEMORY_DIR` | `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/D--Mercury-Mercury/memory` | Override memory dir for all three scripts |
+| `GH_REPO` | (resolved via `gh repo view`) | Pin GitHub repo for `gh` calls |
+| `MERCURY_LANE_STALE_MIN` | `15` | (Phase A) staleness gate for `lane-status.sh` — unrelated to B3's `--days` |
+
+## Source references
+
+- Issue [#323](https://github.com/392fyc/Mercury/issues/323) — Phase B spec
+- Issue [#310](https://github.com/392fyc/Mercury/issues/310) — Rule 3.1
+  REPORT-ONLY contract (resolves #323 wording conflict)
+- Issue [#311](https://github.com/392fyc/Mercury/issues/311) — Rule 3.2
+  lane-close
+- Issue [#314](https://github.com/392fyc/Mercury/issues/314) — HARD-CAP=5
+- PR [#321](https://github.com/392fyc/Mercury/pull/321) — research §Dim
+  1.3 missing modules
+- [`phase-a-install.md`](./phase-a-install.md) — sibling install guide for
+  observability + lane status aggregator

--- a/.mercury/docs/guides/phase-b-install.md
+++ b/.mercury/docs/guides/phase-b-install.md
@@ -143,18 +143,26 @@ when ready to retire.
 
 ## Rollback
 
-The Phase B scripts are independent of Phase A. To roll back Phase B:
+The Phase B scripts are independent of Phase A. To roll back Phase B,
+prefer reverting the merge commit so history is portable rather than
+relying on `HEAD~1` (which depends on local commit ordering and would
+not point at "pre-Phase-B" once subsequent merges land):
 
 ```bash
-# Remove Phase B scripts
-rm -f scripts/lane-spawn.sh scripts/test-lane-spawn.sh
+# Identify the Phase B merge commit on the develop branch
+PHASE_B_MERGE=$(git log develop --merges --grep='Phase B' --format='%H' | head -n 1)
 
-# Revert lane-close.sh --close-issue enhancement
-git checkout HEAD~1 -- scripts/lane-close.sh scripts/test-lane-close.sh
+# Create a revert commit (preferred — preserves history, works on any branch state)
+git revert -m 1 "$PHASE_B_MERGE"
 
-# Drop B3 cron (inside Claude Code)
+# Drop the B3 sweep cron (inside Claude Code)
 # CronDelete <id>
 ```
+
+If `git revert` is not viable (e.g. the merge has already been built upon),
+fall back to manually deleting the Phase B files and reverting the
+`lane-close.sh` `--close-issue` block — `git log -p -- scripts/lane-close.sh`
+shows which lines belong to Phase B vs the prior PR #327 baseline.
 
 Operators who installed Phase A can keep it — Phase A and Phase B touch
 different surfaces (statusline + lane-status.json vs lane lifecycle).

--- a/scripts/lane-close.sh
+++ b/scripts/lane-close.sh
@@ -22,12 +22,20 @@
 #                         [--lanes-file PATH] [--memory-dir PATH]
 #                         [--tmp-dir PATH] [--repo-root PATH]
 #                         [--yes] [--force-cross-lane] [--dry-run]
+#                         [--close-issue --issue N [--rationale TEXT] [--repo OWNER/REPO]]
 #
 # Defaults:
 #   --memory-dir   ${MERCURY_MEMORY_DIR:-${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/D--Mercury-Mercury/memory}
 #   --lanes-file   <memory-dir>/LANES.md
 #   --repo-root    `git rev-parse --show-toplevel`
 #   --tmp-dir      <repo-root>/.tmp/lane-<lane>
+#   --rationale    "Lane <lane-name> closed via scripts/lane-close.sh."
+#   --repo         resolved via gh repo view / GH_REPO env (only when --close-issue)
+#
+# --close-issue (#323 Phase B B2): after Status flip + tmp prune succeed, post
+# a closure-rationale comment on Issue #N then `gh issue close N`. Best-effort
+# external mutation — failure here logs a WARN but does NOT roll back the
+# already-completed local Status flip / tmp prune.
 #
 # Exit codes:
 #   0  lane closed cleanly (or --dry-run path completed)
@@ -48,6 +56,10 @@ REPO_ROOT=""
 YES=0
 FORCE_CROSS_LANE=0
 DRY_RUN=0
+CLOSE_ISSUE=0
+ISSUE_NUM=""
+RATIONALE=""
+REPO=""
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -60,8 +72,12 @@ while [ $# -gt 0 ]; do
     --yes)               YES=1; shift ;;
     --force-cross-lane)  FORCE_CROSS_LANE=1; shift ;;
     --dry-run)           DRY_RUN=1; shift ;;
+    --close-issue)       CLOSE_ISSUE=1; shift ;;
+    --issue)             shift; [ $# -gt 0 ] || die "--issue needs a value"; ISSUE_NUM="$1"; shift ;;
+    --rationale)         shift; [ $# -gt 0 ] || die "--rationale needs a value"; RATIONALE="$1"; shift ;;
+    --repo)              shift; [ $# -gt 0 ] || die "--repo needs a value"; REPO="$1"; shift ;;
     -h|--help)
-      sed -n '2,32p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      sed -n '2,40p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
       exit 0 ;;
     --) shift; while [ $# -gt 0 ]; do
           [ -z "$LANE" ] || die "too many positional args after --: $1"
@@ -79,6 +95,20 @@ case "$LANE" in
   -*) die "lane name must not start with hyphen: '$LANE'" ;;
   *[!A-Za-z0-9_-]*) die "lane name must be [A-Za-z0-9_-]: '$LANE'" ;;
 esac
+
+# --close-issue arg interlock: requires --issue N (positive int).
+if [ "$CLOSE_ISSUE" -eq 1 ]; then
+  [ -n "$ISSUE_NUM" ] || die "--close-issue requires --issue N"
+  case "$ISSUE_NUM" in
+    ''|*[!0-9]*|0) die "--issue must be a positive integer: '$ISSUE_NUM'" ;;
+  esac
+fi
+# --issue / --rationale / --repo without --close-issue is a wiring mistake —
+# surface it loudly. A typo dropping --close-issue would otherwise look
+# correctly configured for remote closure while only closing locally.
+if [ "$CLOSE_ISSUE" -eq 0 ] && { [ -n "$ISSUE_NUM" ] || [ -n "$RATIONALE" ] || [ -n "$REPO" ]; }; then
+  die "--issue/--rationale/--repo only meaningful with --close-issue"
+fi
 
 if [ -z "$MEMORY_DIR" ]; then
   MEMORY_DIR="${MERCURY_MEMORY_DIR:-${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/D--Mercury-Mercury/memory}"
@@ -202,6 +232,10 @@ if [ "$DRY_RUN" -eq 1 ]; then
   else
     printf '[dry-run] no tmp dir at %s (skip rm)\n' "$TMP_DIR"
   fi
+  if [ "$CLOSE_ISSUE" -eq 1 ]; then
+    printf '[dry-run] would gh issue comment #%s + gh issue close #%s (rationale=%s)\n' \
+      "$ISSUE_NUM" "$ISSUE_NUM" "${RATIONALE:-(default)}"
+  fi
   exit 0
 fi
 
@@ -253,4 +287,36 @@ else
 fi
 
 printf 'lane-close: lane %s flipped to `closed` in %s\n' "$LANE" "$LANES_FILE"
+
+# Optional --close-issue: best-effort GitHub Issue closure with rationale.
+# Local Status flip + tmp prune already succeeded above, so a gh failure here
+# emits WARN but does NOT exit non-zero — operator may run `gh issue close` by
+# hand later. Local LANES.md state remains the authoritative record.
+if [ "$CLOSE_ISSUE" -eq 1 ]; then
+  if ! command -v gh >/dev/null 2>&1; then
+    warn "gh CLI not on PATH — skipping --close-issue (lane is already closed locally)"
+  else
+    if [ -z "$REPO" ]; then REPO="${GH_REPO:-}"; fi
+    if [ -z "$REPO" ]; then
+      REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null) \
+        || warn "cannot determine target repo for --close-issue (pass --repo or set GH_REPO)"
+    fi
+    if [ -z "$RATIONALE" ]; then
+      RATIONALE="Lane \`$LANE\` closed via \`scripts/lane-close.sh\` (#323 Phase B B2)."
+    fi
+    if [ -n "$REPO" ]; then
+      if gh issue comment "$ISSUE_NUM" --repo "$REPO" --body "$RATIONALE" >/dev/null 2>&1; then
+        printf 'lane-close: posted closure rationale on #%s\n' "$ISSUE_NUM"
+      else
+        warn "gh issue comment #$ISSUE_NUM failed — closure rationale NOT posted (post manually if needed)"
+      fi
+      if gh issue close "$ISSUE_NUM" --repo "$REPO" --reason completed >/dev/null 2>&1; then
+        printf 'lane-close: closed issue #%s\n' "$ISSUE_NUM"
+      else
+        warn "gh issue close #$ISSUE_NUM failed — issue NOT closed remotely (close manually if needed)"
+      fi
+    fi
+  fi
+fi
+
 exit 0

--- a/scripts/lane-spawn.sh
+++ b/scripts/lane-spawn.sh
@@ -1,0 +1,390 @@
+#!/usr/bin/env bash
+# scripts/lane-spawn.sh — Mercury multi-lane atomic spawn ceremony.
+# Implements #323 Phase B B1 (atomic lane creation).
+#
+# Steps (all-or-nothing semantics where possible):
+#   1. Validate <lane>, <issue>, optional --short / --slug args
+#   2. Refuse if <lane> already appears in LANES.md "## Active Lanes" section
+#   3. Refuse if active-lane count is at HARD-CAP=5 (Rule 7 Delta 7 / Issue #314)
+#   4. Claim Issue via scripts/lane-claim.sh (Rule 1.1 probe-after-write, #309)
+#   5. Create branch `lane/<short>/<issue>-<slug>` off origin/develop (Rule 2.1)
+#   6. Write per-lane handoff template at <memory-dir>/session-handoff-<lane>.md
+#      (refuse to overwrite if file exists — protect prior session state)
+#   7. Append a new lane section to LANES.md (own section per Rule 6)
+#
+# Rollback policy: each step is best-effort idempotent. If step 4 fails,
+# steps 5–7 are skipped. If step 5 fails, steps 6–7 are skipped. Failed
+# step output suggests the manual remediation. Successful steps are NOT
+# rolled back automatically — operator decides whether to keep partial
+# progress (e.g. the Issue label may already be useful even if the branch
+# create fails).
+#
+# Usage:
+#   scripts/lane-spawn.sh <lane> <issue>
+#                         [--short SHORT] [--slug SLUG]
+#                         [--memory-dir PATH] [--lanes-file PATH]
+#                         [--repo-root PATH] [--repo OWNER/REPO]
+#                         [--no-claim] [--no-branch]
+#                         [--dry-run] [--yes]
+#
+# Defaults:
+#   --short          first 8 chars of <lane> after stripping non-[a-z0-9-]
+#   --slug           lowercased Issue title with non-[a-z0-9-] → "-",
+#                    truncated so total branch ≤40 chars (Rule 2.1)
+#   --memory-dir     ${MERCURY_MEMORY_DIR:-${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/D--Mercury-Mercury/memory}
+#   --lanes-file     <memory-dir>/LANES.md
+#   --repo-root      `git rev-parse --show-toplevel`
+#   --repo           resolved via `gh repo view` or GH_REPO env
+#
+# Exit codes:
+#   0  spawn succeeded (or --dry-run path completed)
+#   1  validation failed (lane exists / cap reached / Issue not found / handoff exists)
+#   2  invalid args / missing tools / cannot resolve repo or memory dir / step failure
+
+set -u
+
+die()  { printf 'lane-spawn: %s\n' "$1" >&2; exit 2; }
+warn() { printf 'lane-spawn WARN: %s\n' "$1" >&2; }
+fail() { printf 'lane-spawn: %s\n' "$1" >&2; exit 1; }
+
+LANE=""
+ISSUE=""
+SHORT=""
+SLUG=""
+MEMORY_DIR=""
+LANES_FILE=""
+REPO_ROOT=""
+REPO=""
+NO_CLAIM=0
+NO_BRANCH=0
+DRY_RUN=0
+YES=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --short)       shift; [ $# -gt 0 ] || die "--short needs a value"; SHORT="$1"; shift ;;
+    --slug)        shift; [ $# -gt 0 ] || die "--slug needs a value"; SLUG="$1"; shift ;;
+    --memory-dir)  shift; [ $# -gt 0 ] || die "--memory-dir needs a value"; MEMORY_DIR="$1"; shift ;;
+    --lanes-file)  shift; [ $# -gt 0 ] || die "--lanes-file needs a value"; LANES_FILE="$1"; shift ;;
+    --repo-root)   shift; [ $# -gt 0 ] || die "--repo-root needs a value"; REPO_ROOT="$1"; shift ;;
+    --repo)        shift; [ $# -gt 0 ] || die "--repo needs a value"; REPO="$1"; shift ;;
+    --no-claim)    NO_CLAIM=1; shift ;;
+    --no-branch)   NO_BRANCH=1; shift ;;
+    --dry-run)     DRY_RUN=1; shift ;;
+    --yes)         YES=1; shift ;;
+    -h|--help)
+      sed -n '2,38p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    --) shift
+        if [ -z "$LANE" ]   && [ $# -gt 0 ]; then LANE="$1"; shift; fi
+        if [ -z "$ISSUE" ]  && [ $# -gt 0 ]; then ISSUE="$1"; shift; fi
+        [ $# -eq 0 ] || die "too many positional args after --: $1"
+        break ;;
+    -*) die "unknown flag: $1" ;;
+    *)
+      if [ -z "$LANE" ];   then LANE="$1"
+      elif [ -z "$ISSUE" ]; then ISSUE="$1"
+      else die "too many positional args; got: $1"; fi
+      shift ;;
+  esac
+done
+
+[ -n "$LANE" ]  || die "missing <lane> argument (try --help)"
+[ -n "$ISSUE" ] || die "missing <issue> argument (try --help)"
+
+case "$LANE" in
+  -*) die "lane name must not start with hyphen: '$LANE'" ;;
+  *[!A-Za-z0-9_-]*) die "lane name must be [A-Za-z0-9_-]: '$LANE'" ;;
+esac
+case "$ISSUE" in
+  ''|*[!0-9]*|0) die "issue must be a positive integer: '$ISSUE'" ;;
+esac
+
+# Memory dir resolution mirrors lane-close.sh / lane-sweep.sh.
+if [ -z "$MEMORY_DIR" ]; then
+  MEMORY_DIR="${MERCURY_MEMORY_DIR:-${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/D--Mercury-Mercury/memory}"
+fi
+[ -d "$MEMORY_DIR" ] || die "memory dir not found: $MEMORY_DIR (set --memory-dir or MERCURY_MEMORY_DIR)"
+if [ -z "$LANES_FILE" ]; then LANES_FILE="$MEMORY_DIR/LANES.md"; fi
+[ -f "$LANES_FILE" ] || die "LANES.md not found: $LANES_FILE"
+
+if [ -z "$REPO_ROOT" ]; then
+  REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || die "cannot resolve repo root (pass --repo-root)"
+fi
+[ -d "$REPO_ROOT" ] || die "repo root not a directory: $REPO_ROOT"
+
+# Default --short: lane name lowercased, non-[a-z0-9-] stripped, truncated to 8.
+if [ -z "$SHORT" ]; then
+  SHORT=$(printf '%s' "$LANE" | tr 'A-Z' 'a-z' | tr -cd 'a-z0-9-' | cut -c1-8)
+fi
+case "$SHORT" in
+  ''|-*) die "computed --short is empty or starts with hyphen: '$SHORT' (pass --short explicitly)" ;;
+  *[!a-z0-9-]*) die "--short must be [a-z0-9-]: '$SHORT'" ;;
+esac
+[ "${#SHORT}" -le 8 ] || die "--short must be ≤8 chars: '$SHORT' (${#SHORT} chars)"
+
+# Active-lane uniqueness + cap check via LANES.md.
+# Fail-fast on a malformed registry: the spawn ceremony writes a new section
+# under "## Active Lanes" via awk in step 8. If that header is missing, the
+# awk insert silently no-ops, and a successful spawn would have already
+# claimed the Issue + created a branch + written a handoff with no registry
+# row — a worse-than-pre-spawn state. Refuse here before any mutation.
+if ! grep -q '^## Active Lanes' "$LANES_FILE"; then
+  fail "LANES.md missing '## Active Lanes' header — refusing to spawn (fix the registry first): $LANES_FILE"
+fi
+
+parse_active_lanes() {
+  awk '
+    /^## Active Lanes/ { in_active = 1; next }
+    /^## / && in_active { in_active = 0 }
+    in_active && /^### `[^`]+`/ {
+      match($0, /`[^`]+`/)
+      name = substr($0, RSTART + 1, RLENGTH - 2)
+      print name
+    }
+  ' "$1"
+}
+ACTIVE_LANES=$(parse_active_lanes "$LANES_FILE")
+ACTIVE_COUNT=$(printf '%s\n' "$ACTIVE_LANES" | grep -c -v '^$' || true)
+
+if printf '%s\n' "$ACTIVE_LANES" | grep -qxF "$LANE"; then
+  fail "lane '$LANE' already exists in $LANES_FILE Active Lanes section"
+fi
+
+# Active short-name uniqueness — Rule 2.1 mandates cross-lane unique short.
+# Best-effort: parse Short name field from each active section. Skip if
+# any section has no Short line (legacy lanes pre-Rule 2.1).
+EXISTING_SHORTS=$(awk '
+  /^## Active Lanes/ { in_active = 1; next }
+  /^## / && in_active { in_active = 0 }
+  in_active && /^- \*\*Short name\*\*: `[^`]+`/ {
+    match($0, /`[^`]+`/)
+    print substr($0, RSTART + 1, RLENGTH - 2)
+  }
+' "$LANES_FILE")
+if printf '%s\n' "$EXISTING_SHORTS" | grep -qxF "$SHORT"; then
+  fail "short name '$SHORT' already in use by another active lane (pass --short)"
+fi
+
+if [ "$ACTIVE_COUNT" -ge 5 ]; then
+  fail "HARD-CAP at 5 active lanes reached ($ACTIVE_COUNT/5) — close one before spawning lane '$LANE' (Rule 7 Delta 7 / Issue #314)"
+fi
+
+# Resolve repo (only when claim or slug-derivation needs gh).
+NEED_GH=0
+if [ "$NO_CLAIM" -eq 0 ]; then NEED_GH=1; fi
+if [ -z "$SLUG" ]; then NEED_GH=1; fi
+
+if [ "$NEED_GH" -eq 1 ]; then
+  command -v gh >/dev/null 2>&1 || die "gh CLI required (or pass --no-claim and --slug to bypass)"
+  command -v jq >/dev/null 2>&1 || die "jq required (or pass --no-claim and --slug to bypass)"
+  if [ -z "$REPO" ]; then REPO="${GH_REPO:-}"; fi
+  if [ -z "$REPO" ]; then
+    REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null) \
+      || die "cannot determine target repo (pass --repo or set GH_REPO)"
+  fi
+  case "$REPO" in
+    */*) ;;
+    *) die "invalid repo format '$REPO' (expected owner/repo)" ;;
+  esac
+fi
+
+# Default --slug: derived from Issue title via gh.
+if [ -z "$SLUG" ]; then
+  ISSUE_TITLE=$(gh issue view "$ISSUE" --repo "$REPO" --json title --jq .title 2>/dev/null) \
+    || fail "cannot fetch Issue #$ISSUE title (Issue missing? gh auth?)"
+  [ -n "$ISSUE_TITLE" ] || fail "Issue #$ISSUE has empty title"
+  # Derive: lowercase, non-alnum → "-", squeeze repeats, trim leading/trailing "-".
+  SLUG=$(printf '%s' "$ISSUE_TITLE" \
+    | tr 'A-Z' 'a-z' \
+    | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//')
+fi
+case "$SLUG" in
+  '') die "computed --slug is empty (pass --slug explicitly)" ;;
+  *[!a-z0-9-]*) die "--slug must be [a-z0-9-]: '$SLUG'" ;;
+esac
+
+# Branch name + Rule 2.1 ≤40-char cap. Truncate slug if needed.
+PREFIX="lane/${SHORT}/${ISSUE}-"
+MAX_BRANCH=40
+PREFIX_LEN=${#PREFIX}
+SLUG_BUDGET=$(( MAX_BRANCH - PREFIX_LEN ))
+if [ "$SLUG_BUDGET" -lt 1 ]; then
+  fail "branch prefix '$PREFIX' already exceeds Rule 2.1 ≤40-char cap (pass shorter --short)"
+fi
+if [ "${#SLUG}" -gt "$SLUG_BUDGET" ]; then
+  SLUG=$(printf '%s' "$SLUG" | cut -c1-"$SLUG_BUDGET" | sed -E 's/-+$//')
+fi
+BRANCH="${PREFIX}${SLUG}"
+
+HANDOFF_FILE="$MEMORY_DIR/session-handoff-${LANE}.md"
+if [ -e "$HANDOFF_FILE" ]; then
+  fail "handoff file already exists: $HANDOFF_FILE (refusing to overwrite — move or delete first)"
+fi
+
+# Dry-run gate — print intent and exit before any external mutations.
+if [ "$DRY_RUN" -eq 1 ]; then
+  printf '[dry-run] lane=%s issue=%s short=%s slug=%s\n' "$LANE" "$ISSUE" "$SHORT" "$SLUG"
+  printf '[dry-run] branch=%s (%d chars, cap=%d)\n' "$BRANCH" "${#BRANCH}" "$MAX_BRANCH"
+  printf '[dry-run] memory-dir=%s\n' "$MEMORY_DIR"
+  printf '[dry-run] handoff=%s\n' "$HANDOFF_FILE"
+  printf '[dry-run] LANES.md=%s (%d active lanes pre-spawn)\n' "$LANES_FILE" "$ACTIVE_COUNT"
+  if [ "$NO_CLAIM" -eq 0 ]; then
+    printf '[dry-run] step 1: scripts/lane-claim.sh %s %s --no-assignee\n' "$LANE" "$ISSUE"
+  else
+    printf '[dry-run] step 1: SKIPPED (--no-claim)\n'
+  fi
+  if [ "$NO_BRANCH" -eq 0 ]; then
+    printf '[dry-run] step 2: git branch %s origin/develop\n' "$BRANCH"
+  else
+    printf '[dry-run] step 2: SKIPPED (--no-branch)\n'
+  fi
+  printf '[dry-run] step 3: write %s\n' "$HANDOFF_FILE"
+  printf '[dry-run] step 4: append section to %s\n' "$LANES_FILE"
+  exit 0
+fi
+
+# Confirm before mutations unless --yes or non-interactive with --no-claim+--no-branch.
+if [ "$YES" -eq 0 ]; then
+  if [ -t 0 ]; then
+    printf 'Spawn lane "%s" for issue #%s (branch=%s)? [y/N] ' "$LANE" "$ISSUE" "$BRANCH"
+    read -r ans
+    case "${ans:-}" in
+      y|Y|yes|YES) ;;
+      *) fail "aborted by user" ;;
+    esac
+  else
+    fail "refusing in non-interactive context without --yes"
+  fi
+fi
+
+# Step 1: claim Issue (Rule 1.1 wrapper).
+if [ "$NO_CLAIM" -eq 0 ]; then
+  CLAIM_SCRIPT="$REPO_ROOT/scripts/lane-claim.sh"
+  [ -x "$CLAIM_SCRIPT" ] || die "lane-claim.sh not executable at $CLAIM_SCRIPT (Rule 1.1 dep #309)"
+  GH_REPO="$REPO" "$CLAIM_SCRIPT" "$LANE" "$ISSUE" --no-assignee \
+    || fail "lane-claim.sh failed for lane=$LANE issue=#$ISSUE (see message above; nothing further mutated)"
+  printf 'lane-spawn: claimed issue #%s with lane:%s\n' "$ISSUE" "$LANE"
+fi
+
+# Step 2: create branch off origin/develop.
+if [ "$NO_BRANCH" -eq 0 ]; then
+  if git -C "$REPO_ROOT" rev-parse --verify --quiet "refs/heads/$BRANCH" >/dev/null 2>&1; then
+    fail "branch '$BRANCH' already exists locally (delete or rename first)"
+  fi
+  if ! git -C "$REPO_ROOT" rev-parse --verify --quiet "refs/remotes/origin/develop" >/dev/null 2>&1; then
+    fail "origin/develop not found locally — run 'git fetch origin' first"
+  fi
+  git -C "$REPO_ROOT" branch "$BRANCH" "origin/develop" \
+    || fail "git branch $BRANCH origin/develop failed"
+  printf 'lane-spawn: created branch %s\n' "$BRANCH"
+fi
+
+# Step 3: write handoff template.
+TODAY=$(date -u +'%Y-%m-%d')
+cat > "$HANDOFF_FILE" <<EOF
+---
+name: session_handoff_${LANE}
+description: Initial handoff for lane '${LANE}' (Issue #${ISSUE}). Written by scripts/lane-spawn.sh.
+type: project
+originSessionId: spawn-${LANE}-${ISSUE}-${TODAY}
+---
+
+# Lane '${LANE}' — Initial Session Handoff
+
+## Starting Prompt
+
+This is Mercury **lane '${LANE}'** session 1 (lane info in \`LANES.md\` + \`feedback_lane_protocol.md\`).
+
+### 当前状态
+
+- 仓库 \`$(basename "$REPO_ROOT")\` branch \`${BRANCH}\` (off origin/develop)
+- 关联 Issue: [#${ISSUE}](https://github.com/${REPO:-OWNER/REPO}/issues/${ISSUE})
+- 第一步：\`git fetch origin && git switch ${BRANCH}\`
+
+### 主任务
+
+参考 Issue #${ISSUE} body for spec.
+
+### 边界 (lane 不做)
+
+- Rule 4: 不动 \`.mercury/docs/DIRECTION.md\` / \`.mercury/docs/EXECUTION-PLAN.md\` (开 Issue 给 main lane)
+- Rule 6: 不编辑 LANES.md 其他 lane 的 section
+- Rule 7: shared index append-only (S{N}-${LANE} 自己 row OK，其他 lane row 永不动)
+
+### 关键参考
+
+- \`memory/feedback_lane_protocol.md\` v0+v0.1+v0.2 — 7+ rules
+- \`memory/LANES.md\` — lane registry
+- Issue #${ISSUE} body — task spec
+
+## Task State
+
+- **Primary**: 实施 Issue #${ISSUE}
+- **Branch**: \`${BRANCH}\`
+- **In progress**: 无
+
+## User Instructions
+
+(written by lane-spawn.sh on ${TODAY} — replace with session-specific content as work begins)
+EOF
+printf 'lane-spawn: wrote handoff %s\n' "$HANDOFF_FILE"
+
+# Step 4: append lane section to LANES.md (own section per Rule 6).
+# Strategy: locate the "## Active Lanes" header, then locate the next "## "
+# header (Closed Lanes / Governance / Rollback). Insert new section at the
+# end of the Active Lanes block (immediately before the next "## " header).
+# The awk script exits 7 if either (a) the Active Lanes header was never seen,
+# or (b) end-of-file was reached without inserting (header missing trailing
+# `## ` AND we somehow fell through). Both cases preserve LANES.md unchanged
+# because mv only runs on awk success.
+TMP_LANES=$(mktemp)
+awk -v lane="$LANE" -v branch="$BRANCH" -v issue="$ISSUE" \
+    -v handoff="session-handoff-${LANE}.md" -v short="$SHORT" -v today="$TODAY" '
+  BEGIN { saw_active = 0; in_active = 0; printed = 0 }
+  /^## Active Lanes/ { saw_active = 1; in_active = 1; print; next }
+  /^## / && in_active && !printed {
+    # Insert new section right before this next "## " header.
+    print "### `" lane "`"
+    print ""
+    print "- **Short name**: `" short "`"
+    print "- **Branch**: `" branch "`"
+    print "- **Handoff file**: `" handoff "`"
+    print "- **Status**: `active`"
+    print "- **Spawned**: " today " (Issue #" issue ")"
+    print ""
+    in_active = 0
+    printed = 1
+    print
+    next
+  }
+  { print }
+  END {
+    if (saw_active && !printed) {
+      # Active Lanes was the LAST `## ` block → append at EOF.
+      print ""
+      print "### `" lane "`"
+      print ""
+      print "- **Short name**: `" short "`"
+      print "- **Branch**: `" branch "`"
+      print "- **Handoff file**: `" handoff "`"
+      print "- **Status**: `active`"
+      print "- **Spawned**: " today " (Issue #" issue ")"
+      printed = 1
+    }
+    if (!saw_active || !printed) {
+      # Defense in depth — the precheck above should have caught
+      # !saw_active, but if LANES.md mutated between precheck and now,
+      # surface a deterministic failure rather than a silent no-op.
+      exit 7
+    }
+  }
+' "$LANES_FILE" > "$TMP_LANES" && mv "$TMP_LANES" "$LANES_FILE" || {
+  rm -f "$TMP_LANES"
+  fail "failed to append lane section to $LANES_FILE — Active Lanes header may have been removed mid-spawn (manual edit required)"
+}
+printf 'lane-spawn: appended lane section to %s\n' "$LANES_FILE"
+
+printf '\nlane-spawn: lane "%s" spawned (issue=#%s branch=%s).\n' "$LANE" "$ISSUE" "$BRANCH"
+printf 'next: git switch %s && start work\n' "$BRANCH"
+exit 0

--- a/scripts/lane-spawn.sh
+++ b/scripts/lane-spawn.sh
@@ -109,6 +109,18 @@ fi
 if [ -z "$LANES_FILE" ]; then LANES_FILE="$MEMORY_DIR/LANES.md"; fi
 [ -f "$LANES_FILE" ] || die "LANES.md not found: $LANES_FILE"
 
+# Path-traversal defense (Argus #334 iter 2 importance:2/10): if --lanes-file
+# was passed explicitly with a path that resolves outside MEMORY_DIR, refuse.
+# The default ($MEMORY_DIR/LANES.md) trivially passes. Operators with custom
+# layouts can pass --memory-dir to widen the boundary deliberately.
+LANES_REAL=$(realpath -m "$LANES_FILE" 2>/dev/null || readlink -f "$LANES_FILE" 2>/dev/null || printf '%s' "$LANES_FILE")
+MEMORY_REAL=$(realpath -m "$MEMORY_DIR" 2>/dev/null || readlink -f "$MEMORY_DIR" 2>/dev/null || printf '%s' "$MEMORY_DIR")
+case "$LANES_REAL" in
+  "${MEMORY_REAL%/}"/*) ;;
+  "$MEMORY_REAL") ;;
+  *) die "--lanes-file resolves outside --memory-dir: '$LANES_REAL' (memory-dir='$MEMORY_REAL')" ;;
+esac
+
 if [ -z "$REPO_ROOT" ]; then
   REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || die "cannot resolve repo root (pass --repo-root)"
 fi
@@ -146,15 +158,35 @@ parse_active_lanes() {
   ' "$1"
 }
 ACTIVE_LANES=$(parse_active_lanes "$LANES_FILE")
-ACTIVE_COUNT=$(printf '%s\n' "$ACTIVE_LANES" | grep -c -v '^$' || true)
+
+# HARD-CAP enforcement counts lanes whose Status resolves to `active`, mirroring
+# scripts/lane-cap-check.sh (Rule 7 reference impl). Counting `### ` headings
+# alone would over-count paused/deprecated rows that linger in the Active Lanes
+# section. awk walks each lane block and emits the lane name only when the
+# block's first **Status** line is exactly `active`.
+ACTIVE_COUNT=$(awk '
+  /^## Active Lanes/ { in_active = 1; in_lane = 0; next }
+  /^## / && in_active { in_active = 0; in_lane = 0 }
+  in_active && /^### `[^`]+`/ { in_lane = 1; status_seen = 0; next }
+  in_lane && !status_seen && /^- \*\*Status\*\*: `?active`?/ {
+    status_seen = 1
+    count++
+    in_lane = 0
+  }
+  in_lane && /^- \*\*Status\*\*:/ { status_seen = 1; in_lane = 0 }
+  END { print count + 0 }
+' "$LANES_FILE")
 
 if printf '%s\n' "$ACTIVE_LANES" | grep -qxF "$LANE"; then
   fail "lane '$LANE' already exists in $LANES_FILE Active Lanes section"
 fi
 
 # Active short-name uniqueness — Rule 2.1 mandates cross-lane unique short.
-# Best-effort: parse Short name field from each active section. Skip if
-# any section has no Short line (legacy lanes pre-Rule 2.1).
+# Parse Short-name field from each active lane section; sections without a
+# `**Short name**:` line (legacy lanes pre-Rule 2.1) simply emit nothing
+# for that section, so they cannot collide with the requested SHORT — they
+# are tolerated rather than skipped explicitly. New spawns always get a
+# Short field written to LANES.md (see step 4 awk).
 EXISTING_SHORTS=$(awk '
   /^## Active Lanes/ { in_active = 1; next }
   /^## / && in_active { in_active = 0 }
@@ -177,8 +209,10 @@ if [ "$NO_CLAIM" -eq 0 ]; then NEED_GH=1; fi
 if [ -z "$SLUG" ]; then NEED_GH=1; fi
 
 if [ "$NEED_GH" -eq 1 ]; then
+  # gh CLI required directly. Note: this script does NOT call jq itself —
+  # `gh --jq` uses gh's built-in jq engine, not the external binary. The
+  # downstream lane-claim.sh wrapper performs its own jq check at exec time.
   command -v gh >/dev/null 2>&1 || die "gh CLI required (or pass --no-claim and --slug to bypass)"
-  command -v jq >/dev/null 2>&1 || die "jq required (or pass --no-claim and --slug to bypass)"
   if [ -z "$REPO" ]; then REPO="${GH_REPO:-}"; fi
   if [ -z "$REPO" ]; then
     REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null) \
@@ -282,8 +316,11 @@ if [ "$NO_BRANCH" -eq 0 ]; then
 fi
 
 # Step 3: write handoff template.
+# Trap heredoc/redirect failure (disk full, permissions, ENOSPC) before any
+# LANES.md mutation in step 4 — leaving step 4 to run on a missing handoff
+# would create a registry row pointing at a file that never existed.
 TODAY=$(date -u +'%Y-%m-%d')
-cat > "$HANDOFF_FILE" <<EOF
+if ! cat > "$HANDOFF_FILE" <<EOF
 ---
 name: session_handoff_${LANE}
 description: Initial handoff for lane '${LANE}' (Issue #${ISSUE}). Written by scripts/lane-spawn.sh.
@@ -329,6 +366,9 @@ This is Mercury **lane '${LANE}'** session 1 (lane info in \`LANES.md\` + \`feed
 
 (written by lane-spawn.sh on ${TODAY} — replace with session-specific content as work begins)
 EOF
+then
+  fail "failed to write handoff template at $HANDOFF_FILE (disk / permissions / quota — LANES.md NOT mutated)"
+fi
 printf 'lane-spawn: wrote handoff %s\n' "$HANDOFF_FILE"
 
 # Step 4: append lane section to LANES.md (own section per Rule 6).
@@ -339,7 +379,10 @@ printf 'lane-spawn: wrote handoff %s\n' "$HANDOFF_FILE"
 # or (b) end-of-file was reached without inserting (header missing trailing
 # `## ` AND we somehow fell through). Both cases preserve LANES.md unchanged
 # because mv only runs on awk success.
-TMP_LANES=$(mktemp)
+# mktemp template: BSD/macOS mktemp requires an explicit XXXXXX template; GNU
+# mktemp without a template silently uses "tmp.XXXXXXXXXX" but the explicit
+# form works on both. Honor $TMPDIR for sandboxed CI environments.
+TMP_LANES=$(mktemp "${TMPDIR:-/tmp}/lane-spawn.XXXXXX")
 awk -v lane="$LANE" -v branch="$BRANCH" -v issue="$ISSUE" \
     -v handoff="session-handoff-${LANE}.md" -v short="$SHORT" -v today="$TODAY" '
   BEGIN { saw_active = 0; in_active = 0; printed = 0 }

--- a/scripts/lane-spawn.sh
+++ b/scripts/lane-spawn.sh
@@ -39,8 +39,11 @@
 #
 # Exit codes:
 #   0  spawn succeeded (or --dry-run path completed)
-#   1  validation failed (lane exists / cap reached / Issue not found / handoff exists)
-#   2  invalid args / missing tools / cannot resolve repo or memory dir / step failure
+#   1  state failure (lane exists / cap reached / Issue not found / handoff
+#      exists / lane-claim conflict / branch exists / git step failure /
+#      awk LANES.md insert failure / user aborted at confirm prompt)
+#   2  argument or environment error (invalid flag / missing gh / cannot
+#      resolve repo or memory dir / unsafe --lanes-file path)
 
 set -u
 
@@ -279,7 +282,10 @@ if [ "$DRY_RUN" -eq 1 ]; then
   exit 0
 fi
 
-# Confirm before mutations unless --yes or non-interactive with --no-claim+--no-branch.
+# Confirm before mutations unless --yes is set. Non-interactive contexts
+# (no tty on stdin) MUST pass --yes regardless of --no-claim/--no-branch —
+# the script never auto-confirms based on flag combination, only on tty
+# detection + explicit --yes.
 if [ "$YES" -eq 0 ]; then
   if [ -t 0 ]; then
     printf 'Spawn lane "%s" for issue #%s (branch=%s)? [y/N] ' "$LANE" "$ISSUE" "$BRANCH"

--- a/scripts/lane-spawn.sh
+++ b/scripts/lane-spawn.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
-# scripts/lane-spawn.sh — Mercury multi-lane atomic spawn ceremony.
-# Implements #323 Phase B B1 (atomic lane creation).
+# scripts/lane-spawn.sh — Mercury multi-lane spawn ceremony.
+# Implements #323 Phase B B1 (lane creation with documented rollback semantics).
 #
-# Steps (all-or-nothing semantics where possible):
+# Steps (best-effort sequencing — see Rollback policy below for partial-failure
+# semantics; this is NOT cryptographic atomicity):
 #   1. Validate <lane>, <issue>, optional --short / --slug args
 #   2. Refuse if <lane> already appears in LANES.md "## Active Lanes" section
 #   3. Refuse if active-lane count is at HARD-CAP=5 (Rule 7 Delta 7 / Issue #314)

--- a/scripts/test-lane-close.sh
+++ b/scripts/test-lane-close.sh
@@ -256,6 +256,136 @@ RC_OK=$?
 [ "$RC_OK" = "0" ] && pass "valid --tmp-dir under .tmp/ accepted" \
   || fail "valid --tmp-dir rejected: exit=$RC_OK out=$OUT_OK"
 
+# ---- --close-issue arg interlock ----
+echo
+echo "[close-issue-args]"
+MEM9="$TMP/case9"; mkdir -p "$MEM9"; write_fixture_lanes "$MEM9/LANES.md"
+mkdir -p "$TMP/case9-repo"
+
+assert_exit 2 "--close-issue without --issue refused" \
+  "$SCRIPT" side-target --yes --force-cross-lane --close-issue \
+    --lanes-file "$MEM9/LANES.md" --memory-dir "$MEM9" \
+    --repo-root "$TMP/case9-repo"
+
+assert_exit 2 "--issue without --close-issue refused" \
+  "$SCRIPT" side-target --yes --force-cross-lane --issue 100 \
+    --lanes-file "$MEM9/LANES.md" --memory-dir "$MEM9" \
+    --repo-root "$TMP/case9-repo"
+
+assert_exit 2 "--rationale without --close-issue refused" \
+  "$SCRIPT" side-target --yes --force-cross-lane --rationale "x" \
+    --lanes-file "$MEM9/LANES.md" --memory-dir "$MEM9" \
+    --repo-root "$TMP/case9-repo"
+
+assert_exit 2 "--repo without --close-issue refused" \
+  "$SCRIPT" side-target --yes --force-cross-lane --repo "owner/repo" \
+    --lanes-file "$MEM9/LANES.md" --memory-dir "$MEM9" \
+    --repo-root "$TMP/case9-repo"
+
+assert_exit 2 "--issue=0 rejected" \
+  "$SCRIPT" side-target --yes --force-cross-lane --close-issue --issue 0 \
+    --lanes-file "$MEM9/LANES.md" --memory-dir "$MEM9" \
+    --repo-root "$TMP/case9-repo"
+
+assert_exit 2 "--issue=abc rejected" \
+  "$SCRIPT" side-target --yes --force-cross-lane --close-issue --issue abc \
+    --lanes-file "$MEM9/LANES.md" --memory-dir "$MEM9" \
+    --repo-root "$TMP/case9-repo"
+
+# ---- --close-issue dry-run printout ----
+echo
+echo "[close-issue-dry-run]"
+MEM10="$TMP/case10"; mkdir -p "$MEM10"; write_fixture_lanes "$MEM10/LANES.md"
+mkdir -p "$TMP/case10-repo"
+OUT10=$("$SCRIPT" side-target --dry-run --force-cross-lane \
+        --close-issue --issue 999 --rationale "test reason" \
+        --lanes-file "$MEM10/LANES.md" --memory-dir "$MEM10" \
+        --repo-root "$TMP/case10-repo" 2>&1)
+RC10=$?
+[ "$RC10" = "0" ] && pass "dry-run with --close-issue exits 0" \
+  || fail "dry-run with --close-issue exit=$RC10: $OUT10"
+case "$OUT10" in
+  *"would gh issue comment #999"*) pass "dry-run prints issue close intent" ;;
+  *) fail "dry-run output missing close intent: $OUT10" ;;
+esac
+
+# ---- --close-issue with stubbed gh ----
+echo
+echo "[close-issue-stub-gh]"
+MEM11="$TMP/case11"; mkdir -p "$MEM11"; write_fixture_lanes "$MEM11/LANES.md"
+mkdir -p "$TMP/case11-repo"
+
+# Build a fake gh on PATH that records its argv to a log file and exits 0.
+STUB_BIN="$TMP/case11-bin"
+mkdir -p "$STUB_BIN"
+GH_LOG="$TMP/case11-gh.log"
+cat > "$STUB_BIN/gh" <<'STUBEOF'
+#!/usr/bin/env bash
+echo "$@" >> "$GH_LOG"
+exit 0
+STUBEOF
+chmod +x "$STUB_BIN/gh"
+
+OUT11=$(PATH="$STUB_BIN:$PATH" GH_LOG="$GH_LOG" GH_REPO="acme/widget" \
+  "$SCRIPT" side-target --yes --force-cross-lane \
+    --close-issue --issue 1234 --rationale "phase b done" \
+    --lanes-file "$MEM11/LANES.md" --memory-dir "$MEM11" \
+    --repo-root "$TMP/case11-repo" 2>&1)
+RC11=$?
+[ "$RC11" = "0" ] && pass "stubbed --close-issue happy path exit 0" \
+  || fail "stubbed --close-issue exit=$RC11: $OUT11"
+
+# Verify Status was flipped despite the new code path.
+TARGET11=$(awk '/^### `side-target`/{s=1; next} /^### / && s {exit} s && /^- \*\*Status\*\*:/ {print; exit}' "$MEM11/LANES.md")
+case "$TARGET11" in
+  *closed*) pass "Status flipped with --close-issue path" ;;
+  *) fail "Status not flipped: '$TARGET11'" ;;
+esac
+
+# gh stub should have been called twice: comment + close.
+[ -f "$GH_LOG" ] && pass "gh stub log written" || fail "gh stub log missing"
+case "$(cat "$GH_LOG" 2>/dev/null)" in
+  *"issue comment 1234"*) pass "gh issue comment recorded" ;;
+  *) fail "gh issue comment not recorded: $(cat "$GH_LOG" 2>/dev/null)" ;;
+esac
+case "$(cat "$GH_LOG" 2>/dev/null)" in
+  *"issue close 1234"*) pass "gh issue close recorded" ;;
+  *) fail "gh issue close not recorded: $(cat "$GH_LOG" 2>/dev/null)" ;;
+esac
+
+# ---- --close-issue: gh failure does NOT roll back local close ----
+echo
+echo "[close-issue-gh-failure]"
+MEM12="$TMP/case12"; mkdir -p "$MEM12"; write_fixture_lanes "$MEM12/LANES.md"
+mkdir -p "$TMP/case12-repo"
+
+STUB_BIN12="$TMP/case12-bin"
+mkdir -p "$STUB_BIN12"
+cat > "$STUB_BIN12/gh" <<'STUBEOF'
+#!/usr/bin/env bash
+exit 1
+STUBEOF
+chmod +x "$STUB_BIN12/gh"
+
+OUT12=$(PATH="$STUB_BIN12:$PATH" GH_REPO="acme/widget" \
+  "$SCRIPT" side-target --yes --force-cross-lane \
+    --close-issue --issue 5678 \
+    --lanes-file "$MEM12/LANES.md" --memory-dir "$MEM12" \
+    --repo-root "$TMP/case12-repo" 2>&1)
+RC12=$?
+# Per design: gh failure WARNs but exit stays 0 because local state was committed.
+[ "$RC12" = "0" ] && pass "gh failure does not flip exit code (local Status already flipped)" \
+  || fail "gh failure should not flip exit: exit=$RC12 out=$OUT12"
+TARGET12=$(awk '/^### `side-target`/{s=1; next} /^### / && s {exit} s && /^- \*\*Status\*\*:/ {print; exit}' "$MEM12/LANES.md")
+case "$TARGET12" in
+  *closed*) pass "Status flipped despite gh failure" ;;
+  *) fail "Status not flipped on gh failure: '$TARGET12'" ;;
+esac
+case "$OUT12" in
+  *WARN*) pass "WARN emitted on gh failure" ;;
+  *) fail "no WARN on gh failure: $OUT12" ;;
+esac
+
 echo
 printf '%d pass / %d fail\n' "$PASS" "$FAIL"
 [ "$FAIL" = "0" ]

--- a/scripts/test-lane-spawn.sh
+++ b/scripts/test-lane-spawn.sh
@@ -13,7 +13,9 @@ REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
 SCRIPT="$REPO_ROOT/scripts/lane-spawn.sh"
 [ -x "$SCRIPT" ] || { echo "test-lane-spawn: $SCRIPT missing or not executable" >&2; exit 2; }
 
-TMP=$(mktemp -d)
+# BSD/macOS mktemp requires explicit template form for portability; GNU
+# tolerates either. Honor $TMPDIR for CI sandboxes.
+TMP=$(mktemp -d "${TMPDIR:-/tmp}/test-lane-spawn.XXXXXX")
 trap 'rm -rf "$TMP"' EXIT
 
 PASS=0; FAIL=0
@@ -252,6 +254,27 @@ case "$(cat "$MEM8/LANES.md")" in
   *"**Short name**: \`autolane\`"*) pass "auto-derived short = autolane" ;;
   *) fail "auto-derived short missing/wrong in LANES.md" ;;
 esac
+
+# ---- --lanes-file path traversal defense (Argus iter 2 importance:2/10) ----
+# Spec: --lanes-file resolving outside MEMORY_DIR must be refused before any
+# external mutation. Default --lanes-file = $MEMORY_DIR/LANES.md trivially OK.
+echo
+echo "[lanes-file-path-traversal]"
+MEM_PT="$TMP/case-pt"; mkdir -p "$MEM_PT"; write_fixture_lanes "$MEM_PT/LANES.md"
+mkdir -p "$TMP/case-pt-repo"
+# Create a side LANES.md OUTSIDE memory-dir
+SIDE_LANES="$TMP/elsewhere-lanes.md"
+write_fixture_lanes "$SIDE_LANES"
+
+OUT_PT=$("$SCRIPT" newlane 400 --short newl --slug "x" \
+        --no-claim --no-branch --yes \
+        --memory-dir "$MEM_PT" --lanes-file "$SIDE_LANES" \
+        --repo-root "$TMP/case-pt-repo" 2>&1)
+RC_PT=$?
+[ "$RC_PT" = "2" ] && pass "--lanes-file outside --memory-dir refused (exit=2)" \
+  || fail "--lanes-file path traversal not refused: exit=$RC_PT out=$OUT_PT"
+
+# Default --lanes-file (under --memory-dir) accepted via prior happy-path tests.
 
 # ---- malformed LANES.md (Codex audit Medium) ----
 # Spec: spawn must REFUSE before any external mutation when the registry is

--- a/scripts/test-lane-spawn.sh
+++ b/scripts/test-lane-spawn.sh
@@ -1,0 +1,324 @@
+#!/usr/bin/env bash
+# scripts/test-lane-spawn.sh — smoke tests for lane-spawn.sh
+#
+# Builds synthetic LANES.md + memory dir, exercises argument validation,
+# dry-run, --no-claim/--no-branch happy path, duplicate-lane refusal,
+# HARD-CAP=5 detection, short-name uniqueness, and handoff overwrite guard.
+# Tests run offline (no gh / no live Issue probe). Exit 0 if all pass.
+
+set -u
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
+  echo "test-lane-spawn: not inside a git repo" >&2; exit 2; }
+SCRIPT="$REPO_ROOT/scripts/lane-spawn.sh"
+[ -x "$SCRIPT" ] || { echo "test-lane-spawn: $SCRIPT missing or not executable" >&2; exit 2; }
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+PASS=0; FAIL=0
+pass() { printf '  PASS: %s\n' "$1"; PASS=$((PASS+1)); }
+fail() { printf '  FAIL: %s\n' "$1"; FAIL=$((FAIL+1)); }
+
+assert_exit() {
+  local expected=$1 desc=$2; shift 2
+  "$@" >/dev/null 2>&1; local actual=$?
+  if [ "$actual" = "$expected" ]; then pass "$desc (exit=$actual)"
+  else fail "$desc (expected=$expected got=$actual)"; fi
+}
+
+write_fixture_lanes() {
+  local path="$1"
+  cat > "$path" <<'EOF'
+# Mercury Lanes Registry
+
+## Active Lanes
+
+### `main` (default lane)
+
+- **Short name**: `main`
+- **Branch**: `develop`
+- **Handoff file**: `session-handoff.md`
+- **Status**: `active`
+
+### `existing-lane`
+
+- **Short name**: `existing`
+- **Branch**: `lane/existing/100-foo`
+- **Handoff file**: `session-handoff-existing-lane.md`
+- **Status**: `active`
+
+## Closed Lanes
+
+(none)
+EOF
+}
+
+write_fixture_lanes_at_cap() {
+  local path="$1"
+  cat > "$path" <<'EOF'
+# Mercury Lanes Registry
+
+## Active Lanes
+
+### `lane1`
+- **Short name**: `lane1`
+- **Status**: `active`
+
+### `lane2`
+- **Short name**: `lane2`
+- **Status**: `active`
+
+### `lane3`
+- **Short name**: `lane3`
+- **Status**: `active`
+
+### `lane4`
+- **Short name**: `lane4`
+- **Status**: `active`
+
+### `lane5`
+- **Short name**: `lane5`
+- **Status**: `active`
+
+## Closed Lanes
+
+(none)
+EOF
+}
+
+# ---- arg validation ----
+echo "[arg-validation]"
+assert_exit 0 "--help"                        "$SCRIPT" --help
+assert_exit 2 "missing both args"             "$SCRIPT"
+assert_exit 2 "missing issue arg"             "$SCRIPT" mylane
+assert_exit 2 "lane name with space rejected" "$SCRIPT" "bad lane" 100 --no-claim --no-branch --yes
+assert_exit 2 "lane starting with hyphen"     "$SCRIPT" -bad 100 --no-claim --no-branch --yes
+assert_exit 2 "issue must be int"             "$SCRIPT" mylane abc --no-claim --no-branch --yes
+assert_exit 2 "issue zero rejected"           "$SCRIPT" mylane 0 --no-claim --no-branch --yes
+assert_exit 2 "unknown flag"                  "$SCRIPT" --bogus
+
+# ---- dry-run path ----
+echo
+echo "[dry-run]"
+MEM1="$TMP/mem1"; mkdir -p "$MEM1"; write_fixture_lanes "$MEM1/LANES.md"
+mkdir -p "$TMP/repo1"
+
+OUT1=$("$SCRIPT" newlane 200 --dry-run --no-claim --no-branch --slug "test-spawn" \
+        --memory-dir "$MEM1" --lanes-file "$MEM1/LANES.md" \
+        --repo-root "$TMP/repo1" 2>&1)
+RC1=$?
+[ "$RC1" = "0" ] && pass "dry-run exits 0" || fail "dry-run exit=$RC1: $OUT1"
+case "$OUT1" in
+  *"[dry-run] lane=newlane issue=200"*) pass "dry-run prints lane+issue" ;;
+  *) fail "dry-run output missing lane/issue: $OUT1" ;;
+esac
+case "$OUT1" in
+  *"branch=lane/newlane/200-test-spawn"*) pass "dry-run prints branch" ;;
+  *) fail "dry-run output missing branch line: $OUT1" ;;
+esac
+# dry-run must NOT mutate LANES.md
+LANES_AFTER=$(cat "$MEM1/LANES.md")
+case "$LANES_AFTER" in
+  *"### \`newlane\`"*) fail "dry-run mutated LANES.md (newlane present)" ;;
+  *) pass "dry-run did not mutate LANES.md" ;;
+esac
+[ ! -f "$MEM1/session-handoff-newlane.md" ] \
+  && pass "dry-run did not write handoff" \
+  || fail "dry-run wrote handoff file"
+
+# ---- duplicate-lane refusal ----
+echo
+echo "[duplicate-lane]"
+MEM2="$TMP/mem2"; mkdir -p "$MEM2"; write_fixture_lanes "$MEM2/LANES.md"
+mkdir -p "$TMP/repo2"
+OUT2=$("$SCRIPT" existing-lane 201 --no-claim --no-branch --yes --slug "x" \
+        --memory-dir "$MEM2" --lanes-file "$MEM2/LANES.md" \
+        --repo-root "$TMP/repo2" 2>&1)
+RC2=$?
+[ "$RC2" = "1" ] && pass "existing-lane rejected (exit=1)" \
+  || fail "existing-lane should refuse: exit=$RC2 out=$OUT2"
+
+# ---- short-name uniqueness ----
+echo
+echo "[short-name-uniqueness]"
+MEM3="$TMP/mem3"; mkdir -p "$MEM3"; write_fixture_lanes "$MEM3/LANES.md"
+mkdir -p "$TMP/repo3"
+# Try a new lane name BUT reuse existing-lane's short ("existing").
+OUT3=$("$SCRIPT" newname 202 --short existing --slug "x" --no-claim --no-branch --yes \
+        --memory-dir "$MEM3" --lanes-file "$MEM3/LANES.md" \
+        --repo-root "$TMP/repo3" 2>&1)
+RC3=$?
+[ "$RC3" = "1" ] && pass "duplicate short name rejected (exit=1)" \
+  || fail "duplicate short should refuse: exit=$RC3 out=$OUT3"
+
+# ---- HARD-CAP=5 detection ----
+echo
+echo "[hard-cap]"
+MEM4="$TMP/mem4"; mkdir -p "$MEM4"; write_fixture_lanes_at_cap "$MEM4/LANES.md"
+mkdir -p "$TMP/repo4"
+OUT4=$("$SCRIPT" lane6 203 --short l6 --slug "x" --no-claim --no-branch --yes \
+        --memory-dir "$MEM4" --lanes-file "$MEM4/LANES.md" \
+        --repo-root "$TMP/repo4" 2>&1)
+RC4=$?
+[ "$RC4" = "1" ] && pass "HARD-CAP=5 enforced (exit=1)" \
+  || fail "cap check failed: exit=$RC4 out=$OUT4"
+case "$OUT4" in
+  *HARD-CAP*) pass "cap-check error message mentions HARD-CAP" ;;
+  *) fail "cap-check error message missing 'HARD-CAP': $OUT4" ;;
+esac
+
+# ---- happy path with --no-claim --no-branch --yes ----
+echo
+echo "[happy-path-offline]"
+MEM5="$TMP/mem5"; mkdir -p "$MEM5"; write_fixture_lanes "$MEM5/LANES.md"
+mkdir -p "$TMP/repo5"
+OUT5=$("$SCRIPT" newlane 204 --short newl --slug "phase-b-test" \
+        --no-claim --no-branch --yes \
+        --memory-dir "$MEM5" --lanes-file "$MEM5/LANES.md" \
+        --repo-root "$TMP/repo5" 2>&1)
+RC5=$?
+[ "$RC5" = "0" ] && pass "happy path exit 0" || fail "happy path exit=$RC5: $OUT5"
+[ -f "$MEM5/session-handoff-newlane.md" ] \
+  && pass "handoff file created" \
+  || fail "handoff file missing: $MEM5/session-handoff-newlane.md"
+case "$(cat "$MEM5/LANES.md")" in
+  *"### \`newlane\`"*) pass "newlane section appended to LANES.md" ;;
+  *) fail "newlane section NOT in LANES.md after spawn" ;;
+esac
+case "$(cat "$MEM5/LANES.md")" in
+  *"**Branch**: \`lane/newl/204-phase-b-test\`"*) pass "branch field recorded" ;;
+  *) fail "branch field missing in LANES.md" ;;
+esac
+case "$(cat "$MEM5/LANES.md")" in
+  *"**Status**: \`active\`"*) pass "status active recorded" ;;
+  *) fail "status active missing" ;;
+esac
+# Other lanes' Status untouched.
+EXISTING_STATUS=$(awk '/^### `existing-lane`/{s=1; next} /^### / && s {exit} s && /^- \*\*Status\*\*:/ {print; exit}' "$MEM5/LANES.md")
+case "$EXISTING_STATUS" in
+  *active*) pass "existing-lane Status untouched" ;;
+  *) fail "existing-lane Status modified: '$EXISTING_STATUS'" ;;
+esac
+
+# ---- handoff overwrite refusal ----
+echo
+echo "[handoff-overwrite]"
+MEM6="$TMP/mem6"; mkdir -p "$MEM6"; write_fixture_lanes "$MEM6/LANES.md"
+mkdir -p "$TMP/repo6"
+echo "preexisting content" > "$MEM6/session-handoff-newlane.md"
+OUT6=$("$SCRIPT" newlane 205 --short newl --slug "x" --no-claim --no-branch --yes \
+        --memory-dir "$MEM6" --lanes-file "$MEM6/LANES.md" \
+        --repo-root "$TMP/repo6" 2>&1)
+RC6=$?
+[ "$RC6" = "1" ] && pass "handoff overwrite refused (exit=1)" \
+  || fail "handoff overwrite should refuse: exit=$RC6 out=$OUT6"
+# Original handoff content preserved.
+case "$(cat "$MEM6/session-handoff-newlane.md")" in
+  "preexisting content") pass "preexisting handoff content preserved" ;;
+  *) fail "preexisting handoff modified" ;;
+esac
+# LANES.md NOT mutated on this failure path.
+case "$(cat "$MEM6/LANES.md")" in
+  *"### \`newlane\`"*) fail "LANES.md mutated despite handoff guard" ;;
+  *) pass "LANES.md untouched on handoff guard failure" ;;
+esac
+
+# ---- non-interactive without --yes refused ----
+echo
+echo "[interactive-guard]"
+MEM7="$TMP/mem7"; mkdir -p "$MEM7"; write_fixture_lanes "$MEM7/LANES.md"
+mkdir -p "$TMP/repo7"
+"$SCRIPT" newlane 206 --no-claim --no-branch --short newl --slug "x" \
+  --memory-dir "$MEM7" --lanes-file "$MEM7/LANES.md" \
+  --repo-root "$TMP/repo7" </dev/null >/dev/null 2>&1
+RC7=$?
+[ "$RC7" = "1" ] && pass "non-interactive without --yes refuses" \
+  || fail "non-interactive exit=$RC7 (expected 1)"
+
+# ---- --short auto-derive ----
+echo
+echo "[short-derive]"
+MEM8="$TMP/mem8"; mkdir -p "$MEM8"; write_fixture_lanes "$MEM8/LANES.md"
+mkdir -p "$TMP/repo8"
+# Auto-derived short from "AutoLane" → "autolane" → cut to 8 chars = "autolane"
+OUT8=$("$SCRIPT" AutoLane 207 --slug "x" --no-claim --no-branch --yes \
+        --memory-dir "$MEM8" --lanes-file "$MEM8/LANES.md" \
+        --repo-root "$TMP/repo8" 2>&1)
+RC8=$?
+[ "$RC8" = "0" ] && pass "auto-derive happy path exit 0" \
+  || fail "auto-derive failed: exit=$RC8 out=$OUT8"
+case "$(cat "$MEM8/LANES.md")" in
+  *"**Short name**: \`autolane\`"*) pass "auto-derived short = autolane" ;;
+  *) fail "auto-derived short missing/wrong in LANES.md" ;;
+esac
+
+# ---- malformed LANES.md (Codex audit Medium) ----
+# Spec: spawn must REFUSE before any external mutation when the registry is
+# missing '## Active Lanes' — otherwise step 8 awk would silently no-op
+# leaving the issue claim / branch / handoff with no registry row.
+echo
+echo "[malformed-lanes-md]"
+MEM_BAD1="$TMP/case-bad1"; mkdir -p "$MEM_BAD1"
+# Empty LANES.md (no Active Lanes header at all)
+printf '# Mercury Lanes Registry\n\n(empty)\n' > "$MEM_BAD1/LANES.md"
+mkdir -p "$TMP/case-bad1-repo"
+
+OUT_BAD1=$("$SCRIPT" newlane 300 --short newl --slug "x" \
+        --no-claim --no-branch --yes \
+        --memory-dir "$MEM_BAD1" --lanes-file "$MEM_BAD1/LANES.md" \
+        --repo-root "$TMP/case-bad1-repo" 2>&1)
+RC_BAD1=$?
+[ "$RC_BAD1" = "1" ] && pass "missing '## Active Lanes' header refused (exit=1)" \
+  || fail "missing-header should refuse: exit=$RC_BAD1 out=$OUT_BAD1"
+case "$OUT_BAD1" in
+  *"Active Lanes"*) pass "error message names the missing header" ;;
+  *) fail "error message missing 'Active Lanes': $OUT_BAD1" ;;
+esac
+# Confirm no FS mutation: LANES.md unchanged, no handoff written.
+LANES_BAD1_AFTER=$(cat "$MEM_BAD1/LANES.md")
+case "$LANES_BAD1_AFTER" in
+  *"### \`newlane\`"*) fail "LANES.md mutated despite refusal" ;;
+  *) pass "LANES.md untouched on missing-header refusal" ;;
+esac
+[ ! -f "$MEM_BAD1/session-handoff-newlane.md" ] \
+  && pass "handoff NOT written on missing-header refusal" \
+  || fail "handoff written despite refusal"
+
+# Truly empty LANES.md
+MEM_BAD2="$TMP/case-bad2"; mkdir -p "$MEM_BAD2"
+: > "$MEM_BAD2/LANES.md"
+mkdir -p "$TMP/case-bad2-repo"
+
+OUT_BAD2=$("$SCRIPT" newlane 301 --short newl --slug "x" \
+        --no-claim --no-branch --yes \
+        --memory-dir "$MEM_BAD2" --lanes-file "$MEM_BAD2/LANES.md" \
+        --repo-root "$TMP/case-bad2-repo" 2>&1)
+RC_BAD2=$?
+[ "$RC_BAD2" = "1" ] && pass "empty LANES.md refused (exit=1)" \
+  || fail "empty LANES.md should refuse: exit=$RC_BAD2 out=$OUT_BAD2"
+[ ! -f "$MEM_BAD2/session-handoff-newlane.md" ] \
+  && pass "handoff NOT written on empty-LANES.md refusal" \
+  || fail "handoff written despite empty-LANES.md refusal"
+
+# ---- branch length cap (Rule 2.1 ≤40 chars) ----
+echo
+echo "[branch-cap]"
+MEM9="$TMP/mem9"; mkdir -p "$MEM9"; write_fixture_lanes "$MEM9/LANES.md"
+mkdir -p "$TMP/repo9"
+OUT9=$("$SCRIPT" longLane 208 --short ll --slug "very-very-very-long-task-slug-overflow" \
+        --no-claim --no-branch --yes \
+        --memory-dir "$MEM9" --lanes-file "$MEM9/LANES.md" \
+        --repo-root "$TMP/repo9" 2>&1)
+RC9=$?
+[ "$RC9" = "0" ] && pass "long slug truncated (exit 0)" \
+  || fail "long slug failed: exit=$RC9 out=$OUT9"
+# Pull the recorded branch and check ≤40 chars.
+BR=$(awk '/^### `longLane`/{s=1} s && /^- \*\*Branch\*\*: `[^`]+`/{match($0,/`[^`]+`/); print substr($0,RSTART+1,RLENGTH-2); exit}' "$MEM9/LANES.md")
+[ -n "$BR" ] && [ "${#BR}" -le 40 ] \
+  && pass "branch length ${#BR} ≤40 (cap honored)" \
+  || fail "branch length ${#BR}: '$BR' (cap violated)"
+
+echo
+printf '%d pass / %d fail\n' "$PASS" "$FAIL"
+[ "$FAIL" = "0" ]


### PR DESCRIPTION
## Summary

Phase B (#323) lane lifecycle modules:

- **B1** `scripts/lane-spawn.sh` (new, ~370 LOC) — atomic lane creation: claim Issue via `lane-claim.sh` (Rule 1.1 #309), branch off `origin/develop` with Rule 2.1 short prefix `lane/<short>/<issue>-<slug>` ≤40 chars, write per-lane handoff template, append `LANES.md` section (Rule 6 own-section). Refuses on duplicate lane / short collision / HARD-CAP=5 / missing `## Active Lanes` header.
- **B2 enhancement** — `scripts/lane-close.sh` adds opt-in `--close-issue / --issue N / --rationale TEXT / --repo OWNER/REPO` flags satisfying #323 spec line "Close GitHub Issue with rationale". `gh` failure WARNs but does NOT roll back local Status flip — local state remains authoritative.
- **Install guide** `.mercury/docs/guides/phase-b-install.md` — B1/B2/B3 quick-ref + cron registration via `CronCreate durable: true`. Documents the #323 spec vs Rule 6 reconciliation: B3 stays REPORT-ONLY because Rule 3.1 (#310 merged) supersedes the original "auto-flip" wording.
- **Companion guide** `.mercury/docs/guides/lane-spawn.md` — usage, args, examples, exit codes, Rule 2.1 / Rule 6 / HARD-CAP cross-refs.

## Why now

Phase A (#322 / PR #333) shipped observability + cross-lane status aggregator. Phase B makes the lane lifecycle atomic. Side lane PRs #327/#328 already landed B2 (lane-close Rule 3.2) and B3 (lane-sweep Rule 3.1) as part of v0.1 deltas — this PR completes the trio with B1 and adds the `--close-issue` enhancement on B2.

## Test plan

- [x] `bash scripts/test-lane-spawn.sh` → 37/37 PASS
- [x] `bash scripts/test-lane-close.sh` → 43/43 PASS (includes 7 new `--close-issue` cases + 6 `--repo` interlock + arg validation)
- [x] `bash scripts/test-lane-claim.sh` → 18/18 PASS (regression)
- [x] `bash scripts/test-lane-sweep.sh` → 24/24 PASS (regression)
- [x] **TOTAL: 122/122 PASS**
- [x] `dual-verify`: Codex NEEDS-CHANGES (1 High + 2 Medium + 1 Low) + Claude deep-review PASS (1 Medium + 4 Low) — all Codex findings + agreed High addressed
- [x] Help output verified: `bash scripts/lane-spawn.sh --help` and `bash scripts/lane-close.sh --help`

## Dual-verify resolution

Both reviewers' agreed High issue: lane-spawn.sh awk step 8 silently no-op'd when `## Active Lanes` header missing → would leave handoff/branch/Issue claim with no LANES.md row. **Fix**: added `grep -q '^## Active Lanes'` precheck before any external mutation, plus awk END sentinel that exits 7 if the insert never fired (defense-in-depth in case header is mutated mid-spawn). New test fixtures cover empty LANES.md + missing-header cases.

Codex Mediums: (1) `--repo` flag in lane-close was silently accepted without `--close-issue` — now rejected with clear error. (2) Test suite missing malformed-LANES.md fixture — added.

Codex Low: lane-spawn.md doc clarified that `--dry-run` may still call `gh repo view` / `gh issue view` for slug derivation unless `--no-claim --slug` combo passed.

## Refs

- Closes #323
- Depends on (already merged): #309 (Rule 1.1 lane-claim.sh), #310 (Rule 3.1 lane-sweep), #311 (Rule 3.2 lane-close), #313/#314 (Rule 2.1 / HARD-CAP), #322/PR #333 (Phase A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)