### PR TITLE
feat(phase-c): auto-report hook + Director command surface (#324)

### DIFF
--- a/.mercury/docs/guides/phase-c-install.md
+++ b/.mercury/docs/guides/phase-c-install.md
@@ -42,7 +42,8 @@ MERCURY_LANE_REPORT_QUIET=1 bash scripts/lane-auto-report.sh
 
 ```bash
 bash scripts/test-lane-auto-report.sh
-# → 13/13 PASS
+# → 15/15 PASS (covers diff transitions, atomic promote, lock contention,
+#               POST-failure retry semantics)
 ```
 
 ### Step 3 — Register cron via Claude Code `CronCreate`

--- a/.mercury/docs/guides/phase-c-install.md
+++ b/.mercury/docs/guides/phase-c-install.md
@@ -1,0 +1,151 @@
+# Phase C Install Guide — Auto-report + Director Command Surface
+
+Issue #324 · Phase C · `scripts/lane-auto-report.sh` + `adapters/mercury-channel-router/router.cjs` enhancements
+
+Subsumes #308 (`/dir`, `/model`, `/permission-mode` cmds) and #318 (lane-aware routing reframe).
+
+---
+
+## Prerequisites
+
+- Phase A installed (`scripts/lane-status.sh` writes `.mercury/state/lane-status.json`)
+- Phase 5 MVP installed (`mercury-channel-router` running with Telegram bot token)
+- `jq` and `curl` on PATH
+- Claude Code CLI (for `CronCreate`)
+
+---
+
+## C1 — Install lane-auto-report cron
+
+`scripts/lane-auto-report.sh` diffs the latest `lane-status.json` against the previous
+snapshot and POSTs transition notifications to the channel router's `/notify` endpoint.
+Director receives unprompted Telegram updates without polling.
+
+### Step 1 — Verify the script runs locally (dry-run)
+
+```bash
+cd /path/to/Mercury
+
+# Ensure lane-status.json exists (run Phase A aggregator first)
+bash scripts/lane-status.sh
+
+# First invocation seeds baseline; expect "no diff on first run"
+MERCURY_LANE_REPORT_QUIET=1 bash scripts/lane-auto-report.sh
+# → [lane-auto-report] seeded baseline; no diff on first run
+
+# Second invocation diffs (no real changes yet → 0 emits)
+MERCURY_LANE_REPORT_QUIET=1 bash scripts/lane-auto-report.sh
+# → [lane-auto-report] emitted 0 notifications
+```
+
+### Step 2 — Run the test suite
+
+```bash
+bash scripts/test-lane-auto-report.sh
+# → 13/13 PASS
+```
+
+### Step 3 — Register cron via Claude Code `CronCreate`
+
+Use `durable: true` so the schedule survives session restarts (per
+`feedback_cron_safety.md`). Off-`:00` minute jitter (`2-59/5`) avoids fleet
+collision per `feedback_cron_interval_argus.md`.
+
+In a Claude Code session, run:
+
+```
+CronCreate({
+  schedule: "2-59/5 * * * *",
+  durable: true,
+  prompt: "Run `bash scripts/lane-status.sh && bash scripts/lane-auto-report.sh` from the Mercury repo root and report the emit count."
+})
+```
+
+The first cron tick re-seeds the baseline; subsequent ticks emit on real
+transitions only (lane add/remove, `is_stale` flip, issue-set change, branch
+commit jump, new branch on existing lane).
+
+### Step 4 — Suppress notifications for noisy windows
+
+Set `MERCURY_LANE_REPORT_QUIET=1` in the cron environment (or shell profile)
+when running release-week soak — diffs still update the previous snapshot but
+nothing posts to Telegram.
+
+---
+
+## C2 — Verify router lane-aware enhancements
+
+The router enhancements are in-place edits to `adapters/mercury-channel-router/router.cjs`.
+No install ceremony — restart any running router instance to pick them up.
+
+### Step 1 — Restart the router (if running)
+
+If the router is currently running, the lock file pins it to the old code. Stop it:
+
+```bash
+LOCK_FILE="$HOME/.mercury/router.lock"
+if [ -f "$LOCK_FILE" ]; then
+  PID=$(cat "$LOCK_FILE")
+  kill "$PID" 2>/dev/null || true
+fi
+```
+
+Restart by opening a Claude Code session in any Mercury-rooted repo that loads
+the channel client MCP server (the client auto-spawns the router).
+
+### Step 2 — Smoke checklist
+
+From a Telegram chat with the bot (must be in `MERCURY_TELEGRAM_ALLOWED_USER_IDS`):
+
+| Command | Expected response |
+|---|---|
+| `/help` | Lists `/status /list /lanes /help`, plus `/cancel`, `/continue`, `/dir`, `/model`, `/permission-mode` with usage hints |
+| `/lanes` | Per-lane structured rows: `[label] active branch:feature/... sse:N` |
+| `/dir @<label> /tmp/test` | `Sent /dir /tmp/test to [<label>]` (target session sees `<channel cmd="dir" path="/tmp/test">dir requested by user: path=/tmp/test</channel>`) |
+| `/model @<label> sonnet` | `Sent /model sonnet to [<label>]` (target session sees `<channel cmd="model" model="sonnet">…</channel>`) |
+| `/permission-mode @<label> strict` | `Sent /permission-mode strict to [<label>]` (target session sees `<channel cmd="permission-mode" mode="strict">…</channel>`) |
+| `/dir` (no args) | `Usage: /dir @<label> <path>` |
+| `/dir @nope foo` | `No session matching @nope` |
+
+### Step 3 — Verify MAX_SESS bump (default 5)
+
+The change is non-interactive — observable only when ≥4 simultaneous sessions register.
+
+```bash
+# Inspect the live router /sessions endpoint (use the IPC token from ~/.mercury/router.token)
+TOKEN=$(cat "$HOME/.mercury/router.token")
+curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8788/sessions | jq 'length'
+```
+
+To override default 5 (e.g., for cap stress tests):
+
+```bash
+MERCURY_ROUTER_MAX_SESS=2 node adapters/mercury-channel-router/router.cjs
+```
+
+---
+
+## Rollback
+
+C1 (script): delete cron via `CronDelete`. The script is additive — leaving it
+in place with the cron disabled has no runtime impact.
+
+C2 (router edits): `git revert` of the Phase C commit on `develop` plus a
+router restart. The `MAX_SESS` env variable is read at startup, so rolling back
+the binary plus restart is sufficient.
+
+---
+
+## Known limitations
+
+- **Adapter LOC**: `router.cjs` grew from 220 to ~270 LOC, exceeding Mercury's
+  200-LOC adapter cap. Cleanup tracked under #303 (M6 split).
+- **Router unit tests**: not added in Phase C — full test harness is M6 scope.
+  Smoke checklist above is the Phase C verification surface.
+- **`/dir` etc. enforcement**: the router relays the command event to the lane
+  inbox and the channel client (`mercury-channel-client`) forwards `path`,
+  `model`, and `mode` payloads as XML attributes on the `<channel cmd="...">`
+  notification. The actual cwd / model / permission-mode change still happens
+  inside the lane session — Claude Code reads the notification and either acts
+  on it directly or surfaces it to the user. The router is responsible for
+  *delivery*, not *enforcement*.

--- a/.mercury/docs/research/phase-c-surface-choice-2026-04-27.md
+++ b/.mercury/docs/research/phase-c-surface-choice-2026-04-27.md
@@ -1,0 +1,123 @@
+# Phase C — Surface Choice & Implementation Decision
+
+**Issue**: [#324 Phase C — Auto-report + Director command surface (lane-aware)](https://github.com/392fyc/Mercury/issues/324)
+**Author**: main lane S79 (2026-04-27)
+**Status**: Design locked, ready for implementation
+**Refs**: #318 (architecture reframe parent), #308 (subsumed cmd suite), PR #321 (research §Dim 1.3), PR #333 (Phase A merged), PR #334 (Phase B merged)
+
+## Context recap
+
+Issue #324 already fixes the Director surface as **Telegram via `mercury-channel-router`** — not an open `Telegram-only / Claude-Code-only / Hybrid` choice. Handoff doc framed it as open; #324 body removed that ambiguity.
+
+So the research question is not *which channel*, but *how* to wire C1 (auto-report) and C2 (lane-aware routing) on top of the existing router that Phase 5 MVP already shipped.
+
+## Existing surface inventory (read 2026-04-27)
+
+`adapters/mercury-channel-router/router.cjs` — 221 LOC
+
+- `MAX_SESS = 3` (line 16) — needs bump to 5 per #324 Acceptance + `feedback_lane_protocol.md` HARD-CAP
+- `POST /notify` (line 186) — already accepts `{severity, title, body, label}` and forwards to Telegram. C1 backend = no change.
+- `@<label-prefix> <text>` routing (line 144) — already lane-aware: finds session by `label.startsWith(prefix)` derived from branch (`feature/lane-XXX/...`).
+- `/cancel @<label-prefix>` and `/continue @<label-prefix>` (line 117) — already lane-aware.
+- `handleCmd` covers only `status / list / cancel / continue / help` — missing `/lanes`, `/dir`, `/model`, `/permission-mode`.
+
+`adapters/mercury-channel-client/channel.cjs` — 231 LOC
+
+- SSE inbox consumer relays `message / verdict / command` events to MCP. No change needed for C2 (router does the routing; client just relays).
+
+**Conclusion**: ~80% of C2 already exists. Phase C is a thin enhancement, not a rewrite.
+
+## Decision
+
+### C1 — Side lane auto-report hook
+
+**Mechanism**: cron-driven `scripts/lane-auto-report.sh` that diffs `lane-status.json` and posts `POST /notify` when state changes. No git hook (per-commit is too noisy; cron 5-min cadence matches Phase A statusline + Argus poll cadence per `feedback_cron_interval_argus.md`).
+
+**Why cron over git post-commit hook**:
+- Git hooks fire per commit — most commits aren't "milestones" worth pinging Director.
+- Cron + state diff = only fires on actual state transitions (lane spawn / claim / close / commit-jump / soak-complete).
+- Reuses Phase A `lane-status.sh` aggregator (already produces canonical JSON).
+- Same trigger pattern as Phase A statusline refresh — one mental model.
+
+**Backend**: `POST /notify` already exists. Zero router changes for C1.
+
+**Script outline** (`scripts/lane-auto-report.sh`, est. ~120 LOC):
+1. Run `lane-status.sh --json` → write to `.mercury/state/lane-status.current.json`
+2. Diff against `.mercury/state/lane-status.previous.json` (created on first run; missing → diff = "all new")
+3. For each detected transition (lane added / removed / claimed-issue-changed / commit-sha-jumped / lane-status-state-changed), build a notify payload `{severity:'info', title:'<lane> <transition>', body:'<details>', label:'<lane>'}`
+4. POST to `http://127.0.0.1:${MERCURY_ROUTER_PORT:-8788}/notify` with router token from `~/.mercury/router.token`
+5. Move current → previous for next diff
+
+**Install**: `phase-c-install.md` documents cron registration (`durable: true`, 5-min interval `2-59/5` to avoid `:00` collision per `feedback_cron_interval_argus.md`).
+
+**Tests** (`test-lane-auto-report.sh`, est. ~60 cases):
+- Diff detects: lane added, lane removed, claimed-issue change, commit-sha jump, status-field change
+- Diff ignores: cosmetic field changes (timestamps in non-state fields)
+- Empty previous → emits "all new" notification
+- Network failure → exit non-zero, leaves previous untouched (next run retries)
+- Missing token → exit non-zero with diagnostic
+
+### C2 — Router lane-aware routing enhancement
+
+**Changes to `router.cjs`** (~50 LOC added, total ~270 → over 200-LOC adapter cap, see Follow-up below):
+
+1. **`MAX_SESS = 3 → 5`** (1 line). Add `process.env.MERCURY_ROUTER_MAX_SESS` override for future tuning.
+2. **`/lanes` command** — structured lane list (vs `/list` flat session list):
+   - Output: `[label] active|idle | issue:#N | branch:feat/... | sse:N` per session, sorted by activity.
+   - Subsumes the `lane-aware status` ask in #318.
+3. **`/dir @<lane> <path>` command** — sends `{type:'command', cmd:'change_cwd', payload:{path}, from_chat:chatId}` to lane inbox; client relays as MCP notification (channel.cjs already handles `type:'command'` at line 186).
+4. **`/model @<lane> <name>` command** — same pattern, `cmd:'switch_model'`.
+5. **`/permission-mode @<lane> <mode>` command** — same pattern, `cmd:'set_permission_mode'`.
+6. **Update `/help` text** to advertise new commands.
+
+**Why no full router refactor**: the M6 split issue (#303) is the right place for that. Phase C is the *capability* delivery, not the *layout* delivery. Follow-up Issue will note that #324 lands at ~270 LOC (over 200-cap) and explicitly references #303 as the cleanup vehicle.
+
+**Backwards compatibility**:
+- `MAX_SESS` env override is additive. Default 5 (was 3) — sessions 4 and 5 now register where they previously got HTTP 429.
+- New `/lanes` command does not collide with existing names.
+- New `/dir`/`/model`/`/permission-mode` send `command` events; the channel client's existing `command` branch needed a small extension (~13 LOC) to forward the new payload keys (`path`/`model`/`mode`) as XML attributes on the channel notification — without that the verb arrived but the operand was dropped. Existing message/verdict paths unchanged.
+
+**Tests** (smoke + targeted):
+- Phase 5 MVP shipped without router unit tests; adding a full test harness is M6 work.
+- Phase C adds: a small `test-lane-auto-report.sh` for C1 (shell), and a manual smoke checklist in `phase-c-install.md` §"Verification" for C2 (start router with `MAX_SESS=2` env, register 3rd → expect 429 fail; then `MAX_SESS=5` → expect 200 ok; send `/lanes` → expect structured output; send `/dir @lbl /tmp` → expect target session sees channel notification).
+- A C2 unit test belongs in #303 M6 split (where router gets restructured into testable modules).
+
+### What we are NOT doing in Phase C
+
+- ❌ No router refactor / module split (defer to #303).
+- ❌ No `/permission-mode` *enforcement* (just plumb the command; actual mode change happens in client / Claude Code).
+- ❌ No Telegram bot reply formatter changes.
+- ❌ No new hook events (cron only).
+- ❌ No Phase D anything (deferred until Anthropic Agent Teams GA per S75 reframe).
+
+## LOC estimate (rolled up)
+
+| File | Before | Added | After |
+|---|---|---|---|
+| `adapters/mercury-channel-router/router.cjs` | 221 | +46 | 267 (over 200-cap; Follow-up referenced) |
+| `adapters/mercury-channel-client/channel.cjs` | 231 | +13 | 244 (payload forward fix found in deep-review) |
+| `scripts/lane-auto-report.sh` | (new) | 161 | 161 |
+| `scripts/test-lane-auto-report.sh` | (new) | ~250 (14 cases) | 250 |
+| `.mercury/docs/guides/phase-c-install.md` | (new) | ~120 | 120 |
+| **Total Phase C delta** | | **~590 LOC** | |
+
+Within the 1-2d effort estimate from #324.
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Cron auto-report spams Telegram on noisy lanes | Diff-based emission: only fires on state transitions, not every poll. Optional `MERCURY_LANE_REPORT_QUIET=1` env to suppress entirely. |
+| MAX_SESS bump breaks router lock contract (file lock is per-process, not per-slot — safe) | None needed (`acquireLock` is per-process pid, MAX_SESS only gates `/register` capacity). Verified by reading router.cjs lines 25-41 + 167-176. |
+| `/dir` command security (arbitrary path) | Allowlist already enforced at routeMessage line 130 (`isAllowed`); only allowlisted Telegram users can send commands. No new attack surface. |
+| Router LOC over 200-cap | Follow-up Issue notes #303 M6 split as cleanup vehicle. Phase C ships capability now; cleanup deferred per CLAUDE.md "modular design" — adapter becomes detachable later via #303, not now. |
+| Test coverage gap on router additions | Smoke checklist in install guide; full unit tests = #303 scope. Acceptable risk per Phase 5 MVP precedent. |
+
+## Follow-up Issues to file post-merge
+
+1. **Adapter LOC cap** — file new Issue: "router.cjs grew to ~270 LOC during Phase C, exceeds 200-cap; M6 split (#303) is the cleanup vehicle". Reference both #324 and #303.
+2. **C2 unit tests** — track under #303 (no new Issue needed; #303 already covers M6 split + testability).
+
+## Open questions for user (none blocking)
+
+None — design is locked from #324 spec + reading existing surface. Implementation proceeds.

--- a/adapters/mercury-channel-client/channel.cjs
+++ b/adapters/mercury-channel-client/channel.cjs
@@ -184,10 +184,23 @@ async function connectInbox() {
                 params: { verdict: evt.verdict, request_id: evt.request_id },
               });
             } else if (evt.type === 'command') {
+              // Phase C (#324): forward known payload keys (path/model/mode) as XML
+              // attributes AND in body so dir/model/permission-mode commands deliver
+              // the operand to the lane session, not just the bare verb.
+              const chatAttr = String(evt.from_chat).replace(/[^0-9-]/g,'');
+              const payloadParts = [];
+              const bodyParts = [`${xmlEsc(evt.cmd)} requested by user`];
+              for (const key of ['path', 'model', 'mode']) {
+                if (typeof evt[key] === 'string' && evt[key].length > 0) {
+                  payloadParts.push(`${key}="${xmlEsc(evt[key])}"`);
+                  bodyParts.push(`${key}=${xmlEsc(evt[key])}`);
+                }
+              }
+              const attrs = payloadParts.length ? ' ' + payloadParts.join(' ') : '';
               await mcp.notification({
                 method: 'notifications/claude/channel',
                 params: { source: 'mercury-telegram', label: SESSION_ID,
-                  content: `<channel source="mercury-telegram" chat_id="${String(evt.from_chat).replace(/[^0-9-]/g,'')}" cmd="${xmlEsc(evt.cmd)}">${xmlEsc(evt.cmd)} requested by user</channel>` },
+                  content: `<channel source="mercury-telegram" chat_id="${chatAttr}" cmd="${xmlEsc(evt.cmd)}"${attrs}>${bodyParts.join(': ')}</channel>` },
               });
             }
           } catch {}

--- a/adapters/mercury-channel-router/router.cjs
+++ b/adapters/mercury-channel-router/router.cjs
@@ -106,12 +106,20 @@ async function tgSend(chatId, text) {
 }
 
 // Phase C (#324): find session whose label matches the given prefix.
-// Mercury labels include `#324 director-surface` (TASK branches) and
-// `lane-main/foo` (lane branches). Match plain prefix OR the label with a
-// leading `#` stripped, so `@324` finds `#324 director`. Used by
-// /cancel /continue /dir /model /permission-mode.
-const findByLabel = prefix => [...sessions.values()].find(s =>
-  s.label.startsWith(prefix) || s.label.replace(/^#/, '').startsWith(prefix));
+// Resolution order is deterministic regardless of session-register order:
+//   1. exact label equality wins outright
+//   2. otherwise pick the SHORTEST label that prefix-matches (most specific)
+//   3. `#` is stripped from stored labels before prefix-comparison so TASK-style
+//      labels (`#324 director`) match `@324` AND `@#324`
+// Returns undefined if no candidate matches.
+const findByLabel = prefix => {
+  const sess = [...sessions.values()];
+  const exact = sess.find(s => s.label === prefix);
+  if (exact) return exact;
+  const matches = sess.filter(s =>
+    s.label.startsWith(prefix) || s.label.replace(/^#/, '').startsWith(prefix));
+  return matches.sort((a, b) => a.label.length - b.label.length)[0];
+};
 
 // Phase C: parse `@<lane> <payload>` from cmd args. Returns {lane, payload} or null.
 // Lane token allows `#`, word chars and `-` so users can address `@#324` directly
@@ -122,11 +130,29 @@ const parseLanePayload = args => {
   return m ? { lane: m[1].replace(/^#/, ''), payload: m[2].trim() } : null;
 };
 
+// Phase C: payload validators per cmd. Reject anything we can't safely deliver
+// before crossing the trust boundary into the lane session. Allowlist already
+// gates upstream (routeMessage::isAllowed), but defense-in-depth keeps a typo
+// from a trusted user out of `cwd` / `model` / `permission-mode` commands.
+// `dir`: filesystem-safe chars only, no `..` (path traversal).
+// `model`: alphanumeric + `.` `-` `_`, max 64 (covers `claude-opus-4-7`, `sonnet`, etc.).
+// `permission-mode`: enum drawn from Claude Code's documented modes.
+const PERMISSION_MODES = new Set(['strict', 'standard', 'trust', 'plan', 'edit', 'acceptEdits', 'bypassPermissions', 'default']);
+const COMMAND_VALIDATORS = {
+  dir:               v => /^[A-Za-z0-9_./:\\-]+$/.test(v) && !v.split(/[/\\]/).includes('..'),
+  model:             v => /^[A-Za-z0-9._-]{1,64}$/.test(v),
+  'permission-mode': v => PERMISSION_MODES.has(v),
+};
+
 // Phase C: relay a command to a lane's inbox; replies to chat with status.
 // `usage` is the help text shown when args parse fails.
 async function relayLaneCmd(chatId, cmd, args, payloadKey, usage) {
   const lp = parseLanePayload(args);
   if (!lp || !lp.payload) return tgSend(chatId, `Usage: ${usage}`);
+  const validator = COMMAND_VALIDATORS[cmd];
+  if (validator && !validator(lp.payload)) {
+    return tgSend(chatId, `Invalid payload for /${htmlEsc(cmd)}: ${htmlEsc(lp.payload)}`);
+  }
   const t = findByLabel(lp.lane);
   if (!t) return tgSend(chatId, `No session matching @${htmlEsc(lp.lane)}`);
   const event = { type: 'command', cmd, from_chat: chatId };

--- a/adapters/mercury-channel-router/router.cjs
+++ b/adapters/mercury-channel-router/router.cjs
@@ -106,20 +106,42 @@ async function tgSend(chatId, text) {
 }
 
 // Phase C (#324): find session whose label matches the given prefix.
-// Resolution order is deterministic regardless of session-register order:
+// Resolution order is strict and never auto-picks among ambiguous candidates:
 //   1. exact label equality wins outright
-//   2. otherwise pick the SHORTEST label that prefix-matches (most specific)
-//   3. `#` is stripped from stored labels before prefix-comparison so TASK-style
-//      labels (`#324 director`) match `@324` AND `@#324`
-// Returns undefined if no candidate matches.
+//   2. exactly one prefix match (with optional leading `#` stripped) wins
+//   3. multiple prefix matches → ambiguous, caller must surface candidates so
+//      the user retries with a longer disambiguating prefix
+//   4. zero matches → undefined match
+// Return shape:
+//   { match: <session> }  — single resolved target
+//   { match: undefined }  — no candidate
+//   { ambiguous: [labels] } — caller emits "ambiguous, candidates: ..." reply
 const findByLabel = prefix => {
   const sess = [...sessions.values()];
   const exact = sess.find(s => s.label === prefix);
-  if (exact) return exact;
+  if (exact) return { match: exact };
   const matches = sess.filter(s =>
     s.label.startsWith(prefix) || s.label.replace(/^#/, '').startsWith(prefix));
-  return matches.sort((a, b) => a.label.length - b.label.length)[0];
+  if (matches.length === 0) return { match: undefined };
+  if (matches.length === 1) return { match: matches[0] };
+  return { ambiguous: matches.map(s => s.label) };
 };
+
+// Helper: collapse a findByLabel result + a `none-match` reply into a single
+// "match-or-tgSend" branch used by every lane-targeted command. Returns
+// the matched session, or null after sending the appropriate user-facing reply.
+async function resolveLane(chatId, prefix) {
+  const r = findByLabel(prefix);
+  if (r.ambiguous) {
+    await tgSend(chatId, `Ambiguous lane @${htmlEsc(prefix)}; candidates: ${r.ambiguous.map(htmlEsc).join(', ')}`);
+    return null;
+  }
+  if (!r.match) {
+    await tgSend(chatId, `No session matching @${htmlEsc(prefix)}`);
+    return null;
+  }
+  return r.match;
+}
 
 // Phase C: parse `@<lane> <payload>` from cmd args. Returns {lane, payload} or null.
 // Lane token allows `#`, word chars and `-` so users can address `@#324` directly
@@ -153,8 +175,8 @@ async function relayLaneCmd(chatId, cmd, args, payloadKey, usage) {
   if (validator && !validator(lp.payload)) {
     return tgSend(chatId, `Invalid payload for /${htmlEsc(cmd)}: ${htmlEsc(lp.payload)}`);
   }
-  const t = findByLabel(lp.lane);
-  if (!t) return tgSend(chatId, `No session matching @${htmlEsc(lp.lane)}`);
+  const t = await resolveLane(chatId, lp.lane);
+  if (!t) return; // resolveLane already replied (ambiguous OR no-match)
   const event = { type: 'command', cmd, from_chat: chatId };
   event[payloadKey] = lp.payload;
   sendToInbox(t.id, event);
@@ -193,9 +215,11 @@ async function handleCmd(chatId, cmd, args) {
       // are addressable. Trailing `#` is stripped before findByLabel match.
       const m = args.match(/^@(#?[\w-]+)$/);
       if (!m) return tgSend(chatId,`Usage: /${htmlEsc(cmd)} @&lt;label-prefix&gt;`);
-      t = findByLabel(m[1].replace(/^#/, ''));
+      t = await resolveLane(chatId, m[1].replace(/^#/, ''));
+      if (!t) return; // resolveLane already sent the ambiguous / no-match reply
+    } else if (!t) {
+      return tgSend(chatId, 'No matching session.');
     }
-    if (!t) return tgSend(chatId,'No matching session.');
     sendToInbox(t.id,{type:'command',cmd,from_chat:chatId});
     return tgSend(chatId,`Sent /${htmlEsc(cmd)} to [${htmlEsc(t.label)}]`);
   }

--- a/adapters/mercury-channel-router/router.cjs
+++ b/adapters/mercury-channel-router/router.cjs
@@ -13,7 +13,11 @@ const crypto = require('crypto');
 const PORT       = Number(process.env.MERCURY_ROUTER_PORT) || 8788;
 const LOCK_FILE  = path.join(os.homedir(), '.mercury', 'router.lock');
 const TOKEN_FILE = path.join(os.homedir(), '.mercury', 'router.token');
-const MAX_SESS   = 3;
+// Phase C (#324): bump default 3→5 to match feedback_lane_protocol.md HARD-CAP.
+// MERCURY_ROUTER_MAX_SESS env override is floored to a positive integer; non-finite
+// or non-positive values fall back to default 5 so the cap is always integer.
+const MAX_SESS_RAW = Number(process.env.MERCURY_ROUTER_MAX_SESS);
+const MAX_SESS   = Number.isFinite(MAX_SESS_RAW) && MAX_SESS_RAW >= 1 ? Math.floor(MAX_SESS_RAW) : 5;
 const TAG        = '[mercury-channel-router]';
 
 // IPC auth token — written to TOKEN_FILE after server.listen succeeds
@@ -101,6 +105,36 @@ async function tgSend(chatId, text) {
   }
 }
 
+// Phase C (#324): find session whose label matches the given prefix.
+// Mercury labels include `#324 director-surface` (TASK branches) and
+// `lane-main/foo` (lane branches). Match plain prefix OR the label with a
+// leading `#` stripped, so `@324` finds `#324 director`. Used by
+// /cancel /continue /dir /model /permission-mode.
+const findByLabel = prefix => [...sessions.values()].find(s =>
+  s.label.startsWith(prefix) || s.label.replace(/^#/, '').startsWith(prefix));
+
+// Phase C: parse `@<lane> <payload>` from cmd args. Returns {lane, payload} or null.
+// Lane token allows `#`, word chars and `-` so users can address `@#324` directly
+// in addition to the bare numeric form `@324`.
+const parseLanePayload = args => {
+  if (!args) return null;
+  const m = args.match(/^@(#?[\w-]+)\s+(.+)$/s);
+  return m ? { lane: m[1].replace(/^#/, ''), payload: m[2].trim() } : null;
+};
+
+// Phase C: relay a command to a lane's inbox; replies to chat with status.
+// `usage` is the help text shown when args parse fails.
+async function relayLaneCmd(chatId, cmd, args, payloadKey, usage) {
+  const lp = parseLanePayload(args);
+  if (!lp || !lp.payload) return tgSend(chatId, `Usage: ${usage}`);
+  const t = findByLabel(lp.lane);
+  if (!t) return tgSend(chatId, `No session matching @${htmlEsc(lp.lane)}`);
+  const event = { type: 'command', cmd, from_chat: chatId };
+  event[payloadKey] = lp.payload;
+  sendToInbox(t.id, event);
+  return tgSend(chatId, `Sent /${htmlEsc(cmd)} ${htmlEsc(lp.payload)} to [${htmlEsc(t.label)}]`);
+}
+
 async function handleCmd(chatId, cmd, args) {
   if (cmd==='status') {
     const a=sessions.get(activeId);
@@ -110,18 +144,39 @@ async function handleCmd(chatId, cmd, args) {
     if (!sessions.size) return tgSend(chatId,'No sessions registered.');
     return tgSend(chatId,[...sessions.values()].map(s=>`[${htmlEsc(s.label)}]${s.id===activeId?' <b>active</b>':''}`).join('\n'));
   }
-  if (cmd==='help') return tgSend(chatId,'/status /list /cancel /continue /help\n@label text — route\nyes/no &lt;id&gt; — verdict');
+  // Phase C (#324): structured per-lane view; sorted by activeId-first then label.
+  if (cmd==='lanes') {
+    if (!sessions.size) return tgSend(chatId,'No lanes registered.');
+    const rows=[...sessions.values()]
+      .sort((a,b)=>(a.id===activeId?-1:b.id===activeId?1:a.label.localeCompare(b.label)))
+      .map(s=>`[${htmlEsc(s.label)}]${s.id===activeId?' <b>active</b>':''} branch:${htmlEsc(s.branch||'?')} sse:${(s.sseClients||[]).length}`);
+    return tgSend(chatId,rows.join('\n'));
+  }
+  if (cmd==='help') return tgSend(chatId,
+    '/status /list /lanes /help\n'+
+    '/cancel [@label] — abort active or named session\n'+
+    '/continue [@label] — resume\n'+
+    '/dir @label &lt;path&gt; — switch session cwd\n'+
+    '/model @label &lt;name&gt; — switch model\n'+
+    '/permission-mode @label &lt;mode&gt; — switch perm mode\n'+
+    '@label text — route message\nyes/no &lt;id&gt; — verdict');
   if (cmd==='cancel'||cmd==='continue') {
     let t = sessions.get(activeId);
     if (args) {
-      const m = args.match(/^@([\w-]+)$/);
+      // Phase C (#324): accept `@#324` as well as `@324` so TASK-style labels
+      // are addressable. Trailing `#` is stripped before findByLabel match.
+      const m = args.match(/^@(#?[\w-]+)$/);
       if (!m) return tgSend(chatId,`Usage: /${htmlEsc(cmd)} @&lt;label-prefix&gt;`);
-      t = [...sessions.values()].find(s=>s.label.startsWith(m[1]));
+      t = findByLabel(m[1].replace(/^#/, ''));
     }
     if (!t) return tgSend(chatId,'No matching session.');
     sendToInbox(t.id,{type:'command',cmd,from_chat:chatId});
     return tgSend(chatId,`Sent /${htmlEsc(cmd)} to [${htmlEsc(t.label)}]`);
   }
+  // Phase C (#324, subsumes #308): pass-through commands to lane inbox.
+  if (cmd==='dir')             return relayLaneCmd(chatId,'dir',            args,'path', '/dir @&lt;label&gt; &lt;path&gt;');
+  if (cmd==='model')           return relayLaneCmd(chatId,'model',          args,'model','/model @&lt;label&gt; &lt;name&gt;');
+  if (cmd==='permission-mode') return relayLaneCmd(chatId,'permission-mode',args,'mode', '/permission-mode @&lt;label&gt; &lt;mode&gt;');
 }
 
 async function routeMessage(msg) {

--- a/scripts/lane-auto-report.sh
+++ b/scripts/lane-auto-report.sh
@@ -81,10 +81,17 @@ post_notify() {
     echo "[lane-auto-report] ERROR: cannot read token at $TOKEN_FILE" >&2
     return 1
   fi
-  local token
+  # Pass the Bearer token via -H @file rather than inline so other users on the
+  # box cannot read it via /proc/<pid>/cmdline or `ps -ef`. mktemp + 600 perms
+  # via umask scope; cleanup is unconditional via local trap so a curl crash
+  # cannot leak the file across cron ticks.
+  local token auth_header_file
   token="$(tr -d '\r\n' < "$TOKEN_FILE")"
+  auth_header_file="$(umask 077 && mktemp "$STATE_DIR/.auth-header.XXXXXX")"
+  printf 'Authorization: Bearer %s\n' "$token" > "$auth_header_file"
+  trap 'rm -f "$auth_header_file"' RETURN
   curl --silent --show-error --fail --max-time 5 \
-    -H "Authorization: Bearer $token" \
+    -H @"$auth_header_file" \
     -H "Content-Type: application/json" \
     -X POST \
     --data "$payload" \
@@ -134,12 +141,16 @@ intersect=$(jq -r --arg p "$prev_lanes_csv" \
 while IFS= read -r lane; do
   [ -z "$lane" ] && continue
 
-  prev_lane=$(jq --arg n "$lane" '.lanes[] | select(.name == $n)' "$PREVIOUS")
-  curr_lane=$(jq --arg n "$lane" '.lanes[] | select(.name == $n)' "$CURRENT")
+  # `first(... | select(...)) // {}` ensures missing-lane returns {}, not nothing —
+  # otherwise a stale snapshot with name-renamed lanes would crash the loop under
+  # set -e. Downstream `.issues // []` / `.branches // []` defaults keep partial
+  # snapshots from blowing up when a lane row is missing those keys.
+  prev_lane=$(jq -c --arg n "$lane" 'first(.lanes[] | select(.name == $n)) // {}' "$PREVIOUS")
+  curr_lane=$(jq -c --arg n "$lane" 'first(.lanes[] | select(.name == $n)) // {}' "$CURRENT")
 
-  # 3a. is_stale flip
-  prev_stale=$(echo "$prev_lane" | jq -r '.is_stale' | tr -d '\r')
-  curr_stale=$(echo "$curr_lane" | jq -r '.is_stale' | tr -d '\r')
+  # 3a. is_stale flip — `// false` so a missing field doesn't yield "null"
+  prev_stale=$(echo "$prev_lane" | jq -r '.is_stale // false' | tr -d '\r')
+  curr_stale=$(echo "$curr_lane" | jq -r '.is_stale // false' | tr -d '\r')
   if [ "$prev_stale" != "$curr_stale" ]; then
     if [ "$curr_stale" = "true" ]; then
       emit info "lane:$lane stale" "Lane went idle (no activity > stale window)" "$lane"
@@ -149,8 +160,8 @@ while IFS= read -r lane; do
   fi
 
   # 3b. Issue set change
-  prev_issues=$(echo "$prev_lane" | jq -r '[.issues[].number] | sort | join(",")' | tr -d '\r')
-  curr_issues=$(echo "$curr_lane" | jq -r '[.issues[].number] | sort | join(",")' | tr -d '\r')
+  prev_issues=$(echo "$prev_lane" | jq -r '[((.issues // [])[]?.number)] | sort | join(",")' | tr -d '\r')
+  curr_issues=$(echo "$curr_lane" | jq -r '[((.issues // [])[]?.number)] | sort | join(",")' | tr -d '\r')
   if [ "$prev_issues" != "$curr_issues" ]; then
     emit info "lane:$lane issues changed" "Issues: ${prev_issues:-none} -> ${curr_issues:-none}" "$lane"
   fi
@@ -158,8 +169,8 @@ while IFS= read -r lane; do
   # 3c. Branch commit jump (per branch ref)
   while IFS= read -r ref; do
     [ -z "$ref" ] && continue
-    prev_ts=$(echo "$prev_lane" | jq -r --arg r "$ref" '.branches[] | select(.ref == $r) | .last_commit_at // ""' | tr -d '\r')
-    curr_ts=$(echo "$curr_lane" | jq -r --arg r "$ref" '.branches[] | select(.ref == $r) | .last_commit_at // ""' | tr -d '\r')
+    prev_ts=$(echo "$prev_lane" | jq -r --arg r "$ref" '(.branches // [])[]? | select(.ref == $r) | .last_commit_at // ""' | tr -d '\r')
+    curr_ts=$(echo "$curr_lane" | jq -r --arg r "$ref" '(.branches // [])[]? | select(.ref == $r) | .last_commit_at // ""' | tr -d '\r')
     if [ -n "$curr_ts" ] && [ "$prev_ts" != "$curr_ts" ]; then
       if [ -z "$prev_ts" ]; then
         emit info "lane:$lane branch added" "$ref @ $curr_ts" "$lane"
@@ -167,7 +178,7 @@ while IFS= read -r lane; do
         emit info "lane:$lane commit" "$ref: $prev_ts -> $curr_ts" "$lane"
       fi
     fi
-  done < <(echo "$curr_lane" | jq -r '.branches[].ref' | tr -d '\r')
+  done < <(echo "$curr_lane" | jq -r '(.branches // [])[]?.ref // empty' | tr -d '\r')
 done <<< "$intersect"
 
 # Promote current → previous only when all emissions succeeded. On partial

--- a/scripts/lane-auto-report.sh
+++ b/scripts/lane-auto-report.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# Mercury lane auto-report (Issue #324, Phase C C1).
+# Diffs lane-status.json snapshots and POSTs transition notifications to the
+# mercury-channel-router /notify endpoint, which forwards to Telegram.
+#
+# Usage: bash scripts/lane-auto-report.sh
+# Cron registration (Claude Code CronCreate, durable: true): see
+# .mercury/docs/guides/phase-c-install.md §C1.
+#
+# Env vars:
+#   MERCURY_LANE_REPORT_QUIET=1  — produce diffs but skip POST (dry-run)
+#   MERCURY_ROUTER_PORT          — defaults to 8788
+#   MERCURY_TEST_REPO_ROOT       — override repo root (test harness)
+#   MERCURY_TEST_TOKEN_FILE      — override token file path (test harness)
+#   MERCURY_TEST_NOTIFY_LOG      — append POST payloads here instead of curl (test harness)
+
+set -euo pipefail
+
+ROUTER_PORT="${MERCURY_ROUTER_PORT:-8788}"
+QUIET="${MERCURY_LANE_REPORT_QUIET:-0}"
+TOKEN_FILE="${MERCURY_TEST_TOKEN_FILE:-$HOME/.mercury/router.token}"
+NOTIFY_LOG="${MERCURY_TEST_NOTIFY_LOG:-}"
+
+# Resolve REPO_ROOT (same pattern as lane-status.sh).
+if [ -n "${MERCURY_TEST_REPO_ROOT:-}" ]; then
+  REPO_ROOT="$MERCURY_TEST_REPO_ROOT"
+elif [ -n "${CLAUDE_PROJECT_DIR:-}" ] && [ -d "$CLAUDE_PROJECT_DIR/.git" ]; then
+  REPO_ROOT="$CLAUDE_PROJECT_DIR"
+else
+  REPO_ROOT="$(git -C "$(pwd)" rev-parse --show-toplevel 2>/dev/null || true)"
+fi
+
+if [ -z "${REPO_ROOT:-}" ]; then
+  echo "[lane-auto-report] ERROR: cannot resolve repo root" >&2
+  exit 1
+fi
+
+STATE_DIR="$REPO_ROOT/.mercury/state"
+CURRENT="$STATE_DIR/lane-status.json"
+PREVIOUS="$STATE_DIR/lane-status.previous.json"
+
+if [ ! -f "$CURRENT" ]; then
+  echo "[lane-auto-report] WARN: $CURRENT missing — run lane-status.sh first" >&2
+  exit 0
+fi
+
+# Atomic single-instance lock via mkdir (POSIX-portable, MINGW-safe). If two cron
+# ticks overlap, the loser exits cleanly without corrupting previous snapshot.
+LOCKDIR="$STATE_DIR/lane-auto-report.lock.d"
+if ! mkdir "$LOCKDIR" 2>/dev/null; then
+  echo "[lane-auto-report] another instance running ($LOCKDIR exists); skipping" >&2
+  exit 0
+fi
+trap 'rmdir "$LOCKDIR" 2>/dev/null || true' EXIT
+
+# First run — seed previous and exit (no diff to report).
+if [ ! -f "$PREVIOUS" ]; then
+  cp "$CURRENT" "$PREVIOUS"
+  echo "[lane-auto-report] seeded baseline; no diff on first run" >&2
+  exit 0
+fi
+
+post_notify() {
+  local severity="$1" title="$2" body="$3" label="$4"
+  local payload
+  # -c keeps each emit on a single line — needed so callers (tests, log scrapers)
+  # can count emissions with `wc -l` and stream-parse with line-delimited JSON.
+  payload=$(jq -nc \
+    --arg sev "$severity" --arg ttl "$title" --arg bod "$body" --arg lbl "$label" \
+    '{severity:$sev,title:$ttl,body:$bod,label:$lbl}')
+
+  if [ -n "$NOTIFY_LOG" ]; then
+    printf '%s\n' "$payload" >> "$NOTIFY_LOG"
+    return 0
+  fi
+  if [ "$QUIET" = "1" ]; then
+    echo "[lane-auto-report] (quiet) would POST: $title" >&2
+    return 0
+  fi
+  if [ ! -r "$TOKEN_FILE" ]; then
+    echo "[lane-auto-report] ERROR: cannot read token at $TOKEN_FILE" >&2
+    return 1
+  fi
+  local token
+  token="$(tr -d '\r\n' < "$TOKEN_FILE")"
+  curl --silent --show-error --fail --max-time 5 \
+    -H "Authorization: Bearer $token" \
+    -H "Content-Type: application/json" \
+    -X POST \
+    --data "$payload" \
+    "http://127.0.0.1:${ROUTER_PORT}/notify" >/dev/null \
+    || { echo "[lane-auto-report] WARN: POST failed for $title" >&2; return 1; }
+}
+
+emit_count=0
+emit_failed=0
+emit() {
+  if post_notify "$@"; then
+    emit_count=$(( emit_count + 1 ))
+  else
+    emit_failed=$(( emit_failed + 1 ))
+  fi
+}
+
+# Compute diff via jq — fields tracked: lane name, is_stale, issue numbers, branch refs+commits.
+# CRLF strip on Windows MINGW: without `tr -d '\r'`, prev_lanes_csv ends with \r,
+# the inside([...]) check below compares "main" vs "main\r" and misreports steady
+# lanes as added/removed every cycle.
+prev_lanes_csv="$(jq -r '[.lanes[].name] | sort | join(",")' "$PREVIOUS" | tr -d '\r')"
+curr_lanes_csv="$(jq -r '[.lanes[].name] | sort | join(",")' "$CURRENT" | tr -d '\r')"
+
+# NOTE: jq on Windows MINGW emits CRLF; every `jq -r` capture below is piped
+# through `tr -d '\r'` so string comparisons (and --arg substitutions) match.
+
+# 1. Added lanes
+added=$(jq -r --arg p "$prev_lanes_csv" \
+  '.lanes[] | select(([.name] | inside(($p | split(",")))) | not) | .name' "$CURRENT" | tr -d '\r')
+while IFS= read -r lane; do
+  [ -z "$lane" ] && continue
+  emit info "lane:$lane spawned" "New lane registered" "$lane"
+done <<< "$added"
+
+# 2. Removed lanes
+removed=$(jq -r --arg c "$curr_lanes_csv" \
+  '.lanes[] | select(([.name] | inside(($c | split(",")))) | not) | .name' "$PREVIOUS" | tr -d '\r')
+while IFS= read -r lane; do
+  [ -z "$lane" ] && continue
+  emit info "lane:$lane closed" "Lane no longer present" "$lane"
+done <<< "$removed"
+
+# 3. Per-lane field transitions (intersect set)
+intersect=$(jq -r --arg p "$prev_lanes_csv" \
+  '.lanes[] | select([.name] | inside(($p | split(",")))) | .name' "$CURRENT" | tr -d '\r')
+while IFS= read -r lane; do
+  [ -z "$lane" ] && continue
+
+  prev_lane=$(jq --arg n "$lane" '.lanes[] | select(.name == $n)' "$PREVIOUS")
+  curr_lane=$(jq --arg n "$lane" '.lanes[] | select(.name == $n)' "$CURRENT")
+
+  # 3a. is_stale flip
+  prev_stale=$(echo "$prev_lane" | jq -r '.is_stale' | tr -d '\r')
+  curr_stale=$(echo "$curr_lane" | jq -r '.is_stale' | tr -d '\r')
+  if [ "$prev_stale" != "$curr_stale" ]; then
+    if [ "$curr_stale" = "true" ]; then
+      emit info "lane:$lane stale" "Lane went idle (no activity > stale window)" "$lane"
+    else
+      emit info "lane:$lane active" "Lane resumed activity" "$lane"
+    fi
+  fi
+
+  # 3b. Issue set change
+  prev_issues=$(echo "$prev_lane" | jq -r '[.issues[].number] | sort | join(",")' | tr -d '\r')
+  curr_issues=$(echo "$curr_lane" | jq -r '[.issues[].number] | sort | join(",")' | tr -d '\r')
+  if [ "$prev_issues" != "$curr_issues" ]; then
+    emit info "lane:$lane issues changed" "Issues: ${prev_issues:-none} -> ${curr_issues:-none}" "$lane"
+  fi
+
+  # 3c. Branch commit jump (per branch ref)
+  while IFS= read -r ref; do
+    [ -z "$ref" ] && continue
+    prev_ts=$(echo "$prev_lane" | jq -r --arg r "$ref" '.branches[] | select(.ref == $r) | .last_commit_at // ""' | tr -d '\r')
+    curr_ts=$(echo "$curr_lane" | jq -r --arg r "$ref" '.branches[] | select(.ref == $r) | .last_commit_at // ""' | tr -d '\r')
+    if [ -n "$curr_ts" ] && [ "$prev_ts" != "$curr_ts" ]; then
+      if [ -z "$prev_ts" ]; then
+        emit info "lane:$lane branch added" "$ref @ $curr_ts" "$lane"
+      else
+        emit info "lane:$lane commit" "$ref: $prev_ts -> $curr_ts" "$lane"
+      fi
+    fi
+  done < <(echo "$curr_lane" | jq -r '.branches[].ref' | tr -d '\r')
+done <<< "$intersect"
+
+# Promote current → previous only when all emissions succeeded. On partial
+# failure, leave previous as-is so the next cron tick retries the same diff —
+# better to re-emit a notification than silently drop one.
+# Promotion uses mktemp+mv so a half-written previous is never readable by an
+# overlapping reader (matches lane-status.sh atomic-write pattern).
+if [ "$emit_failed" -eq 0 ]; then
+  PROMOTE_TMP="$(mktemp "$STATE_DIR/lane-status.previous.json.XXXXXX")"
+  cp "$CURRENT" "$PROMOTE_TMP" && mv "$PROMOTE_TMP" "$PREVIOUS"
+  echo "[lane-auto-report] emitted $emit_count notifications" >&2
+else
+  echo "[lane-auto-report] emitted $emit_count, FAILED $emit_failed — previous snapshot retained for retry" >&2
+  exit 1
+fi

--- a/scripts/lane-auto-report.sh
+++ b/scripts/lane-auto-report.sh
@@ -83,20 +83,24 @@ post_notify() {
   fi
   # Pass the Bearer token via -H @file rather than inline so other users on the
   # box cannot read it via /proc/<pid>/cmdline or `ps -ef`. mktemp + 600 perms
-  # via umask scope; cleanup is unconditional via local trap so a curl crash
-  # cannot leak the file across cron ticks.
-  local token auth_header_file
+  # via umask scope; explicit rc-capture cleanup avoids `trap RETURN` (which
+  # would persist across function reinvocations and re-fire on every later
+  # return — Argus 3144785807 finding).
+  local token auth_header_file rc=0
   token="$(tr -d '\r\n' < "$TOKEN_FILE")"
   auth_header_file="$(umask 077 && mktemp "$STATE_DIR/.auth-header.XXXXXX")"
   printf 'Authorization: Bearer %s\n' "$token" > "$auth_header_file"
-  trap 'rm -f "$auth_header_file"' RETURN
   curl --silent --show-error --fail --max-time 5 \
     -H @"$auth_header_file" \
     -H "Content-Type: application/json" \
     -X POST \
     --data "$payload" \
-    "http://127.0.0.1:${ROUTER_PORT}/notify" >/dev/null \
-    || { echo "[lane-auto-report] WARN: POST failed for $title" >&2; return 1; }
+    "http://127.0.0.1:${ROUTER_PORT}/notify" >/dev/null || rc=$?
+  rm -f "$auth_header_file"
+  if [ "$rc" -ne 0 ]; then
+    echo "[lane-auto-report] WARN: POST failed for $title" >&2
+    return 1
+  fi
 }
 
 emit_count=0

--- a/scripts/test-lane-auto-report.sh
+++ b/scripts/test-lane-auto-report.sh
@@ -1,0 +1,332 @@
+#!/usr/bin/env bash
+# scripts/test-lane-auto-report.sh — smoke tests for lane-auto-report.sh (Issue #324, Phase C C1).
+# Uses MERCURY_TEST_REPO_ROOT + MERCURY_TEST_NOTIFY_LOG to capture POST payloads
+# without requiring a running router.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/lane-auto-report.sh"
+
+PASS=0
+FAIL=0
+
+pass() { echo "PASS: $1"; PASS=$(( PASS + 1 )); }
+fail() { echo "FAIL: $1 — $2"; FAIL=$(( FAIL + 1 )); }
+
+# ---------------------------------------------------------------------------
+# Per-test helpers (each test gets its own clean workspace)
+# ---------------------------------------------------------------------------
+make_workspace() {
+  local ws="/tmp/mercury-lane-report-test-$$-${RANDOM}"
+  mkdir -p "$ws/.git" "$ws/.mercury/state"
+  echo "$ws"
+}
+
+write_status() {
+  # write_status <file> <name> <is_stale> [issue_numbers_csv] [branch_ref:ts,branch_ref:ts]
+  local file="$1" name="$2" stale="$3" issues="${4:-}" branches="${5:-}"
+  local issues_json="[]" branches_json="[]"
+  if [ -n "$issues" ]; then
+    issues_json=$(echo "$issues" | tr ',' '\n' | jq -R 'select(length>0) | tonumber | {number:., title:"t", updated_at:"2026-04-27T00:00:00Z"}' | jq -s '.')
+  fi
+  if [ -n "$branches" ]; then
+    # Branch entries use '=' as ref/timestamp separator because ISO timestamps
+    # contain colons; splitting on ':' garbles the ref. Format: ref=ts,ref=ts.
+    branches_json="["
+    local first=1
+    IFS=',' read -ra parts <<< "$branches"
+    for p in "${parts[@]}"; do
+      local ref="${p%%=*}" ts="${p#*=}"
+      [ "$first" = "0" ] && branches_json+=","
+      branches_json+="{\"ref\":\"$ref\",\"last_commit_at\":\"$ts\"}"
+      first=0
+    done
+    branches_json+="]"
+  fi
+  jq -n \
+    --arg n "$name" --argjson stale "$stale" \
+    --argjson iss "$issues_json" --argjson br "$branches_json" \
+    '{last_checked_at:"2026-04-27T00:00:00Z",stale_threshold_minutes:15,
+      lanes:[{name:$n,is_stale:$stale,issues:$iss,branches:$br}]}' > "$file"
+}
+
+write_status_multi() {
+  # write_status_multi <file> <full_lanes_jq_expr>
+  # The lanes argument is a jq DSL expression (unquoted keys allowed); we evaluate
+  # it via `jq -n` to convert to canonical JSON before --argjson injection.
+  local file="$1" lanes_expr="$2"
+  local lanes_json
+  lanes_json=$(jq -c -n "$lanes_expr")
+  jq -n --argjson l "$lanes_json" \
+    '{last_checked_at:"2026-04-27T00:00:00Z",stale_threshold_minutes:15,lanes:$l}' > "$file"
+}
+
+run_report() {
+  # run_report <workspace> -> echoes notify log path
+  local ws="$1"
+  local log="$ws/.mercury/state/notify.log"
+  : > "$log"
+  MERCURY_TEST_REPO_ROOT="$ws" \
+  MERCURY_TEST_NOTIFY_LOG="$log" \
+    bash "$SCRIPT" >/dev/null 2>&1
+  echo "$log"
+}
+
+count_log() { wc -l < "$1" | tr -d ' '; }
+log_titles() { jq -r '.title' "$1" 2>/dev/null || true; }
+log_labels() { jq -r '.label' "$1" 2>/dev/null || true; }
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+# T1: missing current → exit 0, no log
+{
+  ws=$(make_workspace)
+  log="$ws/.mercury/state/notify.log"; : > "$log"
+  if MERCURY_TEST_REPO_ROOT="$ws" MERCURY_TEST_NOTIFY_LOG="$log" \
+       bash "$SCRIPT" >/dev/null 2>&1 && [ "$(count_log "$log")" = "0" ]; then
+    pass "T1 missing current → no-op"
+  else
+    fail "T1 missing current → no-op" "exit or log unexpected"
+  fi
+  rm -rf "$ws"
+}
+
+# T2: first run → seeds previous + no notifications
+{
+  ws=$(make_workspace)
+  write_status "$ws/.mercury/state/lane-status.json" "main" false "300" "feature/lane-main/x=2026-04-27T00:00:00Z"
+  log=$(run_report "$ws")
+  if [ -f "$ws/.mercury/state/lane-status.previous.json" ] && [ "$(count_log "$log")" = "0" ]; then
+    pass "T2 first run seeds previous + 0 emits"
+  else
+    fail "T2 first run" "previous missing or unexpected emits"
+  fi
+  rm -rf "$ws"
+}
+
+# T3: identical snapshots → 0 emits
+{
+  ws=$(make_workspace)
+  write_status "$ws/.mercury/state/lane-status.json" "main" false "300" "feature/lane-main/x=2026-04-27T00:00:00Z"
+  cp "$ws/.mercury/state/lane-status.json" "$ws/.mercury/state/lane-status.previous.json"
+  log=$(run_report "$ws")
+  if [ "$(count_log "$log")" = "0" ]; then
+    pass "T3 identical → 0 emits"
+  else
+    fail "T3 identical → 0 emits" "got $(count_log "$log")"
+  fi
+  rm -rf "$ws"
+}
+
+# T4: lane added → emit "spawned"
+{
+  ws=$(make_workspace)
+  write_status "$ws/.mercury/state/lane-status.previous.json" "main" false "" ""
+  write_status_multi "$ws/.mercury/state/lane-status.json" \
+    '[{name:"main",is_stale:false,issues:[],branches:[]},{name:"side-x",is_stale:false,issues:[],branches:[]}]'
+  log=$(run_report "$ws")
+  if [ "$(count_log "$log")" = "1" ] && log_titles "$log" | grep -q "side-x spawned"; then
+    pass "T4 lane added → spawned notification"
+  else
+    fail "T4 lane added" "got $(count_log "$log") emits, titles=$(log_titles "$log")"
+  fi
+  rm -rf "$ws"
+}
+
+# T5: lane removed → emit "closed"
+{
+  ws=$(make_workspace)
+  write_status_multi "$ws/.mercury/state/lane-status.previous.json" \
+    '[{name:"main",is_stale:false,issues:[],branches:[]},{name:"side-x",is_stale:false,issues:[],branches:[]}]'
+  write_status "$ws/.mercury/state/lane-status.json" "main" false "" ""
+  log=$(run_report "$ws")
+  if [ "$(count_log "$log")" = "1" ] && log_titles "$log" | grep -q "side-x closed"; then
+    pass "T5 lane removed → closed notification"
+  else
+    fail "T5 lane removed" "got $(count_log "$log") emits, titles=$(log_titles "$log")"
+  fi
+  rm -rf "$ws"
+}
+
+# T6: is_stale false→true emits "stale"
+{
+  ws=$(make_workspace)
+  write_status "$ws/.mercury/state/lane-status.previous.json" "main" false "" ""
+  write_status "$ws/.mercury/state/lane-status.json" "main" true "" ""
+  log=$(run_report "$ws")
+  if [ "$(count_log "$log")" = "1" ] && log_titles "$log" | grep -q "main stale"; then
+    pass "T6 is_stale flip false→true → stale notification"
+  else
+    fail "T6 is_stale flip" "got $(count_log "$log") emits, titles=$(log_titles "$log")"
+  fi
+  rm -rf "$ws"
+}
+
+# T7: is_stale true→false emits "active"
+{
+  ws=$(make_workspace)
+  write_status "$ws/.mercury/state/lane-status.previous.json" "main" true "" ""
+  write_status "$ws/.mercury/state/lane-status.json" "main" false "" ""
+  log=$(run_report "$ws")
+  if [ "$(count_log "$log")" = "1" ] && log_titles "$log" | grep -q "main active"; then
+    pass "T7 is_stale flip true→false → active notification"
+  else
+    fail "T7 is_stale flip back" "got $(count_log "$log") emits, titles=$(log_titles "$log")"
+  fi
+  rm -rf "$ws"
+}
+
+# T8: issue set change emits "issues changed"
+{
+  ws=$(make_workspace)
+  write_status "$ws/.mercury/state/lane-status.previous.json" "main" false "300" ""
+  write_status "$ws/.mercury/state/lane-status.json" "main" false "300,301" ""
+  log=$(run_report "$ws")
+  if [ "$(count_log "$log")" = "1" ] && log_titles "$log" | grep -q "main issues changed"; then
+    pass "T8 issue set change → notification"
+  else
+    fail "T8 issue change" "got $(count_log "$log") emits, titles=$(log_titles "$log")"
+  fi
+  rm -rf "$ws"
+}
+
+# T9: branch commit jump emits "commit"
+{
+  ws=$(make_workspace)
+  write_status "$ws/.mercury/state/lane-status.previous.json" "main" false "" "feature/lane-main/x=2026-04-27T00:00:00Z"
+  write_status "$ws/.mercury/state/lane-status.json"          "main" false "" "feature/lane-main/x=2026-04-27T01:00:00Z"
+  log=$(run_report "$ws")
+  if [ "$(count_log "$log")" = "1" ] && log_titles "$log" | grep -q "main commit"; then
+    pass "T9 branch commit jump → notification"
+  else
+    fail "T9 commit jump" "got $(count_log "$log") emits, titles=$(log_titles "$log")"
+  fi
+  rm -rf "$ws"
+}
+
+# T10: new branch added to existing lane emits "branch added"
+{
+  ws=$(make_workspace)
+  write_status "$ws/.mercury/state/lane-status.previous.json" "main" false "" ""
+  write_status "$ws/.mercury/state/lane-status.json"          "main" false "" "feature/lane-main/y=2026-04-27T01:00:00Z"
+  log=$(run_report "$ws")
+  if [ "$(count_log "$log")" = "1" ] && log_titles "$log" | grep -q "main branch added"; then
+    pass "T10 new branch on existing lane → notification"
+  else
+    fail "T10 new branch" "got $(count_log "$log") emits, titles=$(log_titles "$log")"
+  fi
+  rm -rf "$ws"
+}
+
+# T11: QUIET mode → no log writes (but exit 0)
+{
+  ws=$(make_workspace)
+  write_status "$ws/.mercury/state/lane-status.previous.json" "main" false "" ""
+  write_status_multi "$ws/.mercury/state/lane-status.json" \
+    '[{name:"main",is_stale:false,issues:[],branches:[]},{name:"side-x",is_stale:false,issues:[],branches:[]}]'
+  log="$ws/.mercury/state/notify.log"; : > "$log"
+  # QUIET=1 with no NOTIFY_LOG should not POST
+  unset_log_run() {
+    MERCURY_TEST_REPO_ROOT="$ws" \
+    MERCURY_LANE_REPORT_QUIET=1 \
+      bash "$SCRIPT" >/dev/null 2>&1
+  }
+  if unset_log_run && [ "$(count_log "$log")" = "0" ]; then
+    pass "T11 QUIET mode → no notifications written"
+  else
+    fail "T11 QUIET mode" "exit or unexpected log writes"
+  fi
+  rm -rf "$ws"
+}
+
+# T12: previous promoted after diff
+{
+  ws=$(make_workspace)
+  write_status "$ws/.mercury/state/lane-status.previous.json" "main" false "300" ""
+  write_status "$ws/.mercury/state/lane-status.json"          "main" false "300,301" ""
+  run_report "$ws" >/dev/null
+  prev_issues=$(jq -r '.lanes[0].issues | length' "$ws/.mercury/state/lane-status.previous.json")
+  if [ "$prev_issues" = "2" ]; then
+    pass "T12 previous promoted to current after run"
+  else
+    fail "T12 previous promotion" "previous issue count = $prev_issues, expected 2"
+  fi
+  rm -rf "$ws"
+}
+
+# T13: combined transitions (lane add + is_stale flip on existing) emits 2 notifications
+{
+  ws=$(make_workspace)
+  write_status_multi "$ws/.mercury/state/lane-status.previous.json" \
+    '[{name:"main",is_stale:false,issues:[],branches:[]}]'
+  write_status_multi "$ws/.mercury/state/lane-status.json" \
+    '[{name:"main",is_stale:true,issues:[],branches:[]},{name:"side-x",is_stale:false,issues:[],branches:[]}]'
+  log=$(run_report "$ws")
+  added=$(log_titles "$log" | grep -c "side-x spawned" || true)
+  staled=$(log_titles "$log" | grep -c "main stale" || true)
+  if [ "$added" = "1" ] && [ "$staled" = "1" ]; then
+    pass "T13 combined transitions → 2 notifications"
+  else
+    fail "T13 combined" "added=$added staled=$staled total=$(count_log "$log")"
+  fi
+  rm -rf "$ws"
+}
+
+# T15: lock contention — pre-existing lock dir → second invocation exits 0 without diffing
+{
+  ws=$(make_workspace)
+  write_status "$ws/.mercury/state/lane-status.previous.json" "main" false "" ""
+  write_status_multi "$ws/.mercury/state/lane-status.json" \
+    '[{name:"main",is_stale:false,issues:[],branches:[]},{name:"side-x",is_stale:false,issues:[],branches:[]}]'
+  # Pre-create the lockdir to simulate an in-flight first invocation
+  mkdir "$ws/.mercury/state/lane-auto-report.lock.d"
+  log="$ws/.mercury/state/notify.log"; : > "$log"
+  set +e
+  MERCURY_TEST_REPO_ROOT="$ws" MERCURY_TEST_NOTIFY_LOG="$log" \
+    bash "$SCRIPT" >/dev/null 2>&1
+  rc=$?
+  set -e
+  # Lock-skipped run must NOT promote previous (still has only main, not side-x)
+  prev_lane_count=$(jq -r '.lanes | length' "$ws/.mercury/state/lane-status.previous.json")
+  if [ "$rc" = "0" ] && [ "$(count_log "$log")" = "0" ] && [ "$prev_lane_count" = "1" ]; then
+    pass "T15 lock contention → exit 0, no emits, previous untouched"
+  else
+    fail "T15 lock contention" "rc=$rc emits=$(count_log "$log") prev_lanes=$prev_lane_count"
+  fi
+  rmdir "$ws/.mercury/state/lane-auto-report.lock.d" 2>/dev/null || true
+  rm -rf "$ws"
+}
+
+# T14: POST failure (missing token, no NOTIFY_LOG, QUIET off) → previous NOT promoted, exit 1
+{
+  ws=$(make_workspace)
+  write_status "$ws/.mercury/state/lane-status.previous.json" "main" false "" ""
+  write_status_multi "$ws/.mercury/state/lane-status.json" \
+    '[{name:"main",is_stale:false,issues:[],branches:[]},{name:"side-x",is_stale:false,issues:[],branches:[]}]'
+  # Capture pre-run previous to compare against
+  pre_hash=$(jq -S '.' "$ws/.mercury/state/lane-status.previous.json" | sha1sum | awk '{print $1}')
+  # Point token file at non-existent path so post_notify hits the read-error branch
+  set +e
+  MERCURY_TEST_REPO_ROOT="$ws" \
+  MERCURY_TEST_TOKEN_FILE="$ws/no-such-token" \
+    bash "$SCRIPT" >/dev/null 2>&1
+  rc=$?
+  set -e
+  post_hash=$(jq -S '.' "$ws/.mercury/state/lane-status.previous.json" | sha1sum | awk '{print $1}')
+  if [ "$rc" = "1" ] && [ "$pre_hash" = "$post_hash" ]; then
+    pass "T14 POST failure → exit 1 + previous unchanged for retry"
+  else
+    fail "T14 POST failure" "rc=$rc pre=$pre_hash post=$post_hash"
+  fi
+  rm -rf "$ws"
+}
+
+# ---------------------------------------------------------------------------
+echo
+echo "================================="
+echo "lane-auto-report tests: PASS=$PASS FAIL=$FAIL"
+echo "================================="
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

- **C1 — `scripts/lane-auto-report.sh`** (NEW, 161 LOC, 15/15 tests): cron-driven diff of `.mercury/state/lane-status.json` snapshots; POSTs transition events (lane add/remove, `is_stale` flip, issue change, branch commit jump) to `mercury-channel-router /notify`. Atomic `mkdir` lock + `mktemp+mv` promote prevent overlapping-cron corruption; POST failure leaves previous snapshot intact for next-tick retry.
- **C2 — `adapters/mercury-channel-router/router.cjs`** (220→267 LOC): `MAX_SESS` default 3→5 with `MERCURY_ROUTER_MAX_SESS` env override (Math.floor + ≥1 guard); new `/lanes`, `/dir`, `/model`, `/permission-mode` commands with shared `findByLabel` + `parseLanePayload` + `relayLaneCmd` helpers. Subsumes #308. Label matching tolerates `@#324` and `@324` for TASK-style branches.
- **C2 — `adapters/mercury-channel-client/channel.cjs`** (231→244 LOC): forward `path`/`model`/`mode` payload as XML attributes AND in body so `/dir @lane /tmp` delivers the operand to the lane session, not just the bare verb.

## Test plan

- [x] `bash scripts/test-lane-auto-report.sh` — 15/15 PASS (covers diff transitions, atomic promote, lock contention, POST-failure retry semantics)
- [x] `bash scripts/test-lane-status.sh` — 12/12 regression
- [x] `bash scripts/test-lane-spawn.sh` — 38/38 regression
- [x] `bash scripts/test-lane-close.sh` — 43/43 regression
- [x] `bash scripts/test-lane-claim.sh` — 18/18 regression
- [x] `bash scripts/test-lane-sweep.sh` — 24/24 regression
- [x] `node -c` syntax check on both adapters
- [ ] Manual smoke per `.mercury/docs/guides/phase-c-install.md` §C2 — to be run post-merge against live Telegram bot

**Total: 150/150 automated PASS.**

## Dual-verify (PASS)

| Reviewer | Findings | Status |
|---|---|---|
| Claude deep-review | HIGH (channel.cjs payload drop) + MEDIUM (failure-promote) + MINOR (Math.floor) | All FIXED |
| Codex audit | HIGH×2 (CRLF on `prev/curr_lanes_csv`, label regex rejects `#324`) + MEDIUM (cron concurrency lock) + LOW (Math.floor — already fixed pre-audit) | All FIXED |

Cross-reference + per-finding remediation log: see commit body of `4af366c`.

## Adapter LOC follow-up

`router.cjs` 220→267 LOC and `channel.cjs` 231→244 LOC both exceed Mercury's 200-LOC adapter cap (CLAUDE.md). M6 split is the cleanup vehicle (#303). A follow-up issue will be filed post-merge to track the LOC reduction.

## Refs

- Closes #324
- Subsumes #308 (`/dir`, `/model`, `/permission-mode` commands)
- Refs #318 (architecture reframe parent)
- Refs #321 (research §Dim 1.3)
- Refs #303 (M6 module split — follow-up for adapter cap restoration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)