### PR TITLE
docs(lane-protocol): Path A — lane-level worktree isolation (#342)

### DIFF
--- a/.mercury/docs/guides/lane-naming.md
+++ b/.mercury/docs/guides/lane-naming.md
@@ -185,7 +185,7 @@ ls ~/.claude/projects/ | grep -i <expected-substring>
 
 When two lanes share the same cwd (e.g. both run from `D:/Mercury/Mercury`),
 they share the same project state dir, the same `MEMORY.md`, and the same
-`session-handoff*.md` set — and any SessionStart/SessionEnd hooks that
+`session-handoff[-<lane>].md` set — and any SessionStart/SessionEnd hooks that
 resolve project state from cwd read from the shared state.
 
 S13-side-multi-lane (2026-04-28) hit this empirically: a `main` lane
@@ -257,10 +257,14 @@ After opening a new lane (LANES.md section added, short name declared):
 > proceeding.
 
 ```bash
-# Recommended: create a fresh init branch off develop (avoids checkout collision)
-git worktree add -b lane/<short>/init <repo-root>/Mercury-<short> develop
+# Prerequisite: ensure origin/develop is current to avoid basing the new
+# worktree on a stale local branch (matches scripts/lane-spawn.sh convention)
+git fetch origin
+
+# Recommended: create a fresh init branch off origin/develop (avoids checkout collision)
+git worktree add -b lane/<short>/init <repo-root>/Mercury-<short> origin/develop
 # Mercury team example:
-# git worktree add -b lane/side-mlane/init D:/Mercury/Mercury-side-mlane develop
+# git worktree add -b lane/side-mlane/init D:/Mercury/Mercury-side-mlane origin/develop
 ```
 
 If you instead try `git worktree add <repo-root>/Mercury-<short> develop` and
@@ -268,7 +272,7 @@ If you instead try `git worktree add <repo-root>/Mercury-<short> develop` and
 git refuses with "fatal: 'develop' is already used by worktree at ..." per
 [git-worktree(1)](https://git-scm.com/docs/git-worktree) (a branch can only
 be checked out by one worktree at a time). The `-b lane/<short>/init` form
-above sidesteps the collision by creating a new branch from `develop`. The
+above sidesteps the collision by creating a new branch from `origin/develop`. The
 lane's actual work branches (Rule 2.1 short-prefix `lane/<short>/<N>-<slug>`)
 are created later inside the worktree; the `init` branch can be deleted
 once a real work branch exists.
@@ -292,8 +296,11 @@ your platform's encoding of `<repo-root>/Mercury-<short>`):
 - `~/.claude/projects/<encoded-cwd>/memory/MEMORY.md`
 - `~/.claude/projects/<encoded-cwd>/memory/SESSION_INDEX.md`
 - `~/.claude/projects/<encoded-cwd>/memory/sessions/`
-- `~/.claude/projects/<encoded-cwd>/memory/session-handoff*.md`
-- session transcripts at `~/.claude/projects/<encoded-cwd>/<session>.jsonl`
+- `~/.claude/projects/<encoded-cwd>/memory/session-handoff[-<lane>].md`
+- session transcripts under `~/.claude/projects/<encoded-cwd>/` (Claude Code
+  provides the exact `transcript_path` via the hook payload — see
+  [hooks reference](https://code.claude.com/docs/en/hooks); do not assume a
+  specific filename pattern)
 
 Hooks that resolve project state from cwd (e.g. Mercury's user-level
 SessionStart loader) start routing correctly without code change: SessionStart

--- a/.mercury/docs/guides/lane-naming.md
+++ b/.mercury/docs/guides/lane-naming.md
@@ -170,9 +170,21 @@ Sessions launched by Claude Code store per-project state under
 subdirectory name is derived from the cwd of the `claude` invocation; the
 exact slash-to-dash encoding (e.g. `D:\Mercury\Mercury` → `D--Mercury-Mercury`)
 is empirically observed in this repo and not a documented contract — verify
-the encoding for your platform before relying on a specific path. When two
-lanes share the same cwd (e.g. both run from `D:/Mercury/Mercury`), they
-share the same project state dir, the same `MEMORY.md`, and the same
+the encoding for your platform before relying on a specific path:
+
+```bash
+# Before opening a new lane worktree at <new-path>, check what dirname
+# Claude Code derives by listing existing project state dirs:
+ls ~/.claude/projects/ | head -20
+
+# After running `claude` once in the new worktree (any prompt is fine,
+# even just a no-op exit), list again to confirm the dirname for the
+# new cwd:
+ls ~/.claude/projects/ | grep -i <expected-substring>
+```
+
+When two lanes share the same cwd (e.g. both run from `D:/Mercury/Mercury`),
+they share the same project state dir, the same `MEMORY.md`, and the same
 `session-handoff*.md` set — and any SessionStart/SessionEnd hooks that
 resolve project state from cwd read from the shared state.
 
@@ -223,6 +235,15 @@ distinct `~/.claude/projects/D--Mercury-Mercury-<short>/` dir.
 
 After opening a new lane (LANES.md section added, short name declared):
 
+> **Safety**: `<short>` MUST already pass Rule 2.1 validation (lowercase
+> + digits + hyphen only, ≤8 chars, globally unique — see §Δ6 above).
+> The Rule 2.1 character class `[a-z0-9-]+` excludes path-traversal
+> sequences (`..`, `/`, `\`), shell metacharacters (`;`, `|`, `$`, backtick,
+> spaces), and quote characters — making string interpolation into the
+> commands below safe at the protocol level. Verify the `Short name` field
+> in your lane's LANES.md section matches `^[a-z0-9-]{1,8}$` before
+> proceeding.
+
 ```bash
 # Recommended: create a fresh init branch off develop (avoids checkout collision)
 git worktree add -b lane/<short>/init D:/Mercury/Mercury-<short> develop
@@ -272,10 +293,20 @@ only flips Status to `closed` + prunes `.tmp/lane-<lane>/` per Rule 3.2).
 Operators run worktree cleanup manually as part of the close ceremony:
 
 ```bash
+# Sanity-check the path resolves to the expected worktree before proceeding,
+# especially before the --force variant:
+git worktree list | grep -F "D:/Mercury/Mercury-<short>"
+
 git worktree remove D:/Mercury/Mercury-<short>
 # OR (if uncommitted state exists and is intentionally being discarded)
 git worktree remove --force D:/Mercury/Mercury-<short>
 ```
+
+`git worktree remove` operates on registered worktrees only (verifiable via
+`git worktree list`) — it cannot remove arbitrary filesystem paths even with
+`--force`, so the operation is bounded to the worktree set this repo knows
+about. Combined with the Rule 2.1 `<short>` validation above, the command
+shape is safe for protocol-conforming inputs.
 
 The `~/.claude/projects/D--Mercury-Mercury-<short>/` user-memory dir is
 preserved as audit trail; operators may archive it manually if no longer

--- a/.mercury/docs/guides/lane-naming.md
+++ b/.mercury/docs/guides/lane-naming.md
@@ -160,6 +160,144 @@ lanes, Rule X breach) requiring user arbitration".
 Operators opening cap-raise Issues use this label so the user can triage all
 protocol violations from one filter.
 
+## Lane workspace isolation via git worktree (v0.1 Delta 9, Issue [#342](https://github.com/392fyc/Mercury/issues/342))
+
+### Why lane-level isolation matters
+
+Sessions launched by Claude Code store per-project state under
+`~/.claude/projects/<project>/` (documented at
+<https://code.claude.com/docs/en/claude-directory>). The `<project>`
+subdirectory name is derived from the cwd of the `claude` invocation; the
+exact slash-to-dash encoding (e.g. `D:\Mercury\Mercury` → `D--Mercury-Mercury`)
+is empirically observed in this repo and not a documented contract — verify
+the encoding for your platform before relying on a specific path. When two
+lanes share the same cwd (e.g. both run from `D:/Mercury/Mercury`), they
+share the same project state dir, the same `MEMORY.md`, and the same
+`session-handoff*.md` set — and any SessionStart/SessionEnd hooks that
+resolve project state from cwd read from the shared state.
+
+S13-side-multi-lane (2026-04-28) hit this empirically: a `main` lane
+auto-handoff invocation spawned a new `claude` session in the shared cwd,
+SessionStart hook lane-blindly loaded the **side** lane's handoff (latest
+mtime), and the new session executed side-lane work content under the wrong
+lane identity. Work content was protocol-compliant on its own merits, but
+the routing was wrong — the lane that owned the work had no record of it
+running. See Issue [#342](https://github.com/392fyc/Mercury/issues/342) for
+the full forensic post-mortem.
+
+The fix: give each lane a dedicated git worktree at a distinct path so the
+cwd-encoded project state directory is also distinct.
+
+### Distinguished from task-level worktrees
+
+This § is about **lane-level** isolation (one worktree per active lane,
+long-lived). It is NOT the same scope as the **task-level** worktree spec in
+[`.mercury/docs/guides/worktree-workflow.md`](worktree-workflow.md), which
+covers `.worktrees/{taskId}` worktrees created by the `dev-pipeline` skill
+for a single dev task and removed at PR merge.
+
+| Scope | Path | Lifecycle | Purpose |
+|-------|------|-----------|---------|
+| **Lane-level** (this §) | `D:/Mercury/Mercury-<short>` (or OS-equivalent) | Per active lane; long-lived; removed at lane close | Isolate per-cwd Claude Code project state (MEMORY / handoff / transcripts) |
+| **Task-level** ([`worktree-workflow.md`](worktree-workflow.md)) | `.worktrees/{taskId}` | Per dev task; ephemeral; removed at PR merge | Isolate concurrent dev-pipeline branch checkouts |
+
+A side lane MAY use both: live in `D:/Mercury/Mercury-<short>` for its
+session-state isolation, AND have `dev-pipeline` create
+`.worktrees/{taskId}` inside that lane worktree for parallel dev tasks.
+
+### Worktree path convention
+
+| Lane | Worktree path | Notes |
+|------|---------------|-------|
+| `main` | `D:/Mercury/Mercury` (Windows; Unix example: `~/repos/mercury`) | Backward-compat default; the original repo checkout |
+| `<side>` | `D:/Mercury/Mercury-<short>` (Windows; Unix example: `~/repos/mercury-<short>`) | `<short>` = the lane's `Short name` field (≤8 char, per Δ6); pick any path on Unix that maps cleanly to its encoded `~/.claude/projects/` dirname |
+
+Example: `side-multi-lane` (short name `side-mlane`) →
+`D:/Mercury/Mercury-side-mlane`.
+
+The path lives outside the main checkout so that auto-handoff invocations
+launched from the lane's session can `cd` to a path that resolves to a
+distinct `~/.claude/projects/D--Mercury-Mercury-<short>/` dir.
+
+### Setup at lane open
+
+After opening a new lane (LANES.md section added, short name declared):
+
+```bash
+# Recommended: create a fresh init branch off develop (avoids checkout collision)
+git worktree add -b lane/<short>/init D:/Mercury/Mercury-<short> develop
+```
+
+If you instead try `git worktree add D:/Mercury/Mercury-<short> develop` and
+`develop` is already checked out in the main `D:/Mercury/Mercury` repo,
+git refuses with "fatal: 'develop' is already used by worktree at ..." per
+[git-worktree(1)](https://git-scm.com/docs/git-worktree) (a branch can only
+be checked out by one worktree at a time). The `-b lane/<short>/init` form
+above sidesteps the collision by creating a new branch from `develop`. The
+lane's actual work branches (Rule 2.1 short-prefix `lane/<short>/<N>-<slug>`)
+are created later inside the worktree; the `init` branch can be deleted
+once a real work branch exists.
+
+### Operational expectation
+
+Side-lane sessions launch with the worktree as cwd:
+
+```bash
+cd D:/Mercury/Mercury-<short>
+claude  # SessionStart hook now reads from ~/.claude/projects/D--Mercury-Mercury-<short>/
+```
+
+This makes the per-cwd project state dir distinct from the main lane's,
+which gives each lane its own:
+
+- `~/.claude/projects/D--Mercury-Mercury-<short>/memory/MEMORY.md`
+- `~/.claude/projects/D--Mercury-Mercury-<short>/memory/SESSION_INDEX.md`
+- `~/.claude/projects/D--Mercury-Mercury-<short>/memory/sessions/`
+- `~/.claude/projects/D--Mercury-Mercury-<short>/memory/session-handoff*.md`
+- session transcripts at `~/.claude/projects/D--Mercury-Mercury-<short>/<session>.jsonl`
+
+Hooks that resolve project state from cwd (e.g. Mercury's user-level
+SessionStart loader) start routing correctly without code change: SessionStart
+input includes a `cwd` field
+([documented](https://code.claude.com/docs/en/hooks)), and the hook can
+resolve the corresponding `~/.claude/projects/<project>/` dir from it. Hooks
+that hard-code a project path or use other resolution strategies are
+unaffected by this isolation; verify your specific hook before relying on
+auto-routing.
+
+### Cleanup at lane close
+
+`scripts/lane-close.sh` does **not** currently remove the lane worktree (it
+only flips Status to `closed` + prunes `.tmp/lane-<lane>/` per Rule 3.2).
+Operators run worktree cleanup manually as part of the close ceremony:
+
+```bash
+git worktree remove D:/Mercury/Mercury-<short>
+# OR (if uncommitted state exists and is intentionally being discarded)
+git worktree remove --force D:/Mercury/Mercury-<short>
+```
+
+The `~/.claude/projects/D--Mercury-Mercury-<short>/` user-memory dir is
+preserved as audit trail; operators may archive it manually if no longer
+needed.
+
+### Backward compatibility
+
+- `main` lane keeps `D:/Mercury/Mercury` as its worktree path — no
+  migration needed for existing main-lane workflows.
+- Side lanes that opened before Δ9 ran in the shared cwd; this is a known
+  routing-bleed risk per Issue #342. Migration is per-lane operator decision
+  at next lane-active session.
+
+### Cross-references
+
+- `feedback_lane_protocol.md` Rule 5.1 (sub-rule of Rule 5: Per-lane state
+  separation) formalizes the worktree path convention as protocol
+- `LANES.md` Governance §Lane workspace isolation declares each lane MUST
+  state its `Worktree path` field
+- `.mercury/docs/guides/worktree-workflow.md` covers the orthogonal
+  task-level worktree scope
+
 ## Tests
 
 ```bash
@@ -183,3 +321,8 @@ Tests do NOT touch real GitHub or LANES.md — synthetic fixtures only.
 - [Miller's Law (Laws of UX)](https://lawsofux.com/millers-law/)
 - [Towards a science of scaling agent systems (Google research)](https://research.google/blog/towards-a-science-of-scaling-agent-systems-when-and-why-agent-systems-work/)
 - [Working with WIP limits for Kanban (Atlassian)](https://www.atlassian.com/agile/kanban/wip-limits)
+- Issue [#342](https://github.com/392fyc/Mercury/issues/342) — Δ9 lane-level worktree isolation acceptance criteria + S13 routing-bleed forensic record
+- [Claude Code .claude directory reference](https://code.claude.com/docs/en/claude-directory) — per-project `~/.claude/projects/<project>/` state dir
+- [Claude Code hooks reference](https://code.claude.com/docs/en/hooks) — SessionStart `cwd` JSON field
+- [Windows Terminal command line arguments](https://learn.microsoft.com/en-us/windows/terminal/command-line-arguments) — `new-tab -d <directory>` per-tab starting directory
+- [git-worktree(1)](https://git-scm.com/docs/git-worktree) — multiple working trees from a single repo

--- a/.mercury/docs/guides/lane-naming.md
+++ b/.mercury/docs/guides/lane-naming.md
@@ -200,6 +200,16 @@ the full forensic post-mortem.
 The fix: give each lane a dedicated git worktree at a distinct path so the
 cwd-encoded project state directory is also distinct.
 
+> **Path notation in this §**: examples use `<repo-root>` as a placeholder
+> for the parent directory operators put their Mercury checkouts under
+> (e.g. Mercury team's documented value is `D:/Mercury` per
+> [`CLAUDE.md`](../../CLAUDE.md) §MUST "Install software to `D:\Program Files`,
+> not C drive"; on Unix this might be `~/repos`). Concrete `D:/Mercury/...`
+> paths shown later are the team's actual values; substitute your own
+> `<repo-root>` when reading. The lane protocol does not impose `D:/Mercury`
+> on other operators — only that each lane's `Worktree path` field in
+> `LANES.md` records whatever concrete path that operator chose.
+
 ### Distinguished from task-level worktrees
 
 This § is about **lane-level** isolation (one worktree per active lane,
@@ -210,10 +220,10 @@ for a single dev task and removed at PR merge.
 
 | Scope | Path | Lifecycle | Purpose |
 |-------|------|-----------|---------|
-| **Lane-level** (this §) | `D:/Mercury/Mercury-<short>` (or OS-equivalent) | Per active lane; long-lived; removed at lane close | Isolate per-cwd Claude Code project state (MEMORY / handoff / transcripts) |
-| **Task-level** ([`worktree-workflow.md`](worktree-workflow.md)) | `.worktrees/{taskId}` | Per dev task; ephemeral; removed at PR merge | Isolate concurrent dev-pipeline branch checkouts |
+| **Lane-level** (this §) | `<repo-root>/Mercury-<short>` | Per active lane; long-lived; removed at lane close | Isolate per-cwd Claude Code project state (MEMORY / handoff / transcripts) |
+| **Task-level** ([`worktree-workflow.md`](worktree-workflow.md)) | `<repo-root>/Mercury/.worktrees/{taskId}` | Per dev task; ephemeral; removed at PR merge | Isolate concurrent dev-pipeline branch checkouts |
 
-A side lane MAY use both: live in `D:/Mercury/Mercury-<short>` for its
+A side lane MAY use both: live in `<repo-root>/Mercury-<short>` for its
 session-state isolation, AND have `dev-pipeline` create
 `.worktrees/{taskId}` inside that lane worktree for parallel dev tasks.
 
@@ -221,15 +231,17 @@ session-state isolation, AND have `dev-pipeline` create
 
 | Lane | Worktree path | Notes |
 |------|---------------|-------|
-| `main` | `D:/Mercury/Mercury` (Windows; Unix example: `~/repos/mercury`) | Backward-compat default; the original repo checkout |
-| `<side>` | `D:/Mercury/Mercury-<short>` (Windows; Unix example: `~/repos/mercury-<short>`) | `<short>` = the lane's `Short name` field (≤8 char, per Δ6); pick any path on Unix that maps cleanly to its encoded `~/.claude/projects/` dirname |
+| `main` | `<repo-root>/Mercury` (Mercury team value: `D:/Mercury/Mercury`) | Backward-compat default; the original repo checkout |
+| `<side>` | `<repo-root>/Mercury-<short>` (Mercury team value: `D:/Mercury/Mercury-<short>`) | `<short>` = the lane's `Short name` field (≤8 char, per Δ6); the operator's own `<repo-root>` choice — record concrete value in own LANES.md `Worktree path` field per Rule 5.1 |
 
 Example: `side-multi-lane` (short name `side-mlane`) →
-`D:/Mercury/Mercury-side-mlane`.
+`<repo-root>/Mercury-side-mlane` (Mercury team value:
+`D:/Mercury/Mercury-side-mlane`).
 
 The path lives outside the main checkout so that auto-handoff invocations
 launched from the lane's session can `cd` to a path that resolves to a
-distinct `~/.claude/projects/D--Mercury-Mercury-<short>/` dir.
+distinct `~/.claude/projects/<encoded-cwd>/` dir (Mercury team value:
+`~/.claude/projects/D--Mercury-Mercury-<short>/`).
 
 ### Setup at lane open
 
@@ -246,11 +258,13 @@ After opening a new lane (LANES.md section added, short name declared):
 
 ```bash
 # Recommended: create a fresh init branch off develop (avoids checkout collision)
-git worktree add -b lane/<short>/init D:/Mercury/Mercury-<short> develop
+git worktree add -b lane/<short>/init <repo-root>/Mercury-<short> develop
+# Mercury team example:
+# git worktree add -b lane/side-mlane/init D:/Mercury/Mercury-side-mlane develop
 ```
 
-If you instead try `git worktree add D:/Mercury/Mercury-<short> develop` and
-`develop` is already checked out in the main `D:/Mercury/Mercury` repo,
+If you instead try `git worktree add <repo-root>/Mercury-<short> develop` and
+`develop` is already checked out in the main `<repo-root>/Mercury` repo,
 git refuses with "fatal: 'develop' is already used by worktree at ..." per
 [git-worktree(1)](https://git-scm.com/docs/git-worktree) (a branch can only
 be checked out by one worktree at a time). The `-b lane/<short>/init` form
@@ -264,18 +278,22 @@ once a real work branch exists.
 Side-lane sessions launch with the worktree as cwd:
 
 ```bash
-cd D:/Mercury/Mercury-<short>
-claude  # SessionStart hook now reads from ~/.claude/projects/D--Mercury-Mercury-<short>/
+cd <repo-root>/Mercury-<short>
+claude  # SessionStart hook now reads from ~/.claude/projects/<encoded-cwd>/
+# Mercury team example:
+# cd D:/Mercury/Mercury-side-mlane && claude
+# → ~/.claude/projects/D--Mercury-Mercury-side-mlane/
 ```
 
 This makes the per-cwd project state dir distinct from the main lane's,
-which gives each lane its own:
+which gives each lane its own (paths shown with `<encoded-cwd>` =
+your platform's encoding of `<repo-root>/Mercury-<short>`):
 
-- `~/.claude/projects/D--Mercury-Mercury-<short>/memory/MEMORY.md`
-- `~/.claude/projects/D--Mercury-Mercury-<short>/memory/SESSION_INDEX.md`
-- `~/.claude/projects/D--Mercury-Mercury-<short>/memory/sessions/`
-- `~/.claude/projects/D--Mercury-Mercury-<short>/memory/session-handoff*.md`
-- session transcripts at `~/.claude/projects/D--Mercury-Mercury-<short>/<session>.jsonl`
+- `~/.claude/projects/<encoded-cwd>/memory/MEMORY.md`
+- `~/.claude/projects/<encoded-cwd>/memory/SESSION_INDEX.md`
+- `~/.claude/projects/<encoded-cwd>/memory/sessions/`
+- `~/.claude/projects/<encoded-cwd>/memory/session-handoff*.md`
+- session transcripts at `~/.claude/projects/<encoded-cwd>/<session>.jsonl`
 
 Hooks that resolve project state from cwd (e.g. Mercury's user-level
 SessionStart loader) start routing correctly without code change: SessionStart
@@ -295,11 +313,15 @@ Operators run worktree cleanup manually as part of the close ceremony:
 ```bash
 # Sanity-check the path resolves to the expected worktree before proceeding,
 # especially before the --force variant:
-git worktree list | grep -F "D:/Mercury/Mercury-<short>"
+git worktree list | grep -F "<repo-root>/Mercury-<short>"
 
-git worktree remove D:/Mercury/Mercury-<short>
+git worktree remove <repo-root>/Mercury-<short>
 # OR (if uncommitted state exists and is intentionally being discarded)
-git worktree remove --force D:/Mercury/Mercury-<short>
+git worktree remove --force <repo-root>/Mercury-<short>
+
+# Mercury team example:
+# git worktree list | grep -F "D:/Mercury/Mercury-side-mlane"
+# git worktree remove D:/Mercury/Mercury-side-mlane
 ```
 
 `git worktree remove` operates on registered worktrees only (verifiable via
@@ -308,14 +330,14 @@ git worktree remove --force D:/Mercury/Mercury-<short>
 about. Combined with the Rule 2.1 `<short>` validation above, the command
 shape is safe for protocol-conforming inputs.
 
-The `~/.claude/projects/D--Mercury-Mercury-<short>/` user-memory dir is
-preserved as audit trail; operators may archive it manually if no longer
-needed.
+The `~/.claude/projects/<encoded-cwd>/` user-memory dir is preserved as
+audit trail; operators may archive it manually if no longer needed.
 
 ### Backward compatibility
 
-- `main` lane keeps `D:/Mercury/Mercury` as its worktree path — no
-  migration needed for existing main-lane workflows.
+- `main` lane keeps `<repo-root>/Mercury` as its worktree path (Mercury
+  team value: `D:/Mercury/Mercury`) — no migration needed for existing
+  main-lane workflows.
 - Side lanes that opened before Δ9 ran in the shared cwd; this is a known
   routing-bleed risk per Issue #342. Migration is per-lane operator decision
   at next lane-active session.


### PR DESCRIPTION
## Summary

- Adds new top-level § **"Lane workspace isolation via git worktree"** to `.mercury/docs/guides/lane-naming.md` as v0.1 Delta 9 implementation per Issue #342 (lane routing harness bug)
- Documents the worktree-per-lane convention (`D:/Mercury/Mercury-<short>` or OS-equivalent) that prevents the S13-side-multi-lane routing-bleed failure mode (2026-04-28)
- Companion user-memory edits: `feedback_lane_protocol.md` Rule 5.1 + `LANES.md` §Lane workspace isolation governance subsection + side-multi-lane § `Worktree path` field + F.B soak day 7 ledger row (not in repo — listed below for reviewer transparency)

## Background

Issue #342 forensic post-mortem: a `main` lane auto-handoff invocation spawned a new `claude` session in the shared `D:/Mercury/Mercury` cwd; SessionStart hook lane-blindly loaded the **side** lane's handoff (latest mtime); the new session executed S13-side-multi-lane work content under the wrong lane identity. Work content was protocol-compliant on its own merits — the routing was wrong.

User verdict 2026-04-29: 路径 A (worktree-per-lane physical isolation) + 路径 C (软兜底 agent assertion). This PR implements **path A docs** (the doc landing for the protocol convention). Path C agent assertion + handoff skill `/handoff:auto` `cd <worktree>` wrapper deferred to main lane unfreeze (cross-lane impact).

## Scope per S82 audit (2026-04-30)

All changes within side lane **Rule 8 v0.2 lane lifecycle autonomy**:
- `lane-naming.md` is side lane S5 own work (PR #328)
- `feedback_lane_protocol.md` sub-rules 1.1/2.1/3.1/3.2/4.1/7.A/7.B all added by side lane
- `LANES.md` own-section field additions + governance subsection in Rule 6 boundary

Cross-lane impact items (handoff skill wrapper + path C agent assertion) explicitly deferred to main lane unfreeze.

## In-repo changes (this PR)

- `.mercury/docs/guides/lane-naming.md` (+143 LOC, 0 deletions): new § "Lane workspace isolation via git worktree" between Δ7 HARD-CAP § and Tests §; appends Issue #342 + 4 web-verified source URLs to existing Source references §

## User-memory companion changes (not in repo, reviewer transparency)

**File**: `~/.claude/projects/D--Mercury-Mercury/memory/feedback_lane_protocol.md`
- Adds Rule 5.1 sub-rule (peer to 1.1/2.1/3.1/3.2/4.1/7.A/7.B): \"Side lanes SHOULD use a dedicated git worktree at \`D:/Mercury/Mercury-<short-name>\` ...\"

**File**: `~/.claude/projects/D--Mercury-Mercury/memory/LANES.md`
- New Governance subsection \"Lane workspace isolation\" (peer to Branch naming / Capacity limit / Memory index governance)
- side-multi-lane § \`Worktree path\` field updated from \"TBD\" to \`D:/Mercury/Mercury-side-mlane\`
- F.B soak day 7 ledger row replaced forward gate placeholder with actual S15 PASS row — **session-count gate 7/7 ✅ CLOSED**

## Web research verification

All URLs cited in the new § were verified before writing per Mercury MUST web-research protocol:
- <https://code.claude.com/docs/en/claude-directory> — `~/.claude/projects/<project>/` per-project state dir
- <https://code.claude.com/docs/en/hooks> — SessionStart hook receives `cwd` JSON field
- <https://learn.microsoft.com/en-us/windows/terminal/command-line-arguments> — `wt new-tab -d` per-tab cwd; per-tab env var injection NOT supported
- <https://git-scm.com/docs/git-worktree> — multiple working trees from a single repo

The cwd-to-dirname encoding scheme (e.g. `D:\Mercury\Mercury` → `D--Mercury-Mercury`) is **empirically observed in this repo and not a documented contract** — explicitly noted in the doc.

## Dual-verify pre-commit (per Mercury MUST)

Codex async dual-verify still broken per #326; OMC `oh-my-claudecode:code-reviewer` fallback used as the 5th cross-iter occurrence (S5 #328 / S6 #332 / S9 #340 / S10 #341 / S15 this PR).

- **Critic**: PASS, 14/14 acceptance criteria verified with file:line citations
- **OMC code-reviewer**: APPROVE, 0 HIGH / 3 MEDIUM / 5 LOW-NIT

3 MEDIUM findings addressed pre-commit:
- MED #1: softened `claude-directory` citation — encoding scheme marked as empirical
- MED #2: softened SessionStart `cwd` semantics — \"hooks that resolve project state from cwd\" qualifier added (not universal)
- MED #3: added `git worktree add` checkout-collision warning + recommended `-b lane/<short>/init` form

LOW #4 verified accurate via Issue #342 body (\"S13-side-multi-lane work content\"); LOW #5 verified `.worktrees/{taskId}` matches `worktree-workflow.md`; LOW #6 softened Unix path to \"example\". NIT #7 dropped duplicate §Web-verified citations (URLs in inline body + bottom Source references). NIT #8 anchor links left for Argus iter.

## F.B soak day 7 (independent of this PR but reported here for completeness)

```bash
bash scripts/regenerate-memory-index.sh --in-place
# → exit 0, 81 sessions written
bash scripts/regenerate-memory-index.sh --format diff
# → exit 0, \"no drift\"
```

**F.B 1-week soak session-count gate 7/7 ✅ CLOSED at S15 (2026-05-03)**. Calendar gate 2026-05-05 (2 days remaining); F.C user-level hook deploy unlocks at calendar gate AND #342 routing fix landed (this PR).

## Test plan

- [x] `bash scripts/test-lane-cap-check.sh` → 37/37 PASS (no regression — doc-only change)
- [x] `git diff --stat` shows only `.mercury/docs/guides/lane-naming.md` modified (+143 -0)
- [x] No edits to `.mercury/docs/DIRECTION.md` / `.mercury/docs/EXECUTION-PLAN.md` (Rule 4 red line)
- [x] No edits to other lanes' LANES.md sections or main-lane handoff (Rule 6 boundary preserved)
- [x] Doc cross-references resolve: Rule 5.1 → lane-naming.md §, lane-naming.md §Cross-references → Rule 5.1 + LANES.md governance, LANES.md governance → lane-naming.md §
- [x] Web-verified citations re-checked at write time

## Post-merge actions

- Tag `lane-protocol-v0.1-path-a-landed` @ merge SHA pushed to origin (forensic anchor for routing fix)
- Issue #342 auto-closes via `Closes #342` keyword
- **Main lane unfreeze trigger fires** — main lane may resume auto-handoff at user discretion
- Physical worktree migration of side-multi-lane to `D:/Mercury/Mercury-side-mlane` deferred to S16+ as actual dogfood

Closes #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)