### PR TITLE
feat(loop-detector): broaden progress signal via PROGRESS_TOOLS set (#325)

### DIFF
--- a/.mercury/docs/research/loop-detector-fix-2026-04-27.md
+++ b/.mercury/docs/research/loop-detector-fix-2026-04-27.md
@@ -7,7 +7,7 @@
 
 ## Problem
 
-`adapters/mercury-loop-detector/hook.cjs:101` only resets `np_count` on `Write/Edit/NotebookEdit/MultiEdit/Read/Glob/Grep`. `Bash`, `Agent`, `Task*`, `Skill`, `ToolSearch` accumulate `np_count` even when they represent legitimate work. Verification phases (test runs, git status, gh polling, smoke tests) trip the default `no_progress_threshold=5` after a handful of legitimate Bash calls.
+`adapters/mercury-loop-detector/hook.cjs:108` (in `update()` defined at line 96) only resets `np_count` on `Write/Edit/NotebookEdit/MultiEdit/Read/Glob/Grep`. `Bash`, `Agent`, `Task*`, `Skill`, `ToolSearch` accumulate `np_count` even when they represent legitimate work. Verification phases (test runs, git status, gh polling, smoke tests) trip the default `no_progress_threshold=5` after a handful of legitimate Bash calls.
 
 **S79 main lane empirical hit**: ≥5× false positives during PR #335 (Phase C) Argus review polling, CronCreate/Delete operations, parallel research Read fan-out.
 **S4-side-multi-lane historical hit**: 3× consecutive false positives during a single verification phase.
@@ -31,19 +31,20 @@
 
 ## Implementation plan
 
-### `hook.cjs`
+### `hook.cjs` (post-fix line numbers)
 
-1. Add `PROGRESS_TOOLS` set after line 74:
+1. `PROGRESS_TOOLS` set declared at lines 80-81 (after the `READ_TOOLS` line 74 + 5-line comment block at 75-79):
    ```js
-   const PROGRESS_TOOLS = new Set(['Bash', 'Agent', 'Task', 'Skill', 'TaskCreate', 'TaskUpdate', 'TaskList', 'TaskGet', 'TaskOutput', 'TaskStop', 'ToolSearch']);
+   const PROGRESS_TOOLS = new Set(['Bash', 'Agent', 'Skill', 'ToolSearch',
+     'Task', 'TaskCreate', 'TaskUpdate', 'TaskList', 'TaskGet', 'TaskOutput', 'TaskStop']);
    ```
-2. Pass `is_progress` flag through `update()`:
+2. `is_progress` flag computed in `main()` and passed to `update()` (line 96 signature):
    ```js
    const is_progress = PROGRESS_TOOLS.has(tool_name);
    ```
-3. Update line 101:
+3. `np_count` reset condition at line 108:
    ```js
-   if (is_write || is_read || errored || is_progress) { state.np_count = 0; } else { state.np_count++; }
+   if (is_write || is_read || is_progress || errored) { state.np_count = 0; } else { state.np_count++; }
    ```
 
 **Rationale for PROGRESS_TOOLS membership**:
@@ -83,11 +84,11 @@ To support unit tests of the `update()` helper, either:
 
 No schema change — `no_progress_threshold` keeps default `5`. Behaviour change documented in the loop-detector adapter README/install doc (if any) and in the Issue body / PR description.
 
-### LOC budget
+### LOC budget (post-fix actuals)
 
-- `hook.cjs`: +3 lines (set + flag + condition), -1 line (replace condition). Net +2.
-- `hook.test.cjs`: +~80 lines for 10 new test cases.
-- Adapter cap from PR #335 follow-up (#336): hook.cjs currently ~175 LOC. Net +2 keeps it well under the 200-cap target the side lane is enforcing.
+- `hook.cjs`: 175 → 186 LOC. Net +11 (PROGRESS_TOOLS set + 5-line comment block + threaded `is_progress` flag + dual-mode export wrapper).
+- `hook.test.cjs`: +~190 lines for 13 unit tests + 2 ETE tests.
+- Adapter cap from PR #335 follow-up (#336): 186 LOC well under the 200-cap target the side lane is enforcing.
 
 ## Acceptance criteria
 
@@ -107,7 +108,7 @@ No schema change — `no_progress_threshold` keeps default `5`. Behaviour change
 ## References
 
 - Issue #325 body — full design space + recommended patch sketch
-- `adapters/mercury-loop-detector/hook.cjs:73-101` — current `WRITE_TOOLS`/`READ_TOOLS`/`update()` implementation
+- `adapters/mercury-loop-detector/hook.cjs:73-108` — `WRITE_TOOLS`/`READ_TOOLS`/`PROGRESS_TOOLS` declarations (lines 73-81) + `update()` function (lines 96-109) with the line-108 reset condition
 - `adapters/mercury-loop-detector/hook.test.cjs:55-93` — existing detector regression coverage
 - `memory/feedback_lane_protocol.md` — Rule 8 cross-lane coordination (this Issue is `lane:main` per coordination)
 - S79 handoff doc — Loop-detector false-positive pattern documented in compact-loss section

--- a/.mercury/docs/research/loop-detector-fix-2026-04-27.md
+++ b/.mercury/docs/research/loop-detector-fix-2026-04-27.md
@@ -1,0 +1,113 @@
+# Loop-Detector False-Positive Fix — Research & Decision
+
+**Issue**: [#325](https://github.com/392fyc/Mercury/issues/325) — `feat(loop-detector): broaden progress signal — Bash/Agent should not count toward no_progress`
+**Lane**: `lane:main` (cross-lane impact, claimed via coordination Issue)
+**Session**: S80 main lane, 2026-04-27
+**Branch**: `feat/loop-detector-progress-signal`
+
+## Problem
+
+`adapters/mercury-loop-detector/hook.cjs:101` only resets `np_count` on `Write/Edit/NotebookEdit/MultiEdit/Read/Glob/Grep`. `Bash`, `Agent`, `Task*`, `Skill`, `ToolSearch` accumulate `np_count` even when they represent legitimate work. Verification phases (test runs, git status, gh polling, smoke tests) trip the default `no_progress_threshold=5` after a handful of legitimate Bash calls.
+
+**S79 main lane empirical hit**: ≥5× false positives during PR #335 (Phase C) Argus review polling, CronCreate/Delete operations, parallel research Read fan-out.
+**S4-side-multi-lane historical hit**: 3× consecutive false positives during a single verification phase.
+
+## Design space (per #325 body)
+
+| Option | Approach | Risk | Cost |
+|--------|----------|------|------|
+| **A** | Add `PROGRESS_TOOLS` set (Bash/Agent/Task*/Skill/ToolSearch) — these reset `np_count` | Low — still catches WebSearch/WebFetch loops | ~5 LOC + tests |
+| B | Raise `no_progress_threshold` 5 → 12-15 | Medium — masks real stalls | ~1 LOC config |
+| C | Rewrite as idle timer on `SessionIdle`/`Stop` hook | High — semantic refactor | Days |
+
+## Decision: **Option A**
+
+**Rationale**:
+1. Surgical — single counter behaviour change, no config break, no semantics change for other 3 signals (`duplicate_call`, `same_error`, `read_write_ratio` unchanged).
+2. Preserves true-stall detection: `WebSearch`/`WebFetch`/`mcp__*` loops without artifacts still accumulate `np_count`. Detector remains useful.
+3. Issue body's recommended path. Mirror's the existing pattern of explicit `WRITE_TOOLS`/`READ_TOOLS` sets — easy to extend later.
+4. B alone shifts the threshold but never solves the categorical mis-classification (Bash burst still trips 12 calls eventually).
+5. C would be correct-er but needs a Stop-hook redesign — out of scope for a P1 hotfix.
+
+## Implementation plan
+
+### `hook.cjs`
+
+1. Add `PROGRESS_TOOLS` set after line 74:
+   ```js
+   const PROGRESS_TOOLS = new Set(['Bash', 'Agent', 'Task', 'Skill', 'TaskCreate', 'TaskUpdate', 'TaskList', 'TaskGet', 'TaskOutput', 'TaskStop', 'ToolSearch']);
+   ```
+2. Pass `is_progress` flag through `update()`:
+   ```js
+   const is_progress = PROGRESS_TOOLS.has(tool_name);
+   ```
+3. Update line 101:
+   ```js
+   if (is_write || is_read || errored || is_progress) { state.np_count = 0; } else { state.np_count++; }
+   ```
+
+**Rationale for PROGRESS_TOOLS membership**:
+- `Bash` — git, gh, tests, scripts (the dominant false-positive source).
+- `Agent` — sub-agent dispatch is high-cost legitimate work.
+- `Task` + `TaskCreate`/`Update`/`List`/`Get`/`Output`/`Stop` — task tracking, by definition progress.
+- `Skill` — invoking skills is a deliberate workflow step.
+- `ToolSearch` — schema fetching for deferred tools is necessary setup.
+
+**Tools intentionally NOT in PROGRESS_TOOLS** (still increment `np_count`):
+- `WebSearch`, `WebFetch` — research loops without writes are the true-stall pattern detector should keep catching.
+- `mcp__*` — MCP tool calls are heterogeneous; default to "must produce write" semantics.
+- `EnterPlanMode`/`ExitPlanMode`/`EnterWorktree`/`ExitWorktree` — mode toggles are bookkeeping, not work.
+- `Monitor`, `ScheduleWakeup`, `Cron*`, `RemoteTrigger`, `PushNotification`, `AskUserQuestion` — orchestration / interaction, not progress.
+
+### Tests (`hook.test.cjs`)
+
+Add new `describe` block: `update() progress signal classification`. Tests:
+1. `Bash with non-error response resets np_count` — pre-seed `np_count: 4`, fire Bash success → expect `np_count: 0`.
+2. `Agent call resets np_count` — pre-seed `np_count: 4`, fire Agent success → expect `np_count: 0`.
+3. `Task* tools all reset np_count` — parametric across `Task`, `TaskCreate`, `TaskUpdate`, `TaskList`, `TaskGet`, `TaskOutput`, `TaskStop`.
+4. `Skill resets np_count` — same.
+5. `ToolSearch resets np_count` — same.
+6. `WebSearch still increments np_count` — pre-seed `np_count: 4`, fire WebSearch → expect `np_count: 5` (still trips threshold).
+7. `WebFetch still increments np_count` — same shape.
+8. `mcp__foo still increments np_count` — sample MCP call → still increments.
+9. **End-to-end regression**: 5 consecutive Bash calls with successful responses do NOT trigger block (was previously the false-positive pattern).
+10. **End-to-end stall preservation**: 5 consecutive WebSearch calls DO trigger block (true-stall pattern).
+
+To support unit tests of the `update()` helper, either:
+- (a) Export `update` from `hook.cjs` (small surface change), OR
+- (b) Mirror `update` inline in `hook.test.cjs` (matches existing `detectStall` mirror pattern).
+
+**Choosing (a)** — exporting is cleaner and avoids the drift risk of a parallel mirror. Add `if (require.main === module) main(); else module.exports = { update, detectStall, PROGRESS_TOOLS };` at the bottom. Existing tests already use child-process spawn for hook.cjs invocation, so dual-mode export is consistent.
+
+### Config doc (`.mercury/config/loop-detector.json`)
+
+No schema change — `no_progress_threshold` keeps default `5`. Behaviour change documented in the loop-detector adapter README/install doc (if any) and in the Issue body / PR description.
+
+### LOC budget
+
+- `hook.cjs`: +3 lines (set + flag + condition), -1 line (replace condition). Net +2.
+- `hook.test.cjs`: +~80 lines for 10 new test cases.
+- Adapter cap from PR #335 follow-up (#336): hook.cjs currently ~175 LOC. Net +2 keeps it well under the 200-cap target the side lane is enforcing.
+
+## Acceptance criteria
+
+1. All 10 new tests pass.
+2. All 137 regression tests still pass.
+3. Empirical: in S80 own session, no false-positive `no_progress` triggered after the fix lands and the user-level loop-detector hook reloads with the patched code (will become apparent in S81+).
+4. `hook.cjs` LOC ≤ 200.
+5. Cross-platform — tests run on the same Windows/MINGW + Unix matrix the existing suite covers.
+
+## Out of scope (this PR)
+
+- Option B threshold tuning — addressable later if Option A still trips edges.
+- Option C SessionIdle redesign — defer until Anthropic exposes SessionIdle hook event (currently only PostToolUse + Stop).
+- `mcp__*` whitelisting — requires per-server analysis; revisit if MCP tool surfaces become dominant work pattern.
+- Telemetry / per-tool false-positive rate — would help future tuning but adds state-file schema changes.
+
+## References
+
+- Issue #325 body — full design space + recommended patch sketch
+- `adapters/mercury-loop-detector/hook.cjs:73-101` — current `WRITE_TOOLS`/`READ_TOOLS`/`update()` implementation
+- `adapters/mercury-loop-detector/hook.test.cjs:55-93` — existing detector regression coverage
+- `memory/feedback_lane_protocol.md` — Rule 8 cross-lane coordination (this Issue is `lane:main` per coordination)
+- S79 handoff doc — Loop-detector false-positive pattern documented in compact-loss section

--- a/adapters/mercury-loop-detector/hook.cjs
+++ b/adapters/mercury-loop-detector/hook.cjs
@@ -70,8 +70,15 @@ function saveState(statePath, state) {
 }
 
 // ── Tool classification + helpers ────────────────────────────────────────────
-const WRITE_TOOLS = new Set(['Edit', 'Write', 'NotebookEdit', 'MultiEdit']);
-const READ_TOOLS  = new Set(['Read', 'Glob', 'Grep']);
+const WRITE_TOOLS    = new Set(['Edit', 'Write', 'NotebookEdit', 'MultiEdit']);
+const READ_TOOLS     = new Set(['Read', 'Glob', 'Grep']);
+// Tools that represent legitimate progress but produce no file artifact —
+// running tests/scripts (Bash), dispatching subagents (Agent), task/skill
+// orchestration (Task*/Skill), and deferred-tool schema fetch (ToolSearch).
+// WebSearch/WebFetch/mcp__* are intentionally NOT here — research loops
+// without artifacts remain the canonical true-stall pattern. See Issue #325.
+const PROGRESS_TOOLS = new Set(['Bash', 'Agent', 'Skill', 'ToolSearch',
+  'Task', 'TaskCreate', 'TaskUpdate', 'TaskList', 'TaskGet', 'TaskOutput', 'TaskStop']);
 
 function hashInput(input) {
   const s = typeof input === 'string' ? input : JSON.stringify(input ?? '');
@@ -86,7 +93,7 @@ function errorSig(r) {
 }
 
 // ── Update independent counters ───────────────────────────────────────────────
-function update(state, tool, hash, is_write, is_read, errored, err_sig) {
+function update(state, tool, hash, is_write, is_read, is_progress, errored, err_sig) {
   if (!errored) {
     if (tool === state.dup_tool && hash === state.dup_hash) { state.dup_count++; }
     else { state.dup_count = 1; state.dup_tool = tool; state.dup_hash = hash; }
@@ -98,7 +105,7 @@ function update(state, tool, hash, is_write, is_read, errored, err_sig) {
   if (is_write)     { state.read_count = 0; }
   else if (is_read) { state.read_count++; }
   else              { state.read_count = 0; }
-  if (is_write || is_read || errored) { state.np_count = 0; } else { state.np_count++; }
+  if (is_write || is_read || is_progress || errored) { state.np_count = 0; } else { state.np_count++; }
 }
 
 // ── Detect stall (most-specific signal first) ─────────────────────────────────
@@ -132,14 +139,15 @@ function main() {
   const state     = loadState(statePath);
   if (state.session_id !== session_id) { Object.assign(state, EMPTY_STATE()); state.session_id = session_id; }
 
-  const errored  = hasError(tool_response);
-  const err_sig  = errored ? errorSig(tool_response) : null;
-  const is_write = WRITE_TOOLS.has(tool_name);
-  const is_read  = READ_TOOLS.has(tool_name);
-  const now      = Date.now();
-  const ihash    = hashInput(tool_input);
+  const errored     = hasError(tool_response);
+  const err_sig     = errored ? errorSig(tool_response) : null;
+  const is_write    = WRITE_TOOLS.has(tool_name);
+  const is_read     = READ_TOOLS.has(tool_name);
+  const is_progress = PROGRESS_TOOLS.has(tool_name);
+  const now         = Date.now();
+  const ihash       = hashInput(tool_input);
 
-  update(state, tool_name, ihash, is_write, is_read, errored, err_sig);
+  update(state, tool_name, ihash, is_write, is_read, is_progress, errored, err_sig);
   updateTimestamps(state, is_write, now);
   saveState(statePath, state);
 
@@ -171,4 +179,8 @@ function main() {
   pass();
 }
 
-try { main(); } catch (e) { process.stderr.write(`${TAG} fatal: ${e.message}\n`); process.exit(0); }
+if (require.main === module) {
+  try { main(); } catch (e) { process.stderr.write(`${TAG} fatal: ${e.message}\n`); process.exit(0); }
+} else {
+  module.exports = { update, detectStall, PROGRESS_TOOLS, WRITE_TOOLS, READ_TOOLS };
+}

--- a/adapters/mercury-loop-detector/hook.test.cjs
+++ b/adapters/mercury-loop-detector/hook.test.cjs
@@ -456,6 +456,199 @@ describe('isoFsSafe formatting', () => {
   });
 });
 
+// ── 12. PROGRESS_TOOLS classification (Issue #325) ──────────────────────────
+
+describe('update() progress signal classification', () => {
+  // Pull the actual update fn from hook.cjs to keep behavior in sync — no mirror.
+  const { update, PROGRESS_TOOLS } = require('./hook.cjs');
+
+  function callUpdate(state, tool, opts = {}) {
+    const { is_write = false, is_read = false, errored = false, err_sig = null, hash = 'h1' } = opts;
+    const is_progress = PROGRESS_TOOLS.has(tool);
+    update(state, tool, hash, is_write, is_read, is_progress, errored, err_sig);
+  }
+
+  test('PROGRESS_TOOLS set contains expected tools', () => {
+    for (const t of ['Bash', 'Agent', 'Skill', 'ToolSearch',
+                     'Task', 'TaskCreate', 'TaskUpdate', 'TaskList', 'TaskGet', 'TaskOutput', 'TaskStop']) {
+      assert.ok(PROGRESS_TOOLS.has(t), `${t} should be in PROGRESS_TOOLS`);
+    }
+  });
+
+  test('Bash with success resets np_count', () => {
+    const state = makeState({ np_count: 4 });
+    callUpdate(state, 'Bash');
+    assert.equal(state.np_count, 0, 'Bash should reset np_count');
+  });
+
+  test('Agent call resets np_count', () => {
+    const state = makeState({ np_count: 4 });
+    callUpdate(state, 'Agent');
+    assert.equal(state.np_count, 0);
+  });
+
+  test('All Task* variants reset np_count', () => {
+    for (const t of ['Task', 'TaskCreate', 'TaskUpdate', 'TaskList', 'TaskGet', 'TaskOutput', 'TaskStop']) {
+      const state = makeState({ np_count: 4 });
+      callUpdate(state, t);
+      assert.equal(state.np_count, 0, `${t} should reset np_count`);
+    }
+  });
+
+  test('Skill resets np_count', () => {
+    const state = makeState({ np_count: 4 });
+    callUpdate(state, 'Skill');
+    assert.equal(state.np_count, 0);
+  });
+
+  test('ToolSearch resets np_count', () => {
+    const state = makeState({ np_count: 4 });
+    callUpdate(state, 'ToolSearch');
+    assert.equal(state.np_count, 0);
+  });
+
+  test('WebSearch still increments np_count (true-stall pattern preserved)', () => {
+    const state = makeState({ np_count: 4 });
+    callUpdate(state, 'WebSearch');
+    assert.equal(state.np_count, 5, 'WebSearch should not be in PROGRESS_TOOLS');
+  });
+
+  test('WebFetch still increments np_count', () => {
+    const state = makeState({ np_count: 4 });
+    callUpdate(state, 'WebFetch');
+    assert.equal(state.np_count, 5);
+  });
+
+  test('mcp__foo still increments np_count', () => {
+    const state = makeState({ np_count: 4 });
+    callUpdate(state, 'mcp__claude_ai_Gmail__authenticate');
+    assert.equal(state.np_count, 5, 'MCP tools default to non-progress');
+  });
+
+  test('5 consecutive Bash calls do NOT trigger no_progress (#325 fix)', () => {
+    const state = makeState();
+    for (let i = 0; i < 5; i++) {
+      callUpdate(state, 'Bash', { hash: `h${i}` });
+    }
+    assert.equal(state.np_count, 0, 'np_count should never accumulate for Bash');
+    const stall = detectStall(state, makeCfg());
+    assert.equal(stall, null, 'no stall expected from Bash burst');
+  });
+
+  test('5 consecutive WebSearch calls DO trigger no_progress (true-stall preserved)', () => {
+    const state = makeState();
+    for (let i = 0; i < 5; i++) {
+      callUpdate(state, 'WebSearch', { hash: `h${i}` });
+    }
+    assert.equal(state.np_count, 5);
+    const stall = detectStall(state, makeCfg());
+    assert.ok(stall, 'WebSearch burst should trigger stall');
+    assert.equal(stall.type, 'no_progress');
+  });
+
+  test('Bash with error still resets np_count via errored branch', () => {
+    const state = makeState({ np_count: 4 });
+    callUpdate(state, 'Bash', { errored: true, err_sig: 'error: fail' });
+    assert.equal(state.np_count, 0, 'errored=true also resets np_count');
+  });
+
+  test('Mixed burst: 3 Bash + 2 WebSearch keeps np_count at 2 (only WebSearch counted)', () => {
+    const state = makeState();
+    for (let i = 0; i < 3; i++) callUpdate(state, 'Bash',      { hash: `b${i}` });
+    for (let i = 0; i < 2; i++) callUpdate(state, 'WebSearch', { hash: `w${i}` });
+    assert.equal(state.np_count, 2);
+  });
+});
+
+// ── 13. hook.cjs ETE: PROGRESS_TOOLS via process spawn ──────────────────────
+
+describe('hook.cjs ETE: PROGRESS_TOOLS prevents false positive', () => {
+  const { execFileSync } = require('child_process');
+  const HOOK = path.join(__dirname, 'hook.cjs');
+  let counter = 0;
+  let tmpDirs = [];
+
+  function freshEnv(tmpDir) { return { ...process.env, CLAUDE_PROJECT_DIR: tmpDir }; }
+  function uniqueSession()  { return `ete-prog-${process.pid}-${++counter}-${Date.now()}`; }
+
+  afterEach(() => {
+    for (const d of tmpDirs) {
+      try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* ignore */ }
+    }
+    tmpDirs = [];
+  });
+
+  test('ETE: pre-seeded np_count=4 + Bash call does NOT block (was previous false positive)', () => {
+    const tmpDir = makeTmpDir();
+    tmpDirs.push(tmpDir);
+    const session_id = uniqueSession();
+    const stateDir = path.join(tmpDir, '.mercury', 'state');
+    fs.mkdirSync(stateDir, { recursive: true });
+    fs.writeFileSync(path.join(stateDir, 'loop-detector.json'), JSON.stringify({
+      session_id,
+      dup_count: 0, dup_tool: null, dup_hash: null,
+      err_count: 0, err_last: null,
+      read_count: 0, np_count: 4,
+      last_activity_ts: Date.now(), last_write_ts: Date.now()
+    }, null, 2));
+
+    let stdout = '';
+    try {
+      stdout = execFileSync('node', [HOOK], {
+        input: JSON.stringify({
+          tool_name: 'Bash',
+          tool_input: { command: 'gh pr view 999' },
+          tool_response: 'PR data',
+          session_id
+        }),
+        env: freshEnv(tmpDir),
+        timeout: 10000
+      }).toString();
+    } catch (e) {
+      stdout = e.stdout ? e.stdout.toString() : '';
+      if (e.status !== 0) throw e;
+    }
+    assert.ok(!stdout.includes('"block"'), `Bash should NOT block, got: ${stdout}`);
+
+    const finalState = JSON.parse(fs.readFileSync(path.join(stateDir, 'loop-detector.json'), 'utf8'));
+    assert.equal(finalState.np_count, 0, 'Bash should reset np_count to 0');
+  });
+
+  test('ETE: pre-seeded np_count=4 + WebSearch call DOES block (true-stall preserved)', () => {
+    const tmpDir = makeTmpDir();
+    tmpDirs.push(tmpDir);
+    const session_id = uniqueSession();
+    const stateDir = path.join(tmpDir, '.mercury', 'state');
+    fs.mkdirSync(stateDir, { recursive: true });
+    fs.writeFileSync(path.join(stateDir, 'loop-detector.json'), JSON.stringify({
+      session_id,
+      dup_count: 0, dup_tool: null, dup_hash: null,
+      err_count: 0, err_last: null,
+      read_count: 0, np_count: 4,
+      last_activity_ts: Date.now(), last_write_ts: Date.now()
+    }, null, 2));
+
+    let stdout = '';
+    try {
+      stdout = execFileSync('node', [HOOK], {
+        input: JSON.stringify({
+          tool_name: 'WebSearch',
+          tool_input: { query: 'docs' },
+          tool_response: 'results',
+          session_id
+        }),
+        env: freshEnv(tmpDir),
+        timeout: 10000
+      }).toString();
+    } catch (e) {
+      stdout = e.stdout ? e.stdout.toString() : '';
+      if (e.status !== 0) throw e;
+    }
+    assert.ok(stdout.includes('"block"'), `WebSearch SHOULD block, got: ${stdout}`);
+    assert.ok(stdout.includes('no_progress'), 'block reason should be no_progress');
+  });
+});
+
 // ── 9. hook.cjs end-to-end integration ──────────────────────────────────────
 
 describe('hook.cjs end-to-end integration', () => {
@@ -513,8 +706,9 @@ describe('hook.cjs end-to-end integration', () => {
     fs.mkdirSync(stateDir, { recursive: true });
 
     // Pre-seed np_count at threshold-1 (default=5, seed at 4).
-    // Sending a non-read/non-write/non-error tool call increments np_count to 5 → block.
-    // 'Bash' with successful response and non-error output is classified as "action" (not read/write).
+    // Sending a non-read/non-write/non-progress/non-error tool call increments np_count to 5 → block.
+    // WebSearch is the canonical true-stall pattern (research without artifacts).
+    // NOTE: Bash/Agent/Task*/Skill/ToolSearch are now in PROGRESS_TOOLS (Issue #325) and reset np_count.
     const preState = {
       session_id,
       dup_count: 0, dup_tool: null, dup_hash: null,
@@ -524,11 +718,11 @@ describe('hook.cjs end-to-end integration', () => {
     };
     fs.writeFileSync(path.join(stateDir, 'loop-detector.json'), JSON.stringify(preState, null, 2));
 
-    // Bash with non-error response: is_write=false, is_read=false, errored=false → np_count++
+    // WebSearch: is_write=false, is_read=false, is_progress=false, errored=false → np_count++
     const payload = JSON.stringify({
-      tool_name: 'Bash',
-      tool_input: { command: 'echo hello' },
-      tool_response: 'hello',
+      tool_name: 'WebSearch',
+      tool_input: { query: 'mercury loop detector' },
+      tool_response: 'Search results: 10 hits',
       session_id
     });
 

--- a/adapters/mercury-loop-detector/hook.test.cjs
+++ b/adapters/mercury-loop-detector/hook.test.cjs
@@ -649,7 +649,7 @@ describe('hook.cjs ETE: PROGRESS_TOOLS prevents false positive', () => {
   });
 });
 
-// ── 9. hook.cjs end-to-end integration ──────────────────────────────────────
+// ── 14. hook.cjs end-to-end integration ─────────────────────────────────────
 
 describe('hook.cjs end-to-end integration', () => {
   const { execFileSync } = require('child_process');


### PR DESCRIPTION
**Fixes #325** — Refs #325, Closes #325

## Summary

Loop-detector hook (`adapters/mercury-loop-detector/hook.cjs:101`) only reset `np_count` on Write/Edit/Read/Glob/Grep. Bash, Agent, Task*, Skill, ToolSearch accumulated `np_count` even when they represented legitimate work — verification phases (test runs, gh polling, git status, smoke tests) tripped the default `no_progress_threshold=5` after a handful of legitimate Bash calls.

**Empirical hits**:
- S79 main lane: ≥5× false positives during PR #335 (Phase C) Argus polling, CronCreate/Delete operations, parallel research Read fan-out.
- S4-side-multi-lane: 3× consecutive false positives during a single verification phase.
- S80 main lane (this PR): TaskCreate burst tripped it again during implementation — exactly the pattern this PR fixes.

**Fix** (Issue #325 Option A — surgical 5-line patch):
- Add `PROGRESS_TOOLS = new Set([Bash, Agent, Skill, ToolSearch, Task, TaskCreate, TaskUpdate, TaskList, TaskGet, TaskOutput, TaskStop])`
- Thread `is_progress` flag through `update()` so these tools reset `np_count` alongside Write/Read/error
- WebSearch / WebFetch / mcp__* / EnterPlanMode / Cron* / Monitor / ScheduleWakeup / RemoteTrigger / PushNotification / AskUserQuestion intentionally excluded — research loops without artifacts remain the canonical true-stall pattern (preserves detector usefulness)

**No semantics change** for the 3 other detector signals (`duplicate_call`, `same_error`, `read_write_ratio` unchanged). No config schema change.

## Files

- `adapters/mercury-loop-detector/hook.cjs` (175→186 LOC, under 200 cap): PROGRESS_TOOLS set + threaded `is_progress` flag + dual-mode export (`require.main === module`) so tests import `update`/`detectStall` without a parallel mirror.
- `adapters/mercury-loop-detector/hook.test.cjs` (+193 LOC): 13 unit tests + 2 ETE tests covering classification correctness, false-positive elimination, and true-stall preservation. Modified existing ETE stall-trigger test to use `WebSearch` (Bash now correctly resets).
- `.mercury/docs/research/loop-detector-fix-2026-04-27.md`: design doc with Option A/B/C trade-off analysis + decision rationale + intentionally-excluded list rationale.

## Test plan

- [x] `node --test adapters/**/*.test.cjs` → 44 pass / 0 fail / 1 skip (Unix-only mode test)
- [x] Smoke test: hook.cjs accepts Bash payload → exit 0, no block
- [x] Regression: existing 4 detector signals (duplicate_call, same_error, read_write_ratio, no_progress) unchanged — covered by existing test suite
- [x] LOC budget: hook.cjs 186 LOC (under 200 cap from #336 follow-up)
- [ ] Empirical verification: false-positive rate in S81+ sessions after user-level hook reload (cannot verify in S80 itself)

## Dual-verify

- **Claude Code deep-review**: PASS (Critical:0 High:0 Medium:0 Low:2). Low findings: (1) no explicit pair test for `is_progress=true && errored=true` — covered indirectly; (2) no negative tests for EnterPlanMode/Cron*/Monitor — membership absence already implies behavior.
- **Codex audit**: UNAVAILABLE (rescue subagent silent for >2h after 5 turns of investigation, no final verdict written to output file). Per dual-verify skill fallback protocol, low-risk single-counter behavior change proceeds with documented Claude-only review. Argus PR review will provide cross-perspective coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)