### PR TITLE
feat(lane-protocol): Phase F.C #331 — memory-index lock-in hooks

### DIFF
--- a/.mercury/docs/guides/memory-index-regenerate.md
+++ b/.mercury/docs/guides/memory-index-regenerate.md
@@ -408,8 +408,8 @@ mutated. Check `.bak` file mtime against original cutover commit timestamp.
 ```bash
 scripts/test-regenerate-memory-index.sh           # F.A — 44 cases / 82 assertions
 scripts/test-regenerate-memory-index-in-place.sh  # F.B — 14 cases / 54 assertions
-scripts/test-mercury-memory-index-write-guard.sh  # F.C — 19 cases / 19 assertions
-scripts/test-mercury-memory-index-validator.sh    # F.C — 19 cases / 19 assertions
+scripts/test-mercury-memory-index-write-guard.sh  # F.C — 23 cases / 23 assertions
+scripts/test-mercury-memory-index-validator.sh    # F.C — 26 cases / 26 assertions
 ```
 
 F.A coverage: arg validation, sort ordering (lane suffix variants, range rows),
@@ -429,16 +429,23 @@ canonical MEMORY.md / SESSION_INDEX.md → deny with reason; Edit with
 `old_string` inside marker region → deny; Edit with `old_string` outside
 marker region → silent allow; Edit on canonical file with no markers (pre-cutover
 or post-rollback) → fail-open allow; Edit on missing/unreadable canonical file
-→ fail-open allow; soft-disable via `MERCURY_INDEX_GUARD_DISABLED=1`
+→ fail-open allow; Edit on canonical with invalid UTF-8 bytes → fail-open allow
+(no UnicodeError raise); soft-disable via `MERCURY_INDEX_GUARD_DISABLED=1`
 or `MERCURY_INDEX_REGENERATE=1` → silent allow even on canonical Write;
-basename-matches-but-wrong-parent-dir → silent allow; mixed-form Windows paths
-+ dot-segment paths → resolved consistently.
+case-insensitive bypass attempts (`memory.md`, `Session_Index.MD`) → still
+deny; basename-matches-but-wrong-parent-dir → silent allow; mixed-form
+Windows paths + dot-segment paths → resolved consistently.
 
 F.C validator coverage: regenerate exit 0 (clean) → no warning; exit 1 (drift)
-→ stderr warning with session_id, regen exit code, stderr/stdout tails, fix
-hint; `MERCURY_INDEX_VALIDATOR_DISABLED=1` → silent no-op even on drift;
-malformed/empty stdin → silent no-op; missing repo root → silent no-op;
-payload top-level not a dict → unknown placeholder, no crash.
+→ stderr "drift detected" warning with session_id, regen exit code,
+stderr/stdout tails, fix hint; **exit ≠ 0 and ≠ 1** (script error) → stderr
+"regenerate validation failed" warning distinguishing script errors from
+genuine drift (per regenerate exit-code contract); `MERCURY_INDEX_VALIDATOR_DISABLED=1`
+→ silent no-op even on drift; `bash` missing on PATH → stderr FileNotFoundError
+warning + disable hint (no silent failure); generic OSError → minimal stderr
+warning + disable hint; malformed/empty stdin → silent no-op; missing repo
+root → silent no-op; payload top-level not a dict → unknown placeholder, no
+crash.
 
 Tests use synthetic memory dirs only — never touch real user-memory layer.
 
@@ -452,11 +459,11 @@ Status of subsequent migration phases:
   anchor `lane-protocol-v0.1-pre-cutover` tagged on develop.
 - **#331 (Phase F.C)** — staged. Source-of-truth scripts live at
   `scripts/hooks/mercury-memory-index-write-guard.py` (PreToolUse) and
-  `scripts/hooks/mercury-memory-index-validator.py` (SessionEnd). 38 test
-  assertions across two harnesses pass. Deployment to
-  `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/` (per #259 user-level governance
-  model) is operational and gated on F.B 1-week soak passing — see §Phase F.C
-  for deployment commands and verification checklist.
+  `scripts/hooks/mercury-memory-index-validator.py` (SessionEnd). 49 test
+  assertions across two harnesses pass (write-guard 23 + validator 26).
+  Deployment to `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/` (per #259
+  user-level governance model) is operational and gated on F.B 1-week soak
+  passing — see §Phase F.C for deployment commands and verification checklist.
 
 ## Source references
 

--- a/.mercury/docs/guides/memory-index-regenerate.md
+++ b/.mercury/docs/guides/memory-index-regenerate.md
@@ -470,9 +470,8 @@ Status of subsequent migration phases:
   anchor `lane-protocol-v0.1-pre-cutover` tagged on develop.
 - **#331 (Phase F.C)** — staged. Source-of-truth scripts live at
   `scripts/hooks/mercury-memory-index-write-guard.py` (PreToolUse) and
-  `scripts/hooks/mercury-memory-index-validator.py` (SessionEnd). 49 test
-  assertions across two harnesses pass (write-guard 23 + validator 26).
-  58 test assertions across two harnesses pass (write-guard 23 + validator 35).
+  `scripts/hooks/mercury-memory-index-validator.py` (SessionEnd). 58 test
+  assertions across two harnesses pass (write-guard 23 + validator 35).
   Implements `MERCURY_INDEX_AUTOFIX=1` env path per Issue #331 Hook 2 spec
   (auto `--in-place` on drift). Deployment to
   `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/` (per #259 user-level governance

--- a/.mercury/docs/guides/memory-index-regenerate.md
+++ b/.mercury/docs/guides/memory-index-regenerate.md
@@ -272,12 +272,17 @@ chmod +x "$CC/hooks/mercury-memory-index-write-guard.py" \
          "$CC/hooks/mercury-memory-index-validator.py"
 
 # 3. Set MERCURY_REPO_ROOT in settings.json env block (required when hooks
-#    live outside the repo — no hardcoded fallback):
+#    live outside the repo — no hardcoded fallback). Use placeholder syntax
+#    appropriate to your environment:
 #
 #    "env": {
-#      "MERCURY_REPO_ROOT": "D:\\Mercury\\Mercury",
+#      "MERCURY_REPO_ROOT": "<absolute path to your local Mercury repo>",
 #      ...existing keys...
 #    }
+#
+#    Examples (do NOT copy verbatim — substitute your own checkout path):
+#      Windows:  "MERCURY_REPO_ROOT": "C:\\path\\to\\Mercury"
+#      Unix:     "MERCURY_REPO_ROOT": "/path/to/Mercury"
 #
 # 4. Register in settings.json hooks block — add to PreToolUse and SessionEnd
 #    arrays (preserve existing entries):

--- a/.mercury/docs/guides/memory-index-regenerate.md
+++ b/.mercury/docs/guides/memory-index-regenerate.md
@@ -253,8 +253,9 @@ part of the in-repo PR.
 | `MERCURY_INDEX_GUARD_DISABLED=1` | Short-circuits the PreToolUse hook (allows all edits). Use for emergency manual canonical edits. |
 | `MERCURY_INDEX_REGENERATE=1` | Allows the PreToolUse hook (defense-in-depth marker — auto-set by `regenerate-memory-index.sh`). |
 | `MERCURY_INDEX_VALIDATOR_DISABLED=1` | No-ops the SessionEnd validator. |
+| `MERCURY_INDEX_AUTOFIX=1` | When drift detected at session end, validator runs `regenerate-memory-index.sh --in-place` automatically and emits a confirmation message instead of a drift warning. Per Issue #331 Hook 2 spec. |
 | `MERCURY_REPO_ROOT=<path>` | Mercury repo root used by validator. **Required for deployed hooks** (`~/.claude/hooks/`) — there is no machine-specific fallback. In-repo invocation auto-resolves via `__file__.parents[2]`. If unset and auto-resolution fails → silent no-op. |
-| `MERCURY_MEMORY_DIR=<path>` | Override user-memory dir consumed by both hooks (defaults to `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/D--Mercury-Mercury/memory`). |
+| `MERCURY_MEMORY_DIR=<path>` | User-memory dir consumed by both hooks. **Recommended for deployed hooks**: default `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/D--Mercury-Mercury/memory` is coupled to the project name `Mercury` and cwd `D:\Mercury\Mercury` (Claude Code per-project encoding). For non-default checkouts (different drive, project rename, multi-checkout), set explicitly in `settings.json` env block. |
 
 ### Deployment (per #259 user-level governance pattern)
 
@@ -271,18 +272,25 @@ cp scripts/hooks/mercury-memory-index-validator.py   "$CC/hooks/"
 chmod +x "$CC/hooks/mercury-memory-index-write-guard.py" \
          "$CC/hooks/mercury-memory-index-validator.py"
 
-# 3. Set MERCURY_REPO_ROOT in settings.json env block (required when hooks
-#    live outside the repo — no hardcoded fallback). Use placeholder syntax
+# 3. Set MERCURY_REPO_ROOT (required) and MERCURY_MEMORY_DIR (recommended for
+#    non-default checkouts) in settings.json env block. Use placeholder syntax
 #    appropriate to your environment:
 #
 #    "env": {
-#      "MERCURY_REPO_ROOT": "<absolute path to your local Mercury repo>",
+#      "MERCURY_REPO_ROOT":  "<absolute path to your local Mercury repo>",
+#      "MERCURY_MEMORY_DIR": "<absolute path to your Claude Code per-project memory dir>",
 #      ...existing keys...
 #    }
 #
 #    Examples (do NOT copy verbatim — substitute your own checkout path):
-#      Windows:  "MERCURY_REPO_ROOT": "C:\\path\\to\\Mercury"
-#      Unix:     "MERCURY_REPO_ROOT": "/path/to/Mercury"
+#      Windows:  "MERCURY_REPO_ROOT":  "C:\\path\\to\\Mercury"
+#                "MERCURY_MEMORY_DIR": "C:\\Users\\you\\.claude\\projects\\C--path-to-Mercury\\memory"
+#      Unix:     "MERCURY_REPO_ROOT":  "/path/to/Mercury"
+#                "MERCURY_MEMORY_DIR": "/home/you/.claude/projects/-path-to-Mercury/memory"
+#
+#    MERCURY_REPO_ROOT has no fallback — if missing, validator no-ops silently.
+#    MERCURY_MEMORY_DIR defaults to `${CLAUDE_CONFIG_DIR}/projects/D--Mercury-Mercury/memory`
+#    which is correct only for cwd `D:\Mercury\Mercury` on Windows.
 #
 # 4. Register in settings.json hooks block — add to PreToolUse and SessionEnd
 #    arrays (preserve existing entries):
@@ -409,7 +417,7 @@ mutated. Check `.bak` file mtime against original cutover commit timestamp.
 scripts/test-regenerate-memory-index.sh           # F.A — 44 cases / 82 assertions
 scripts/test-regenerate-memory-index-in-place.sh  # F.B — 14 cases / 54 assertions
 scripts/test-mercury-memory-index-write-guard.sh  # F.C — 23 cases / 23 assertions
-scripts/test-mercury-memory-index-validator.sh    # F.C — 26 cases / 26 assertions
+scripts/test-mercury-memory-index-validator.sh    # F.C — 35 cases / 35 assertions
 ```
 
 F.A coverage: arg validation, sort ordering (lane suffix variants, range rows),
@@ -440,7 +448,10 @@ F.C validator coverage: regenerate exit 0 (clean) → no warning; exit 1 (drift)
 → stderr "drift detected" warning with session_id, regen exit code,
 stderr/stdout tails, fix hint; **exit ≠ 0 and ≠ 1** (script error) → stderr
 "regenerate validation failed" warning distinguishing script errors from
-genuine drift (per regenerate exit-code contract); `MERCURY_INDEX_VALIDATOR_DISABLED=1`
+genuine drift (per regenerate exit-code contract);
+**`MERCURY_INDEX_AUTOFIX=1`** → auto-runs `--in-place` on drift, suppresses
+standard drift warning, emits confirmation when fix succeeds, falls back to
+drift warning when fix fails; `MERCURY_INDEX_VALIDATOR_DISABLED=1`
 → silent no-op even on drift; `bash` missing on PATH → stderr FileNotFoundError
 warning + disable hint (no silent failure); generic OSError → minimal stderr
 warning + disable hint; malformed/empty stdin → silent no-op; missing repo
@@ -461,9 +472,12 @@ Status of subsequent migration phases:
   `scripts/hooks/mercury-memory-index-write-guard.py` (PreToolUse) and
   `scripts/hooks/mercury-memory-index-validator.py` (SessionEnd). 49 test
   assertions across two harnesses pass (write-guard 23 + validator 26).
-  Deployment to `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/` (per #259
-  user-level governance model) is operational and gated on F.B 1-week soak
-  passing — see §Phase F.C for deployment commands and verification checklist.
+  58 test assertions across two harnesses pass (write-guard 23 + validator 35).
+  Implements `MERCURY_INDEX_AUTOFIX=1` env path per Issue #331 Hook 2 spec
+  (auto `--in-place` on drift). Deployment to
+  `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/` (per #259 user-level governance
+  model) is operational and gated on F.B 1-week soak passing — see §Phase F.C
+  for deployment commands and verification checklist.
 
 ## Source references
 

--- a/.mercury/docs/guides/memory-index-regenerate.md
+++ b/.mercury/docs/guides/memory-index-regenerate.md
@@ -22,7 +22,7 @@ cutover.
 |-------|--------------|------|
 | **F.A (additive)** | Adds regenerate script; canonical files untouched | Issue #329 — landed |
 | **F.B (cutover)** | Splits existing rows into per-session files; replaces canonical sections with generated content via `--in-place` | Issue #330 — landed |
-| **F.C (lock-in)** | Claude Code PreToolUse + SessionEnd hooks prevent direct edits to canonical files | Issue #331 — pending F.B soak stable |
+| **F.C (lock-in)** | Claude Code PreToolUse + SessionEnd hooks prevent direct edits to canonical files | Issue #331 — staged in `scripts/hooks/`, deployment pending F.B 1-week soak |
 
 ## Why this exists
 
@@ -233,6 +233,112 @@ commit/handoff to refresh canonical files from per-session sources.
 - `--in-place + --output` → exit 2 (operators uncertain about target file)
 - `--in-place + --format diff` → exit 2 (cutover is not a diff operation)
 
+## Phase F.C (`~/.claude/hooks/`) — staged
+
+Phase F.C deploys two Claude Code hooks under
+`${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/` to mechanically enforce the F.B
+discipline gate. Source-of-truth scripts live in this repo at
+`scripts/hooks/`; deployment to the user-level hooks dir is operational, not
+part of the in-repo PR.
+
+| Hook | Event | Behavior |
+|------|-------|----------|
+| `mercury-memory-index-write-guard.py` | PreToolUse (matcher `Edit\|Write`) | Returns `permissionDecision: "deny"` when target is canonical `MEMORY.md` / `SESSION_INDEX.md` AND tool is `Write` (full overwrite always blocked) OR tool is `Edit` AND `old_string` falls inside the BEGIN/END marker region. Fail-open posture: no markers found OR file unreadable → allow (operator can re-run `--in-place` to restore markers). |
+| `mercury-memory-index-validator.py` | SessionEnd (matcher `""`) | Runs `regenerate-memory-index.sh --format diff` against the configured memory dir; if drift detected (script exit 1), surfaces a stderr warning to the user. Surfaces a separate stderr notice on `subprocess.TimeoutExpired` (30s). Cannot block — SessionEnd hooks are observability-only per Claude Code contract. |
+
+### Soft-disable env vars
+
+| Env var | Effect |
+|---------|--------|
+| `MERCURY_INDEX_GUARD_DISABLED=1` | Short-circuits the PreToolUse hook (allows all edits). Use for emergency manual canonical edits. |
+| `MERCURY_INDEX_REGENERATE=1` | Allows the PreToolUse hook (defense-in-depth marker — auto-set by `regenerate-memory-index.sh`). |
+| `MERCURY_INDEX_VALIDATOR_DISABLED=1` | No-ops the SessionEnd validator. |
+| `MERCURY_REPO_ROOT=<path>` | Mercury repo root used by validator. **Required for deployed hooks** (`~/.claude/hooks/`) — there is no machine-specific fallback. In-repo invocation auto-resolves via `__file__.parents[2]`. If unset and auto-resolution fails → silent no-op. |
+| `MERCURY_MEMORY_DIR=<path>` | Override user-memory dir consumed by both hooks (defaults to `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/D--Mercury-Mercury/memory`). |
+
+### Deployment (per #259 user-level governance pattern)
+
+```bash
+# 0. Pre-conditions: F.B 1-week soak passed; #331 PR merged.
+
+# 1. Backup settings.json
+CC="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+cp "$CC/settings.json" "$CC/settings.json.backup-pre-331"
+
+# 2. Copy hook scripts
+cp scripts/hooks/mercury-memory-index-write-guard.py "$CC/hooks/"
+cp scripts/hooks/mercury-memory-index-validator.py   "$CC/hooks/"
+chmod +x "$CC/hooks/mercury-memory-index-write-guard.py" \
+         "$CC/hooks/mercury-memory-index-validator.py"
+
+# 3. Set MERCURY_REPO_ROOT in settings.json env block (required when hooks
+#    live outside the repo — no hardcoded fallback):
+#
+#    "env": {
+#      "MERCURY_REPO_ROOT": "D:\\Mercury\\Mercury",
+#      ...existing keys...
+#    }
+#
+# 4. Register in settings.json hooks block — add to PreToolUse and SessionEnd
+#    arrays (preserve existing entries):
+#
+#    "PreToolUse": [
+#      ...existing...
+#      {
+#        "matcher": "Edit|Write",
+#        "hooks": [{
+#          "type": "command",
+#          "command": "\"${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.venv/Scripts/pythonw.exe\" \"${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/mercury-memory-index-write-guard.py\"",
+#          "timeout": 5
+#        }]
+#      }
+#    ],
+#    "SessionEnd": [
+#      ...existing...
+#      {
+#        "hooks": [{
+#          "type": "command",
+#          "command": "\"${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.venv/Scripts/pythonw.exe\" \"${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/mercury-memory-index-validator.py\"",
+#          "timeout": 30
+#        }]
+#      }
+#    ]
+
+# 5. Verify settings.json JSON validity
+python -c "import json,os; json.load(open(os.path.expandvars('${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json')))"
+
+# 6. Smoke-test: synthetic stdin must produce expected decision
+printf '{"tool_name":"Write","tool_input":{"file_path":"%s/MEMORY.md","content":"x"}}' \
+  "$CC/projects/D--Mercury-Mercury/memory" \
+  | "$CC/.venv/Scripts/pythonw.exe" "$CC/hooks/mercury-memory-index-write-guard.py"
+# Expected: JSON with "permissionDecision": "deny"
+```
+
+### Rollback (Phase F.C)
+
+Two channels:
+
+1. **Soft-disable** (instant, no redeploy): set
+   `MERCURY_INDEX_GUARD_DISABLED=1` and/or `MERCURY_INDEX_VALIDATOR_DISABLED=1`
+   in `~/.claude/settings.json` `env` block. Hooks short-circuit on next
+   invocation.
+2. **Full removal**: restore `settings.json.backup-pre-331` and delete the two
+   hook files. Reverts to F.B discipline-gate model.
+
+### Verification (per #259)
+
+Required before closing #331:
+
+- [ ] `~/.claude/settings.json` JSON valid post-deployment
+- [ ] PreToolUse synthetic stdin: `permissionDecision: deny` for canonical Write
+- [ ] PreToolUse synthetic stdin: empty output for canonical Write with
+      `MERCURY_INDEX_GUARD_DISABLED=1` set
+- [ ] SessionEnd synthetic run: stderr drift warning when memory dir has drift
+- [ ] Real session edits a per-session file → MEMORY.md regenerate refreshes
+      index → no hook noise on clean state
+- [ ] Repo-side test suites: `bash scripts/test-mercury-memory-index-write-guard.sh` and `bash scripts/test-mercury-memory-index-validator.sh` both exit 0
+- [ ] Verification clean for ≥3 real sessions
+
 ## Rollback procedure (Phase F.B)
 
 The cutover has **three rollback channels** for distinct failure modes — git-side (Channel 1), user-memory side (Channel 2), and combined (Channel 3).
@@ -295,21 +401,41 @@ mutated. Check `.bak` file mtime against original cutover commit timestamp.
 ## Tests
 
 ```bash
-scripts/test-regenerate-memory-index.sh
+scripts/test-regenerate-memory-index.sh           # F.A — 44 cases / 82 assertions
+scripts/test-regenerate-memory-index-in-place.sh  # F.B — 14 cases / 54 assertions
+scripts/test-mercury-memory-index-write-guard.sh  # F.C — 19 cases / 19 assertions
+scripts/test-mercury-memory-index-validator.sh    # F.C — 19 cases / 19 assertions
 ```
 
-44 test cases / 82 assertions covering arg validation, sort ordering (lane
-suffix variants, range rows), source precedence (per-session file overrides
-existing row), malformed-frontmatter detection, missing-required-field
-detection, YAML block-scalar rejection, idempotency (frozen timestamp),
-custom output paths, env-var resolution, diff mode (no drift / drift / no
-existing snapshot / unfrozen timestamp ignored), pipe-character corruption
-WARN, duplicate-row dedup, non-session-filename skip, symlink skip
-(env-aware), I/O failure detection, frontmatter sanitization,
+F.A coverage: arg validation, sort ordering (lane suffix variants, range rows),
+source precedence (per-session file overrides existing row), malformed-frontmatter
+detection, missing-required-field detection, YAML block-scalar rejection,
+idempotency (frozen timestamp), custom output paths, env-var resolution, diff
+mode (no drift / drift / no existing snapshot / unfrozen timestamp ignored),
+pipe-character corruption WARN, duplicate-row dedup, non-session-filename skip,
+symlink skip (env-aware), I/O failure detection, frontmatter sanitization,
 indented-verbatim preservation, ASCII-vs-em-dash separator preservation,
-empty-line-in-section preservation, hostile content preservation, and
-empty SESSION_INDEX. Tests use synthetic memory dirs only — never touch
-real user-memory layer.
+empty-line-in-section preservation, hostile content preservation, and empty
+SESSION_INDEX.
+
+F.C write-guard coverage: empty/malformed stdin → silent allow; non-Edit/Write
+tools → silent allow; Edit on non-canonical paths → silent allow; Write on
+canonical MEMORY.md / SESSION_INDEX.md → deny with reason; Edit with
+`old_string` inside marker region → deny; Edit with `old_string` outside
+marker region → silent allow; Edit on canonical file with no markers (pre-cutover
+or post-rollback) → fail-open allow; Edit on missing/unreadable canonical file
+→ fail-open allow; soft-disable via `MERCURY_INDEX_GUARD_DISABLED=1`
+or `MERCURY_INDEX_REGENERATE=1` → silent allow even on canonical Write;
+basename-matches-but-wrong-parent-dir → silent allow; mixed-form Windows paths
++ dot-segment paths → resolved consistently.
+
+F.C validator coverage: regenerate exit 0 (clean) → no warning; exit 1 (drift)
+→ stderr warning with session_id, regen exit code, stderr/stdout tails, fix
+hint; `MERCURY_INDEX_VALIDATOR_DISABLED=1` → silent no-op even on drift;
+malformed/empty stdin → silent no-op; missing repo root → silent no-op;
+payload top-level not a dict → unknown placeholder, no crash.
+
+Tests use synthetic memory dirs only — never touch real user-memory layer.
 
 ## Forward path
 
@@ -319,11 +445,13 @@ Status of subsequent migration phases:
   flag landed; `migrate-session-index-to-files.sh` helper landed; 75 per-session
   files created; canonical files cut over via marker-bounded splice; pre-cutover
   anchor `lane-protocol-v0.1-pre-cutover` tagged on develop.
-- **#331 (Phase F.C)** — pending. Claude Code PreToolUse hook intercepts direct
-  edits to canonical files between markers; SessionEnd hook validates index
-  drift; deployed under `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/` per #259
-  user-level governance model. Requires F.B soak window (≥1 week stable) before
-  hook deployment.
+- **#331 (Phase F.C)** — staged. Source-of-truth scripts live at
+  `scripts/hooks/mercury-memory-index-write-guard.py` (PreToolUse) and
+  `scripts/hooks/mercury-memory-index-validator.py` (SessionEnd). 38 test
+  assertions across two harnesses pass. Deployment to
+  `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/` (per #259 user-level governance
+  model) is operational and gated on F.B 1-week soak passing — see §Phase F.C
+  for deployment commands and verification checklist.
 
 ## Source references
 

--- a/scripts/hooks/mercury-memory-index-validator.py
+++ b/scripts/hooks/mercury-memory-index-validator.py
@@ -101,6 +101,13 @@ def main() -> int:
             "Mercury repo. Soft-disable: MERCURY_INDEX_VALIDATOR_DISABLED=1.\n"
         )
         return 0
+    except FileNotFoundError:
+        sys.stderr.write(
+            "Mercury memory-index validator: `bash` executable not on PATH — "
+            "drift check skipped. Install Git Bash / MSYS2 / WSL, or set "
+            "MERCURY_INDEX_VALIDATOR_DISABLED=1 to suppress this notice.\n"
+        )
+        return 0
     except OSError:
         return 0
 

--- a/scripts/hooks/mercury-memory-index-validator.py
+++ b/scripts/hooks/mercury-memory-index-validator.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""mercury-memory-index-validator.py — Phase F.C lock-in (Issue #331).
+
+SessionEnd hook for Claude Code. Runs `regenerate-memory-index.sh --format diff`
+against the Mercury user-memory dir; if drift detected (script exit 1), emits a
+warning to stderr (visible to user only — SessionEnd hooks cannot block).
+
+Best-effort observability: never blocks session termination, never raises.
+SessionEnd output JSON is ignored by Claude Code per the hook contract; only
+stderr is surfaced to user.
+
+Soft-disable env var:
+  MERCURY_INDEX_VALIDATOR_DISABLED=1  — no-op the hook
+
+Per Issue #331 acceptance + Mercury CLAUDE.md §Related Repositories user-level
+governance pattern (model: #259).
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REGEN_SCRIPT_REL = Path("scripts") / "regenerate-memory-index.sh"
+
+
+def _resolve_repo_root() -> Path | None:
+    """Resolve Mercury repo root with two strategies, no machine-specific fallback.
+
+    1. `MERCURY_REPO_ROOT` env var (preferred for deployed hooks under
+       ~/.claude/hooks/ — set in settings.json env block per deployment guide).
+    2. `__file__`-relative heuristic: when this script lives at
+       <repo>/scripts/hooks/mercury-memory-index-validator.py, parents[2] is
+       the repo root. Works during in-repo invocation and tests; degrades
+       gracefully when the script is copied into ~/.claude/hooks/ (parents[2]
+       there is ~, which won't contain regenerate-memory-index.sh).
+
+    Returns None when no candidate yields a valid repo (silent no-op per
+    SessionEnd observability-only contract). Hardcoded absolute paths are
+    forbidden per Mercury CLAUDE.md `feedback_no_hardcoded_paths`.
+    """
+    env = os.environ.get("MERCURY_REPO_ROOT", "").strip()
+    if env:
+        candidate = Path(env).expanduser()
+        if (candidate / REGEN_SCRIPT_REL).is_file():
+            return candidate
+    try:
+        self_path = Path(__file__).resolve(strict=False)
+        candidate = self_path.parents[2]
+        if (candidate / REGEN_SCRIPT_REL).is_file():
+            return candidate
+    except (OSError, IndexError):
+        pass
+    return None
+
+
+def main() -> int:
+    if os.environ.get("MERCURY_INDEX_VALIDATOR_DISABLED", "").strip() == "1":
+        return 0
+
+    try:
+        raw = sys.stdin.read()
+        if raw.strip():
+            try:
+                payload = json.loads(raw)
+            except json.JSONDecodeError:
+                fixed = re.sub(r'(?<!\\)\\(?!["\\])', r"\\\\", raw)
+                payload = json.loads(fixed)
+        else:
+            payload = {}
+    except (json.JSONDecodeError, ValueError, OSError):
+        payload = {}
+
+    repo_root = _resolve_repo_root()
+    if repo_root is None:
+        return 0
+
+    script_path = repo_root / REGEN_SCRIPT_REL
+    cmd = ["bash", str(script_path), "--format", "diff"]
+
+    env = os.environ.copy()
+    env["MERCURY_INDEX_REGENERATE"] = "1"
+
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=str(repo_root),
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except subprocess.TimeoutExpired:
+        sys.stderr.write(
+            "Mercury memory-index validator: regenerate timed out after 30s — "
+            "drift check skipped. Run manually: "
+            "`bash scripts/regenerate-memory-index.sh --format diff` from the "
+            "Mercury repo. Soft-disable: MERCURY_INDEX_VALIDATOR_DISABLED=1.\n"
+        )
+        return 0
+    except OSError:
+        return 0
+
+    if result.returncode == 0:
+        return 0
+
+    session_id = payload.get("session_id", "unknown") if isinstance(payload, dict) else "unknown"
+    stderr_tail = (result.stderr or "").strip().splitlines()[-5:]
+    stdout_tail = (result.stdout or "").strip().splitlines()[-5:]
+    sys.stderr.write(
+        "Mercury memory-index validator: drift detected at session end "
+        f"(session={session_id}, regen exit={result.returncode}).\n"
+    )
+    if stderr_tail:
+        sys.stderr.write("  stderr:\n")
+        for line in stderr_tail:
+            sys.stderr.write(f"    {line}\n")
+    if stdout_tail:
+        sys.stderr.write("  stdout:\n")
+        for line in stdout_tail:
+            sys.stderr.write(f"    {line}\n")
+    sys.stderr.write(
+        "  Run `bash scripts/regenerate-memory-index.sh --in-place` from the "
+        "Mercury repo to refresh canonical files. Soft-disable: "
+        "MERCURY_INDEX_VALIDATOR_DISABLED=1.\n"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/hooks/mercury-memory-index-validator.py
+++ b/scripts/hooks/mercury-memory-index-validator.py
@@ -91,6 +91,8 @@ def main() -> int:
             env=env,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=30,
         )
     except subprocess.TimeoutExpired:
@@ -108,7 +110,14 @@ def main() -> int:
             "MERCURY_INDEX_VALIDATOR_DISABLED=1 to suppress this notice.\n"
         )
         return 0
-    except OSError:
+    except OSError as exc:
+        sys.stderr.write(
+            "Mercury memory-index validator: subprocess error invoking "
+            f"regenerate ({exc.__class__.__name__}: {exc}). Drift check "
+            "skipped. Soft-disable: MERCURY_INDEX_VALIDATOR_DISABLED=1.\n"
+        )
+        return 0
+    except UnicodeError:
         return 0
 
     if result.returncode == 0:
@@ -117,8 +126,20 @@ def main() -> int:
     session_id = payload.get("session_id", "unknown") if isinstance(payload, dict) else "unknown"
     stderr_tail = (result.stderr or "").strip().splitlines()[-5:]
     stdout_tail = (result.stdout or "").strip().splitlines()[-5:]
+    if result.returncode == 1:
+        # Per regenerate-memory-index.sh exit-code contract: exit 1 == drift
+        # detected. Anything else is script failure (parse error / args /
+        # missing file) — distinguish so operators do not chase false drift.
+        kind_msg = "drift detected"
+    else:
+        kind_msg = (
+            "regenerate validation failed (exit "
+            f"{result.returncode} != 1; see exit-code contract in "
+            "scripts/regenerate-memory-index.sh header — likely script "
+            "error, not drift)"
+        )
     sys.stderr.write(
-        "Mercury memory-index validator: drift detected at session end "
+        f"Mercury memory-index validator: {kind_msg} at session end "
         f"(session={session_id}, regen exit={result.returncode}).\n"
     )
     if stderr_tail:

--- a/scripts/hooks/mercury-memory-index-validator.py
+++ b/scripts/hooks/mercury-memory-index-validator.py
@@ -9,8 +9,18 @@ Best-effort observability: never blocks session termination, never raises.
 SessionEnd output JSON is ignored by Claude Code per the hook contract; only
 stderr is surfaced to user.
 
-Soft-disable env var:
-  MERCURY_INDEX_VALIDATOR_DISABLED=1  — no-op the hook
+Env vars:
+  MERCURY_INDEX_VALIDATOR_DISABLED=1  — no-op the hook (soft-disable)
+  MERCURY_INDEX_AUTOFIX=1             — when drift detected (regen exit 1),
+                                        run `regenerate-memory-index.sh
+                                        --in-place` automatically; emit a
+                                        confirmation stderr message instead
+                                        of a drift warning. Per Issue #331
+                                        Hook 2 spec ("Auto-fix with --in-place
+                                        if MERCURY_INDEX_AUTOFIX=1 set").
+  MERCURY_REPO_ROOT=<path>            — Mercury repo root (required for
+                                        deployed hooks; in-repo invocation
+                                        auto-resolves via __file__).
 
 Per Issue #331 acceptance + Mercury CLAUDE.md §Related Repositories user-level
 governance pattern (model: #259).
@@ -126,6 +136,48 @@ def main() -> int:
     session_id = payload.get("session_id", "unknown") if isinstance(payload, dict) else "unknown"
     stderr_tail = (result.stderr or "").strip().splitlines()[-5:]
     stdout_tail = (result.stdout or "").strip().splitlines()[-5:]
+
+    # Auto-fix path (Issue #331 Hook 2 spec): when drift detected (exit 1) AND
+    # MERCURY_INDEX_AUTOFIX=1 set, run --in-place to refresh canonical from
+    # per-session sources. Suppresses the drift warning if the auto-fix
+    # itself succeeds; emits a confirmation message instead so operators
+    # can audit silent rewrites.
+    if result.returncode == 1 and os.environ.get("MERCURY_INDEX_AUTOFIX", "").strip() == "1":
+        try:
+            fix_result = subprocess.run(
+                ["bash", str(script_path), "--in-place"],
+                cwd=str(repo_root),
+                env=env,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=30,
+            )
+        except (subprocess.TimeoutExpired, OSError, UnicodeError) as exc:
+            sys.stderr.write(
+                "Mercury memory-index validator: MERCURY_INDEX_AUTOFIX=1 set "
+                "but --in-place auto-fix failed "
+                f"({exc.__class__.__name__}: {exc}). Drift remains; run "
+                "manually: `bash scripts/regenerate-memory-index.sh "
+                f"--in-place`. (session={session_id})\n"
+            )
+            return 0
+        if fix_result.returncode == 0:
+            sys.stderr.write(
+                "Mercury memory-index validator: drift detected at session "
+                f"end (session={session_id}); MERCURY_INDEX_AUTOFIX=1 set "
+                "→ auto-fix via --in-place succeeded. Canonical files "
+                "refreshed from per-session sources.\n"
+            )
+            return 0
+        # Auto-fix attempted but failed — fall through to standard warning
+        sys.stderr.write(
+            "Mercury memory-index validator: MERCURY_INDEX_AUTOFIX=1 set "
+            "but --in-place auto-fix exited "
+            f"{fix_result.returncode}. Falling back to drift warning.\n"
+        )
+
     if result.returncode == 1:
         # Per regenerate-memory-index.sh exit-code contract: exit 1 == drift
         # detected. Anything else is script failure (parse error / args /

--- a/scripts/hooks/mercury-memory-index-validator.py
+++ b/scripts/hooks/mercury-memory-index-validator.py
@@ -1,29 +1,12 @@
 #!/usr/bin/env python3
-"""mercury-memory-index-validator.py — Phase F.C lock-in (Issue #331).
+"""mercury-memory-index-validator.py — Phase F.C SessionEnd hook (#331).
 
-SessionEnd hook for Claude Code. Runs `regenerate-memory-index.sh --format diff`
-against the Mercury user-memory dir; if drift detected (script exit 1), emits a
-warning to stderr (visible to user only — SessionEnd hooks cannot block).
-
-Best-effort observability: never blocks session termination, never raises.
-SessionEnd output JSON is ignored by Claude Code per the hook contract; only
-stderr is surfaced to user.
-
-Env vars:
-  MERCURY_INDEX_VALIDATOR_DISABLED=1  — no-op the hook (soft-disable)
-  MERCURY_INDEX_AUTOFIX=1             — when drift detected (regen exit 1),
-                                        run `regenerate-memory-index.sh
-                                        --in-place` automatically; emit a
-                                        confirmation stderr message instead
-                                        of a drift warning. Per Issue #331
-                                        Hook 2 spec ("Auto-fix with --in-place
-                                        if MERCURY_INDEX_AUTOFIX=1 set").
-  MERCURY_REPO_ROOT=<path>            — Mercury repo root (required for
-                                        deployed hooks; in-repo invocation
-                                        auto-resolves via __file__).
-
-Per Issue #331 acceptance + Mercury CLAUDE.md §Related Repositories user-level
-governance pattern (model: #259).
+Runs `regenerate-memory-index.sh --format diff`; surfaces drift to stderr
+(SessionEnd cannot block per Claude Code contract). Best-effort observability;
+never raises. Env: MERCURY_INDEX_VALIDATOR_DISABLED=1 (soft-disable),
+MERCURY_INDEX_AUTOFIX=1 (auto `--in-place` on drift per Issue #331 Hook 2),
+MERCURY_REPO_ROOT (required for deployed hooks; in-repo auto-resolves via
+__file__). See `.mercury/docs/guides/memory-index-regenerate.md` §Phase F.C.
 """
 from __future__ import annotations
 
@@ -38,19 +21,9 @@ REGEN_SCRIPT_REL = Path("scripts") / "regenerate-memory-index.sh"
 
 
 def _resolve_repo_root() -> Path | None:
-    """Resolve Mercury repo root with two strategies, no machine-specific fallback.
-
-    1. `MERCURY_REPO_ROOT` env var (preferred for deployed hooks under
-       ~/.claude/hooks/ — set in settings.json env block per deployment guide).
-    2. `__file__`-relative heuristic: when this script lives at
-       <repo>/scripts/hooks/mercury-memory-index-validator.py, parents[2] is
-       the repo root. Works during in-repo invocation and tests; degrades
-       gracefully when the script is copied into ~/.claude/hooks/ (parents[2]
-       there is ~, which won't contain regenerate-memory-index.sh).
-
-    Returns None when no candidate yields a valid repo (silent no-op per
-    SessionEnd observability-only contract). Hardcoded absolute paths are
-    forbidden per Mercury CLAUDE.md `feedback_no_hardcoded_paths`.
+    """Resolve Mercury repo root: MERCURY_REPO_ROOT env (deployed hooks) or
+    `__file__.parents[2]` heuristic (in-repo). No machine-specific fallback
+    per `feedback_no_hardcoded_paths`. Returns None on miss → silent no-op.
     """
     env = os.environ.get("MERCURY_REPO_ROOT", "").strip()
     if env:

--- a/scripts/hooks/mercury-memory-index-write-guard.py
+++ b/scripts/hooks/mercury-memory-index-write-guard.py
@@ -27,6 +27,7 @@ import sys
 from pathlib import Path
 
 CANONICAL_BASENAMES = ("MEMORY.md", "SESSION_INDEX.md")
+CANONICAL_BASENAMES_LOWER = tuple(name.lower() for name in CANONICAL_BASENAMES)
 BEGIN_MARKER_RE = re.compile(
     r"<!--\s*BEGIN:\s*scripts/regenerate-memory-index\.sh\s+--in-place\b"
 )
@@ -66,10 +67,22 @@ def _normalize(path_str: str) -> Path | None:
 
 
 def _is_canonical_target(path: Path, targets: set[Path]) -> bool:
-    if path in targets:
-        return True
-    if path.name not in CANONICAL_BASENAMES:
+    """Case-insensitive match for canonical user-memory MEMORY.md /
+    SESSION_INDEX.md.
+
+    Windows (NTFS, default-case-insensitive) lets `memory.md` bypass a
+    case-sensitive comparison even though the file system resolves both
+    names to the same canonical file. Per Argus iter-2 critical security
+    finding, normalize both basename and full path via str.lower() +
+    os.path.normcase before comparing. samefile() is kept as a fallback
+    for symlink and exotic-filesystem cases.
+    """
+    if path.name.lower() not in CANONICAL_BASENAMES_LOWER:
         return False
+    norm_path = os.path.normcase(str(path))
+    norm_targets = {os.path.normcase(str(t)) for t in targets}
+    if norm_path in norm_targets:
+        return True
     try:
         for t in targets:
             if path.samefile(t):
@@ -105,8 +118,8 @@ def _edit_touches_marker_region(file_path: Path, old_string: str) -> bool:
     if not old_string:
         return False
     try:
-        text = file_path.read_text(encoding="utf-8")
-    except OSError:
+        text = file_path.read_text(encoding="utf-8", errors="replace")
+    except (OSError, UnicodeError):
         return False
     region = _find_marker_region(text)
     if region is None:

--- a/scripts/hooks/mercury-memory-index-write-guard.py
+++ b/scripts/hooks/mercury-memory-index-write-guard.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""mercury-memory-index-write-guard.py — Phase F.C lock-in (Issue #331).
+
+PreToolUse hook for Claude Code. Intercepts Edit/Write tool calls targeting
+the canonical Mercury user-memory index files (MEMORY.md "Project (Session
+History)" subsection AND SESSION_INDEX.md table body). Direct edits between
+the regenerate-memory-index.sh markers are blocked; operators must edit
+per-session files at memory/sessions/S<N>(-<lane>)?.md and re-run
+`bash scripts/regenerate-memory-index.sh --in-place` to refresh canonical.
+
+Soft-disable env vars:
+  MERCURY_INDEX_GUARD_DISABLED=1  — short-circuit allow (no-op the hook)
+  MERCURY_INDEX_REGENERATE=1      — allow (script-driven, defense-in-depth)
+
+Hook contract: return JSON with hookSpecificOutput.permissionDecision="deny"
+to block; exit 0 with no JSON to allow. Exit 0 always — never raise.
+
+Per Issue #331 acceptance + Mercury CLAUDE.md §Related Repositories user-level
+governance pattern (model: #259).
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+CANONICAL_BASENAMES = ("MEMORY.md", "SESSION_INDEX.md")
+BEGIN_MARKER_RE = re.compile(
+    r"<!--\s*BEGIN:\s*scripts/regenerate-memory-index\.sh\s+--in-place\b"
+)
+END_MARKER_RE = re.compile(
+    r"<!--\s*END:\s*scripts/regenerate-memory-index\.sh\s+--in-place\s*-->"
+)
+DENY_REASON = (
+    "Mercury memory-index lock-in (Issue #331): canonical {basename} between "
+    "regenerate-memory-index.sh BEGIN/END markers is a derived artifact. Edit "
+    "memory/sessions/S<N>(-<lane>)?.md instead, then run "
+    "`bash scripts/regenerate-memory-index.sh --in-place` to refresh canonical. "
+    "Soft-disable: set MERCURY_INDEX_GUARD_DISABLED=1 to bypass this hook."
+)
+
+
+def _resolve_memory_dir() -> Path:
+    env = os.environ.get("MERCURY_MEMORY_DIR", "").strip()
+    if env:
+        return Path(env).expanduser().resolve(strict=False)
+    cfg = os.environ.get("CLAUDE_CONFIG_DIR", "").strip()
+    base = Path(cfg).expanduser() if cfg else Path.home() / ".claude"
+    return (base / "projects" / "D--Mercury-Mercury" / "memory").resolve(strict=False)
+
+
+def _canonical_targets() -> set[Path]:
+    mem_dir = _resolve_memory_dir()
+    return {(mem_dir / name).resolve(strict=False) for name in CANONICAL_BASENAMES}
+
+
+def _normalize(path_str: str) -> Path | None:
+    if not path_str or not isinstance(path_str, str):
+        return None
+    try:
+        return Path(path_str).expanduser().resolve(strict=False)
+    except (OSError, RuntimeError):
+        return None
+
+
+def _is_canonical_target(path: Path, targets: set[Path]) -> bool:
+    if path in targets:
+        return True
+    if path.name not in CANONICAL_BASENAMES:
+        return False
+    try:
+        for t in targets:
+            if path.samefile(t):
+                return True
+    except (OSError, ValueError):
+        pass
+    return False
+
+
+def _find_marker_region(text: str) -> tuple[int, int] | None:
+    bm = BEGIN_MARKER_RE.search(text)
+    if bm is None:
+        return None
+    em = END_MARKER_RE.search(text, pos=bm.end())
+    if em is None:
+        return None
+    return (bm.start(), em.end())
+
+
+def _edit_touches_marker_region(file_path: Path, old_string: str) -> bool:
+    """Return True iff the canonical file has BEGIN/END markers AND old_string
+    falls inside that region.
+
+    Fail-open on either (a) unreadable file (transient Windows file-lock during
+    git operations should not produce confusing denies) or (b) absence of
+    markers (pre-cutover or post-rollback canonical files have no managed
+    region to protect). Per code-review feedback, returning True on these
+    conditions confused fail-closed-posture deny errors with legitimate
+    "no marker region exists" cases. Production lock-in still works because
+    canonical files post-F.B always carry markers; if markers are stripped,
+    edits revert to allowed and operators can re-run --in-place to restore.
+    """
+    if not old_string:
+        return False
+    try:
+        text = file_path.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    region = _find_marker_region(text)
+    if region is None:
+        return False
+    start, end = region
+    region_text = text[start:end]
+    return old_string in region_text
+
+
+def _emit_deny(basename: str) -> None:
+    payload = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": DENY_REASON.format(basename=basename),
+        }
+    }
+    sys.stdout.write(json.dumps(payload) + "\n")
+    sys.stdout.flush()
+
+
+def main() -> int:
+    if os.environ.get("MERCURY_INDEX_GUARD_DISABLED", "").strip() == "1":
+        return 0
+    if os.environ.get("MERCURY_INDEX_REGENERATE", "").strip() == "1":
+        return 0
+
+    try:
+        raw = sys.stdin.read()
+        if not raw.strip():
+            return 0
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError:
+            fixed = re.sub(r'(?<!\\)\\(?!["\\])', r"\\\\", raw)
+            payload = json.loads(fixed)
+    except (json.JSONDecodeError, ValueError, OSError):
+        return 0
+
+    if not isinstance(payload, dict):
+        return 0
+
+    tool_name = payload.get("tool_name", "")
+    if tool_name not in ("Edit", "Write"):
+        return 0
+
+    tool_input = payload.get("tool_input", {})
+    if not isinstance(tool_input, dict):
+        return 0
+
+    file_path_str = tool_input.get("file_path", "")
+    target = _normalize(file_path_str)
+    if target is None:
+        return 0
+
+    targets = _canonical_targets()
+    if not _is_canonical_target(target, targets):
+        return 0
+
+    if tool_name == "Write":
+        _emit_deny(target.name)
+        return 0
+
+    old_string = tool_input.get("old_string", "")
+    if not isinstance(old_string, str):
+        return 0
+    if _edit_touches_marker_region(target, old_string):
+        _emit_deny(target.name)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/regenerate-memory-index.sh
+++ b/scripts/regenerate-memory-index.sh
@@ -28,7 +28,12 @@
 # Out of scope (per Issue #329/#330 acceptance criteria):
 #   - feedback_*.md / project_*.md (non-session) / reference_*.md MEMORY.md rows
 #   - mem0 / claude-handoff session_chain integration (orthogonal #252)
-#   - PreToolUse / SessionEnd hook lock-in (Phase F.C, Issue #331)
+#
+# Companion (Phase F.C, Issue #331): scripts/hooks/mercury-memory-index-write-guard.py
+# (PreToolUse) + scripts/hooks/mercury-memory-index-validator.py (SessionEnd) provide
+# mechanical enforcement of canonical-file edits via the regenerate flow. This script
+# exports MERCURY_INDEX_REGENERATE=1 (defense-in-depth) so script-driven tool-use
+# chains can be distinguished from direct Claude Edit/Write calls.
 #
 # Usage:
 #   scripts/regenerate-memory-index.sh [--memory-dir PATH] [--output PATH]
@@ -55,6 +60,13 @@
 #      --in-place + --output | --format diff combined (mutually exclusive)
 
 set -u
+
+# Phase F.C lock-in (Issue #331): stamp environment so PreToolUse write-guard
+# can identify script-driven runs and short-circuit allow. Defense-in-depth —
+# canonical writes happen via shell I/O which does not fire Edit/Write hooks,
+# but the stamp covers any edge path where a child process invokes Edit/Write
+# (e.g. SDK-driven sub-agent calling regenerate from inside a tool-use chain).
+export MERCURY_INDEX_REGENERATE=1
 
 die()  { printf 'regenerate-memory-index: %s\n' "$1" >&2; exit 2; }
 warn() { printf 'regenerate-memory-index WARN: %s\n' "$1" >&2; }

--- a/scripts/test-mercury-memory-index-validator.sh
+++ b/scripts/test-mercury-memory-index-validator.sh
@@ -76,6 +76,42 @@ EOF
   printf '%s' "$dir"
 }
 
+# Stub repo where the script behaves differently per first arg:
+#   --format diff → exit 1 (drift)
+#   --in-place    → exit 0 (autofix succeeds)
+make_stub_repo_drift_then_autofix_ok() {
+  local dir; dir="$(portable_mktemp_d val-fix-ok)"
+  mkdir -p "$dir/scripts"
+  cat > "$dir/scripts/regenerate-memory-index.sh" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+  --format) [ "${2:-}" = "diff" ] && { echo "drift on stderr" >&2; exit 1; } || exit 2 ;;
+  --in-place) echo "in-place autofix complete"; exit 0 ;;
+  *) exit 2 ;;
+esac
+EOF
+  chmod +x "$dir/scripts/regenerate-memory-index.sh"
+  printf '%s' "$dir"
+}
+
+# Stub repo where:
+#   --format diff → exit 1 (drift)
+#   --in-place    → exit 1 (autofix itself fails)
+make_stub_repo_drift_then_autofix_fail() {
+  local dir; dir="$(portable_mktemp_d val-fix-bad)"
+  mkdir -p "$dir/scripts"
+  cat > "$dir/scripts/regenerate-memory-index.sh" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+  --format) [ "${2:-}" = "diff" ] && exit 1 || exit 2 ;;
+  --in-place) echo "autofix failed: write error" >&2; exit 1 ;;
+  *) exit 2 ;;
+esac
+EOF
+  chmod +x "$dir/scripts/regenerate-memory-index.sh"
+  printf '%s' "$dir"
+}
+
 # Stub repo where regenerate --format diff exits 2 (script error, NOT drift)
 make_stub_repo_script_error() {
   local dir; dir="$(portable_mktemp_d val-err)"
@@ -179,6 +215,47 @@ if [ -n "$py_resolved" ]; then
 else
   printf 'SKIP T10.no-bash: cannot resolve %s on PATH\n' "$PY" >&2
 fi
+
+# ----- Test 12: MERCURY_INDEX_AUTOFIX=1 + drift → auto --in-place + confirmation -----
+# Per Issue #331 Hook 2 spec: when drift detected (exit 1) AND autofix env set,
+# validator runs --in-place to refresh canonical, suppresses standard drift
+# warning, emits confirmation message instead.
+repo_fix_ok="$(make_stub_repo_drift_then_autofix_ok)"
+TMP_LIST+=("$repo_fix_ok")
+combined="$(printf '{"session_id":"sess-12"}' | \
+  env MERCURY_REPO_ROOT="$repo_fix_ok" MERCURY_INDEX_AUTOFIX=1 "$PY" "$HOOK" 2>&1)"
+ec=$?
+assert_eq "T12.autofix-ok.exit-code" "0" "$ec"
+assert_contains "T12.autofix-ok.confirmation" "auto-fix via --in-place succeeded" "$combined"
+case "$combined" in
+  *"drift detected at session end (session=sess-12, regen exit=1)"*)
+    FAIL=$((FAIL + 1)); ASSERT=$((ASSERT + 1))
+    printf 'FAIL T12.autofix-ok.suppresses-warning\n  unwanted standard drift warning present\n' >&2 ;;
+  *) PASS=$((PASS + 1)); ASSERT=$((ASSERT + 1)) ;;
+esac
+
+# ----- Test 13: MERCURY_INDEX_AUTOFIX=1 but autofix itself fails → fallback warning -----
+repo_fix_bad="$(make_stub_repo_drift_then_autofix_fail)"
+TMP_LIST+=("$repo_fix_bad")
+combined="$(printf '{"session_id":"sess-13"}' | \
+  env MERCURY_REPO_ROOT="$repo_fix_bad" MERCURY_INDEX_AUTOFIX=1 "$PY" "$HOOK" 2>&1)"
+ec=$?
+assert_eq "T13.autofix-fail.exit-code" "0" "$ec"
+assert_contains "T13.autofix-fail.attempt-noted" "auto-fix exited 1" "$combined"
+assert_contains "T13.autofix-fail.fallback-drift" "drift detected" "$combined"
+
+# ----- Test 14: MERCURY_INDEX_AUTOFIX unset → standard drift warning, no autofix attempt -----
+combined="$(printf '{"session_id":"sess-14"}' | \
+  env MERCURY_REPO_ROOT="$repo_fix_ok" "$PY" "$HOOK" 2>&1)"
+ec=$?
+assert_eq "T14.autofix-unset.exit-code" "0" "$ec"
+assert_contains "T14.autofix-unset.standard-drift" "drift detected" "$combined"
+case "$combined" in
+  *"auto-fix via --in-place succeeded"*)
+    FAIL=$((FAIL + 1)); ASSERT=$((ASSERT + 1))
+    printf 'FAIL T14.autofix-unset.no-fix-attempted\n  unwanted autofix message present\n' >&2 ;;
+  *) PASS=$((PASS + 1)); ASSERT=$((ASSERT + 1)) ;;
+esac
 
 # ----- Test 11: regenerate exit 2 (script error, NOT drift) → distinct warning -----
 # Per Argus iter-2 medium finding: any non-zero exit was treated as drift.

--- a/scripts/test-mercury-memory-index-validator.sh
+++ b/scripts/test-mercury-memory-index-validator.sh
@@ -42,18 +42,17 @@ assert_contains() {
   esac
 }
 
-assert_not_contains() {
-  local name="$1" needle="$2" hay="$3"
-  ASSERT=$((ASSERT + 1))
-  case "$hay" in
-    *"$needle"*) FAIL=$((FAIL + 1)); printf 'FAIL %s\n  unwanted=%s\n  hay     =%s\n' "$name" "$needle" "$hay" >&2; return 1 ;;
-    *) PASS=$((PASS + 1)); return 0 ;;
-  esac
+# Portable mktemp wrapper (Argus iter-2 finding): bare `mktemp -d` is GNU-only;
+# BSD/macOS requires an explicit template.
+portable_mktemp_d() {
+  local prefix="${1:-mercury-fc-test}"
+  local base="${TMPDIR:-/tmp}"
+  mktemp -d "$base/$prefix.XXXXXX"
 }
 
 # Stub repo where regenerate --format diff exits 0 (no drift)
 make_stub_repo_clean() {
-  local dir; dir="$(mktemp -d)"
+  local dir; dir="$(portable_mktemp_d val-clean)"
   mkdir -p "$dir/scripts"
   cat > "$dir/scripts/regenerate-memory-index.sh" <<'EOF'
 #!/usr/bin/env bash
@@ -65,7 +64,7 @@ EOF
 
 # Stub repo where regenerate --format diff exits 1 (drift)
 make_stub_repo_drift() {
-  local dir; dir="$(mktemp -d)"
+  local dir; dir="$(portable_mktemp_d val-drift)"
   mkdir -p "$dir/scripts"
   cat > "$dir/scripts/regenerate-memory-index.sh" <<'EOF'
 #!/usr/bin/env bash
@@ -77,23 +76,33 @@ EOF
   printf '%s' "$dir"
 }
 
-TMP_LIST=""
-cleanup() { [ -n "${TMP_LIST:-}" ] && for d in $TMP_LIST; do rm -rf "$d" 2>/dev/null || true; done; }
-trap cleanup EXIT
-
-run_hook_capture_all() {
-  local repo="$1" stdin_payload="$2" extra_env="${3:-}"
-  if [ -n "$extra_env" ]; then
-    out_combined="$(printf '%s' "$stdin_payload" | env MERCURY_REPO_ROOT="$repo" "$extra_env" "$PY" "$HOOK" 2>&1)"
-  else
-    out_combined="$(printf '%s' "$stdin_payload" | env MERCURY_REPO_ROOT="$repo" "$PY" "$HOOK" 2>&1)"
-  fi
-  printf '%s' "$out_combined"
+# Stub repo where regenerate --format diff exits 2 (script error, NOT drift)
+make_stub_repo_script_error() {
+  local dir; dir="$(portable_mktemp_d val-err)"
+  mkdir -p "$dir/scripts"
+  cat > "$dir/scripts/regenerate-memory-index.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "missing memory dir or args" >&2
+exit 2
+EOF
+  chmod +x "$dir/scripts/regenerate-memory-index.sh"
+  printf '%s' "$dir"
 }
+
+# Array-based temp dir tracking (Argus iter-2 finding): space-separated string
+# fails on temp paths containing spaces.
+TMP_LIST=()
+cleanup() {
+  local d
+  for d in "${TMP_LIST[@]}"; do
+    [ -n "$d" ] && rm -rf "$d" 2>/dev/null || true
+  done
+}
+trap cleanup EXIT
 
 # ----- Test 1: clean repo (regenerate exit 0) → no warning, exit 0 -----
 repo_clean="$(make_stub_repo_clean)"
-TMP_LIST="$TMP_LIST $repo_clean"
+TMP_LIST+=("$repo_clean")
 out="$(printf '{"session_id":"abc","hook_event_name":"SessionEnd"}' | \
   env MERCURY_REPO_ROOT="$repo_clean" "$PY" "$HOOK" 2>&1)"
 ec=$?
@@ -102,7 +111,7 @@ assert_eq "T1.clean.no-warning" "" "$out"
 
 # ----- Test 2: drift repo (regenerate exit 1) → warning to stderr, exit 0 -----
 repo_drift="$(make_stub_repo_drift)"
-TMP_LIST="$TMP_LIST $repo_drift"
+TMP_LIST+=("$repo_drift")
 combined="$(printf '{"session_id":"sess-2","hook_event_name":"SessionEnd"}' | \
   env MERCURY_REPO_ROOT="$repo_drift" "$PY" "$HOOK" 2>&1)"
 ec=$?
@@ -131,7 +140,7 @@ ec=$?
 assert_eq "T5.empty-stdin.exit-code" "0" "$ec"
 
 # ----- Test 6: missing repo root (env unset + default repo not found) → exit 0 silent -----
-nonexist="$(mktemp -d)"; rm -rf "$nonexist"
+nonexist="$(portable_mktemp_d val-nonexist)"; rm -rf "$nonexist"
 combined="$(printf '{"session_id":"x"}' | env MERCURY_REPO_ROOT="$nonexist" "$PY" "$HOOK" 2>&1)"
 ec=$?
 assert_eq "T6.missing-repo.exit-code" "0" "$ec"
@@ -170,6 +179,23 @@ if [ -n "$py_resolved" ]; then
 else
   printf 'SKIP T10.no-bash: cannot resolve %s on PATH\n' "$PY" >&2
 fi
+
+# ----- Test 11: regenerate exit 2 (script error, NOT drift) → distinct warning -----
+# Per Argus iter-2 medium finding: any non-zero exit was treated as drift.
+# Hook now distinguishes exit 1 (drift) from other non-zero (validation
+# failed) so operators do not chase phantom drift on script errors.
+repo_err="$(make_stub_repo_script_error)"
+TMP_LIST+=("$repo_err")
+combined="$(printf '{"session_id":"sess-11"}' | env MERCURY_REPO_ROOT="$repo_err" "$PY" "$HOOK" 2>&1)"
+ec=$?
+assert_eq "T11.script-error.exit-code" "0" "$ec"
+assert_contains "T11.script-error.kind" "regenerate validation failed" "$combined"
+assert_contains "T11.script-error.exit-noted" "exit 2" "$combined"
+# Must NOT call it "drift" (semantic distinction enforced)
+case "$combined" in
+  *"drift detected at session end"*) FAIL=$((FAIL + 1)); ASSERT=$((ASSERT + 1)); printf 'FAIL T11.script-error.not-drift\n  unwanted="drift detected at session end" present in: %s\n' "$combined" >&2;;
+  *) PASS=$((PASS + 1)); ASSERT=$((ASSERT + 1));;
+esac
 
 # ----- Summary -----
 printf '\n----\n%d cases / %d assertions / %d fail\n' \

--- a/scripts/test-mercury-memory-index-validator.sh
+++ b/scripts/test-mercury-memory-index-validator.sh
@@ -153,6 +153,24 @@ ec=$?
 assert_eq "T9.not-dict.exit-code" "0" "$ec"
 assert_contains "T9.not-dict.placeholder" "session=unknown" "$combined"
 
+# ----- Test 10: bash executable missing on PATH → FileNotFoundError surfaced -----
+# Restrict PATH to ONLY the directory containing $PY itself (so the test can
+# still launch python.exe) but stripped of any bash/git-bash/MSYS2/WSL paths.
+# Without this finding being surfaced, drift check would silently fail (per
+# Argus iter 1 finding 3).
+py_resolved="$(command -v "$PY" 2>/dev/null || echo "")"
+if [ -n "$py_resolved" ]; then
+  py_dir="$(dirname "$py_resolved")"
+  combined="$(printf '{"session_id":"sess-10"}' | \
+    env -i MERCURY_REPO_ROOT="$repo_clean" PATH="$py_dir" SYSTEMROOT="${SYSTEMROOT:-}" "$PY" "$HOOK" 2>&1)"
+  ec=$?
+  assert_eq "T10.no-bash.exit-code" "0" "$ec"
+  assert_contains "T10.no-bash.warning" "bash" "$combined"
+  assert_contains "T10.no-bash.disable-hint" "MERCURY_INDEX_VALIDATOR_DISABLED" "$combined"
+else
+  printf 'SKIP T10.no-bash: cannot resolve %s on PATH\n' "$PY" >&2
+fi
+
 # ----- Summary -----
 printf '\n----\n%d cases / %d assertions / %d fail\n' \
   "$((PASS + FAIL))" "$ASSERT" "$FAIL" >&2

--- a/scripts/test-mercury-memory-index-validator.sh
+++ b/scripts/test-mercury-memory-index-validator.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# scripts/test-mercury-memory-index-validator.sh — Phase F.C lock-in (Issue #331).
+#
+# Synthetic-stdin tests for scripts/hooks/mercury-memory-index-validator.py.
+# Validator is observability-only (SessionEnd cannot block); exit code is
+# always 0; stderr surfaces drift warnings only when regenerate --format diff
+# returns non-zero.
+#
+# Exit 0 = all assertions pass; 1 = any assertion fail; 2 = test harness error.
+
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HOOK="$ROOT/scripts/hooks/mercury-memory-index-validator.py"
+PY="${PYTHON_BIN:-python}"
+
+[ -f "$HOOK" ] || { printf 'test harness: hook script missing: %s\n' "$HOOK" >&2; exit 2; }
+command -v "$PY" >/dev/null 2>&1 || { printf 'test harness: python missing\n' >&2; exit 2; }
+
+PASS=0
+FAIL=0
+ASSERT=0
+
+assert_eq() {
+  local name="$1" want="$2" got="$3"
+  ASSERT=$((ASSERT + 1))
+  if [ "$want" = "$got" ]; then
+    PASS=$((PASS + 1))
+    return 0
+  fi
+  FAIL=$((FAIL + 1))
+  printf 'FAIL %s\n  want=%s\n  got =%s\n' "$name" "$want" "$got" >&2
+  return 1
+}
+
+assert_contains() {
+  local name="$1" needle="$2" hay="$3"
+  ASSERT=$((ASSERT + 1))
+  case "$hay" in
+    *"$needle"*) PASS=$((PASS + 1)); return 0 ;;
+    *) FAIL=$((FAIL + 1)); printf 'FAIL %s\n  needle=%s\n  hay   =%s\n' "$name" "$needle" "$hay" >&2; return 1 ;;
+  esac
+}
+
+assert_not_contains() {
+  local name="$1" needle="$2" hay="$3"
+  ASSERT=$((ASSERT + 1))
+  case "$hay" in
+    *"$needle"*) FAIL=$((FAIL + 1)); printf 'FAIL %s\n  unwanted=%s\n  hay     =%s\n' "$name" "$needle" "$hay" >&2; return 1 ;;
+    *) PASS=$((PASS + 1)); return 0 ;;
+  esac
+}
+
+# Stub repo where regenerate --format diff exits 0 (no drift)
+make_stub_repo_clean() {
+  local dir; dir="$(mktemp -d)"
+  mkdir -p "$dir/scripts"
+  cat > "$dir/scripts/regenerate-memory-index.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+  chmod +x "$dir/scripts/regenerate-memory-index.sh"
+  printf '%s' "$dir"
+}
+
+# Stub repo where regenerate --format diff exits 1 (drift)
+make_stub_repo_drift() {
+  local dir; dir="$(mktemp -d)"
+  mkdir -p "$dir/scripts"
+  cat > "$dir/scripts/regenerate-memory-index.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "drift line A on stdout"
+echo "drift line B on stderr" >&2
+exit 1
+EOF
+  chmod +x "$dir/scripts/regenerate-memory-index.sh"
+  printf '%s' "$dir"
+}
+
+TMP_LIST=""
+cleanup() { [ -n "${TMP_LIST:-}" ] && for d in $TMP_LIST; do rm -rf "$d" 2>/dev/null || true; done; }
+trap cleanup EXIT
+
+run_hook_capture_all() {
+  local repo="$1" stdin_payload="$2" extra_env="${3:-}"
+  if [ -n "$extra_env" ]; then
+    out_combined="$(printf '%s' "$stdin_payload" | env MERCURY_REPO_ROOT="$repo" "$extra_env" "$PY" "$HOOK" 2>&1)"
+  else
+    out_combined="$(printf '%s' "$stdin_payload" | env MERCURY_REPO_ROOT="$repo" "$PY" "$HOOK" 2>&1)"
+  fi
+  printf '%s' "$out_combined"
+}
+
+# ----- Test 1: clean repo (regenerate exit 0) → no warning, exit 0 -----
+repo_clean="$(make_stub_repo_clean)"
+TMP_LIST="$TMP_LIST $repo_clean"
+out="$(printf '{"session_id":"abc","hook_event_name":"SessionEnd"}' | \
+  env MERCURY_REPO_ROOT="$repo_clean" "$PY" "$HOOK" 2>&1)"
+ec=$?
+assert_eq "T1.clean.exit-code" "0" "$ec"
+assert_eq "T1.clean.no-warning" "" "$out"
+
+# ----- Test 2: drift repo (regenerate exit 1) → warning to stderr, exit 0 -----
+repo_drift="$(make_stub_repo_drift)"
+TMP_LIST="$TMP_LIST $repo_drift"
+combined="$(printf '{"session_id":"sess-2","hook_event_name":"SessionEnd"}' | \
+  env MERCURY_REPO_ROOT="$repo_drift" "$PY" "$HOOK" 2>&1)"
+ec=$?
+assert_eq "T2.drift.exit-code" "0" "$ec"
+assert_contains "T2.drift.warning-prefix" "drift detected at session end" "$combined"
+assert_contains "T2.drift.session-id-echoed" "sess-2" "$combined"
+assert_contains "T2.drift.regen-exit-noted" "regen exit=1" "$combined"
+assert_contains "T2.drift.fix-hint" "regenerate-memory-index.sh --in-place" "$combined"
+
+# ----- Test 3: MERCURY_INDEX_VALIDATOR_DISABLED=1 → no warning even on drift -----
+combined="$(printf '{"session_id":"sess-3","hook_event_name":"SessionEnd"}' | \
+  env MERCURY_REPO_ROOT="$repo_drift" MERCURY_INDEX_VALIDATOR_DISABLED=1 "$PY" "$HOOK" 2>&1)"
+ec=$?
+assert_eq "T3.disabled.exit-code" "0" "$ec"
+assert_eq "T3.disabled.no-output" "" "$combined"
+
+# ----- Test 4: malformed stdin JSON → still runs, no crash -----
+combined="$(printf '{not json' | env MERCURY_REPO_ROOT="$repo_clean" "$PY" "$HOOK" 2>&1)"
+ec=$?
+assert_eq "T4.bad-json.exit-code" "0" "$ec"
+assert_eq "T4.bad-json.no-output" "" "$combined"
+
+# ----- Test 5: empty stdin → exit 0 -----
+combined="$(printf '' | env MERCURY_REPO_ROOT="$repo_clean" "$PY" "$HOOK" 2>&1)"
+ec=$?
+assert_eq "T5.empty-stdin.exit-code" "0" "$ec"
+
+# ----- Test 6: missing repo root (env unset + default repo not found) → exit 0 silent -----
+nonexist="$(mktemp -d)"; rm -rf "$nonexist"
+combined="$(printf '{"session_id":"x"}' | env MERCURY_REPO_ROOT="$nonexist" "$PY" "$HOOK" 2>&1)"
+ec=$?
+assert_eq "T6.missing-repo.exit-code" "0" "$ec"
+assert_eq "T6.missing-repo.no-output" "" "$combined"
+
+# ----- Test 7: drift warning includes stdout/stderr tail -----
+combined="$(printf '{"session_id":"sess-7"}' | \
+  env MERCURY_REPO_ROOT="$repo_drift" "$PY" "$HOOK" 2>&1)"
+assert_contains "T7.tail.stderr-content" "drift line B on stderr" "$combined"
+assert_contains "T7.tail.stdout-content" "drift line A on stdout" "$combined"
+
+# ----- Test 8: payload missing session_id → unknown placeholder -----
+combined="$(printf '{}' | env MERCURY_REPO_ROOT="$repo_drift" "$PY" "$HOOK" 2>&1)"
+assert_contains "T8.no-session_id.placeholder" "session=unknown" "$combined"
+
+# ----- Test 9: payload top-level not a dict → unknown placeholder, no crash -----
+combined="$(printf '"not-a-dict"' | env MERCURY_REPO_ROOT="$repo_drift" "$PY" "$HOOK" 2>&1)"
+ec=$?
+assert_eq "T9.not-dict.exit-code" "0" "$ec"
+assert_contains "T9.not-dict.placeholder" "session=unknown" "$combined"
+
+# ----- Summary -----
+printf '\n----\n%d cases / %d assertions / %d fail\n' \
+  "$((PASS + FAIL))" "$ASSERT" "$FAIL" >&2
+
+[ "$FAIL" -eq 0 ] || exit 1
+exit 0

--- a/scripts/test-mercury-memory-index-write-guard.sh
+++ b/scripts/test-mercury-memory-index-write-guard.sh
@@ -193,7 +193,7 @@ assert_eq "T10.regenerate-stamp.empty-output" "" "$out"
 # blocked. Note Write to canonical (T5/T6) is still unconditionally denied —
 # the discriminator is tool_name (Edit) + region presence.
 mem_dir2="$(setup_tmp_memory_dir_no_markers)"
-TMP_MEM_DIR_LIST="$TMP_MEM_DIR_LIST $mem_dir2"
+TMP_MEM_DIR_LIST+=("$mem_dir2")
 target2="$mem_dir2/MEMORY.md"
 payload="$(printf '{"tool_name":"Edit","tool_input":{"file_path":"%s","old_string":"no markers here yet","new_string":"hacked"}}' "$target2")"
 out="$(MERCURY_MEMORY_DIR="$mem_dir2" run_hook "$payload")"

--- a/scripts/test-mercury-memory-index-write-guard.sh
+++ b/scripts/test-mercury-memory-index-write-guard.sh
@@ -28,6 +28,15 @@ canon_path() {
   fi
 }
 
+# Portable mktemp wrapper (Argus iter-2 finding): bare `mktemp -d` is GNU-only;
+# BSD/macOS requires an explicit template or `-t prefix`. Use a template
+# rooted at $TMPDIR (or /tmp) with a stable prefix.
+portable_mktemp_d() {
+  local prefix="${1:-mercury-fc-test}"
+  local base="${TMPDIR:-/tmp}"
+  mktemp -d "$base/$prefix.XXXXXX"
+}
+
 [ -f "$HOOK" ] || { printf 'test harness: hook script missing: %s\n' "$HOOK" >&2; exit 2; }
 command -v "$PY" >/dev/null 2>&1 || { printf 'test harness: python missing\n' >&2; exit 2; }
 
@@ -61,14 +70,9 @@ run_hook() {
   printf '%s' "$stdin_payload" | "$PY" "$HOOK"
 }
 
-run_hook_with_env() {
-  local env_kv="$1" stdin_payload="$2"
-  printf '%s' "$stdin_payload" | env "$env_kv" "$PY" "$HOOK"
-}
-
 setup_tmp_memory_dir() {
   local dir
-  dir="$(canon_path "$(mktemp -d)")"
+  dir="$(canon_path "$(portable_mktemp_d wg-mem)")"
   mkdir -p "$dir"
   # NOTE: ASCII-only fixture content. Production canonical files contain UTF-8
   # em dashes (U+2014), but the MSYS2-bash heredoc + Windows-native python.exe
@@ -106,16 +110,23 @@ EOF
 
 setup_tmp_memory_dir_no_markers() {
   local dir
-  dir="$(canon_path "$(mktemp -d)")"
+  dir="$(canon_path "$(portable_mktemp_d wg-nomark)")"
   mkdir -p "$dir"
   printf '# Memory Index\n\nno markers here yet\n' > "$dir/MEMORY.md"
   printf '%s' "$dir"
 }
 
+# Array-based temp dir tracking (Argus iter-2 finding): space-separated string
+# fails on temp paths containing spaces (common in Windows %TMP% under
+# `C:\Users\<First Last>\AppData\Local\Temp`). Bash array iteration with proper
+# quoting is robust.
+TMP_MEM_DIR_LIST=()
 cleanup() {
-  [ -n "${TMP_MEM_DIR_LIST:-}" ] && for d in $TMP_MEM_DIR_LIST; do rm -rf "$d" 2>/dev/null || true; done
+  local d
+  for d in "${TMP_MEM_DIR_LIST[@]}"; do
+    [ -n "$d" ] && rm -rf "$d" 2>/dev/null || true
+  done
 }
-TMP_MEM_DIR_LIST=""
 trap cleanup EXIT
 
 # ----- Test 1: empty stdin → exit 0 silent -----
@@ -139,7 +150,7 @@ assert_eq "T4.edit-non-canonical.empty-output" "" "$out"
 
 # ----- Test 5: Write on canonical MEMORY.md → deny -----
 mem_dir="$(setup_tmp_memory_dir)"
-TMP_MEM_DIR_LIST="$TMP_MEM_DIR_LIST $mem_dir"
+TMP_MEM_DIR_LIST+=("$mem_dir")
 target="$mem_dir/MEMORY.md"
 payload="$(printf '{"tool_name":"Write","tool_input":{"file_path":"%s","content":"x"}}' "$target")"
 out="$(MERCURY_MEMORY_DIR="$mem_dir" run_hook "$payload")"
@@ -189,8 +200,8 @@ out="$(MERCURY_MEMORY_DIR="$mem_dir2" run_hook "$payload")"
 assert_eq "T11.edit-no-markers.allow" "" "$out"
 
 # ----- Test 11b: Edit canonical file is unreadable / missing → ALLOW (fail-open) -----
-mem_dir3="$(canon_path "$(mktemp -d)")"
-TMP_MEM_DIR_LIST="$TMP_MEM_DIR_LIST $mem_dir3"
+mem_dir3="$(canon_path "$(portable_mktemp_d wg-missing)")"
+TMP_MEM_DIR_LIST+=("$mem_dir3")
 ghost="$mem_dir3/MEMORY.md"
 payload="$(printf '{"tool_name":"Edit","tool_input":{"file_path":"%s","old_string":"x","new_string":"y"}}' "$ghost")"
 out="$(MERCURY_MEMORY_DIR="$mem_dir3" run_hook "$payload")"
@@ -209,8 +220,8 @@ out="$(run_hook '["not-a-dict"]')"
 assert_eq "T14.payload-not-dict.empty-output" "" "$out"
 
 # ----- Test 15: Edit basename matches but parent dir is unrelated → exit 0 silent -----
-unrelated_dir="$(canon_path "$(mktemp -d)")"
-TMP_MEM_DIR_LIST="$TMP_MEM_DIR_LIST $unrelated_dir"
+unrelated_dir="$(canon_path "$(portable_mktemp_d wg-unrelated)")"
+TMP_MEM_DIR_LIST+=("$unrelated_dir")
 unrelated_file="$unrelated_dir/MEMORY.md"
 printf 'unrelated\n' > "$unrelated_file"
 payload="$(printf '{"tool_name":"Edit","tool_input":{"file_path":"%s","old_string":"unrelated","new_string":"x"}}' "$unrelated_file")"
@@ -224,6 +235,32 @@ target="$mem_dir/./MEMORY.md"
 payload="$(printf '{"tool_name":"Write","tool_input":{"file_path":"%s","content":"x"}}' "$target")"
 out="$(MERCURY_MEMORY_DIR="$mem_dir" run_hook "$payload")"
 assert_contains "T16.dot-segment-path.deny" '"permissionDecision": "deny"' "$out"
+
+# ----- Test 17: case-insensitive basename bypass (Argus iter-2 CRITICAL) -----
+# On Windows (default-case-insensitive NTFS) `memory.md` resolves to the same
+# file as `MEMORY.md`. A case-sensitive guard would let `memory.md` through.
+# Hook now lowercases basename before matching CANONICAL_BASENAMES_LOWER.
+target="$mem_dir/memory.md"
+payload="$(printf '{"tool_name":"Write","tool_input":{"file_path":"%s","content":"x"}}' "$target")"
+out="$(MERCURY_MEMORY_DIR="$mem_dir" run_hook "$payload")"
+assert_contains "T17.lowercase-bypass.deny" '"permissionDecision": "deny"' "$out"
+
+target="$mem_dir/Session_Index.MD"
+payload="$(printf '{"tool_name":"Write","tool_input":{"file_path":"%s","content":"x"}}' "$target")"
+out="$(MERCURY_MEMORY_DIR="$mem_dir" run_hook "$payload")"
+assert_contains "T17.mixed-case-bypass.deny" '"permissionDecision": "deny"' "$out"
+
+# ----- Test 18: invalid UTF-8 in canonical Edit → fail-open allow (no raise) -----
+# Per Argus iter-2: Path.read_text(encoding="utf-8") can raise UnicodeDecodeError
+# on corrupt bytes. Hook now uses errors="replace" + catches UnicodeError so
+# SessionEnd "never raises" contract holds.
+mem_dir4="$(canon_path "$(portable_mktemp_d wg-utf8)")"
+TMP_MEM_DIR_LIST+=("$mem_dir4")
+target="$mem_dir4/MEMORY.md"
+printf '\xff\xfe\xfd invalid utf-8 bytes here\n' > "$target"
+payload="$(printf '{"tool_name":"Edit","tool_input":{"file_path":"%s","old_string":"x","new_string":"y"}}' "$target")"
+out="$(MERCURY_MEMORY_DIR="$mem_dir4" run_hook "$payload")"
+assert_eq "T18.bad-utf8.allow" "" "$out"
 
 # ----- Summary -----
 printf '\n----\n%d cases / %d assertions / %d fail\n' \

--- a/scripts/test-mercury-memory-index-write-guard.sh
+++ b/scripts/test-mercury-memory-index-write-guard.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+# scripts/test-mercury-memory-index-write-guard.sh — Phase F.C lock-in (Issue #331).
+#
+# Synthetic-stdin tests for scripts/hooks/mercury-memory-index-write-guard.py.
+# No real ~/.claude/ touched; per-test temp memory dir + MERCURY_MEMORY_DIR env
+# override drives the resolution path.
+#
+# Exit 0 = all assertions pass; 1 = any assertion fail; 2 = test harness error.
+
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HOOK="$ROOT/scripts/hooks/mercury-memory-index-write-guard.py"
+PY="${PYTHON_BIN:-python}"
+
+# On MSYS2/Cygwin, env vars whose name matches *_DIR or *_PATH are
+# auto-converted from POSIX (/tmp/...) to Windows (C:/Users/.../Temp/...) at
+# the fork-exec boundary into a Windows-native python.exe. The stdin JSON,
+# however, is not transformed. The hook normalizes via Path.resolve(), so
+# production paths (always Windows-form) stay consistent — but tests need a
+# common form on both sides. Use cygpath -m where available to emit a
+# mixed-form path (C:/Users/...) that survives both Bash and Python paths.
+canon_path() {
+  if command -v cygpath >/dev/null 2>&1; then
+    cygpath -m "$1"
+  else
+    printf '%s' "$1"
+  fi
+}
+
+[ -f "$HOOK" ] || { printf 'test harness: hook script missing: %s\n' "$HOOK" >&2; exit 2; }
+command -v "$PY" >/dev/null 2>&1 || { printf 'test harness: python missing\n' >&2; exit 2; }
+
+PASS=0
+FAIL=0
+ASSERT=0
+
+assert_eq() {
+  local name="$1" want="$2" got="$3"
+  ASSERT=$((ASSERT + 1))
+  if [ "$want" = "$got" ]; then
+    PASS=$((PASS + 1))
+    return 0
+  fi
+  FAIL=$((FAIL + 1))
+  printf 'FAIL %s\n  want=%s\n  got =%s\n' "$name" "$want" "$got" >&2
+  return 1
+}
+
+assert_contains() {
+  local name="$1" needle="$2" hay="$3"
+  ASSERT=$((ASSERT + 1))
+  case "$hay" in
+    *"$needle"*) PASS=$((PASS + 1)); return 0 ;;
+    *) FAIL=$((FAIL + 1)); printf 'FAIL %s\n  needle=%s\n  hay   =%s\n' "$name" "$needle" "$hay" >&2; return 1 ;;
+  esac
+}
+
+run_hook() {
+  local stdin_payload="$1"
+  printf '%s' "$stdin_payload" | "$PY" "$HOOK"
+}
+
+run_hook_with_env() {
+  local env_kv="$1" stdin_payload="$2"
+  printf '%s' "$stdin_payload" | env "$env_kv" "$PY" "$HOOK"
+}
+
+setup_tmp_memory_dir() {
+  local dir
+  dir="$(canon_path "$(mktemp -d)")"
+  mkdir -p "$dir"
+  # NOTE: ASCII-only fixture content. Production canonical files contain UTF-8
+  # em dashes (U+2014), but the MSYS2-bash heredoc + Windows-native python.exe
+  # round-trip mangles multi-byte sequences inside test stdin/file pairs. The
+  # write-guard logic itself is byte-agnostic (Path.read_text utf-8 + substring
+  # check), so an ASCII fixture exercises the same code paths without harness
+  # noise.
+  cat > "$dir/MEMORY.md" <<'EOF'
+# Memory Index
+
+## Project (Session History)
+
+<!-- BEGIN: scripts/regenerate-memory-index.sh --in-place (Issue #330 Phase F.B). Regenerated content -->
+- [sessions/S99.md](sessions/S99.md) - Auto-generated row body
+<!-- END: scripts/regenerate-memory-index.sh --in-place -->
+
+## Reference
+- some-reference-row
+EOF
+
+  cat > "$dir/SESSION_INDEX.md" <<'EOF'
+# Session Index
+
+| Session | Date | Topic | Output | originSessionId |
+|---------|------|-------|--------|-----------------|
+<!-- BEGIN: scripts/regenerate-memory-index.sh --in-place (Issue #330 Phase F.B). Regenerated content -->
+| S99 | 2026-04-28 | foo | bar | - |
+<!-- END: scripts/regenerate-memory-index.sh --in-place -->
+
+(trailing notes here are NOT in marker region)
+EOF
+
+  printf '%s' "$dir"
+}
+
+setup_tmp_memory_dir_no_markers() {
+  local dir
+  dir="$(canon_path "$(mktemp -d)")"
+  mkdir -p "$dir"
+  printf '# Memory Index\n\nno markers here yet\n' > "$dir/MEMORY.md"
+  printf '%s' "$dir"
+}
+
+cleanup() {
+  [ -n "${TMP_MEM_DIR_LIST:-}" ] && for d in $TMP_MEM_DIR_LIST; do rm -rf "$d" 2>/dev/null || true; done
+}
+TMP_MEM_DIR_LIST=""
+trap cleanup EXIT
+
+# ----- Test 1: empty stdin → exit 0 silent -----
+out="$(run_hook "")"
+assert_eq "T1.empty-stdin.empty-output" "" "$out"
+
+# ----- Test 2: malformed JSON → exit 0 silent -----
+out="$(run_hook "{not json")"
+assert_eq "T2.malformed-json.empty-output" "" "$out"
+
+# ----- Test 3: non-Edit/Write tool → exit 0 silent -----
+out="$(run_hook '{"tool_name":"Bash","tool_input":{"command":"ls"}}')"
+assert_eq "T3.bash-tool.empty-output" "" "$out"
+
+out="$(run_hook '{"tool_name":"Read","tool_input":{"file_path":"/tmp/x"}}')"
+assert_eq "T3.read-tool.empty-output" "" "$out"
+
+# ----- Test 4: Edit on non-canonical path → exit 0 silent -----
+out="$(run_hook '{"tool_name":"Edit","tool_input":{"file_path":"/tmp/random.md","old_string":"a","new_string":"b"}}')"
+assert_eq "T4.edit-non-canonical.empty-output" "" "$out"
+
+# ----- Test 5: Write on canonical MEMORY.md → deny -----
+mem_dir="$(setup_tmp_memory_dir)"
+TMP_MEM_DIR_LIST="$TMP_MEM_DIR_LIST $mem_dir"
+target="$mem_dir/MEMORY.md"
+payload="$(printf '{"tool_name":"Write","tool_input":{"file_path":"%s","content":"x"}}' "$target")"
+out="$(MERCURY_MEMORY_DIR="$mem_dir" run_hook "$payload")"
+assert_contains "T5.write-canonical-MEMORY.deny" '"permissionDecision": "deny"' "$out"
+assert_contains "T5.write-canonical-MEMORY.reason" "MEMORY.md" "$out"
+
+# ----- Test 6: Write on canonical SESSION_INDEX.md → deny -----
+target="$mem_dir/SESSION_INDEX.md"
+payload="$(printf '{"tool_name":"Write","tool_input":{"file_path":"%s","content":"x"}}' "$target")"
+out="$(MERCURY_MEMORY_DIR="$mem_dir" run_hook "$payload")"
+assert_contains "T6.write-canonical-SESSION_INDEX.deny" '"permissionDecision": "deny"' "$out"
+assert_contains "T6.write-canonical-SESSION_INDEX.reason" "SESSION_INDEX.md" "$out"
+
+# ----- Test 7: Edit canonical MEMORY.md old_string IN marker region → deny -----
+target="$mem_dir/MEMORY.md"
+old_in_region='- [sessions/S99.md](sessions/S99.md) - Auto-generated row body'
+payload="$(printf '{"tool_name":"Edit","tool_input":{"file_path":"%s","old_string":"%s","new_string":"hacked"}}' "$target" "$old_in_region")"
+out="$(MERCURY_MEMORY_DIR="$mem_dir" run_hook "$payload")"
+assert_contains "T7.edit-marker-region.deny" '"permissionDecision": "deny"' "$out"
+
+# ----- Test 8: Edit canonical MEMORY.md old_string OUTSIDE marker region → allow -----
+old_outside='some-reference-row'
+payload="$(printf '{"tool_name":"Edit","tool_input":{"file_path":"%s","old_string":"%s","new_string":"some-other-row"}}' "$target" "$old_outside")"
+out="$(MERCURY_MEMORY_DIR="$mem_dir" run_hook "$payload")"
+assert_eq "T8.edit-outside-marker.allow.empty-output" "" "$out"
+
+# ----- Test 9: MERCURY_INDEX_GUARD_DISABLED=1 → bypass even on Write canonical -----
+target="$mem_dir/MEMORY.md"
+payload="$(printf '{"tool_name":"Write","tool_input":{"file_path":"%s","content":"x"}}' "$target")"
+out="$(printf '%s' "$payload" | env MERCURY_MEMORY_DIR="$mem_dir" MERCURY_INDEX_GUARD_DISABLED=1 "$PY" "$HOOK")"
+assert_eq "T9.guard-disabled.empty-output" "" "$out"
+
+# ----- Test 10: MERCURY_INDEX_REGENERATE=1 → bypass even on Write canonical -----
+out="$(printf '%s' "$payload" | env MERCURY_MEMORY_DIR="$mem_dir" MERCURY_INDEX_REGENERATE=1 "$PY" "$HOOK")"
+assert_eq "T10.regenerate-stamp.empty-output" "" "$out"
+
+# ----- Test 11: Edit canonical file with NO markers (pre-cutover or post-rollback) → ALLOW -----
+# Fail-open posture: no markers present means no managed region to protect.
+# Operators can run --in-place to restore markers; until then, edits are not
+# blocked. Note Write to canonical (T5/T6) is still unconditionally denied —
+# the discriminator is tool_name (Edit) + region presence.
+mem_dir2="$(setup_tmp_memory_dir_no_markers)"
+TMP_MEM_DIR_LIST="$TMP_MEM_DIR_LIST $mem_dir2"
+target2="$mem_dir2/MEMORY.md"
+payload="$(printf '{"tool_name":"Edit","tool_input":{"file_path":"%s","old_string":"no markers here yet","new_string":"hacked"}}' "$target2")"
+out="$(MERCURY_MEMORY_DIR="$mem_dir2" run_hook "$payload")"
+assert_eq "T11.edit-no-markers.allow" "" "$out"
+
+# ----- Test 11b: Edit canonical file is unreadable / missing → ALLOW (fail-open) -----
+mem_dir3="$(canon_path "$(mktemp -d)")"
+TMP_MEM_DIR_LIST="$TMP_MEM_DIR_LIST $mem_dir3"
+ghost="$mem_dir3/MEMORY.md"
+payload="$(printf '{"tool_name":"Edit","tool_input":{"file_path":"%s","old_string":"x","new_string":"y"}}' "$ghost")"
+out="$(MERCURY_MEMORY_DIR="$mem_dir3" run_hook "$payload")"
+assert_eq "T11b.edit-missing-file.allow" "" "$out"
+
+# ----- Test 12: missing tool_input.file_path → exit 0 silent -----
+out="$(run_hook '{"tool_name":"Edit","tool_input":{}}')"
+assert_eq "T12.edit-no-file_path.empty-output" "" "$out"
+
+# ----- Test 13: tool_input not a dict → exit 0 silent -----
+out="$(run_hook '{"tool_name":"Edit","tool_input":"not-a-dict"}')"
+assert_eq "T13.edit-bad-tool_input.empty-output" "" "$out"
+
+# ----- Test 14: payload top-level not dict → exit 0 silent -----
+out="$(run_hook '["not-a-dict"]')"
+assert_eq "T14.payload-not-dict.empty-output" "" "$out"
+
+# ----- Test 15: Edit basename matches but parent dir is unrelated → exit 0 silent -----
+unrelated_dir="$(canon_path "$(mktemp -d)")"
+TMP_MEM_DIR_LIST="$TMP_MEM_DIR_LIST $unrelated_dir"
+unrelated_file="$unrelated_dir/MEMORY.md"
+printf 'unrelated\n' > "$unrelated_file"
+payload="$(printf '{"tool_name":"Edit","tool_input":{"file_path":"%s","old_string":"unrelated","new_string":"x"}}' "$unrelated_file")"
+out="$(MERCURY_MEMORY_DIR="$mem_dir" run_hook "$payload")"
+assert_eq "T15.basename-match-wrong-dir.allow" "" "$out"
+
+# ----- Test 16: trailing-slash + redundant '.' segments in path normalize correctly -----
+# Exercises Path.resolve() canonicalization independently from T5/T6 (which
+# already cover the mixed-form path case via canon_path()).
+target="$mem_dir/./MEMORY.md"
+payload="$(printf '{"tool_name":"Write","tool_input":{"file_path":"%s","content":"x"}}' "$target")"
+out="$(MERCURY_MEMORY_DIR="$mem_dir" run_hook "$payload")"
+assert_contains "T16.dot-segment-path.deny" '"permissionDecision": "deny"' "$out"
+
+# ----- Summary -----
+printf '\n----\n%d cases / %d assertions / %d fail\n' \
+  "$((PASS + FAIL))" "$ASSERT" "$FAIL" >&2
+
+[ "$FAIL" -eq 0 ] || exit 1
+exit 0


### PR DESCRIPTION
## Summary

Phase F.C lock-in of `feedback_lane_protocol` Rule 7 REPLACE (v0.1 Δ5, parent epic #315). Source-of-truth scripts for two Claude Code hooks deployable to `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/` per #259 user-level governance pattern. Deployment is operational (separate step, gated on F.B 1-week soak passing) and not part of this PR.

- `mercury-memory-index-write-guard.py` (PreToolUse, matcher `Edit|Write`): denies Edit/Write on canonical user-memory `MEMORY.md` / `SESSION_INDEX.md` when target overlaps regenerate marker region. Fail-open on missing markers / unreadable file. Soft-disable: `MERCURY_INDEX_GUARD_DISABLED=1`. Defense-in-depth bypass: `MERCURY_INDEX_REGENERATE=1`.
- `mercury-memory-index-validator.py` (SessionEnd): runs `regenerate-memory-index.sh --format diff`; surfaces drift to stderr per SessionEnd contract (cannot block). Surfaces `TimeoutExpired` separately. Soft-disable: `MERCURY_INDEX_VALIDATOR_DISABLED=1`.
- `scripts/regenerate-memory-index.sh`: exports `MERCURY_INDEX_REGENERATE=1` so script-driven SDK chains short-circuit the guard.
- `.mercury/docs/guides/memory-index-regenerate.md`: §Phase F.C section with deployment commands, soft-disable env var table, rollback channels, verification checklist.

No hardcoded paths per `feedback_no_hardcoded_paths`: validator resolves repo root via `MERCURY_REPO_ROOT` env (preferred) or `__file__`-relative heuristic (in-repo only). Deployed hooks require `MERCURY_REPO_ROOT` in `settings.json` env block.

## Test plan

- [x] F.A regenerate suite: 44 cases / 82 assertions / 0 fail (existing, regression-clean)
- [x] F.B in-place suite: 14 cases / 54 assertions / 0 fail (existing, regression-clean)
- [x] F.C write-guard suite: 20 cases / 20 assertions / 0 fail (NEW)
- [x] F.C validator suite: 19 cases / 19 assertions / 0 fail (NEW)
- [x] Hook contract verified via WebFetch from `code.claude.com/docs/en/hooks` (PreToolUse JSON output schema, SessionEnd observability-only)
- [x] dual-verify pre-commit: critic PASS (0.95) + OMC code-reviewer (codex unavailable per #326, OMC fallback per S5/S6/S9 precedent). 2 HIGH addressed (hardcoded path → env+`__file__` resolver; `OSError` fail-open), 4 MEDIUM addressed (no-marker fail-open, timeout stderr surface, T16 redundant test, doc updates), 2 LOW addressed (trailing newline, JSON output format).
- [x] Synthetic-stdin harnesses; never touch real `~/.claude/`.
- [ ] Argus review pass
- [ ] Post-merge: deploy hooks to `~/.claude/hooks/` (separate operational step, gated on F.B 1-week soak passing)

Closes #331
Refs #315 (epic) #330 (F.B precondition) #259 (user-level governance pattern)