### PR TITLE
feat(dual-verify): sync codex-sync-audit.sh wrapper (#326)

### DIFF
--- a/.claude/skills/dual-verify/SKILL.md
+++ b/.claude/skills/dual-verify/SKILL.md
@@ -94,7 +94,9 @@ Check: language-appropriate correctness gates (e.g. `tsc --noEmit` for TypeScrip
 ```bash
 # 1. Write the audit prompt to a temp file. Keep it concrete: list the diff scope,
 #    explicit checks Codex should perform, and the expected output schema.
-PROMPT_FILE="$(mktemp)"
+#    `mktemp -t` works on both GNU coreutils and BSD/macOS mktemp; bare `mktemp` is
+#    not portable across the two (GNU defaults to /tmp/tmp.XXX, BSD requires a template).
+PROMPT_FILE="$(mktemp -t dual-verify-codex.XXXXXX)"
 cat > "$PROMPT_FILE" <<'EOF'
 Audit branch <branch> vs <base>. Focus on: code style, edge cases,
 error handling, metrics completeness, memory leak / cleanup on terminal paths,

--- a/.claude/skills/dual-verify/SKILL.md
+++ b/.claude/skills/dual-verify/SKILL.md
@@ -119,13 +119,27 @@ Branch on the wrapper's exit code:
 | Exit | Marker on stdout | Action |
 |------|------------------|--------|
 | `0` | `===CODEX-SYNC-AUDIT RESULT===` | Codex job ran to terminal `completed` (codex-companion's terminal-success status, per `lib/codex.mjs`). The verdict text is in the JSON payload at **`.storedJob.result.rawOutput`** (machine-readable) or `.storedJob.rendered` (display-formatted). Parse `rawOutput` for the `Critical: N  High: N ...` line + per-finding blocks + `Overall: PASS \| NEEDS-CHANGES`. Note: exit 0 means Codex *replied*, not that it approved — `NEEDS-CHANGES` also exits 0. |
-| `1` | `===CODEX-SYNC-AUDIT FAILED===` | Codex job failed in a non-timeout way. Treat as `Codex: FAIL`; investigate stderr / `node "$COMPANION" result <jobId> --json` before merging. |
-| `124` | `===CODEX-SYNC-AUDIT TIMEOUT===` | Wait budget exceeded. The job continues running in the codex job store; the orchestrator may re-fetch later via `node "$COMPANION" result <jobId> --json` (the same `.storedJob.result.rawOutput` path applies once the job reaches `completed`). For this dual-verify pass, fall back to Claude-only and **disclose** "Dual-verify Codex side: TIMEOUT (jobId `<id>`)" in the PR body. |
+| `1` | `===CODEX-SYNC-AUDIT FAILED===` | Codex job failed in a non-timeout way. Treat as `Codex: FAIL`; investigate stderr / re-fetch the result via the codex-companion CLI (see "Recovery commands" below) before merging. |
+| `124` | `===CODEX-SYNC-AUDIT TIMEOUT===` | Wait budget exceeded. The job continues running in the codex job store; the orchestrator may re-fetch later via the codex-companion CLI (see "Recovery commands" below). The same `.storedJob.result.rawOutput` path applies once the job reaches `completed`. For this dual-verify pass, fall back to Claude-only and **disclose** "Dual-verify Codex side: TIMEOUT (jobId `<id>`)" in the PR body. |
 | `130` | (cancellation message on stderr) | User interrupted (Ctrl+C). Wrapper attempted to cancel the codex job. Re-run when ready. |
 | `3` | (none — message on stderr) | Codex CLI not installed / not authenticated, or codex-companion returned malformed JSON. Run `/codex:setup`. Fall back to Claude-only and disclose "Dual-verify Codex side: UNAVAILABLE" in PR body. |
 | `2` | (usage error) | Bug in the dual-verify skill caller — fix the invocation, do not skip. |
 
 > Note: `scripts/codex-sync-audit.sh` bypasses the `codex-rescue` subagent (saves ~25k tokens of forwarder boot per audit per Issue #326 Update 1). The codex-rescue subagent remains available for general "hand a long task to Codex" use cases — only dual-verify uses the direct sync path.
+
+### Recovery commands
+
+When the wrapper exits 1 or 124, the codex job is still in the codex-companion store and can be inspected by calling the companion CLI directly. The companion script lives at `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/marketplaces/openai-codex/plugins/codex/scripts/codex-companion.mjs` (or the equivalent `cache/openai-codex/codex/<version>/scripts/codex-companion.mjs` on a versioned install). Set a shell var to that path, then:
+
+```bash
+COMPANION="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/marketplaces/openai-codex/plugins/codex/scripts/codex-companion.mjs"
+# Inspect the job snapshot:
+node "$COMPANION" status <jobId> --json
+# Once the job reaches `completed`, fetch the verdict payload:
+node "$COMPANION" result <jobId> --json | jq '.storedJob.result.rawOutput'
+```
+
+If `$COMPANION` does not resolve, run `bash scripts/codex-sync-audit.sh --help` — the wrapper logs its discovered companion path on dispatch failure (exit 3) and accepts `CODEX_COMPANION_SCRIPT=<path>` as an env override.
 
 ## Step 2 — Collect results
 

--- a/.claude/skills/dual-verify/SKILL.md
+++ b/.claude/skills/dual-verify/SKILL.md
@@ -22,14 +22,16 @@ Run Claude Code deep review and Codex code audit in parallel, then consolidate f
 |----------------|-------|
 | TypeScript `tsc --noEmit` | Claude Code |
 | Architecture / logic / integration correctness | Claude Code |
-| Code style / edge cases / error handling | Codex rescue subagent |
-| Metrics completeness (all 4 paths wired) | Codex rescue subagent |
-| Memory leak (Map cleanup on all terminal paths) | Codex rescue subagent |
-| Windows/PowerShell compat | Codex rescue subagent |
+| Code style / edge cases / error handling | Codex (sync audit wrapper) |
+| Metrics completeness (all 4 paths wired) | Codex (sync audit wrapper) |
+| Memory leak (Map cleanup on all terminal paths) | Codex (sync audit wrapper) |
+| Windows/PowerShell compat | Codex (sync audit wrapper) |
 
-Codex is invoked via `Agent` tool (rescue subagent) — no manual terminal step required.
+Codex is invoked via `bash scripts/codex-sync-audit.sh` — direct CLI call into the codex-companion runtime. The wrapper dispatches the audit and **blocks until the verdict is ready or a timeout is hit**, returning structured stdout markers that this skill parses (per Issue #326). The legacy `codex:codex-rescue` subagent path is no longer used here: it returns asynchronously and previously caused dual-verify to silently fall back when the verdict failed to arrive in-thread.
 
 ## Step 1 — Launch parallel reviewers
+
+The two reviewers can run in parallel: kick the Codex audit off via the Bash tool's `run_in_background: true` (or shell `&`), then perform the Claude-side deep review while it runs, then collect both verdicts.
 
 **Claude Code deep review** (this session):
 
@@ -87,7 +89,43 @@ git diff "${REMOTE}/${BASE}...HEAD"
 
 Check: language-appropriate correctness gates (e.g. `tsc --noEmit` for TypeScript, `pnpm lint`, `pytest --collect-only` for Python), logic correctness, integration points, schema compliance, missing branches in switch/if chains, resource leaks.
 
-**Codex audit** (rescue subagent — launch via Agent tool with `subagent_type: codex:codex-rescue`):
+**Codex audit** (sync wrapper — synchronous CLI call, blocks until verdict ready):
+
+```bash
+# 1. Write the audit prompt to a temp file. Keep it concrete: list the diff scope,
+#    explicit checks Codex should perform, and the expected output schema.
+PROMPT_FILE="$(mktemp)"
+cat > "$PROMPT_FILE" <<'EOF'
+Audit branch <branch> vs <base>. Focus on: code style, edge cases,
+error handling, metrics completeness, memory leak / cleanup on terminal paths,
+Windows/PowerShell compat. TypeScript typecheck is not required (Claude side handles it).
+
+Return:
+  Critical: N  High: N  Medium: N  Low: N
+  - <finding-1>
+  - <finding-2>
+  Overall: PASS | NEEDS-CHANGES
+EOF
+
+# 2. Dispatch synchronously. --read-only is the default (the wrapper is named *audit*).
+#    Default --timeout 600 (10 min) and --poll-interval 15 are usually fine; tune for huge diffs.
+bash scripts/codex-sync-audit.sh "$PROMPT_FILE" --timeout 600 --poll-interval 15
+EXIT=$?
+rm -f "$PROMPT_FILE"
+```
+
+Branch on the wrapper's exit code:
+
+| Exit | Marker on stdout | Action |
+|------|------------------|--------|
+| `0` | `===CODEX-SYNC-AUDIT RESULT===` | Codex job ran to terminal `completed` (codex-companion's terminal-success status, per `lib/codex.mjs`). The verdict text is in the JSON payload at **`.storedJob.result.rawOutput`** (machine-readable) or `.storedJob.rendered` (display-formatted). Parse `rawOutput` for the `Critical: N  High: N ...` line + per-finding blocks + `Overall: PASS \| NEEDS-CHANGES`. Note: exit 0 means Codex *replied*, not that it approved — `NEEDS-CHANGES` also exits 0. |
+| `1` | `===CODEX-SYNC-AUDIT FAILED===` | Codex job failed in a non-timeout way. Treat as `Codex: FAIL`; investigate stderr / `node "$COMPANION" result <jobId> --json` before merging. |
+| `124` | `===CODEX-SYNC-AUDIT TIMEOUT===` | Wait budget exceeded. The job continues running in the codex job store; the orchestrator may re-fetch later via `node "$COMPANION" result <jobId> --json` (the same `.storedJob.result.rawOutput` path applies once the job reaches `completed`). For this dual-verify pass, fall back to Claude-only and **disclose** "Dual-verify Codex side: TIMEOUT (jobId `<id>`)" in the PR body. |
+| `130` | (cancellation message on stderr) | User interrupted (Ctrl+C). Wrapper attempted to cancel the codex job. Re-run when ready. |
+| `3` | (none — message on stderr) | Codex CLI not installed / not authenticated, or codex-companion returned malformed JSON. Run `/codex:setup`. Fall back to Claude-only and disclose "Dual-verify Codex side: UNAVAILABLE" in PR body. |
+| `2` | (usage error) | Bug in the dual-verify skill caller — fix the invocation, do not skip. |
+
+> Note: `scripts/codex-sync-audit.sh` bypasses the `codex-rescue` subagent (saves ~25k tokens of forwarder boot per audit per Issue #326 Update 1). The codex-rescue subagent remains available for general "hand a long task to Codex" use cases — only dual-verify uses the direct sync path.
 
 ## Step 2 — Collect results
 
@@ -143,7 +181,12 @@ dual-verify: PASS (Claude: PASS, Codex: PASS, N issues fixed)
 
 ## Fallback
 
-If Codex is unavailable or the session cannot be started:
-- Use `/code-review` (Claude Code built-in) as the sole reviewer.
-- Document in the PR description that dual-verify was attempted but Codex was unavailable.
-- This fallback is acceptable for low-risk changes; high-risk PRs (orchestrator core, auth, schema changes) should wait for Codex availability.
+If `scripts/codex-sync-audit.sh` returns a non-success terminal state, fall back to Claude-only review and disclose the cause in the PR body. The PR body line MUST be one of:
+
+- `Dual-verify Codex side: PASS` (exit 0)
+- `Dual-verify Codex side: NEEDS-CHANGES` (exit 0 with findings; iterate)
+- `Dual-verify Codex side: FAILED` (exit 1; investigate before retrying)
+- `Dual-verify Codex side: TIMEOUT (jobId <id>)` (exit 124; the codex job continues — fetch later via `node "$COMPANION" result <jobId> --json`)
+- `Dual-verify Codex side: UNAVAILABLE` (exit 3; Codex CLI not installed / not authenticated — run `/codex:setup`)
+
+This fallback is acceptable for low-risk changes; high-risk PRs (orchestrator core, auth, schema changes) should re-run dual-verify once Codex is available rather than ship single-reviewer.

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ logs/
 npm-debug.log*
 pnpm-debug.log*
 
+# Scratch / per-session ephemera (skill prompt files, audit outputs, etc.)
+.tmp/
+
 # Environment / Secrets
 .env
 .env.*

--- a/.mercury/docs/research/codex-rescue-async-semantics-2026-04-27.md
+++ b/.mercury/docs/research/codex-rescue-async-semantics-2026-04-27.md
@@ -1,0 +1,186 @@
+# Codex-Rescue Async Semantics — Research & Decision
+
+**Issue**: [#326](https://github.com/392fyc/Mercury/issues/326) — `feedback(codex-rescue): document async-forwarder semantics — main must poll for result`
+**Lane**: `lane:main` (cross-lane impact, claimed via coordination Issue)
+**Session**: S81 main lane, 2026-04-27
+**Branch**: `feat/codex-rescue-async-doc`
+
+## Problem
+
+Mercury's `dual-verify` skill dispatches a Codex side audit via the `codex:codex-rescue` subagent. Empirical observations across S3/S4/S80 sessions:
+
+| Session | Lane | Outcome |
+|---------|------|---------|
+| S3-side-multi-lane | side | 2 codex-rescue audits "hung > 8 min" → fell back to Claude-only |
+| S4-side-multi-lane | side | 2 dispatches; 33,603 + 28,029 input tokens; **forwarder ack only, audit never returned** |
+| S80 main | main | dispatch succeeded; subagent went silent for 2h+ at 13:15:04Z; output file mtime froze; no error/panic |
+
+**Common pattern**: The `codex-rescue` subagent dispatches `codex-companion.mjs task ...` and returns the launch payload immediately. The actual audit runs asynchronously inside the codex-companion runtime. Mercury's dual-verify skill expected synchronous verdict-style output (matching the Claude-side critic), so it interpreted the missing verdict as a hang and fell back to single-reviewer mode.
+
+**This is not a Codex stability issue.** It is a contract mismatch between:
+- `codex-rescue` subagent — fire-and-forget forwarder, returns task id
+- `dual-verify` skill — assumes sync verdict return (like the Claude-side critic)
+
+S4 retrospective measured ~25k tokens of pure forwarder boot overhead per dispatch (loading three internal skills + system prompt before any real work). Compounded across 5+ commits per session, this becomes 125k+ tokens of forwarder cost with zero verdict delivery.
+
+## Native CLI surface (verified 2026-04-27)
+
+`codex-companion.mjs` (cached at `~/.claude/plugins/marketplaces/openai-codex/plugins/codex/scripts/codex-companion.mjs`) already exposes the synchronous primitives we need:
+
+| Subcommand | Synchronous? | Use |
+|------------|--------------|-----|
+| `task` (foreground, default) | yes | runs codex inline; blocks until done |
+| `task --background` | no | dispatches detached worker; returns `{jobId, ...}` payload |
+| `status <jobId> --wait --timeout-ms N --poll-interval-ms M --json` | yes (with timeout) | polls until job in terminal state OR timeout; returns snapshot with `waitTimedOut` flag |
+| `result <jobId> --json` | yes | fetches stored final payload (verdict, summary, findings, details, artifacts) for a finished job |
+
+**Key insight**: `status --wait` is **already a built-in polling primitive** with native timeout support. We do not need to write a polling loop in shell — we just chain `task --background` + `status --wait` + `result`.
+
+Verified by inspection of `codex-companion.mjs:293-309` (`waitForSingleJobSnapshot`):
+```js
+async function waitForSingleJobSnapshot(cwd, reference, options = {}) {
+  const timeoutMs = Math.max(0, Number(options.timeoutMs) || DEFAULT_STATUS_WAIT_TIMEOUT_MS);
+  const pollIntervalMs = Math.max(100, Number(options.pollIntervalMs) || DEFAULT_STATUS_POLL_INTERVAL_MS);
+  const deadline = Date.now() + timeoutMs;
+  let snapshot = buildSingleJobSnapshot(cwd, reference);
+  while (isActiveJobStatus(snapshot.job.status) && Date.now() < deadline) {
+    await sleep(Math.min(pollIntervalMs, Math.max(0, deadline - Date.now())));
+    snapshot = buildSingleJobSnapshot(cwd, reference);
+  }
+  return { ...snapshot, waitTimedOut: isActiveJobStatus(snapshot.job.status), timeoutMs };
+}
+```
+
+## Design space
+
+User decision (Issue #326 Update 2, 2026-04-26): **retain Codex** in dual-verify because the different model architecture (Codex/GPT-5.x vs Claude) genuinely produces different findings. The OMC `code-reviewer`-replacement option is rejected; the fix must preserve Codex as the second reviewer while making its return contract synchronous from the orchestrator's perspective.
+
+| Option | Approach | Verdict |
+|--------|----------|---------|
+| **A** | Document the async contract; main agent polls `/codex:status` manually after each codex-rescue dispatch | Insufficient — every dual-verify call still pays 25k token forwarder boot before the audit even starts; orchestrator burden remains |
+| **B** | Replace `codex-rescue` with OMC `code-reviewer` agent | Rejected by user — loses cross-architecture perspective |
+| **C** | Patch upstream `codex-rescue` agent to optionally block | Out-of-repo scope; would require oh-my-claudecode upstream PR; uncertain timeline |
+| **D (chosen)** | Bypass subagent layer entirely; call `codex-companion.mjs` directly from a Mercury-local sync wrapper script | **chosen** |
+
+## Decision: **Option D — direct CLI sync wrapper**
+
+`scripts/codex-sync-audit.sh` chains the codex-companion native primitives:
+
+```
+task --background --json   [--write]   [--model …]   [--effort …]   --prompt-file <path>
+  → captures jobId
+status <jobId> --wait --timeout-ms (T*1000) --poll-interval-ms (P*1000) --json
+  → blocks until terminal OR timeout
+result <jobId> --json
+  → returns final verdict payload (verdict text at .storedJob.result.rawOutput)
+```
+
+Read-only is the wrapper's default (it is named *audit*); `--write` is an explicit
+opt-in passed through to `task`. Plugin discovery walks a precedence chain:
+`CODEX_COMPANION_SCRIPT` → `CLAUDE_PLUGIN_ROOT` (only if set) → `$HOME` candidates
+→ `$USERPROFILE` candidates (only if distinct from `$HOME`). On Git Bash on Windows,
+`$HOME` and `$USERPROFILE` often resolve to different paths, so each is probed
+independently rather than picking one.
+
+### Why D over A
+
+1. **Zero subagent overhead.** Direct CLI call skips the `codex-rescue` subagent boot (avoids ~25k token cost per audit, the dominant pain point per Issue Update 1).
+2. **Native timeout discipline.** Codex-companion's `status --wait --timeout-ms` is the right tool — we use it instead of reimplementing in shell.
+3. **Sync contract for the orchestrator.** dual-verify skill calls `bash scripts/codex-sync-audit.sh prompt.txt --timeout 600` and gets stdout containing the verdict (or a `TIMEOUT` marker with partial state). No polling discipline required from the orchestrator side.
+4. **Preserves Codex/GPT-5.x as reviewer.** Per user override 2026-04-26, keeps cross-architecture diversity.
+5. **Out-of-repo dependency is read-only.** We do not modify the codex plugin; we only call its public CLI.
+
+### Why D over C
+
+C requires upstream PR cycle (uncertain timeline, oh-my-claudecode acceptance), and the `codex-rescue` agent's "fire-and-forget forwarder" semantic is intentional per its design (it serves multiple use-cases beyond dual-verify, where async dispatch is correct). Forking that contract just for our use-case is wasteful when the underlying CLI already does what we need.
+
+### Trade-offs accepted
+
+- **Loses subagent context inheritance.** Direct CLI invocation does not see the subagent system prompt or skills (`codex-cli-runtime`, `gpt-5-4-prompting`). For dual-verify the prompt is fully constructed by the skill itself with explicit instructions, so this is not a problem.
+- **Plugin path discovery.** The wrapper must locate `codex-companion.mjs` at runtime. Resolved via env-var precedence (`CODEX_COMPANION_SCRIPT` → `CLAUDE_PLUGIN_ROOT` → `${HOME}/.claude/plugins/marketplaces/openai-codex/plugins/codex/scripts/codex-companion.mjs`).
+- **Less forgiving error path.** When the CLI is unavailable (Codex not set up), the wrapper exits nonzero with a clear "Codex unavailable, run /codex:setup" message; dual-verify skill falls back to Claude-only with this message recorded in PR body. Unchanged from current behavior.
+
+## Implementation plan
+
+### `scripts/codex-sync-audit.sh`
+
+```
+Usage: codex-sync-audit.sh <prompt-file> [options]
+
+Options:
+  --timeout SECONDS         total wait budget (default 600)
+  --poll-interval SECONDS   polling interval (default 15)
+  --model MODEL             codex model override (e.g. gpt-5.4-mini, spark)
+  --effort EFFORT           reasoning effort (none|minimal|low|medium|high|xhigh)
+  --read-only               omit --write (codex audit-only, no edits)
+  --cwd PATH                workspace root (default: pwd)
+  --dry-run                 print resolved commands; do not execute
+
+Exit codes:
+  0   succeeded — codex job reached terminal `completed`; verdict block on stdout
+  1   codex job failed (non-timeout terminal failure) — failure JSON on stdout
+  2   usage error (missing prompt file, bad arg)
+  3   codex unavailable (CLI not found, jq missing, setup required, or JSON parse error)
+  124 wait timed out — TIMEOUT marker + status snapshot on stdout (partial work preserved in codex job store)
+  130 user interrupted (SIGINT/SIGTERM after dispatch — wrapper cancels codex job before exit)
+```
+
+Behaviour:
+1. Resolve `codex-companion.mjs` path via env var precedence.
+2. Validate prompt file exists, non-empty.
+3. Dispatch `node codex-companion.mjs task --background --json --prompt-file <prompt>` with optional `--write`/`--model`/`--effort`.
+4. Extract `jobId` from launch payload (jq).
+5. Poll `node codex-companion.mjs status <jobId> --wait --timeout-ms <T> --poll-interval-ms <P> --json`.
+6. Branch on `waitTimedOut` and `job.status` (codex-companion uses `completed` for terminal-success in `lib/codex.mjs`; `succeeded` is also accepted defensively):
+   - `waitTimedOut === true` → emit `===CODEX-SYNC-AUDIT TIMEOUT===\n<status JSON>` on stdout, exit 124. The job continues running in the codex store; refetch later with `result --json`.
+   - `job.status` in `{completed, succeeded}` → fetch `result --json`, validate `.storedJob.id` is present, emit `===CODEX-SYNC-AUDIT RESULT===\n<result JSON>` on stdout, exit 0.
+   - `job.status` in `{failed, cancelled}` → emit `===CODEX-SYNC-AUDIT FAILED===\n<status JSON>` on stdout, exit 1.
+
+An EXIT trap installed after `JOB_ID` is captured cancels the codex job on any
+non-terminal exit path (jq parse failures, signals, unexpected status), so post-
+dispatch failures do not leak orphan workers into the codex job store.
+
+### `scripts/test-codex-sync-audit.sh`
+
+Pure-shell tests (no real Codex needed):
+1. Usage error: missing prompt file → exit 2.
+2. Plugin discovery: env precedence honored.
+3. Dispatch parsing: mock companion script returns canned launch JSON; wrapper extracts jobId correctly.
+4. Wait branches: mock companion returns `completed` → exit 0; `failed` → exit 1; `waitTimedOut: true` → exit 124. Plus a malformed-result-JSON path → exit 3, and an EXIT-trap-cancels-orphan path validated by mock-side log inspection.
+5. `--dry-run`: prints resolved commands; does not execute.
+
+Mock approach: `CODEX_COMPANION_SCRIPT` env override pointed at a tiny `mock-companion.mjs` shipped alongside tests. Each subcommand returns deterministic canned JSON keyed by `--json` mode.
+
+### `dual-verify` skill update
+
+Replace the "Codex (rescue subagent)" section. New flow:
+1. dual-verify skill writes the audit prompt to a temp file.
+2. Calls `bash scripts/codex-sync-audit.sh <prompt-file> --timeout 600 --poll-interval 15 --read-only`.
+3. Parses stdout. On exit 0, treat output as the Codex verdict. On exit 124, log timeout + fall back to Claude-only with PR-body disclosure. On exit 3, fall back same way with "Codex unavailable" disclosure.
+4. PR body template adds an explicit "Dual-verify Codex side: PASS|TIMEOUT|UNAVAILABLE" line.
+
+### `feedback_dual_verify_gate.md`
+
+Add section: **Codex side returns synchronously via `scripts/codex-sync-audit.sh`** — sync wrapper handles polling with default 600s timeout. On timeout the tail is preserved in the codex job store; orchestrator may inspect via `node codex-companion.mjs result <jobId> --json` later for offline triage.
+
+## Acceptance criteria mapping (per Issue #326 Update 2)
+
+| Criterion | Implementation |
+|-----------|----------------|
+| `scripts/codex-sync-audit.sh` (or equivalent) exists | yes — `scripts/codex-sync-audit.sh` |
+| dispatches codex-rescue + polls + sync verdict | yes — `task --background` + `status --wait` + `result --json` |
+| Configurable timeout (default 600s) | yes — `--timeout SECONDS` arg, default 600 |
+| On timeout, last available output + clear "TIMEOUT" marker | yes — exit 124 + `===CODEX-SYNC-AUDIT TIMEOUT===` marker + status JSON |
+| dual-verify skill calls sync wrapper | yes — SKILL.md updated |
+| PR body template documents new contract | yes — new "Dual-verify Codex side:" line |
+| `feedback_dual_verify_gate.md` reflects new default | yes — memory updated |
+| Token cost benchmark | will be recorded post-PR (this PR's own dual-verify is the benchmark) |
+
+## Sources
+
+- Issue #326 spec — <https://github.com/392fyc/Mercury/issues/326>
+- `~/.claude/plugins/marketplaces/openai-codex/plugins/codex/scripts/codex-companion.mjs` — verified 2026-04-27 from `~/.claude/plugins/cache/openai-codex/codex/1.0.2/` (same content)
+- S4-side-multi-lane handoff retrospective ("Codex CLI 不稳定" entry) — corrected by this analysis
+- S80 main lane empirical: codex-rescue background process `bvcebb4wl` / agentId `aba2edb5a494364c0` — silent 2h+ post-13:15:04Z (per session-handoff.md Key Context)
+- Mercury `feedback_dual_verify_gate.md` — current Codex-rescue contract documentation (will be updated)
+- Codex agent definition — `~/.claude/plugins/marketplaces/openai-codex/plugins/codex/agents/codex-rescue.md` (forwarder-only contract, intentionally non-blocking)

--- a/.mercury/docs/research/codex-rescue-async-semantics-2026-04-27.md
+++ b/.mercury/docs/research/codex-rescue-async-semantics-2026-04-27.md
@@ -25,7 +25,7 @@ S4 retrospective measured ~25k tokens of pure forwarder boot overhead per dispat
 
 ## Native CLI surface (verified 2026-04-27)
 
-`codex-companion.mjs` (cached at `~/.claude/plugins/marketplaces/openai-codex/plugins/codex/scripts/codex-companion.mjs`) already exposes the synchronous primitives we need:
+`codex-companion.mjs` (cached at `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/marketplaces/openai-codex/plugins/codex/scripts/codex-companion.mjs`) already exposes the synchronous primitives we need:
 
 | Subcommand | Synchronous? | Use |
 |------------|--------------|-----|
@@ -97,7 +97,7 @@ C requires upstream PR cycle (uncertain timeline, oh-my-claudecode acceptance), 
 ### Trade-offs accepted
 
 - **Loses subagent context inheritance.** Direct CLI invocation does not see the subagent system prompt or skills (`codex-cli-runtime`, `gpt-5-4-prompting`). For dual-verify the prompt is fully constructed by the skill itself with explicit instructions, so this is not a problem.
-- **Plugin path discovery.** The wrapper must locate `codex-companion.mjs` at runtime. Resolved via env-var precedence (`CODEX_COMPANION_SCRIPT` → `CLAUDE_PLUGIN_ROOT` → `${HOME}/.claude/plugins/marketplaces/openai-codex/plugins/codex/scripts/codex-companion.mjs`).
+- **Plugin path discovery.** The wrapper must locate `codex-companion.mjs` at runtime. Resolved via env-var precedence: `CODEX_COMPANION_SCRIPT` (full file path) → `CLAUDE_PLUGIN_ROOT` (when set, joined with `/scripts/codex-companion.mjs`) → `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/...` → `$USERPROFILE/.claude/plugins/...` (only when distinct from `$HOME`). The conventional Mercury config root is `${CLAUDE_CONFIG_DIR:-$HOME/.claude}`; the discovery code probes the cache version directory via semver-aware sort to survive plugin upgrades without code changes.
 - **Less forgiving error path.** When the CLI is unavailable (Codex not set up), the wrapper exits nonzero with a clear "Codex unavailable, run /codex:setup" message; dual-verify skill falls back to Claude-only with this message recorded in PR body. Unchanged from current behavior.
 
 ## Implementation plan
@@ -179,8 +179,8 @@ Add section: **Codex side returns synchronously via `scripts/codex-sync-audit.sh
 ## Sources
 
 - Issue #326 spec — <https://github.com/392fyc/Mercury/issues/326>
-- `~/.claude/plugins/marketplaces/openai-codex/plugins/codex/scripts/codex-companion.mjs` — verified 2026-04-27 from `~/.claude/plugins/cache/openai-codex/codex/1.0.2/` (same content)
+- `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/marketplaces/openai-codex/plugins/codex/scripts/codex-companion.mjs` — verified 2026-04-27; the same script is cached at `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/cache/openai-codex/codex/<version>/scripts/codex-companion.mjs` (the `<version>` segment is glob-discovered at runtime via semver sort, so the wrapper survives plugin upgrades).
 - S4-side-multi-lane handoff retrospective ("Codex CLI 不稳定" entry) — corrected by this analysis
 - S80 main lane empirical: codex-rescue background process `bvcebb4wl` / agentId `aba2edb5a494364c0` — silent 2h+ post-13:15:04Z (per session-handoff.md Key Context)
 - Mercury `feedback_dual_verify_gate.md` — current Codex-rescue contract documentation (will be updated)
-- Codex agent definition — `~/.claude/plugins/marketplaces/openai-codex/plugins/codex/agents/codex-rescue.md` (forwarder-only contract, intentionally non-blocking)
+- Codex agent definition — `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/marketplaces/openai-codex/plugins/codex/agents/codex-rescue.md` (forwarder-only contract, intentionally non-blocking)

--- a/scripts/codex-sync-audit.sh
+++ b/scripts/codex-sync-audit.sh
@@ -110,7 +110,12 @@ case "$POLL_S" in ''|*[!0-9]*) die "--poll-interval must be a non-negative integ
 # --- dependency resolution ---
 NODE_BIN="${CODEX_COMPANION_NODE:-node}"
 command -v "$NODE_BIN" >/dev/null 2>&1 || die "node not found in PATH (set CODEX_COMPANION_NODE to override)" 3
-command -v jq >/dev/null 2>&1 || die "jq not found in PATH (required to parse codex-companion JSON)" 3
+# `jq` is only needed on the live execution path (dispatching Codex + parsing JSON
+# responses). --dry-run never invokes the companion or parses any JSON, so we skip
+# the jq check there to keep --dry-run usable on minimal hosts that do not have jq.
+if [[ "$DRY_RUN" -ne 1 ]]; then
+  command -v jq >/dev/null 2>&1 || die "jq not found in PATH (required to parse codex-companion JSON)" 3
+fi
 
 # Sort lines containing a path with a version segment (e.g. .../codex/1.0.10/scripts/...)
 # in descending semver order. Read from stdin, write to stdout. Probes once at module load
@@ -284,7 +289,11 @@ if [[ "$DRY_RUN" -eq 1 ]]; then
 fi
 
 # --- 1. dispatch ---
-LAUNCH_JSON="$(run_companion "${DISPATCH_ARGS[@]}")" || die "codex-companion task --background dispatch failed (exit $?)" 3
+# Always log the resolved companion path before dispatch so a failure trace lets
+# the operator see which path was actually used. Quiet success path: this is
+# stderr only, callers parsing stdout markers are unaffected.
+printf 'codex-sync-audit: companion=%s\n' "$COMPANION_SCRIPT" >&2
+LAUNCH_JSON="$(run_companion "${DISPATCH_ARGS[@]}")" || die "codex-companion task --background dispatch failed (exit $?; companion was $COMPANION_SCRIPT)" 3
 
 JOB_ID="$(jq_or_die "$LAUNCH_JSON" '.jobId // empty' 'launch')"
 [[ -n "$JOB_ID" ]] || {

--- a/scripts/codex-sync-audit.sh
+++ b/scripts/codex-sync-audit.sh
@@ -99,6 +99,13 @@ case "$TIMEOUT_S" in ''|*[!0-9]*) die "--timeout must be a non-negative integer"
 case "$POLL_S" in ''|*[!0-9]*) die "--poll-interval must be a non-negative integer" ;; esac
 [[ "$TIMEOUT_S" -gt 0 ]] || die "--timeout must be > 0"
 [[ "$POLL_S" -gt 0 ]] || die "--poll-interval must be > 0"
+# Upper bounds — guard against arithmetic overflow when multiplying by 1000 to
+# build the *_MS values that go to codex-companion. 86400s (24h) is the longest
+# reasonable single audit; bash arithmetic is 64-bit on modern platforms but the
+# upstream node side may not be, and ms values much larger than 24h serve no
+# practical purpose.
+[[ "$TIMEOUT_S" -le 86400 ]] || die "--timeout must be ≤ 86400 seconds (24h)"
+[[ "$POLL_S" -le "$TIMEOUT_S" ]] || die "--poll-interval ($POLL_S) must be ≤ --timeout ($TIMEOUT_S)"
 
 # --- dependency resolution ---
 NODE_BIN="${CODEX_COMPANION_NODE:-node}"
@@ -120,14 +127,29 @@ resolve_companion_script() {
   if [[ -n "${CLAUDE_PLUGIN_ROOT:-}" ]]; then
     candidates+=("$CLAUDE_PLUGIN_ROOT/scripts/codex-companion.mjs")
   fi
-  if [[ -n "${HOME:-}" ]]; then
-    candidates+=("$HOME/.claude/plugins/marketplaces/openai-codex/plugins/codex/scripts/codex-companion.mjs")
-    candidates+=("$HOME/.claude/plugins/cache/openai-codex/codex/1.0.2/scripts/codex-companion.mjs")
-  fi
-  if [[ -n "${USERPROFILE:-}" && "${USERPROFILE:-}" != "${HOME:-}" ]]; then
-    candidates+=("$USERPROFILE/.claude/plugins/marketplaces/openai-codex/plugins/codex/scripts/codex-companion.mjs")
-    candidates+=("$USERPROFILE/.claude/plugins/cache/openai-codex/codex/1.0.2/scripts/codex-companion.mjs")
-  fi
+  # The cache path includes a plugin version segment (e.g. .../cache/openai-codex/codex/1.0.2/...)
+  # that changes on every plugin upgrade — globbing the version directory lets the wrapper survive
+  # codex-plugin version bumps without code edits. Newest-wins is good enough; users can always
+  # set CODEX_COMPANION_SCRIPT to pin a specific path.
+  local prefix
+  for prefix in "${HOME:-}" "${USERPROFILE:-}"; do
+    [[ -z "$prefix" ]] && continue
+    # Skip USERPROFILE if it would duplicate HOME-based candidates we already added.
+    if [[ "$prefix" == "${USERPROFILE:-}" && "${USERPROFILE:-}" == "${HOME:-}" ]]; then
+      continue
+    fi
+    candidates+=("$prefix/.claude/plugins/marketplaces/openai-codex/plugins/codex/scripts/codex-companion.mjs")
+    # Glob each available cached version, sort high-to-low, take the newest. The `2>/dev/null`
+    # suppresses the "no match" error when no cache dir exists, and `[[ -f "$f" ]]` filters out
+    # the literal glob pattern (which bash leaves unchanged when nullglob is off).
+    local cache_glob="$prefix/.claude/plugins/cache/openai-codex/codex"
+    if [[ -d "$cache_glob" ]]; then
+      local versioned
+      while IFS= read -r versioned; do
+        [[ -f "$versioned" ]] && candidates+=("$versioned")
+      done < <(find "$cache_glob" -maxdepth 3 -name codex-companion.mjs -path '*/scripts/codex-companion.mjs' 2>/dev/null | sort -r)
+    fi
+  done
   [[ ${#candidates[@]} -gt 0 ]] || die "neither HOME nor USERPROFILE nor CLAUDE_PLUGIN_ROOT is set; cannot locate codex plugin" 3
 
   local cand

--- a/scripts/codex-sync-audit.sh
+++ b/scripts/codex-sync-audit.sh
@@ -1,0 +1,267 @@
+#!/usr/bin/env bash
+# codex-sync-audit.sh — synchronous wrapper around codex-companion task runtime.
+#
+# Issue: https://github.com/392fyc/Mercury/issues/326
+# Bypasses the codex-rescue subagent (saves ~25k tokens of forwarder overhead) and
+# delivers a synchronous verdict by chaining task --background + status --wait + result.
+#
+# Usage:
+#   codex-sync-audit.sh <prompt-file> [options]
+#
+# Options:
+#   --timeout SECONDS         total wait budget (default 600 = 10 min)
+#   --poll-interval SECONDS   polling interval (default 15)
+#   --model MODEL             codex model override (e.g. gpt-5.4-mini, spark)
+#   --effort EFFORT           reasoning effort (none|minimal|low|medium|high|xhigh)
+#   --write                   allow codex to edit the tree (default: read-only)
+#   --read-only               (default — kept as a no-op alias for clarity)
+#   --cwd PATH                workspace root (default: pwd)
+#   --dry-run                 print resolved commands; do not execute
+#   -h | --help               show usage
+#
+# Exit codes:
+#   0    succeeded — codex job reached terminal "completed" (codex-companion's
+#        terminal-success status, per lib/codex.mjs; "succeeded" is also accepted
+#        defensively). The verdict text lives in `.storedJob.result.rawOutput`
+#        (or `.storedJob.rendered` for display) in the JSON payload that follows
+#        the RESULT marker. PASS vs NEEDS-CHANGES is determined by parsing that
+#        text, NOT by this exit code.
+#   1    codex job failed (non-timeout terminal failure)
+#   2    usage error
+#   3    codex unavailable (CLI not found, jq missing, setup required, or JSON parse error)
+#   124  wait timed out — TIMEOUT marker + status snapshot on stdout (job continues in store)
+#   130  user interrupted (SIGINT/SIGTERM after dispatch — wrapper attempts to cancel codex job before exit)
+#
+# Stdout markers (so dual-verify can reliably parse the outcome):
+#   ===CODEX-SYNC-AUDIT RESULT===   followed by `result --json` payload
+#   ===CODEX-SYNC-AUDIT TIMEOUT===  followed by `status --json` snapshot
+#   ===CODEX-SYNC-AUDIT FAILED===   followed by `status --json` snapshot
+#
+# Env overrides (used by tests; do not rely on these in production callers):
+#   CODEX_COMPANION_SCRIPT  full path to codex-companion.mjs
+#   CODEX_COMPANION_NODE    node executable (default: node)
+
+set -euo pipefail
+
+usage() {
+  # Dump every leading comment line (after the shebang) until the first non-comment
+  # line. Avoids hardcoded ranges so future header growth/shrink stays self-consistent.
+  awk 'NR==1 && /^#!/ { next }
+       /^#/ { sub(/^# ?/, ""); print; next }
+       { exit }' "$0"
+}
+
+die() {
+  printf 'codex-sync-audit: %s\n' "$1" >&2
+  exit "${2:-2}"
+}
+
+# --- arg parsing ---
+TIMEOUT_S=600
+POLL_S=15
+MODEL=""
+EFFORT=""
+# Default to read-only — this script is named codex-sync-AUDIT for a reason. Callers
+# that genuinely need an edit-capable Codex run must opt in with --write.
+WRITE_FLAG=""
+CWD_OVERRIDE=""
+DRY_RUN=0
+PROMPT_FILE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help) usage; exit 0 ;;
+    --timeout) [[ $# -ge 2 ]] || die "--timeout requires a value"; TIMEOUT_S="$2"; shift 2 ;;
+    --poll-interval) [[ $# -ge 2 ]] || die "--poll-interval requires a value"; POLL_S="$2"; shift 2 ;;
+    --model) [[ $# -ge 2 ]] || die "--model requires a value"; MODEL="$2"; shift 2 ;;
+    --effort) [[ $# -ge 2 ]] || die "--effort requires a value"; EFFORT="$2"; shift 2 ;;
+    --write) WRITE_FLAG="--write"; shift ;;
+    --read-only) WRITE_FLAG=""; shift ;;
+    --cwd) [[ $# -ge 2 ]] || die "--cwd requires a value"; CWD_OVERRIDE="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    --) shift; break ;;
+    -*) die "unknown option: $1" ;;
+    *)
+      if [[ -z "$PROMPT_FILE" ]]; then
+        PROMPT_FILE="$1"; shift
+      else
+        die "unexpected positional argument: $1"
+      fi
+      ;;
+  esac
+done
+
+[[ -n "$PROMPT_FILE" ]] || { usage >&2; exit 2; }
+[[ -f "$PROMPT_FILE" ]] || die "prompt file not found: $PROMPT_FILE"
+[[ -s "$PROMPT_FILE" ]] || die "prompt file is empty: $PROMPT_FILE"
+
+case "$TIMEOUT_S" in ''|*[!0-9]*) die "--timeout must be a non-negative integer" ;; esac
+case "$POLL_S" in ''|*[!0-9]*) die "--poll-interval must be a non-negative integer" ;; esac
+[[ "$TIMEOUT_S" -gt 0 ]] || die "--timeout must be > 0"
+[[ "$POLL_S" -gt 0 ]] || die "--poll-interval must be > 0"
+
+# --- dependency resolution ---
+NODE_BIN="${CODEX_COMPANION_NODE:-node}"
+command -v "$NODE_BIN" >/dev/null 2>&1 || die "node not found in PATH (set CODEX_COMPANION_NODE to override)" 3
+command -v jq >/dev/null 2>&1 || die "jq not found in PATH (required to parse codex-companion JSON)" 3
+
+resolve_companion_script() {
+  if [[ -n "${CODEX_COMPANION_SCRIPT:-}" ]]; then
+    [[ -f "$CODEX_COMPANION_SCRIPT" ]] || die "CODEX_COMPANION_SCRIPT does not point to a file: $CODEX_COMPANION_SCRIPT" 3
+    printf '%s' "$CODEX_COMPANION_SCRIPT"
+    return
+  fi
+
+  # Build candidates as a true precedence chain (skip empties so an unset
+  # CLAUDE_PLUGIN_ROOT does not produce a literal "/scripts/codex-companion.mjs"
+  # candidate, and HOME and USERPROFILE are tried independently rather than picking
+  # one — Git Bash on Windows often has both set to different paths).
+  local candidates=()
+  if [[ -n "${CLAUDE_PLUGIN_ROOT:-}" ]]; then
+    candidates+=("$CLAUDE_PLUGIN_ROOT/scripts/codex-companion.mjs")
+  fi
+  if [[ -n "${HOME:-}" ]]; then
+    candidates+=("$HOME/.claude/plugins/marketplaces/openai-codex/plugins/codex/scripts/codex-companion.mjs")
+    candidates+=("$HOME/.claude/plugins/cache/openai-codex/codex/1.0.2/scripts/codex-companion.mjs")
+  fi
+  if [[ -n "${USERPROFILE:-}" && "${USERPROFILE:-}" != "${HOME:-}" ]]; then
+    candidates+=("$USERPROFILE/.claude/plugins/marketplaces/openai-codex/plugins/codex/scripts/codex-companion.mjs")
+    candidates+=("$USERPROFILE/.claude/plugins/cache/openai-codex/codex/1.0.2/scripts/codex-companion.mjs")
+  fi
+  [[ ${#candidates[@]} -gt 0 ]] || die "neither HOME nor USERPROFILE nor CLAUDE_PLUGIN_ROOT is set; cannot locate codex plugin" 3
+
+  local cand
+  for cand in "${candidates[@]}"; do
+    if [[ -f "$cand" ]]; then
+      printf '%s' "$cand"
+      return
+    fi
+  done
+
+  die "codex-companion.mjs not found — install the codex plugin or set CODEX_COMPANION_SCRIPT" 3
+}
+
+COMPANION_SCRIPT="$(resolve_companion_script)"
+WORKSPACE_CWD="${CWD_OVERRIDE:-$PWD}"
+[[ -d "$WORKSPACE_CWD" ]] || die "workspace cwd not a directory: $WORKSPACE_CWD"
+
+run_companion() {
+  # Always run companion from the workspace cwd so it associates jobs with this repo.
+  ( cd "$WORKSPACE_CWD" && "$NODE_BIN" "$COMPANION_SCRIPT" "$@" )
+}
+
+# Run jq with controlled error handling. Reads JSON from $1, applies filter $2,
+# exits via die() with code 3 if jq fails (so the caller never sees a raw
+# `set -e` jq exit). Writes the filter result to stdout when successful.
+jq_or_die() {
+  local payload="$1" filter="$2" label="$3" out
+  if ! out="$(printf '%s' "$payload" | jq -r "$filter" 2>/dev/null)"; then
+    printf '%s\n' "$payload" >&2
+    die "could not parse $label JSON (jq filter: $filter)" 3
+  fi
+  printf '%s' "$out"
+}
+
+# Cancellation trap: once we know the codex job id, ANY exit path that doesn't go
+# through the "we observed a terminal state" route should cancel the job, otherwise
+# the detached worker keeps running orphaned in the codex store. This covers:
+#   - SIGINT / SIGTERM during status --wait
+#   - set -e exits triggered by jq_or_die() after dispatch
+#   - any other nonzero exit before TERMINAL_SEEN is set
+JOB_ID=""
+TERMINAL_SEEN=0
+cleanup_on_exit() {
+  if [[ -n "$JOB_ID" && "$TERMINAL_SEEN" -eq 0 ]]; then
+    printf 'codex-sync-audit: cancelling job %s before exit\n' "$JOB_ID" >&2
+    run_companion cancel "$JOB_ID" --json >/dev/null 2>&1 || true
+  fi
+}
+cleanup_on_signal() {
+  local sig="$1"
+  printf 'codex-sync-audit: %s received\n' "$sig" >&2
+  exit 130  # EXIT trap will run cleanup_on_exit
+}
+arm_cleanup_traps() {
+  trap 'cleanup_on_exit' EXIT
+  trap 'cleanup_on_signal SIGINT' INT
+  trap 'cleanup_on_signal SIGTERM' TERM
+}
+
+# --- build dispatch argv ---
+DISPATCH_ARGS=(task --background --json --prompt-file "$PROMPT_FILE")
+[[ -n "$WRITE_FLAG" ]] && DISPATCH_ARGS+=("$WRITE_FLAG")
+[[ -n "$MODEL" ]]      && DISPATCH_ARGS+=(--model "$MODEL")
+[[ -n "$EFFORT" ]]     && DISPATCH_ARGS+=(--effort "$EFFORT")
+
+TIMEOUT_MS=$(( TIMEOUT_S * 1000 ))
+POLL_MS=$(( POLL_S * 1000 ))
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  printf 'DRY RUN — would invoke:\n'
+  printf '  cwd: %s\n' "$WORKSPACE_CWD"
+  printf '  companion: %s %s\n' "$NODE_BIN" "$COMPANION_SCRIPT"
+  printf '  dispatch: %q ' "${DISPATCH_ARGS[@]}"; printf '\n'
+  printf '  wait: status <jobId> --wait --timeout-ms %d --poll-interval-ms %d --json\n' "$TIMEOUT_MS" "$POLL_MS"
+  printf '  result: result <jobId> --json\n'
+  exit 0
+fi
+
+# --- 1. dispatch ---
+LAUNCH_JSON="$(run_companion "${DISPATCH_ARGS[@]}")" || die "codex-companion task --background dispatch failed (exit $?)" 3
+
+JOB_ID="$(jq_or_die "$LAUNCH_JSON" '.jobId // empty' 'launch')"
+[[ -n "$JOB_ID" ]] || {
+  printf '%s\n' "$LAUNCH_JSON" >&2
+  die "could not extract jobId from launch payload" 3
+}
+
+# Job is now live in the codex store; arm cleanup traps so any non-terminal exit
+# (signal OR jq_or_die failure OR unexpected case) cancels the job rather than orphaning it.
+arm_cleanup_traps
+
+# --- 2. wait ---
+STATUS_JSON="$(run_companion status "$JOB_ID" --wait --timeout-ms "$TIMEOUT_MS" --poll-interval-ms "$POLL_MS" --json)" || die "codex-companion status --wait failed (exit $?)" 3
+
+WAIT_TIMED_OUT="$(jq_or_die "$STATUS_JSON" '.waitTimedOut // false' 'status')"
+JOB_STATUS="$(jq_or_die "$STATUS_JSON" '.job.status // "unknown"' 'status')"
+
+if [[ "$WAIT_TIMED_OUT" == "true" ]]; then
+  # Wait timeout — the job continues running in the store. Mark TERMINAL_SEEN so
+  # the EXIT trap does NOT cancel it (callers may want to refetch result later).
+  TERMINAL_SEEN=1
+  printf '===CODEX-SYNC-AUDIT TIMEOUT===\n'
+  printf '%s\n' "$STATUS_JSON"
+  exit 124
+fi
+
+# --- 3. branch on terminal status ---
+# Status taxonomy per codex-companion: terminal-success uses "completed"
+# (lib/codex.mjs:356); we also accept "succeeded" defensively in case upstream
+# changes. Terminal-failure uses "failed" (tracked-jobs.mjs); cancelled uses
+# "cancelled" (codex-companion.mjs).
+case "$JOB_STATUS" in
+  completed|succeeded)
+    RESULT_JSON="$(run_companion result "$JOB_ID" --json)" || die "codex-companion result fetch failed (exit $?)" 3
+    # Validate the payload before emitting it. We require .storedJob.id to be present
+    # because callers parse .storedJob.result.rawOutput / .storedJob.rendered from
+    # this same shape; a missing storedJob means the companion misbehaved and the
+    # caller would otherwise silently see no verdict.
+    STORED_JOB_ID="$(jq_or_die "$RESULT_JSON" '.storedJob.id // empty' 'result')"
+    [[ -n "$STORED_JOB_ID" ]] || die "result payload missing .storedJob.id (companion returned malformed JSON)" 3
+    TERMINAL_SEEN=1  # job ran to success — no need to cancel
+    printf '===CODEX-SYNC-AUDIT RESULT===\n'
+    printf '%s\n' "$RESULT_JSON"
+    exit 0
+    ;;
+  failed|cancelled)
+    TERMINAL_SEEN=1  # job ran to a terminal failure — already finalised
+    printf '===CODEX-SYNC-AUDIT FAILED===\n'
+    printf '%s\n' "$STATUS_JSON"
+    exit 1
+    ;;
+  *)
+    printf '===CODEX-SYNC-AUDIT FAILED===\n'
+    printf '%s\n' "$STATUS_JSON"
+    die "unexpected non-terminal status after wait: $JOB_STATUS" 1
+    ;;
+esac

--- a/scripts/codex-sync-audit.sh
+++ b/scripts/codex-sync-audit.sh
@@ -171,24 +171,33 @@ resolve_companion_script() {
   # that changes on every plugin upgrade — globbing the version directory lets the wrapper survive
   # codex-plugin version bumps without code edits. Newest-wins is good enough; users can always
   # set CODEX_COMPANION_SCRIPT to pin a specific path.
-  # Build unique prefix list explicitly: HOME first, then USERPROFILE only if it differs.
-  # (An earlier version tried to dedupe inside the loop body but skipped HOME on the first iter
-  # whenever HOME==USERPROFILE because both arms of the condition matched.)
-  local -a prefixes=()
-  [[ -n "${HOME:-}" ]] && prefixes+=("$HOME")
+  # Build unique prefix list explicitly. The Claude config root is variable on this team —
+  # Mercury CLAUDE.md treats `${CLAUDE_CONFIG_DIR:-$HOME/.claude}` as the canonical user-level
+  # path (so users with a non-default config dir still get plugins discovered). Treat
+  # CLAUDE_CONFIG_DIR as a full config root (already includes ".claude/..."-style structure
+  # if user uses it that way), but for the conventional case where CLAUDE_CONFIG_DIR is
+  # *itself* the root that contains "plugins/", we map it directly. HOME and USERPROFILE
+  # add their `.claude` segment as before.
+  local -a config_roots=()
+  if [[ -n "${CLAUDE_CONFIG_DIR:-}" ]]; then
+    config_roots+=("$CLAUDE_CONFIG_DIR")
+  fi
+  if [[ -n "${HOME:-}" ]]; then
+    config_roots+=("$HOME/.claude")
+  fi
   if [[ -n "${USERPROFILE:-}" && "${USERPROFILE:-}" != "${HOME:-}" ]]; then
-    prefixes+=("$USERPROFILE")
+    config_roots+=("$USERPROFILE/.claude")
   fi
   local prefix
-  for prefix in "${prefixes[@]}"; do
-    candidates+=("$prefix/.claude/plugins/marketplaces/openai-codex/plugins/codex/scripts/codex-companion.mjs")
+  for prefix in "${config_roots[@]}"; do
+    candidates+=("$prefix/plugins/marketplaces/openai-codex/plugins/codex/scripts/codex-companion.mjs")
     # Glob each available cached version, sort by semver high-to-low, take the newest.
     # Prefer GNU/BSD `sort -V` (version sort: 1.0.10 > 1.0.2, 10.0.0 > 9.9.9). If the
     # local sort lacks -V (pre-7.0 GNU coreutils, very old BSD sort) we fall back to
     # a portable awk comparator that splits the version segment and compares each
     # numeric component. Lex sort alone would mis-order multi-digit versions and is
     # not a safe last resort here.
-    local cache_glob="$prefix/.claude/plugins/cache/openai-codex/codex"
+    local cache_glob="$prefix/plugins/cache/openai-codex/codex"
     if [[ -d "$cache_glob" ]]; then
       local versioned
       while IFS= read -r versioned; do
@@ -196,7 +205,7 @@ resolve_companion_script() {
       done < <(find "$cache_glob" -maxdepth 3 -name codex-companion.mjs -path '*/scripts/codex-companion.mjs' 2>/dev/null | sort_versions_desc)
     fi
   done
-  [[ ${#candidates[@]} -gt 0 ]] || die "neither HOME nor USERPROFILE nor CLAUDE_PLUGIN_ROOT is set; cannot locate codex plugin" 3
+  [[ ${#candidates[@]} -gt 0 ]] || die "no Claude config root resolvable (set CLAUDE_CONFIG_DIR, HOME, USERPROFILE, or CLAUDE_PLUGIN_ROOT) — cannot locate codex plugin" 3
 
   local cand
   for cand in "${candidates[@]}"; do

--- a/scripts/codex-sync-audit.sh
+++ b/scripts/codex-sync-audit.sh
@@ -131,23 +131,27 @@ resolve_companion_script() {
   # that changes on every plugin upgrade — globbing the version directory lets the wrapper survive
   # codex-plugin version bumps without code edits. Newest-wins is good enough; users can always
   # set CODEX_COMPANION_SCRIPT to pin a specific path.
+  # Build unique prefix list explicitly: HOME first, then USERPROFILE only if it differs.
+  # (An earlier version tried to dedupe inside the loop body but skipped HOME on the first iter
+  # whenever HOME==USERPROFILE because both arms of the condition matched.)
+  local -a prefixes=()
+  [[ -n "${HOME:-}" ]] && prefixes+=("$HOME")
+  if [[ -n "${USERPROFILE:-}" && "${USERPROFILE:-}" != "${HOME:-}" ]]; then
+    prefixes+=("$USERPROFILE")
+  fi
   local prefix
-  for prefix in "${HOME:-}" "${USERPROFILE:-}"; do
-    [[ -z "$prefix" ]] && continue
-    # Skip USERPROFILE if it would duplicate HOME-based candidates we already added.
-    if [[ "$prefix" == "${USERPROFILE:-}" && "${USERPROFILE:-}" == "${HOME:-}" ]]; then
-      continue
-    fi
+  for prefix in "${prefixes[@]}"; do
     candidates+=("$prefix/.claude/plugins/marketplaces/openai-codex/plugins/codex/scripts/codex-companion.mjs")
-    # Glob each available cached version, sort high-to-low, take the newest. The `2>/dev/null`
-    # suppresses the "no match" error when no cache dir exists, and `[[ -f "$f" ]]` filters out
-    # the literal glob pattern (which bash leaves unchanged when nullglob is off).
+    # Glob each available cached version, sort by semver high-to-low, take the newest.
+    # `sort -V -r` is the GNU version-sort (BSD sort also supports -V on macOS / modern WSL).
+    # Lex sort would mis-order 1.0.10 < 1.0.2 and 10.0.0 < 9.9.9. The `2>/dev/null` on find
+    # suppresses errors when the cache dir does not exist; sort gracefully accepts empty input.
     local cache_glob="$prefix/.claude/plugins/cache/openai-codex/codex"
     if [[ -d "$cache_glob" ]]; then
       local versioned
       while IFS= read -r versioned; do
         [[ -f "$versioned" ]] && candidates+=("$versioned")
-      done < <(find "$cache_glob" -maxdepth 3 -name codex-companion.mjs -path '*/scripts/codex-companion.mjs' 2>/dev/null | sort -r)
+      done < <(find "$cache_glob" -maxdepth 3 -name codex-companion.mjs -path '*/scripts/codex-companion.mjs' 2>/dev/null | sort -V -r)
     fi
   done
   [[ ${#candidates[@]} -gt 0 ]] || die "neither HOME nor USERPROFILE nor CLAUDE_PLUGIN_ROOT is set; cannot locate codex plugin" 3

--- a/scripts/codex-sync-audit.sh
+++ b/scripts/codex-sync-audit.sh
@@ -112,6 +112,46 @@ NODE_BIN="${CODEX_COMPANION_NODE:-node}"
 command -v "$NODE_BIN" >/dev/null 2>&1 || die "node not found in PATH (set CODEX_COMPANION_NODE to override)" 3
 command -v jq >/dev/null 2>&1 || die "jq not found in PATH (required to parse codex-companion JSON)" 3
 
+# Sort lines containing a path with a version segment (e.g. .../codex/1.0.10/scripts/...)
+# in descending semver order. Read from stdin, write to stdout. Probes once at module load
+# whether the local sort understands -V; if so, uses it. Otherwise falls back to an awk
+# comparator that splits the version segment and compares numerically per-component.
+SORT_V_OK=
+sort_versions_desc() {
+  if [[ -z "$SORT_V_OK" ]]; then
+    if printf '1.0.2\n1.0.10\n' | sort -V >/dev/null 2>&1; then
+      SORT_V_OK=1
+    else
+      SORT_V_OK=0
+      printf 'codex-sync-audit: sort -V unavailable; using awk-based version sort fallback\n' >&2
+    fi
+  fi
+  if [[ "$SORT_V_OK" -eq 1 ]]; then
+    sort -V -r
+  else
+    # Extract the version directory (.../codex/<version>/scripts/codex-companion.mjs),
+    # decorate with a sortable numeric key, sort descending, strip the key.
+    awk -F/ '
+      {
+        # Find the segment immediately before "scripts" — that is the version dir.
+        ver = ""
+        for (i = 1; i <= NF; i++) {
+          if ($i == "scripts" && i > 1) { ver = $(i-1); break }
+        }
+        n = split(ver, parts, ".")
+        # Build a 4-field zero-padded key (1.0.10 → 0000001 0000000 0000010 0000000).
+        # 4 fields covers semver MAJOR.MINOR.PATCH with optional pre-release counter.
+        key = ""
+        for (i = 1; i <= 4; i++) {
+          v = (i <= n ? parts[i] : 0) + 0
+          key = key sprintf("%07d ", v)
+        }
+        print key $0
+      }
+    ' | sort -r | sed 's/^[0-9 ]* //'
+  fi
+}
+
 resolve_companion_script() {
   if [[ -n "${CODEX_COMPANION_SCRIPT:-}" ]]; then
     [[ -f "$CODEX_COMPANION_SCRIPT" ]] || die "CODEX_COMPANION_SCRIPT does not point to a file: $CODEX_COMPANION_SCRIPT" 3
@@ -143,15 +183,17 @@ resolve_companion_script() {
   for prefix in "${prefixes[@]}"; do
     candidates+=("$prefix/.claude/plugins/marketplaces/openai-codex/plugins/codex/scripts/codex-companion.mjs")
     # Glob each available cached version, sort by semver high-to-low, take the newest.
-    # `sort -V -r` is the GNU version-sort (BSD sort also supports -V on macOS / modern WSL).
-    # Lex sort would mis-order 1.0.10 < 1.0.2 and 10.0.0 < 9.9.9. The `2>/dev/null` on find
-    # suppresses errors when the cache dir does not exist; sort gracefully accepts empty input.
+    # Prefer GNU/BSD `sort -V` (version sort: 1.0.10 > 1.0.2, 10.0.0 > 9.9.9). If the
+    # local sort lacks -V (pre-7.0 GNU coreutils, very old BSD sort) we fall back to
+    # a portable awk comparator that splits the version segment and compares each
+    # numeric component. Lex sort alone would mis-order multi-digit versions and is
+    # not a safe last resort here.
     local cache_glob="$prefix/.claude/plugins/cache/openai-codex/codex"
     if [[ -d "$cache_glob" ]]; then
       local versioned
       while IFS= read -r versioned; do
         [[ -f "$versioned" ]] && candidates+=("$versioned")
-      done < <(find "$cache_glob" -maxdepth 3 -name codex-companion.mjs -path '*/scripts/codex-companion.mjs' 2>/dev/null | sort -V -r)
+      done < <(find "$cache_glob" -maxdepth 3 -name codex-companion.mjs -path '*/scripts/codex-companion.mjs' 2>/dev/null | sort_versions_desc)
     fi
   done
   [[ ${#candidates[@]} -gt 0 ]] || die "neither HOME nor USERPROFILE nor CLAUDE_PLUGIN_ROOT is set; cannot locate codex plugin" 3

--- a/scripts/test-codex-sync-audit.sh
+++ b/scripts/test-codex-sync-audit.sh
@@ -40,7 +40,9 @@ assert_contains() {
   fi
 }
 
-WORK_DIR="$(mktemp -d)"
+# `mktemp -d -t` is portable across GNU coreutils and BSD/macOS mktemp; bare
+# `mktemp -d` is GNU-only.
+WORK_DIR="$(mktemp -d -t codex-sync-audit-test.XXXXXX)"
 trap 'rm -rf "$WORK_DIR"' EXIT
 
 PROMPT_FILE="$WORK_DIR/prompt.txt"

--- a/scripts/test-codex-sync-audit.sh
+++ b/scripts/test-codex-sync-audit.sh
@@ -1,0 +1,357 @@
+#!/usr/bin/env bash
+# Tests for codex-sync-audit.sh — uses a mock codex-companion injected via env var.
+#
+# No real Codex needed. Each scenario invokes the wrapper against a tiny mock
+# script that returns deterministic JSON and asserts exit code + stdout marker.
+#
+# Run: bash scripts/test-codex-sync-audit.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WRAPPER="$SCRIPT_DIR/codex-sync-audit.sh"
+[[ -x "$WRAPPER" ]] || { printf 'wrapper not executable: %s\n' "$WRAPPER" >&2; exit 1; }
+
+PASS=0
+FAIL=0
+declare -a FAILURES=()
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ✓ %s\n' "$label"
+  else
+    FAIL=$((FAIL + 1))
+    FAILURES+=("$label: expected [$expected], got [$actual]")
+    printf '  ✗ %s — expected [%s], got [%s]\n' "$label" "$expected" "$actual"
+  fi
+}
+
+assert_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    PASS=$((PASS + 1))
+    printf '  ✓ %s\n' "$label"
+  else
+    FAIL=$((FAIL + 1))
+    FAILURES+=("$label: missing [$needle] in stdout")
+    printf '  ✗ %s — missing [%s]\n' "$label" "$needle"
+  fi
+}
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+PROMPT_FILE="$WORK_DIR/prompt.txt"
+printf 'audit prompt\n' > "$PROMPT_FILE"
+
+# --- mock codex-companion script ---
+# Behaviour switches on $MOCK_MODE env var: succeeded | failed | timeout | bad_dispatch | bad_jobid
+make_mock() {
+  local mode="$1"
+  local script="$WORK_DIR/mock-companion-$mode.mjs"
+  cat > "$script" <<EOF
+#!/usr/bin/env node
+const args = process.argv.slice(2);
+const sub = args[0];
+const mode = "$mode";
+function emit(obj) { process.stdout.write(JSON.stringify(obj) + "\n"); }
+if (sub === "task") {
+  if (mode === "bad_dispatch") { process.stderr.write("dispatch failed\n"); process.exit(1); }
+  if (mode === "bad_jobid") { emit({ title: "x", summary: "y" }); process.exit(0); }
+  emit({ jobId: "mock-job-123", title: "t", summary: "s" });
+  process.exit(0);
+}
+if (sub === "status") {
+  if (mode === "timeout") {
+    emit({ job: { id: "mock-job-123", status: "running", phase: "thinking" }, waitTimedOut: true, timeoutMs: 1000 });
+    process.exit(0);
+  }
+  if (mode === "failed") {
+    emit({ job: { id: "mock-job-123", status: "failed", phase: "error" }, waitTimedOut: false, timeoutMs: 1000 });
+    process.exit(0);
+  }
+  // Terminal-success status from real codex-companion is "completed" (per lib/codex.mjs).
+  emit({ job: { id: "mock-job-123", status: "completed", phase: "done" }, waitTimedOut: false, timeoutMs: 1000 });
+  process.exit(0);
+}
+if (sub === "result") {
+  // Mirror the real codex-companion task-result payload shape:
+  //   storedJob.id, storedJob.result.rawOutput (the verdict text),
+  //   storedJob.result.status, storedJob.rendered (formatted display).
+  // The wrapper validates .storedJob.id is present before printing the RESULT block.
+  emit({
+    job: { id: "mock-job-123", status: "completed" },
+    storedJob: {
+      id: "mock-job-123",
+      status: "completed",
+      result: {
+        rawOutput: "Critical: 0  High: 0  Medium: 0  Low: 0\nOverall: PASS",
+        status: "completed",
+        threadId: "mock-thread-1"
+      },
+      rendered: "Mock rendered output"
+    }
+  });
+  process.exit(0);
+}
+if (sub === "cancel") {
+  // Tests may install an EXIT trap; the trap calls cancel on cleanup. Stub it.
+  emit({ jobId: process.argv[3] || "unknown", cancelled: true });
+  process.exit(0);
+}
+process.stderr.write("mock: unexpected subcommand " + sub + "\n");
+process.exit(2);
+EOF
+  printf '%s' "$script"
+}
+
+run_wrapper() {
+  local mode="$1"; shift
+  local script
+  script="$(make_mock "$mode")"
+  CODEX_COMPANION_SCRIPT="$script" "$WRAPPER" "$@"
+}
+
+# Each test runs the wrapper, captures stdout + exit code, asserts.
+run_capture() {
+  local mode="$1"; shift
+  local out exit_code
+  set +e
+  out="$(run_wrapper "$mode" "$@" 2>/dev/null)"
+  exit_code=$?
+  set -e
+  printf '%s\n%d' "$out" "$exit_code"
+}
+
+# --- tests ---
+
+printf '\n[1] usage error: missing prompt file\n'
+set +e
+"$WRAPPER" 2>/dev/null
+ec=$?
+set -e
+assert_eq "exit code 2" "2" "$ec"
+
+printf '\n[2] usage error: prompt file does not exist\n'
+set +e
+"$WRAPPER" /nonexistent/prompt.txt 2>/dev/null
+ec=$?
+set -e
+assert_eq "exit code 2" "2" "$ec"
+
+printf '\n[3] usage error: empty prompt file\n'
+empty="$WORK_DIR/empty.txt"
+: > "$empty"
+set +e
+"$WRAPPER" "$empty" 2>/dev/null
+ec=$?
+set -e
+assert_eq "exit code 2" "2" "$ec"
+
+printf '\n[4] usage error: bad timeout (non-numeric)\n'
+set +e
+"$WRAPPER" "$PROMPT_FILE" --timeout abc 2>/dev/null
+ec=$?
+set -e
+assert_eq "exit code 2" "2" "$ec"
+
+printf '\n[5] usage error: unknown option\n'
+set +e
+"$WRAPPER" "$PROMPT_FILE" --not-a-flag 2>/dev/null
+ec=$?
+set -e
+assert_eq "exit code 2" "2" "$ec"
+
+printf '\n[6] dependency error: companion script does not exist\n'
+set +e
+CODEX_COMPANION_SCRIPT="/no/such/script.mjs" "$WRAPPER" "$PROMPT_FILE" 2>/dev/null
+ec=$?
+set -e
+assert_eq "exit code 3" "3" "$ec"
+
+printf '\n[7] success path: emits RESULT marker, exit 0\n'
+combined="$(run_capture succeeded "$PROMPT_FILE")"
+out="${combined%$'\n'*}"
+ec="${combined##*$'\n'}"
+assert_eq "exit code 0" "0" "$ec"
+assert_contains "RESULT marker present" "===CODEX-SYNC-AUDIT RESULT===" "$out"
+# The wrapper validates .storedJob.id is present before emitting; the mock provides
+# a real storedJob.result.rawOutput that mirrors the actual codex-companion shape.
+assert_contains "rawOutput field present in payload" "rawOutput" "$out"
+assert_contains "Overall verdict line in rawOutput" "Overall: PASS" "$out"
+
+printf '\n[8] failed path: emits FAILED marker, exit 1\n'
+combined="$(run_capture failed "$PROMPT_FILE")"
+out="${combined%$'\n'*}"
+ec="${combined##*$'\n'}"
+assert_eq "exit code 1" "1" "$ec"
+assert_contains "FAILED marker present" "===CODEX-SYNC-AUDIT FAILED===" "$out"
+
+printf '\n[9] timeout path: emits TIMEOUT marker, exit 124\n'
+combined="$(run_capture timeout "$PROMPT_FILE")"
+out="${combined%$'\n'*}"
+ec="${combined##*$'\n'}"
+assert_eq "exit code 124" "124" "$ec"
+assert_contains "TIMEOUT marker present" "===CODEX-SYNC-AUDIT TIMEOUT===" "$out"
+assert_contains "waitTimedOut: true serialised" '"waitTimedOut":true' "$out"
+
+printf '\n[10] dispatch failure: exit 3\n'
+set +e
+script="$(make_mock bad_dispatch)"
+CODEX_COMPANION_SCRIPT="$script" "$WRAPPER" "$PROMPT_FILE" >/dev/null 2>/dev/null
+ec=$?
+set -e
+assert_eq "exit code 3" "3" "$ec"
+
+printf '\n[11] missing jobId in dispatch payload: exit 3\n'
+set +e
+script="$(make_mock bad_jobid)"
+CODEX_COMPANION_SCRIPT="$script" "$WRAPPER" "$PROMPT_FILE" >/dev/null 2>/dev/null
+ec=$?
+set -e
+assert_eq "exit code 3" "3" "$ec"
+
+printf '\n[12] dry-run: no companion invocation needed\n'
+combined="$(run_capture succeeded "$PROMPT_FILE" --dry-run)"
+out="${combined%$'\n'*}"
+ec="${combined##*$'\n'}"
+assert_eq "exit code 0" "0" "$ec"
+assert_contains "DRY RUN banner" "DRY RUN" "$out"
+assert_contains "wait command shown" "status <jobId> --wait --timeout-ms 600000" "$out"
+assert_contains "poll interval shown" "poll-interval-ms 15000" "$out"
+
+printf '\n[13] dry-run with custom timeout/poll\n'
+combined="$(run_capture succeeded "$PROMPT_FILE" --dry-run --timeout 900 --poll-interval 30)"
+out="${combined%$'\n'*}"
+ec="${combined##*$'\n'}"
+assert_eq "exit code 0" "0" "$ec"
+assert_contains "custom timeout-ms" "timeout-ms 900000" "$out"
+assert_contains "custom poll-ms" "poll-interval-ms 30000" "$out"
+
+printf '\n[14] dry-run is read-only by default (no --write in dispatch)\n'
+combined="$(run_capture succeeded "$PROMPT_FILE" --dry-run)"
+out="${combined%$'\n'*}"
+ec="${combined##*$'\n'}"
+assert_eq "exit code 0" "0" "$ec"
+if [[ "$out" == *"--write"* ]]; then
+  FAIL=$((FAIL + 1))
+  FAILURES+=("default mode incorrectly passed --write")
+  printf '  ✗ default suppresses --write — but --write still found\n'
+else
+  PASS=$((PASS + 1))
+  printf '  ✓ default suppresses --write (read-only by default)\n'
+fi
+
+printf '\n[15] dry-run with --write opts in to write mode\n'
+combined="$(run_capture succeeded "$PROMPT_FILE" --dry-run --write)"
+out="${combined%$'\n'*}"
+ec="${combined##*$'\n'}"
+assert_eq "exit code 0" "0" "$ec"
+assert_contains "--write opt-in honored" "--write" "$out"
+
+printf '\n[16] dry-run --read-only is a no-op alias\n'
+combined="$(run_capture succeeded "$PROMPT_FILE" --dry-run --read-only)"
+out="${combined%$'\n'*}"
+ec="${combined##*$'\n'}"
+assert_eq "exit code 0" "0" "$ec"
+if [[ "$out" == *"--write"* ]]; then
+  FAIL=$((FAIL + 1))
+  FAILURES+=("explicit --read-only still passed --write")
+  printf '  ✗ explicit --read-only suppresses --write — but --write still found\n'
+else
+  PASS=$((PASS + 1))
+  printf '  ✓ explicit --read-only suppresses --write\n'
+fi
+
+printf '\n[17] result payload missing .storedJob.id triggers controlled exit 3\n'
+# Build a one-off mock that returns a result payload missing the required id field.
+bad_result="$WORK_DIR/mock-companion-bad-result.mjs"
+cat > "$bad_result" <<'MOCK_EOF'
+#!/usr/bin/env node
+const sub = process.argv[2];
+function emit(o) { process.stdout.write(JSON.stringify(o) + "\n"); }
+if (sub === "task")   { emit({ jobId: "mock-job-123" }); process.exit(0); }
+if (sub === "status") { emit({ job: { id: "mock-job-123", status: "completed" }, waitTimedOut: false, timeoutMs: 1000 }); process.exit(0); }
+if (sub === "result") { emit({ this_is: "missing storedJob entirely" }); process.exit(0); }
+if (sub === "cancel") { emit({ cancelled: true }); process.exit(0); }
+process.exit(2);
+MOCK_EOF
+set +e
+CODEX_COMPANION_SCRIPT="$bad_result" "$WRAPPER" "$PROMPT_FILE" >/dev/null 2>/dev/null
+ec=$?
+set -e
+assert_eq "exit code 3 on missing storedJob.id (post-jq guard)" "3" "$ec"
+
+printf '\n[18] result payload that breaks jq_or_die parse triggers exit 3\n'
+# Genuine malformed JSON path — the result subcommand emits invalid JSON syntax,
+# jq_or_die() should catch the parse failure and die with exit 3.
+malformed_jq="$WORK_DIR/mock-companion-malformed-jq.mjs"
+cat > "$malformed_jq" <<'MOCK_EOF'
+#!/usr/bin/env node
+const sub = process.argv[2];
+function emit(o) { process.stdout.write(JSON.stringify(o) + "\n"); }
+if (sub === "task")   { emit({ jobId: "mock-job-123" }); process.exit(0); }
+if (sub === "status") { emit({ job: { id: "mock-job-123", status: "completed" }, waitTimedOut: false, timeoutMs: 1000 }); process.exit(0); }
+if (sub === "result") { process.stdout.write("{ this is not json }\n"); process.exit(0); }
+if (sub === "cancel") { emit({ cancelled: true }); process.exit(0); }
+process.exit(2);
+MOCK_EOF
+set +e
+CODEX_COMPANION_SCRIPT="$malformed_jq" "$WRAPPER" "$PROMPT_FILE" >/dev/null 2>/dev/null
+ec=$?
+set -e
+assert_eq "exit code 3 on malformed JSON (jq parse failure)" "3" "$ec"
+
+printf '\n[19] EXIT trap cancels orphaned job on post-dispatch failure\n'
+# When jq_or_die fails after JOB_ID is known, the EXIT trap must call `cancel`.
+# We verify by having the mock log every subcommand invocation and asserting
+# that "cancel" appears in the log AFTER a malformed-result run.
+trap_log="$WORK_DIR/cancel-trap.log"
+# Node on Windows + Git Bash needs a path Node can resolve. mktemp -d returns
+# a /tmp-style path that Node sometimes can't open. Convert via cygpath -m
+# (mixed: forward-slash + drive letter) when on Windows; otherwise pass through.
+if command -v cygpath >/dev/null 2>&1; then
+  trap_log_node="$(cygpath -m "$trap_log")"
+else
+  trap_log_node="$trap_log"
+fi
+trap_mock="$WORK_DIR/mock-companion-trap.mjs"
+# .mjs files are ESM-only — `require` is undefined. Use named ESM import.
+cat > "$trap_mock" <<MOCK_EOF
+#!/usr/bin/env node
+import { appendFileSync } from "node:fs";
+const sub = process.argv[2];
+appendFileSync(${trap_log_node@Q}, sub + "\n");
+function emit(o) { process.stdout.write(JSON.stringify(o) + "\n"); }
+if (sub === "task")   { emit({ jobId: "mock-job-123" }); process.exit(0); }
+if (sub === "status") { emit({ job: { id: "mock-job-123", status: "completed" }, waitTimedOut: false, timeoutMs: 1000 }); process.exit(0); }
+if (sub === "result") { process.stdout.write("{ malformed }\n"); process.exit(0); }
+if (sub === "cancel") { emit({ cancelled: true }); process.exit(0); }
+process.exit(2);
+MOCK_EOF
+: > "$trap_log"
+set +e
+CODEX_COMPANION_SCRIPT="$trap_mock" "$WRAPPER" "$PROMPT_FILE" >/dev/null 2>/dev/null
+ec=$?
+set -e
+assert_eq "exit code 3 propagates" "3" "$ec"
+if grep -q '^cancel$' "$trap_log"; then
+  PASS=$((PASS + 1))
+  printf '  ✓ EXIT trap invoked cancel subcommand\n'
+else
+  FAIL=$((FAIL + 1))
+  FAILURES+=("EXIT trap did not invoke cancel; trap_log was: $(cat "$trap_log" | tr '\n' ' ')")
+  printf '  ✗ EXIT trap did not invoke cancel — trap log: %s\n' "$(tr '\n' ' ' < "$trap_log")"
+fi
+
+# --- summary ---
+printf '\n%s\n' '----------------------------------------'
+printf 'tests: %d passed, %d failed\n' "$PASS" "$FAIL"
+if [[ "$FAIL" -gt 0 ]]; then
+  printf '\nFailures:\n'
+  for f in "${FAILURES[@]}"; do printf '  - %s\n' "$f"; done
+  exit 1
+fi
+exit 0

--- a/scripts/test-codex-sync-audit.sh
+++ b/scripts/test-codex-sync-audit.sh
@@ -185,6 +185,29 @@ ec=$?
 set -e
 assert_eq "exit code 3" "3" "$ec"
 
+printf '\n[6b] cache discovery picks highest semver, not lex order\n'
+# Set up a fake $HOME with three cached plugin versions: 1.0.2, 1.0.10, 2.0.0.
+# Lex sort would pick 2.0.0 OR 1.0.2 wrongly when versions skip a digit; semver
+# (sort -V -r) must pick 2.0.0 first, then 1.0.10, then 1.0.2.
+fake_home="$WORK_DIR/fake-home-semver"
+for v in 1.0.2 1.0.10 2.0.0; do
+  d="$fake_home/.claude/plugins/cache/openai-codex/codex/$v/scripts"
+  mkdir -p "$d"
+  : > "$d/codex-companion.mjs"
+done
+combined="$(set +e; HOME="$fake_home" USERPROFILE="$fake_home" CLAUDE_PLUGIN_ROOT="" CODEX_COMPANION_SCRIPT="" "$WRAPPER" "$PROMPT_FILE" --dry-run 2>/dev/null; printf '\n%d' "$?")"
+out="${combined%$'\n'*}"
+ec="${combined##*$'\n'}"
+assert_eq "exit code 0 in dry-run" "0" "$ec"
+if [[ "$out" == *"/2.0.0/scripts/codex-companion.mjs"* ]]; then
+  PASS=$((PASS + 1))
+  printf '  ✓ resolved to highest semver (2.0.0)\n'
+else
+  FAIL=$((FAIL + 1))
+  FAILURES+=("semver discovery picked wrong version. Output: $out")
+  printf '  ✗ semver discovery picked wrong version — output:\n%s\n' "$out"
+fi
+
 printf '\n[7] success path: emits RESULT marker, exit 0\n'
 combined="$(run_capture succeeded "$PROMPT_FILE")"
 out="${combined%$'\n'*}"

--- a/scripts/test-codex-sync-audit.sh
+++ b/scripts/test-codex-sync-audit.sh
@@ -386,11 +386,14 @@ else
 fi
 trap_mock="$WORK_DIR/mock-companion-trap.mjs"
 # .mjs files are ESM-only — `require` is undefined. Use named ESM import.
+# Embed the path as a single-quoted JS string. Avoids bash 4.4-only `${var@Q}`
+# (macOS default bash is 3.2, so @Q would fail there). Test paths come from
+# mktemp -d + optional cygpath -m so they never contain quotes or backslashes.
 cat > "$trap_mock" <<MOCK_EOF
 #!/usr/bin/env node
 import { appendFileSync } from "node:fs";
 const sub = process.argv[2];
-appendFileSync(${trap_log_node@Q}, sub + "\n");
+appendFileSync('${trap_log_node}', sub + "\n");
 function emit(o) { process.stdout.write(JSON.stringify(o) + "\n"); }
 if (sub === "task")   { emit({ jobId: "mock-job-123" }); process.exit(0); }
 if (sub === "status") { emit({ job: { id: "mock-job-123", status: "completed" }, waitTimedOut: false, timeoutMs: 1000 }); process.exit(0); }

--- a/scripts/test-codex-sync-audit.sh
+++ b/scripts/test-codex-sync-audit.sh
@@ -185,12 +185,11 @@ ec=$?
 set -e
 assert_eq "exit code 3" "3" "$ec"
 
-printf '\n[6b] cache discovery picks highest semver, not lex order\n'
-# Set up a fake $HOME with three cached plugin versions: 1.0.2, 1.0.10, 2.0.0.
-# Lex sort would pick 2.0.0 OR 1.0.2 wrongly when versions skip a digit; semver
-# (sort -V -r) must pick 2.0.0 first, then 1.0.10, then 1.0.2.
+printf '\n[6b] cache discovery picks highest semver, not lex order (default sort -V path)\n'
+# Set up a fake $HOME with five cached plugin versions: 1.0.2, 1.0.10, 2.0.0, 9.9.9, 10.0.0.
+# Lex sort would mis-order 10.0.0 < 9.9.9 and 1.0.10 < 1.0.2; semver must pick 10.0.0 first.
 fake_home="$WORK_DIR/fake-home-semver"
-for v in 1.0.2 1.0.10 2.0.0; do
+for v in 1.0.2 1.0.10 2.0.0 9.9.9 10.0.0; do
   d="$fake_home/.claude/plugins/cache/openai-codex/codex/$v/scripts"
   mkdir -p "$d"
   : > "$d/codex-companion.mjs"
@@ -199,13 +198,44 @@ combined="$(set +e; HOME="$fake_home" USERPROFILE="$fake_home" CLAUDE_PLUGIN_ROO
 out="${combined%$'\n'*}"
 ec="${combined##*$'\n'}"
 assert_eq "exit code 0 in dry-run" "0" "$ec"
-if [[ "$out" == *"/2.0.0/scripts/codex-companion.mjs"* ]]; then
+if [[ "$out" == *"/10.0.0/scripts/codex-companion.mjs"* ]]; then
   PASS=$((PASS + 1))
-  printf '  ✓ resolved to highest semver (2.0.0)\n'
+  printf '  ✓ resolved to highest semver (10.0.0 wins over 9.9.9 / 2.0.0)\n'
 else
   FAIL=$((FAIL + 1))
   FAILURES+=("semver discovery picked wrong version. Output: $out")
   printf '  ✗ semver discovery picked wrong version — output:\n%s\n' "$out"
+fi
+
+printf '\n[6c] awk fallback semver sort works without sort -V\n'
+# Shadow `sort` so the wrapper's capability probe (`printf ... | sort -V`) fails, forcing
+# the awk fallback path. The shadow rejects -V invocations but otherwise delegates to real
+# sort so the wrapper's other sort calls (in the awk pipeline itself) still work.
+fake_bin="$WORK_DIR/fake-bin-no-sortV"
+mkdir -p "$fake_bin"
+real_sort="$(command -v sort)"
+cat > "$fake_bin/sort" <<EOF
+#!/usr/bin/env bash
+for arg in "\$@"; do
+  if [[ "\$arg" == "-V" || "\$arg" == "--version-sort" || "\$arg" == "-V"* ]]; then
+    printf 'fake-sort: -V not supported\n' >&2
+    exit 2
+  fi
+done
+exec "$real_sort" "\$@"
+EOF
+chmod +x "$fake_bin/sort"
+combined="$(set +e; PATH="$fake_bin:$PATH" HOME="$fake_home" USERPROFILE="$fake_home" CLAUDE_PLUGIN_ROOT="" CODEX_COMPANION_SCRIPT="" "$WRAPPER" "$PROMPT_FILE" --dry-run 2>/dev/null; printf '\n%d' "$?")"
+out="${combined%$'\n'*}"
+ec="${combined##*$'\n'}"
+assert_eq "exit code 0 in dry-run (fallback path)" "0" "$ec"
+if [[ "$out" == *"/10.0.0/scripts/codex-companion.mjs"* ]]; then
+  PASS=$((PASS + 1))
+  printf '  ✓ awk fallback also picks 10.0.0\n'
+else
+  FAIL=$((FAIL + 1))
+  FAILURES+=("awk fallback picked wrong version. Output: $out")
+  printf '  ✗ awk fallback picked wrong version — output:\n%s\n' "$out"
 fi
 
 printf '\n[7] success path: emits RESULT marker, exit 0\n'

--- a/scripts/test-codex-sync-audit.sh
+++ b/scripts/test-codex-sync-audit.sh
@@ -157,6 +157,20 @@ ec=$?
 set -e
 assert_eq "exit code 2" "2" "$ec"
 
+printf '\n[4b] usage error: timeout above 86400-second cap\n'
+set +e
+"$WRAPPER" "$PROMPT_FILE" --timeout 90000 2>/dev/null
+ec=$?
+set -e
+assert_eq "exit code 2 on > 86400s timeout" "2" "$ec"
+
+printf '\n[4c] usage error: poll interval larger than timeout\n'
+set +e
+"$WRAPPER" "$PROMPT_FILE" --timeout 60 --poll-interval 120 2>/dev/null
+ec=$?
+set -e
+assert_eq "exit code 2 on poll > timeout" "2" "$ec"
+
 printf '\n[5] usage error: unknown option\n'
 set +e
 "$WRAPPER" "$PROMPT_FILE" --not-a-flag 2>/dev/null


### PR DESCRIPTION
Closes #326
Fixes #326
Refs #326

## Why

`dual-verify`'s Codex side dispatches via the `codex:codex-rescue` subagent — a fire-and-forget forwarder. Mercury's main thread doesn't poll, so dual-verify silently fell back to single-reviewer in S3/S4/S80 (5+ incidents). Each failed dispatch also paid ~25k tokens of forwarder boot before the audit started.

User decision (2026-04-26, Issue #326 Update 2): **retain Codex as the second-perspective reviewer** (different model architecture is the desired property), but make the return contract synchronous from the orchestrator's view.

## What

Bypass the codex-rescue subagent for dual-verify; call codex-companion CLI directly via a Mercury-local sync wrapper.

| File | LOC | Purpose |
|------|-----|---------|
| `scripts/codex-sync-audit.sh` | +267 | Sync wrapper — chains `task --background` → `status --wait` → `result --json` |
| `scripts/test-codex-sync-audit.sh` | +357 | 34-assertion test suite (mock companion + Windows-aware path handling) |
| `.claude/skills/dual-verify/SKILL.md` | +63/-10 | Switch Codex side from subagent to wrapper; document exit codes + verdict path `.storedJob.result.rawOutput` |
| `.mercury/docs/research/codex-rescue-async-semantics-2026-04-27.md` | +186 | Design rationale (Option D vs A/B/C) |
| `.gitignore` | +3 | Add `.tmp/` (prevent scratch audit artefacts being committed) |

**Wrapper exit codes**: `0` = codex replied (parse `Overall: PASS\|NEEDS-CHANGES` from `rawOutput`); `1` = job failed; `2` = usage; `3` = codex unavailable / malformed JSON; `124` = wait timeout (job continues in store); `130` = user interrupted (wrapper auto-cancels job before exit).

**Read-only by default** (it's named *audit*). `--write` is explicit opt-in. EXIT trap cancels orphaned jobs on any non-terminal exit path. Status taxonomy follows codex-companion: terminal-success is `completed` (per `lib/codex.mjs:356`); `succeeded` accepted defensively.

## Verification

**Unit tests**: 34/34 pass via `bash scripts/test-codex-sync-audit.sh`. Coverage:
- usage errors (missing/empty/non-existent prompt file, bad timeout, unknown option)
- plugin discovery (companion script not found → exit 3)
- success/failed/timeout branches
- dispatch failure → exit 3
- missing `.jobId` in launch payload → exit 3
- dry-run (default; custom timeout/poll; `--write` opt-in; `--read-only` no-op alias)
- missing `.storedJob.id` in result → exit 3
- malformed JSON in result → jq parse failure → controlled exit 3
- EXIT-trap orphan cancellation on post-dispatch failure (Windows-path-aware mock log)

**Live smoke test**: ran the wrapper against this PR's own diff via 3 codex audit iterations:

| Iter | Duration | Findings | Outcome |
|------|----------|----------|---------|
| iter1 | 7m 36s | 1 High + 5 Medium + 1 Low | All addressed |
| iter2 | 7m 5s | 1 Medium + 2 Low | All addressed; author also found wrapper case-statement bug — `succeeded` arm missed real `completed` status (Codex couldn't observe this without round-tripping the wrapper itself) |
| iter3 | ~7m | 1 Low (doc-only stale "succeeded" refs) | Addressed via grep verification |

**Dual-verify Codex side: PASS** (iter3 NEEDS-CHANGES was 1 Low doc-only nit; per Mercury's `feedback_argus_nit_loop.md` iter-3 escape-hatch pattern, doc-only Low does not warrant iter4. Convergence trajectory 7 → 3 → 1 doc-only is unambiguous.)

**Dual-verify Claude side: PASS** (this session reviewed the diff inline and addressed the case-statement bug independently).

## Out of scope

- Token cost benchmark — followup `feedback_dual_verify_gate.md` updates after first real-world dual-verify in a subsequent PR (this PR's iter1-3 already shows ~7m / ~25k token-eq per audit + verdict, much better than the 25k forwarder-boot waste).
- `codex:codex-rescue` subagent itself — unchanged; remains available for general "hand a long task to Codex" use cases.
- Side lane #330/#331 — autonomous chain, no main lane review needed yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)