### PR TITLE
feat(lane-protocol): /handoff:auto worktree integration + Path C lane-assertion (#345)

### DIFF
--- a/.claude/skills/handoff/SKILL.md
+++ b/.claude/skills/handoff/SKILL.md
@@ -283,103 +283,141 @@ Optional: offer to launch if the user later says so (Step 6).
 
 After Step 5.1 + 5.2, and Pre-Termination Checklist passed:
 
-**Required launch pattern — write prompt to a locked-down temp file, then
-pass via `claude "$(cat ...)"` as a single positional argument.** This
-matches the canonical `claude-handoff` plugin shape
-(<https://github.com/392fyc/claude-handoff>) which has been validated
-end-to-end on Windows (wt + PowerShell profile). Do NOT insert a `--`
-sentinel between `claude` and the prompt — on Windows, `wt` spawns
-`claude.cmd` (npm shim) directly via CreateProcess; cmd.exe's batch
-re-parser can mis-handle the extra `--`, causing the new tab to open
-with no running process. Handoff prompts always start with literal text
-(e.g. `这是 S{N+1}`), never with `-`, so the `--` sentinel is unnecessary.
+**Required launch pattern — use a SHORT reference prompt, never inline the
+full handoff content into the command line.** The SessionStart hook already
+injects the full handoff document as `additionalContext`, so the new session
+receives everything automatically. Inlining multi-line/multi-KB content into
+`wt`/`tmux`/shell commands causes catastrophic failures on Windows
+(multi-line expansion breaks argument parsing → error 0x80070002, multiple
+ghost terminal windows; see `feedback_handoff_short_prompt_only.md` —
+S3-side-multi-lane 2026-04-26 forensic record).
 
-**Prerequisites**: auto-mode launch assumes a POSIX-like shell (`mktemp`,
-`chmod`, `cat`, heredoc). On Windows this means **Git Bash / MSYS2 / WSL**
-(which Mercury uses) — native `cmd.exe` and non-interactive PowerShell do
-**not** satisfy this. If the host shell is not POSIX-compatible, fall back
-to manual mode or use the PowerShell equivalent shown further below.
+**SHORT_PROMPT contract (Δ11 — Path C lane assertion)**:
 
-**Command-line length**: `claude` receives the prompt as a single positional
-argument, which is subject to OS argv limits (Windows `CreateProcess` ≈
-32 KB, Linux/macOS 128 KB+). Typical handoff prompts (~1–3 KB) are well
-under any limit. For abnormally large prompts (> 30 KB on Windows), pipe
-the file to `claude` via stdin or split the prompt into a separate
-`--input-file`-style mechanism (check `claude --help` on the installed
-version; stdin support is documented at
-<https://code.claude.com/docs/en/cli-reference>).
+The prompt MUST start with a `[LANE=<name>]` marker as its first
+whitespace-delimited token. The new session's startup checks (via
+`scripts/lane-assertion.sh`) verify three-way alignment between this marker,
+the cwd-encoded project state dir, and the current git branch prefix. If
+the marker is missing or any pair disagrees, the assertion fails fast and
+guides recovery — preventing the share-cwd routing-bleed failure mode
+(Issue #342, S13-side-multi-lane forensic record).
 
 ```bash
-# Step A (POSIX shells — Git Bash, WSL, macOS, Linux):
-# Create temp file, register cleanup BEFORE writing sensitive content, then write.
-# Ordering rationale: if any later step (chmod, heredoc, launch) fails or is
-# interrupted, the EXIT trap still fires and removes the file. Registering the
-# trap after the write would leave a window where a crash leaks handoff content.
-TMP=$(mktemp) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-trap 'rm -f "$TMP"' EXIT
-chmod 600 "$TMP" || { echo "ERROR: chmod failed" >&2; exit 1; }
-cat > "$TMP" <<'PROMPT_EOF'
-<STARTING_PROMPT_VERBATIM>
-PROMPT_EOF
+# Resolve the active lane:
+#   - main lane handoff file    → lane=main
+#   - lane-suffixed handoff file → lane=<suffix> (after first hyphen)
+HANDOFF_BASENAME=$(basename "$HANDOFF_PATH" .md)
+case "$HANDOFF_BASENAME" in
+  session-handoff)             LANE_NAME="main" ;;
+  session-handoff-*)           LANE_NAME="${HANDOFF_BASENAME#session-handoff-}" ;;
+  *)                           echo "ERROR: unrecognised handoff filename: $HANDOFF_BASENAME" >&2; exit 1 ;;
+esac
+
+# Resolve the worktree path from LANES.md (Rule 5.1, Issue #342).
+# This is the cwd that wt/tmux must launch the new session at — its
+# encoding determines ~/.claude/projects/<encoded>/ project state dir.
+LANES_FILE="${MERCURY_MEMORY_DIR:-${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/D--Mercury-Mercury/memory}/LANES.md"
+WORKTREE_PATH_RAW=$(awk -v lane="$LANE_NAME" '
+BEGIN { in_section=0; in_fence=0 }
+/^```/ { in_fence = !in_fence; next }
+in_fence { next }
+/^### `[^`]+`/ {
+  match($0, /^### `[^`]+`/)
+  hdr=substr($0, RSTART+5, RLENGTH-6)
+  in_section=(hdr == lane) ? 1 : 0
+  next
+}
+in_section && /\*\*Worktree path\*\*/ {
+  s=$0
+  i=index(s, "**Worktree path**"); s=substr(s, i+length("**Worktree path**"))
+  if (substr(s, 1, 2) == " (") { e=index(s, ")"); if (e > 0) s=substr(s, e+1) }
+  c=index(s, ":"); if (c == 0) next
+  s=substr(s, c+1); sub(/^[[:space:]]+/, "", s)
+  if (substr(s, 1, 1) == "`") {
+    # Backtick-quoted (canonical) — preserves paths with spaces, but trims
+    # trailing whitespace inside the quoted region to defang invisible typos.
+    s=substr(s, 2); bt=index(s, "`")
+    if (bt > 0) { out=substr(s, 1, bt-1); sub(/[[:space:]]+$/, "", out); if (out != "") print out }
+  } else {
+    sub(/[[:space:]]+$/, "", s); if (s != "") print s
+  }
+}
+' "$LANES_FILE")
+if [ -z "$WORKTREE_PATH_RAW" ]; then
+  echo "ERROR: lane '$LANE_NAME' has no Worktree path field in $LANES_FILE" >&2
+  echo "       Add it per feedback_lane_protocol.md Rule 5.1 before auto-handoff." >&2
+  exit 1
+fi
+# Reject duplicate Worktree path bullets — first-wins would silently route
+# to a stale value.
+WORKTREE_COUNT=$(printf '%s\n' "$WORKTREE_PATH_RAW" | grep -c '^.')
+if [ "$WORKTREE_COUNT" -gt 1 ]; then
+  echo "ERROR: lane '$LANE_NAME' has $WORKTREE_COUNT Worktree path bullets in $LANES_FILE" >&2
+  echo "       Edit the lane section to keep exactly one before auto-handoff." >&2
+  exit 1
+fi
+WORKTREE_PATH="$WORKTREE_PATH_RAW"
+
+SHORT_PROMPT="[LANE=${LANE_NAME}] Continue from session handoff. The SessionStart hook injects the full document. Fallback: read ${HANDOFF_PATH}"
 ```
 
-```powershell
-# Step A (PowerShell on Windows, if no Git Bash):
-# Register cleanup via try/finally around the launch (see Step B below).
-$TMP = [System.IO.Path]::GetTempFileName()
-Set-Content -LiteralPath $TMP -Value @'
-<STARTING_PROMPT_VERBATIM>
-'@
-# PowerShell $TMP permissions default to user-only on NTFS.
-```
+`<encoded_cwd>` for the handoff doc path uses the same `encode_project_path()`
+logic referenced earlier (`:` `\` `/` → `-`, strip leading `-`).
 
-**Windows** (Windows Terminal, new tab — `wt` opens a real new tab):
+**SHORT_PROMPT must remain free of `wt`/`tmux` metacharacters** —
+`;` (command separator), `&` (background), `|` (pipe), `\` outside quotes,
+`$()` (command substitution). The `[LANE=<name>]` marker only contains
+`[a-z0-9-]+` per Rule 2.1 + the literal `[`/`]`/`=` brackets, none of which
+are `wt`/`tmux` metacharacters. The lane name is read from LANES.md (which
+the protocol governs), so injection via crafted lane names is bounded by
+Rule 2.1 + Rule 6 (lane sections only edited by their owning lane).
+
+**Pre-launch alignment smoke check (recommended)**:
+
+If `scripts/lane-assertion.sh` is present in the repo, run it once with the
+SHORT_PROMPT as input — it verifies the marker resolves and Worktree path
+extraction works before spawning a process you may have to clean up:
+
 ```bash
-wt -w 0 nt --title "Handoff" -- claude "$(cat "$TMP")"
+if [ -x scripts/lane-assertion.sh ]; then
+  if ! BOOTSTRAP_PROMPT="$SHORT_PROMPT" bash scripts/lane-assertion.sh \
+       --cwd "$WORKTREE_PATH" --branch "$(git -C "$WORKTREE_PATH" branch --show-current 2>/dev/null || echo develop)"; then
+    echo "ERROR: lane-assertion pre-flight failed — refusing to spawn" >&2
+    exit 1
+  fi
+fi
+```
+
+(Soft-disable via `MERCURY_LANE_ASSERT_DISABLED=1` if break-glass.)
+
+**Windows** (Windows Terminal, new tab):
+```bash
+wt -w 0 nt --title "Handoff: $LANE_NAME" -d "$WORKTREE_PATH" -- claude -- "$SHORT_PROMPT"
 ```
 
 **macOS / Linux with tmux** (real new window, detached from current TTY):
 ```bash
-tmux new-window -n handoff "claude \"\$(cat \"$TMP\")\""
+tmux new-window -n handoff -c "$WORKTREE_PATH" "claude -- '$SHORT_PROMPT'"
 ```
 
 **macOS / Linux without tmux** — there is no portable "new terminal"
-primitive. `claude "..." &` only backgrounds the process in the **current
-shell**; it will inherit the current TTY and die when the shell exits or
-the tab is closed. If you need real isolation, use `tmux new-session -d`
-or the terminal emulator's own CLI (e.g. `osascript -e 'tell app
-"Terminal" to do script ...'` on macOS, `gnome-terminal --` on Linux).
-Otherwise fall back to manual mode and let the user open the new session
-themselves.
+primitive. Use `tmux new-session -d` or the terminal emulator's own CLI
+(`osascript -e 'tell app "Terminal" to do script ...'` on macOS,
+`gnome-terminal --` on Linux). Otherwise fall back to manual mode.
 
 ```bash
-# Detached tmux session (survives current shell exit):
-tmux new-session -d -s handoff "claude \"\$(cat \"$TMP\")\""
-# Then `tmux attach -t handoff` from the user's preferred terminal.
+tmux new-session -d -s handoff -c "$WORKTREE_PATH" "claude -- '$SHORT_PROMPT'"
 ```
 
-The positional argument to `claude` is the session's first user message —
-documented at <https://code.claude.com/docs/en/cli-reference>. The
-SessionStart hook will inject the full handoff document as
-`additionalContext`, so the new session has everything.
-
-**Cleanup**:
-
-On POSIX shells the `trap 'rm -f "$TMP"' EXIT` is already registered in
-Step A above, immediately after `mktemp` — it fires on the shell's EXIT
-regardless of whether the launch command succeeded, failed, or was
-interrupted. No additional cleanup code is needed here.
-
-On PowerShell, wrap the launch in try/finally so the temp file is removed
-even if the launch throws:
-
-```powershell
-# PowerShell: register cleanup around the launch.
-try { <launch command> } finally { Remove-Item -LiteralPath $TMP -Force -ErrorAction SilentlyContinue }
-```
-
-This guarantees the handoff prompt (which may reference internal paths
-or planning context) never persists on disk past the launch moment.
+The positional argument after `--` is the session's first user message —
+documented at <https://code.claude.com/docs/en/cli-reference>. The `--`
+sentinel ensures a prompt beginning with `-` is not parsed as a CLI option
+(<https://github.com/anthropics/claude-code/issues/3844>) — and the
+`[LANE=...]` marker starts with `[` so the sentinel is also defensive
+against any future SHORT_PROMPT variants. The `-d "$WORKTREE_PATH"` flag
+(wt) / `-c "$WORKTREE_PATH"` flag (tmux) sets the new tab's cwd to the
+lane's worktree, so `~/.claude/projects/<encoded>/` resolves to the
+lane-specific state dir per Rule 5.1.
 
 After spawning the new process, do NOT continue producing output in the old
 session. The old session's job is done. Advise user to `/exit` (or close
@@ -412,3 +450,11 @@ the auto path from Step 5 (auto mode).
   DEPRECATED. Do not invoke it. The `claude-handoff` plugin is the
   canonical session-continuity module
   (<https://github.com/392fyc/claude-handoff>).
+- **Δ10/Δ11 (Issue #345)** — auto-mode SHORT_PROMPT MUST start with
+  `[LANE=<name>]` marker, and `wt -d` / `tmux -c` MUST be set to the
+  lane's `Worktree path` field from `LANES.md` (Rule 5.1). The new
+  session's `scripts/lane-assertion.sh` validates three-way alignment
+  (marker × cwd-encoded × branch prefix) at startup. Soft-disable via
+  `MERCURY_LANE_ASSERT_DISABLED=1`. See
+  `.mercury/docs/guides/lane-naming.md` §Lane workspace isolation
+  Δ10/Δ11 sub-sections for the full contract.

--- a/.claude/skills/handoff/SKILL.md
+++ b/.claude/skills/handoff/SKILL.md
@@ -390,14 +390,22 @@ fi
 
 (Soft-disable via `MERCURY_LANE_ASSERT_DISABLED=1` if break-glass.)
 
-**Windows** (Windows Terminal, new tab):
+**Windows** (Windows Terminal, new tab) — `wt`'s `-- ...` passes argv
+directly to `CreateProcess`, so the prompt is one argv element with no
+shell re-parse; no extra quoting needed:
 ```bash
 wt -w 0 nt --title "Handoff: $LANE_NAME" -d "$WORKTREE_PATH" -- claude -- "$SHORT_PROMPT"
 ```
 
-**macOS / Linux with tmux** (real new window, detached from current TTY):
+**macOS / Linux with tmux** (real new window, detached from current TTY) —
+`tmux new-window <cmd>` evaluates `<cmd>` via `/bin/sh -c`, so the prompt
+must be safely shell-quoted before embedding. `printf %q` produces a
+bash-portable shell-safe representation that survives even if the prompt
+contains single quotes, dollar signs, or other metacharacters (Argus iter1
+Minor #346: previous naked single-quote wrap was injection-vulnerable):
 ```bash
-tmux new-window -n handoff -c "$WORKTREE_PATH" "claude -- '$SHORT_PROMPT'"
+SHORT_PROMPT_QUOTED=$(printf '%q' "$SHORT_PROMPT")
+tmux new-window -n handoff -c "$WORKTREE_PATH" "claude -- $SHORT_PROMPT_QUOTED"
 ```
 
 **macOS / Linux without tmux** — there is no portable "new terminal"
@@ -406,7 +414,8 @@ primitive. Use `tmux new-session -d` or the terminal emulator's own CLI
 `gnome-terminal --` on Linux). Otherwise fall back to manual mode.
 
 ```bash
-tmux new-session -d -s handoff -c "$WORKTREE_PATH" "claude -- '$SHORT_PROMPT'"
+SHORT_PROMPT_QUOTED=$(printf '%q' "$SHORT_PROMPT")
+tmux new-session -d -s handoff -c "$WORKTREE_PATH" "claude -- $SHORT_PROMPT_QUOTED"
 ```
 
 The positional argument after `--` is the session's first user message —

--- a/.claude/skills/handoff/SKILL.md
+++ b/.claude/skills/handoff/SKILL.md
@@ -398,14 +398,17 @@ wt -w 0 nt --title "Handoff: $LANE_NAME" -d "$WORKTREE_PATH" -- claude -- "$SHOR
 ```
 
 **macOS / Linux with tmux** (real new window, detached from current TTY) —
-`tmux new-window <cmd>` evaluates `<cmd>` via `/bin/sh -c`, so the prompt
-must be safely shell-quoted before embedding. `printf %q` produces a
-bash-portable shell-safe representation that survives even if the prompt
-contains single quotes, dollar signs, or other metacharacters (Argus iter1
-Minor #346: previous naked single-quote wrap was injection-vulnerable):
+`tmux new-window <cmd>` runs `<cmd>` via `/bin/sh -c`. Bash's `printf %q`
+can emit `$'...'` ANSI-C quoting for some inputs, which is a bash extension
+not recognized by POSIX sh (dash on Debian/Ubuntu, busybox sh) — so we
+explicitly route through `bash -c` to ensure the quoted form is parsed by
+bash regardless of what `/bin/sh` resolves to. The outer `sh` only sees a
+plain `bash -c "..."` invocation, which is POSIX-portable. Closes Copilot
+iter3 finding on PR #346 (printf %q × dash sh portability):
 ```bash
 SHORT_PROMPT_QUOTED=$(printf '%q' "$SHORT_PROMPT")
-tmux new-window -n handoff -c "$WORKTREE_PATH" "claude -- $SHORT_PROMPT_QUOTED"
+tmux new-window -n handoff -c "$WORKTREE_PATH" \
+  "bash -c \"claude -- $SHORT_PROMPT_QUOTED\""
 ```
 
 **macOS / Linux without tmux** — there is no portable "new terminal"
@@ -415,7 +418,8 @@ primitive. Use `tmux new-session -d` or the terminal emulator's own CLI
 
 ```bash
 SHORT_PROMPT_QUOTED=$(printf '%q' "$SHORT_PROMPT")
-tmux new-session -d -s handoff -c "$WORKTREE_PATH" "claude -- $SHORT_PROMPT_QUOTED"
+tmux new-session -d -s handoff -c "$WORKTREE_PATH" \
+  "bash -c \"claude -- $SHORT_PROMPT_QUOTED\""
 ```
 
 The positional argument after `--` is the session's first user message —

--- a/.mercury/docs/guides/lane-naming.md
+++ b/.mercury/docs/guides/lane-naming.md
@@ -404,7 +404,7 @@ work. The script compares:
 |--------|----------|---------------|
 | `[LANE=<name>]` marker (CLI / `MERCURY_LANE_MARKER` / `BOOTSTRAP_PROMPT` / stdin) | parsable lane name (`[a-z0-9-]+`) | `1` |
 | Encoded cwd vs encoded `Worktree path` from `LANES.md` | byte-equal after `: \\ /` → `-` slash-encoding | `2` |
-| `git branch --show-current` | matches lane's branch-prefix convention (Rule 2.1 `lane/<short>/*` or legacy `feature/lane-<lane>/TASK-*`; `develop`/`master`/`main` tolerated as pre-checkout) | `3` |
+| `git branch --show-current` | matches lane's branch-prefix convention (Rule 2.1 `lane/<short>/*` or legacy `feature/lane-<lane>/TASK-*`). For **side lanes** only `develop` is tolerated as pre-checkout; `master`/`main` are NOT — accepting them would mean a misrouted session on those branches passes the assertion. **Main lane** tolerates all three (`develop`/`master`/`main`) since they are legitimate main-lane operating branches. | `3` |
 | `Worktree path` field present in lane's `LANES.md` section | non-empty | `4` |
 
 Marker source priority: `--marker` CLI → `MERCURY_LANE_MARKER` env →
@@ -449,8 +449,12 @@ unconditional infrastructure.
 - `.claude/skills/handoff/SKILL.md` Step 5 Auto mode for the spawn-side
   contract
 - `scripts/lane-assertion.sh` + `scripts/test-lane-assertion.sh` for the
-  consumer-side check (41-assertion test suite covers happy paths, every
-  exit-code branch, marker source priority, JSON format, and soft-disable)
+  consumer-side check (test suite covers happy paths for both lanes,
+  every exit-code branch including `worktree_path_duplicate`, marker
+  source priority + first-non-blank-line semantics, JSON format with
+  backslash/quote escaping, soft-disable, code-fence isolation, paths
+  with spaces/parens, and side-lane branch tightening — see the suite
+  for the current assertion count)
 
 ## Tests
 

--- a/.mercury/docs/guides/lane-naming.md
+++ b/.mercury/docs/guides/lane-naming.md
@@ -349,14 +349,93 @@ audit trail; operators may archive it manually if no longer needed.
   routing-bleed risk per Issue #342. Migration is per-lane operator decision
   at next lane-active session.
 
+### Δ10 — `/handoff:auto` worktree integration (Issue [#345](https://github.com/392fyc/Mercury/issues/345))
+
+The `handoff` skill (`.claude/skills/handoff/SKILL.md` Step 5 Auto mode) now
+auto-resolves the active lane's `Worktree path` from `LANES.md` and uses it
+as the new tab's cwd:
+
+1. Lane name is derived from the handoff filename pattern:
+   - `session-handoff.md` → `main`
+   - `session-handoff-<lane>.md` → `<lane>`
+2. `LANES.md` is read for that lane's `Worktree path` bullet (this §
+   Worktree path convention table). awk extraction is bounded by the
+   `### \`<lane-name>\`` heading scope so cross-lane bleed is impossible.
+3. The path is substituted into the spawn command:
+   - Windows: `wt -w 0 nt --title "Handoff: <lane>" -d "<worktree>" -- claude -- "$SHORT_PROMPT"`
+   - tmux:    `tmux new-window -n handoff -c "<worktree>" "claude -- '$SHORT_PROMPT'"`
+4. If the `Worktree path` field is missing → spawn aborts with explicit
+   `Rule 5.1` guidance pointing at `LANES.md`.
+
+This closes the manual-`<cwd>`-substitution failure mode where an operator
+or agent invoking `/handoff:auto` from the main checkout (`D:/Mercury/Mercury`)
+forgot to override `<cwd>` before spawning a side-lane session — reproducing
+the share-cwd routing-bleed scenario that Δ9 was designed to prevent.
+
+### Δ11 — Path C: `[LANE=<name>]` marker + `lane-assertion.sh` (Issue [#345](https://github.com/392fyc/Mercury/issues/345))
+
+The auto-mode SHORT_PROMPT now starts with a `[LANE=<name>]` marker as its
+first whitespace-delimited token:
+
+```
+[LANE=side-mlane] Continue from session handoff. The SessionStart hook injects the full document. Fallback: read <HANDOFF_PATH>
+```
+
+The new session validates three-way lane alignment via
+[`scripts/lane-assertion.sh`](../../../scripts/lane-assertion.sh) before any
+work. The script compares:
+
+| Source | Expected | Mismatch exit |
+|--------|----------|---------------|
+| `[LANE=<name>]` marker (CLI / `MERCURY_LANE_MARKER` / `BOOTSTRAP_PROMPT` / stdin) | parsable lane name (`[a-z0-9-]+`) | `1` |
+| Encoded cwd vs encoded `Worktree path` from `LANES.md` | byte-equal after `: \\ /` → `-` slash-encoding | `2` |
+| `git branch --show-current` | matches lane's branch-prefix convention (Rule 2.1 `lane/<short>/*` or legacy `feature/lane-<lane>/TASK-*`; `develop`/`master`/`main` tolerated as pre-checkout) | `3` |
+| `Worktree path` field present in lane's `LANES.md` section | non-empty | `4` |
+
+Marker source priority: `--marker` CLI → `MERCURY_LANE_MARKER` env →
+`BOOTSTRAP_PROMPT` env → stdin. The first source that yields a parseable
+`[LANE=<name>]` token wins; subsequent sources are not consulted.
+
+The marker character class is intentionally `[a-z0-9-]+` (matches Rule 2.1
+short-name validation): no path-traversal sequences, shell metacharacters,
+or quote characters can leak into the assertion logic via a crafted lane
+name. The lane name is also bounded by Rule 6 (only the owning lane edits
+its own `LANES.md` section), so injection from outside the protocol is
+prevented at the source.
+
+#### Soft-disable
+
+`MERCURY_LANE_ASSERT_DISABLED=1` skips all checks and exits 0 — break-glass
+for legitimate scenarios (recovery sessions, intentional cross-lane debug,
+single-lane operators who don't want the discipline). The skip writes one
+line to stdout so it is auditable in transcripts. Soft-disable is
+session-scoped only; it does not persist.
+
+#### Hook integration (forward-looking)
+
+This Issue scope keeps assertion as a manual / agent-as-first-action step
+to validate the contract in production. If proven stable across ≥3 sessions
+of real auto-handoff usage, follow-up work may wire it into a user-level
+SessionStart hook per `feedback_lane_protocol.md` Rule 5.1 §F.C governance
+pattern (analogous to Issue #259 deployment for mem0). The deferred-hook
+choice is intentional: a SessionStart-time assertion that runs by default
+needs a track record of low false-positive rate before it becomes
+unconditional infrastructure.
+
 ### Cross-references
 
 - `feedback_lane_protocol.md` Rule 5.1 (sub-rule of Rule 5: Per-lane state
-  separation) formalizes the worktree path convention as protocol
+  separation) formalizes the worktree path convention as protocol; §5.1.1
+  + §5.1.2 cover the Δ10/Δ11 contracts
 - `LANES.md` Governance §Lane workspace isolation declares each lane MUST
   state its `Worktree path` field
 - `.mercury/docs/guides/worktree-workflow.md` covers the orthogonal
   task-level worktree scope
+- `.claude/skills/handoff/SKILL.md` Step 5 Auto mode for the spawn-side
+  contract
+- `scripts/lane-assertion.sh` + `scripts/test-lane-assertion.sh` for the
+  consumer-side check (41-assertion test suite covers happy paths, every
+  exit-code branch, marker source priority, JSON format, and soft-disable)
 
 ## Tests
 
@@ -382,7 +461,9 @@ Tests do NOT touch real GitHub or LANES.md — synthetic fixtures only.
 - [Towards a science of scaling agent systems (Google research)](https://research.google/blog/towards-a-science-of-scaling-agent-systems-when-and-why-agent-systems-work/)
 - [Working with WIP limits for Kanban (Atlassian)](https://www.atlassian.com/agile/kanban/wip-limits)
 - Issue [#342](https://github.com/392fyc/Mercury/issues/342) — Δ9 lane-level worktree isolation acceptance criteria + S13 routing-bleed forensic record
+- Issue [#345](https://github.com/392fyc/Mercury/issues/345) — Δ10/Δ11 `/handoff:auto` worktree integration + Path C agent lane-assertion acceptance criteria
 - [Claude Code .claude directory reference](https://code.claude.com/docs/en/claude-directory) — per-project `~/.claude/projects/<project>/` state dir
 - [Claude Code hooks reference](https://code.claude.com/docs/en/hooks) — SessionStart `cwd` JSON field
 - [Windows Terminal command line arguments](https://learn.microsoft.com/en-us/windows/terminal/command-line-arguments) — `new-tab -d <directory>` per-tab starting directory
 - [git-worktree(1)](https://git-scm.com/docs/git-worktree) — multiple working trees from a single repo
+- `feedback_handoff_short_prompt_only.md` — S3-side-multi-lane SHORT_PROMPT lesson (Δ10/Δ11 SHORT_PROMPT design rests on this rule)

--- a/.mercury/docs/guides/lane-naming.md
+++ b/.mercury/docs/guides/lane-naming.md
@@ -375,11 +375,26 @@ the share-cwd routing-bleed scenario that Δ9 was designed to prevent.
 ### Δ11 — Path C: `[LANE=<name>]` marker + `lane-assertion.sh` (Issue [#345](https://github.com/392fyc/Mercury/issues/345))
 
 The auto-mode SHORT_PROMPT now starts with a `[LANE=<name>]` marker as its
-first whitespace-delimited token:
+first whitespace-delimited token. **`<name>` is the lane's full section
+name** (the heading text under `## Active Lanes` in `LANES.md`), NOT the
+short name from the §Δ6 short-prefix convention. The handoff skill
+derives `<name>` from the handoff filename pattern (`session-handoff.md`
+→ `main`; `session-handoff-side-multi-lane.md` → `side-multi-lane`), and
+[`scripts/lane-assertion.sh`](../../../scripts/lane-assertion.sh) looks up
+the matching lane section by exact heading equality. Operators executing
+the assertion manually MUST use the lane section name; using the short
+name (e.g. `side-mlane`) instead would yield exit 4 (Worktree path
+missing) because no lane section heading matches.
 
 ```
-[LANE=side-mlane] Continue from session handoff. The SessionStart hook injects the full document. Fallback: read <HANDOFF_PATH>
+[LANE=side-multi-lane] Continue from session handoff. The SessionStart hook injects the full document. Fallback: read <HANDOFF_PATH>
 ```
+
+For the `main` lane the section name and short name happen to be
+identical, so `[LANE=main]` works regardless. The distinction matters
+only for side lanes whose section name and short name differ
+(e.g. `side-multi-lane` vs `side-mlane`). Fixes Argus iter2 Minor
+"文档一致性" (PR #346).
 
 The new session validates three-way lane alignment via
 [`scripts/lane-assertion.sh`](../../../scripts/lane-assertion.sh) before any

--- a/scripts/lane-assertion.sh
+++ b/scripts/lane-assertion.sh
@@ -229,7 +229,7 @@ extract_worktree_path() {
 WORKTREE_PATH_RAW=$(extract_worktree_path "$LANE_NAME" "$LANES_FILE")
 if [ -z "$WORKTREE_PATH_RAW" ]; then
   if [ "$FORMAT" = "json" ]; then
-    printf '{"verdict":"worktree_path_missing","exit":4,"lane":"%s","reason":"no Worktree path field in LANES.md section"}\n' "$LANE_NAME"
+    printf '{"verdict":"worktree_path_missing","exit":4,"lane":"%s","reason":"no Worktree path field in LANES.md section"}\n' "$(json_escape "$LANE_NAME")"
   else
     cat >&2 <<EOF
 $PROG: BLOCKED — lane '$LANE_NAME' has no Worktree path field in LANES.md.
@@ -248,7 +248,7 @@ WORKTREE_COUNT=$(printf '%s\n' "$WORKTREE_PATH_RAW" | grep -c '^.')
 if [ "$WORKTREE_COUNT" -gt 1 ]; then
   if [ "$FORMAT" = "json" ]; then
     printf '{"verdict":"worktree_path_duplicate","exit":6,"lane":"%s","count":%d}\n' \
-      "$LANE_NAME" "$WORKTREE_COUNT"
+      "$(json_escape "$LANE_NAME")" "$WORKTREE_COUNT"
   else
     cat >&2 <<EOF
 $PROG: BLOCKED — lane '$LANE_NAME' has $WORKTREE_COUNT Worktree path bullets in LANES.md.
@@ -268,6 +268,21 @@ WORKTREE_PATH="$WORKTREE_PATH_RAW"
 # slash and colon characters in the cwd become dashes, leading dashes are
 # stripped. Encode both the actual cwd and the expected worktree path,
 # then compare.
+# JSON-string escape: backslash (Windows paths!) and double-quote, plus
+# minimal control-char handling. Pure bash parameter expansion, no fork.
+# Closes Argus iter1 Minor (#346) — `--format json` previously interpolated
+# raw strings into the output, producing invalid JSON for Windows paths
+# containing backslashes or any value containing literal quotes.
+json_escape() {
+  local s="$1"
+  s="${s//\\/\\\\}"   # \ → \\  (must be FIRST so \ in subsequent escapes survives)
+  s="${s//\"/\\\"}"   # " → \"
+  s="${s//$'\n'/\\n}" # newline → \n  (defensive — paths/branches shouldn't contain LF)
+  s="${s//$'\r'/\\r}" # CR → \r
+  s="${s//$'\t'/\\t}" # tab → \t
+  printf '%s' "$s"
+}
+
 encode_path() {
   # Defensive normalization before encoding to dampen trivial-mismatch
   # false-blocks: strip trailing slashes (`D:/Mercury/Mercury/` ≡
@@ -295,7 +310,7 @@ EXPECTED_CWD_ENC=$(encode_path "$WORKTREE_PATH")
 if [ "$ACTUAL_CWD_ENC" != "$EXPECTED_CWD_ENC" ]; then
   if [ "$FORMAT" = "json" ]; then
     printf '{"verdict":"cwd_mismatch","exit":2,"lane":"%s","actual_cwd":"%s","expected_worktree":"%s"}\n' \
-      "$LANE_NAME" "$ACTUAL_CWD" "$WORKTREE_PATH"
+      "$(json_escape "$LANE_NAME")" "$(json_escape "$ACTUAL_CWD")" "$(json_escape "$WORKTREE_PATH")"
   else
     cat >&2 <<EOF
 $PROG: BLOCKED — cwd does not match lane '$LANE_NAME' worktree path.
@@ -391,7 +406,7 @@ fi
 if [ "$branch_ok" -ne 1 ]; then
   if [ "$FORMAT" = "json" ]; then
     printf '{"verdict":"branch_mismatch","exit":3,"lane":"%s","actual_branch":"%s","reason":"%s"}\n' \
-      "$LANE_NAME" "$ACTUAL_BRANCH" "$branch_reason"
+      "$(json_escape "$LANE_NAME")" "$(json_escape "$ACTUAL_BRANCH")" "$(json_escape "$branch_reason")"
   else
     cat >&2 <<EOF
 $PROG: BLOCKED — branch does not match lane '$LANE_NAME' convention.
@@ -406,7 +421,7 @@ fi
 # ── all checks passed ───────────────────────────────────────────
 if [ "$FORMAT" = "json" ]; then
   printf '{"verdict":"aligned","exit":0,"lane":"%s","cwd":"%s","branch":"%s","worktree":"%s"}\n' \
-    "$LANE_NAME" "$ACTUAL_CWD" "$ACTUAL_BRANCH" "$WORKTREE_PATH"
+    "$(json_escape "$LANE_NAME")" "$(json_escape "$ACTUAL_CWD")" "$(json_escape "$ACTUAL_BRANCH")" "$(json_escape "$WORKTREE_PATH")"
 else
   printf '%s: aligned — lane=%s cwd=%s branch=%s\n' "$PROG" "$LANE_NAME" "$ACTUAL_CWD" "$ACTUAL_BRANCH"
 fi

--- a/scripts/lane-assertion.sh
+++ b/scripts/lane-assertion.sh
@@ -62,6 +62,24 @@ warn() {
   printf '%s: warn: %s\n' "$PROG" "$1" >&2
 }
 
+# JSON-string escape: backslash (Windows paths!) and double-quote, plus
+# minimal control-char handling. Pure bash parameter expansion, no fork.
+# Closes Argus iter1 Minor #346 — `--format json` previously interpolated
+# raw strings into the output, producing invalid JSON for Windows paths
+# containing backslashes or any value containing literal quotes. Defined
+# at script top so all error-branch JSON printers (worktree_path_missing
+# at line ~232, worktree_path_duplicate at line ~250, etc.) see it
+# regardless of execution path. Fixes Argus iter2 Minor "潜在运行错误".
+json_escape() {
+  local s="$1"
+  s="${s//\\/\\\\}"   # \ → \\  (must be FIRST so \ in subsequent escapes survives)
+  s="${s//\"/\\\"}"   # " → \"
+  s="${s//$'\n'/\\n}" # newline → \n  (defensive — paths/branches shouldn't contain LF)
+  s="${s//$'\r'/\\r}" # CR → \r
+  s="${s//$'\t'/\\t}" # tab → \t
+  printf '%s' "$s"
+}
+
 # Soft-disable break-glass — exits cleanly without running checks.
 if [ "${MERCURY_LANE_ASSERT_DISABLED:-}" = "1" ]; then
   printf '%s: soft-disabled via MERCURY_LANE_ASSERT_DISABLED=1\n' "$PROG"
@@ -268,21 +286,6 @@ WORKTREE_PATH="$WORKTREE_PATH_RAW"
 # slash and colon characters in the cwd become dashes, leading dashes are
 # stripped. Encode both the actual cwd and the expected worktree path,
 # then compare.
-# JSON-string escape: backslash (Windows paths!) and double-quote, plus
-# minimal control-char handling. Pure bash parameter expansion, no fork.
-# Closes Argus iter1 Minor (#346) — `--format json` previously interpolated
-# raw strings into the output, producing invalid JSON for Windows paths
-# containing backslashes or any value containing literal quotes.
-json_escape() {
-  local s="$1"
-  s="${s//\\/\\\\}"   # \ → \\  (must be FIRST so \ in subsequent escapes survives)
-  s="${s//\"/\\\"}"   # " → \"
-  s="${s//$'\n'/\\n}" # newline → \n  (defensive — paths/branches shouldn't contain LF)
-  s="${s//$'\r'/\\r}" # CR → \r
-  s="${s//$'\t'/\\t}" # tab → \t
-  printf '%s' "$s"
-}
-
 encode_path() {
   # Defensive normalization before encoding to dampen trivial-mismatch
   # false-blocks: strip trailing slashes (`D:/Mercury/Mercury/` ≡
@@ -395,11 +398,18 @@ else
   ' "$LANES_FILE")
   # Without short name, fall back to lane name itself for branch matching.
   [ -z "$SHORT_NAME" ] && SHORT_NAME="$LANE_NAME"
+  # Side-lane branch tolerance: only `develop` is the canonical pre-checkout
+  # state (lane-naming.md §Setup at lane open uses `git worktree add ...
+  # origin/develop` to scaffold). master/main are NOT legitimate side-lane
+  # operating branches — accepting them would mean a misrouted session on
+  # those branches passes the assertion. Tightened per Argus iter2 Minor
+  # "校验放宽风险" (PR #346). Scaffold + work branches remain accepted via
+  # the lane/<short>/* and feature/lane-<lane>/TASK-* patterns below.
   case "$ACTUAL_BRANCH" in
-    develop|master|main) branch_ok=1 ;;  # tolerated pre-checkout
+    develop) branch_ok=1 ;;  # canonical pre-checkout state for fresh side worktree
     "feature/lane-${LANE_NAME}/TASK-"*) branch_ok=1 ;;
     "lane/${SHORT_NAME}/"*) branch_ok=1 ;;
-    *) branch_reason="lane '$LANE_NAME' (short '$SHORT_NAME') expects feature/lane-${LANE_NAME}/TASK-* or lane/${SHORT_NAME}/*; got '$ACTUAL_BRANCH'" ;;
+    *) branch_reason="lane '$LANE_NAME' (short '$SHORT_NAME') expects develop / feature/lane-${LANE_NAME}/TASK-* / lane/${SHORT_NAME}/*; got '$ACTUAL_BRANCH'" ;;
   esac
 fi
 

--- a/scripts/lane-assertion.sh
+++ b/scripts/lane-assertion.sh
@@ -1,0 +1,413 @@
+#!/usr/bin/env bash
+# lane-assertion.sh — three-way lane consistency check at session start.
+#
+# Verifies the agent session is bound to a single, coherent lane identity by
+# asserting alignment across three independent sources:
+#
+#   1. [LANE=<name>] marker — first whitespace-delimited token of the user's
+#      first prompt (or BOOTSTRAP_PROMPT env var). Set by the /handoff:auto
+#      skill on the SHORT_PROMPT, per `feedback_handoff_short_prompt_only.md`
+#      lessons learned.
+#   2. cwd-encoded — Claude Code derives `~/.claude/projects/<encoded-cwd>/`
+#      from the cwd of the `claude` invocation (slash-to-dash encoding,
+#      empirically observed; reference:
+#      https://code.claude.com/docs/en/claude-directory). The encoded form
+#      MUST match the lane's worktree path encoded.
+#   3. git current branch — MUST match the lane's branch-prefix convention:
+#      - main: `feature/lane-main/TASK-<N>-*` OR `feature/TASK-<N>-*` (legacy)
+#        OR `lane/main/<N>-<slug>` (Rule 2.1, future) OR `develop` itself
+#        (a session can run on develop while not yet branched).
+#      - side: `feature/lane-<lane>/TASK-<N>-*` (legacy) OR
+#        `lane/<short>/<N>-<slug>` (Rule 2.1) OR `lane/<short>/init`
+#        (scaffold per lane-naming.md §Setup at lane open).
+#
+# If all three align → exit 0. Mismatch → fail loud with explicit guidance.
+# Soft-disable via MERCURY_LANE_ASSERT_DISABLED=1 for break-glass scenarios.
+#
+# Usage:
+#   scripts/lane-assertion.sh [--marker LANE=name] [--memory-dir PATH]
+#                             [--lanes-file PATH] [--repo-root PATH]
+#                             [--cwd PATH] [--branch NAME] [--format text|json]
+#
+# Exit codes:
+#   0 — alignment OK
+#   1 — marker missing / unparseable
+#   2 — cwd mismatch (worktree path drift — Issue #342 routing-bleed risk)
+#   3 — branch prefix mismatch
+#   4 — Worktree path field missing in LANES.md (Rule 5.1 violation)
+#   5 — argument or environment error
+#
+# Marker resolution priority:
+#   --marker CLI flag
+#   $MERCURY_LANE_MARKER env var
+#   $BOOTSTRAP_PROMPT env var (parsed for first token)
+#   stdin (parsed for first token)
+#
+# Reference docs:
+#   - .mercury/docs/guides/lane-naming.md §Lane workspace isolation
+#   - feedback_lane_protocol.md Rule 5.1 (Per-lane state separation)
+#   - Issue #342 (routing-bleed forensic record)
+#   - Issue #345 (this assertion implementation)
+
+set -u
+
+PROG="lane-assertion.sh"
+
+die() {
+  printf '%s: error: %s\n' "$PROG" "$1" >&2
+  exit "${2:-5}"
+}
+
+warn() {
+  printf '%s: warn: %s\n' "$PROG" "$1" >&2
+}
+
+# Soft-disable break-glass — exits cleanly without running checks.
+if [ "${MERCURY_LANE_ASSERT_DISABLED:-}" = "1" ]; then
+  printf '%s: soft-disabled via MERCURY_LANE_ASSERT_DISABLED=1\n' "$PROG"
+  exit 0
+fi
+
+# ── argv parsing ────────────────────────────────────────────────
+MARKER_ARG=""
+MEMORY_DIR=""
+LANES_FILE=""
+REPO_ROOT=""
+CWD_OVERRIDE=""
+BRANCH_OVERRIDE=""
+FORMAT="text"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --marker)      shift; [ $# -gt 0 ] || die "--marker needs a value" 5
+                   MARKER_ARG="$1" ;;
+    --memory-dir)  shift; [ $# -gt 0 ] || die "--memory-dir needs a value" 5
+                   [ -n "$1" ] || die "--memory-dir requires a non-empty path" 5
+                   MEMORY_DIR="$1" ;;
+    --lanes-file)  shift; [ $# -gt 0 ] || die "--lanes-file needs a value" 5
+                   [ -n "$1" ] || die "--lanes-file requires a non-empty path" 5
+                   LANES_FILE="$1" ;;
+    --repo-root)   shift; [ $# -gt 0 ] || die "--repo-root needs a value" 5
+                   REPO_ROOT="$1" ;;
+    --cwd)         shift; [ $# -gt 0 ] || die "--cwd needs a value" 5
+                   CWD_OVERRIDE="$1" ;;
+    --branch)      shift; [ $# -gt 0 ] || die "--branch needs a value" 5
+                   BRANCH_OVERRIDE="$1" ;;
+    --format)      shift; [ $# -gt 0 ] || die "--format needs a value" 5
+                   case "$1" in text|json) FORMAT="$1" ;;
+                                *) die "--format: unknown value '$1' (text|json)" 5 ;; esac ;;
+    -h|--help)
+      sed -n '2,/^$/p' "$0" | sed 's/^# \?//'
+      exit 0 ;;
+    *) die "unknown argument: $1" 5 ;;
+  esac
+  shift
+done
+
+# ── memory dir + LANES.md resolution (mirrors lane-cap-check.sh) ─
+if [ -z "$MEMORY_DIR" ]; then
+  MEMORY_DIR="${MERCURY_MEMORY_DIR:-${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/D--Mercury-Mercury/memory}"
+fi
+[ -d "$MEMORY_DIR" ] || die "memory dir not found: $MEMORY_DIR (set --memory-dir or MERCURY_MEMORY_DIR)" 5
+[ -z "$LANES_FILE" ] && LANES_FILE="$MEMORY_DIR/LANES.md"
+[ -f "$LANES_FILE" ] || die "LANES.md not found: $LANES_FILE" 5
+
+# ── marker extraction ───────────────────────────────────────────
+# Try each source in priority order; the FIRST source that yields a
+# parseable [LANE=<name>] token wins. A non-empty but malformed earlier
+# source does NOT block fallback to a later source — the contract is
+# documented as "first source that yields a parseable token wins"
+# (lane-naming.md §Δ11). Fixes Codex iter1 Low #1 (audit 2026-05-03).
+_try_parse_marker() {
+  # stdout: lane name on success; empty on failure. exit code: 0 success / 1 fail.
+  local raw="$1" first inner
+  [ -z "$raw" ] && return 1
+  # Per contract (lane-naming.md §Δ11): the marker MUST be the FIRST
+  # whitespace-delimited token. Skip leading whitespace-only lines so
+  # `BOOTSTRAP_PROMPT` / stdin that wrap the marker after a blank line
+  # are still accepted (Codex iter3 Low #1). The first non-blank line's
+  # `$1` is the first whitespace-delimited token; subsequent lines are
+  # not consulted (the contract is about the FIRST token, not anywhere).
+  first=$(printf '%s' "$raw" | awk '
+    /^[[:space:]]*$/ { next }
+    { if ($1 ~ /^\[LANE=[a-z0-9-]+\]$/) print $1; exit }')
+  [ -z "$first" ] && return 1
+  inner="${first#\[LANE=}"
+  inner="${inner%\]}"
+  case "$inner" in
+    ''|*[!a-z0-9-]*) return 1 ;;  # defensive — awk regex already enforced
+  esac
+  printf '%s' "$inner"
+  return 0
+}
+
+LANE_NAME=""
+for _src in "$MARKER_ARG" "${MERCURY_LANE_MARKER:-}" "${BOOTSTRAP_PROMPT:-}"; do
+  parsed=$(_try_parse_marker "$_src") && { LANE_NAME="$parsed"; break; }
+done
+
+# Stdin fallback — only consulted if every explicit source failed AND
+# stdin is connected to data (not a terminal).
+if [ -z "$LANE_NAME" ] && [ ! -t 0 ]; then
+  STDIN_DATA=$(cat)
+  parsed=$(_try_parse_marker "$STDIN_DATA") && LANE_NAME="$parsed"
+fi
+
+if [ -z "$LANE_NAME" ]; then
+  if [ "$FORMAT" = "json" ]; then
+    printf '{"verdict":"missing_marker","exit":1,"reason":"no parseable [LANE=<name>] marker found in --marker / MERCURY_LANE_MARKER / BOOTSTRAP_PROMPT / stdin"}\n'
+  else
+    cat >&2 <<EOF
+$PROG: BLOCKED — no parseable [LANE=<name>] marker found.
+Expected: [LANE=<name>] as the first whitespace-delimited token of the
+session's bootstrap prompt (set by /handoff:auto SHORT_PROMPT). Sources
+checked, in order: --marker / MERCURY_LANE_MARKER / BOOTSTRAP_PROMPT / stdin.
+Soft-disable: export MERCURY_LANE_ASSERT_DISABLED=1
+Reference: .mercury/docs/guides/lane-naming.md §Lane workspace isolation Δ11
+EOF
+  fi
+  exit 1
+fi
+
+# ── extract Worktree path from LANES.md for this lane ───────────
+# LANES.md format: per-lane section starts at `### \`<name>\`` heading.
+# `Worktree path` field appears as a `- **Worktree path** [optional notes]: \`<PATH>\``
+# bullet. The canonical form is BACKTICK-quoted; parsing prefers backticks
+# as the path delimiter so paths containing whitespace or `(` (e.g.
+# `/Users/Alice Smith/...`, `C:/Program Files (x86)/...`) survive intact.
+# Without backticks, the parser falls back to "rest of line, trimmed" —
+# legacy/freeform but still single-line. Fixes Codex iter1 High #1.
+#
+# Duplicate detection: every match emits one line. Shell counts the lines —
+# >1 means the lane section has multiple Worktree path bullets, which is
+# ambiguous and unsafe to silently first-wins. Fixes Codex iter1 High #2.
+extract_worktree_path() {
+  awk -v lane="$1" '
+  BEGIN { in_section=0; in_fence=0 }
+  /^```/ { in_fence = !in_fence; next }
+  in_fence { next }
+  /^### `[^`]+`/ {
+    match($0, /^### `[^`]+`/)
+    hdr=substr($0, RSTART+5, RLENGTH-6)
+    in_section=(hdr == lane) ? 1 : 0
+    next
+  }
+  in_section && /\*\*Worktree path\*\*/ {
+    s=$0
+    i=index(s, "**Worktree path**")
+    s=substr(s, i+length("**Worktree path**"))
+    # Drop optional " (notes...)" parenthesized block ONLY when it appears
+    # immediately before the colon (the LANES.md convention).
+    if (substr(s, 1, 2) == " (") {
+      end=index(s, ")")
+      if (end > 0) s=substr(s, end+1)
+    }
+    c=index(s, ":")
+    if (c == 0) next
+    s=substr(s, c+1)
+    sub(/^[[:space:]]+/, "", s)
+    if (substr(s, 1, 1) == "`") {
+      # Backtick-quoted (canonical). Take everything up to closing backtick,
+      # then trim trailing whitespace inside the quoted region — protects
+      # against invisible-typo paths like `` `/path ` `` (Codex iter2 M#1).
+      s=substr(s, 2)
+      bt=index(s, "`")
+      if (bt > 0) {
+        out=substr(s, 1, bt-1)
+        sub(/[[:space:]]+$/, "", out)
+        if (out != "") print out
+      }
+    } else {
+      # Unquoted (legacy/freeform). Take rest of line, strip trailing space.
+      sub(/[[:space:]]+$/, "", s)
+      if (s != "") print s
+    }
+  }
+  ' "$2"
+}
+
+WORKTREE_PATH_RAW=$(extract_worktree_path "$LANE_NAME" "$LANES_FILE")
+if [ -z "$WORKTREE_PATH_RAW" ]; then
+  if [ "$FORMAT" = "json" ]; then
+    printf '{"verdict":"worktree_path_missing","exit":4,"lane":"%s","reason":"no Worktree path field in LANES.md section"}\n' "$LANE_NAME"
+  else
+    cat >&2 <<EOF
+$PROG: BLOCKED — lane '$LANE_NAME' has no Worktree path field in LANES.md.
+Per feedback_lane_protocol.md Rule 5.1 (landed S15-side-multi-lane Issue
+#342), every active lane MUST declare a Worktree path field. Add the
+field to the lane's section in:
+  $LANES_FILE
+Soft-disable: export MERCURY_LANE_ASSERT_DISABLED=1
+EOF
+  fi
+  exit 4
+fi
+# Reject duplicate entries — first-wins would let a stale bullet route
+# the session to an old worktree.
+WORKTREE_COUNT=$(printf '%s\n' "$WORKTREE_PATH_RAW" | grep -c '^.')
+if [ "$WORKTREE_COUNT" -gt 1 ]; then
+  if [ "$FORMAT" = "json" ]; then
+    printf '{"verdict":"worktree_path_duplicate","exit":6,"lane":"%s","count":%d}\n' \
+      "$LANE_NAME" "$WORKTREE_COUNT"
+  else
+    cat >&2 <<EOF
+$PROG: BLOCKED — lane '$LANE_NAME' has $WORKTREE_COUNT Worktree path bullets in LANES.md.
+Multiple entries are ambiguous and a stale first-bullet could silently route
+the session to an old worktree. Edit the lane section to keep exactly ONE
+Worktree path bullet:
+  $LANES_FILE
+Soft-disable: export MERCURY_LANE_ASSERT_DISABLED=1
+EOF
+  fi
+  exit 6
+fi
+WORKTREE_PATH="$WORKTREE_PATH_RAW"
+
+# ── cwd encoding check ──────────────────────────────────────────
+# Claude Code's encoding rule (per claude-directory docs + lane-naming.md):
+# slash and colon characters in the cwd become dashes, leading dashes are
+# stripped. Encode both the actual cwd and the expected worktree path,
+# then compare.
+encode_path() {
+  # Defensive normalization before encoding to dampen trivial-mismatch
+  # false-blocks: strip trailing slashes (`D:/Mercury/Mercury/` ≡
+  # `D:/Mercury/Mercury`). Case normalization is intentionally skipped —
+  # macOS/Linux paths are case-sensitive and silently lowercasing them
+  # would mask real divergence on those platforms. Windows operators
+  # whose worktree-path field disagrees with cwd by case alone should
+  # fix the field, not lean on the assertion. Codex iter1 Medium #1.
+  local p="$1"
+  # Trim ALL trailing slashes (and Windows backslashes) to handle e.g.
+  # "D:/Mercury/Mercury//" — repeat-strip via parameter expansion.
+  while :; do
+    case "$p" in
+      */|*\\) p="${p%/}"; p="${p%\\}" ;;
+      *) break ;;
+    esac
+  done
+  printf '%s' "$p" | tr ':\\/' '-' | sed 's/^-*//'
+}
+
+ACTUAL_CWD="${CWD_OVERRIDE:-$PWD}"
+ACTUAL_CWD_ENC=$(encode_path "$ACTUAL_CWD")
+EXPECTED_CWD_ENC=$(encode_path "$WORKTREE_PATH")
+
+if [ "$ACTUAL_CWD_ENC" != "$EXPECTED_CWD_ENC" ]; then
+  if [ "$FORMAT" = "json" ]; then
+    printf '{"verdict":"cwd_mismatch","exit":2,"lane":"%s","actual_cwd":"%s","expected_worktree":"%s"}\n' \
+      "$LANE_NAME" "$ACTUAL_CWD" "$WORKTREE_PATH"
+  else
+    cat >&2 <<EOF
+$PROG: BLOCKED — cwd does not match lane '$LANE_NAME' worktree path.
+  actual cwd:        $ACTUAL_CWD
+  expected worktree: $WORKTREE_PATH
+This is the share-cwd routing-bleed failure mode (Issue #342). The session
+is reading the wrong lane's project state (~/.claude/projects/<encoded>/).
+Resolution: cd to the lane worktree before launching claude:
+  cd "$WORKTREE_PATH" && claude
+Soft-disable: export MERCURY_LANE_ASSERT_DISABLED=1
+EOF
+  fi
+  exit 2
+fi
+
+# ── branch prefix check ─────────────────────────────────────────
+# Resolve current branch. If --branch override given, use it; else query git.
+ACTUAL_BRANCH="$BRANCH_OVERRIDE"
+if [ -z "$ACTUAL_BRANCH" ]; then
+  if [ -n "$REPO_ROOT" ]; then
+    ACTUAL_BRANCH=$(git -C "$REPO_ROOT" branch --show-current 2>/dev/null || true)
+  else
+    ACTUAL_BRANCH=$(git branch --show-current 2>/dev/null || true)
+  fi
+fi
+
+# Branch validation rules per lane (matches lane-naming.md §Δ6 + main lane
+# legacy convention). Detached HEAD and an empty branch (e.g. before any
+# checkout) are tolerated as warn — not a fatal mismatch — to avoid
+# blocking sessions that legitimately operate without a branch.
+branch_ok=0
+branch_reason=""
+if [ -z "$ACTUAL_BRANCH" ]; then
+  warn "git current branch is empty (detached HEAD or non-git cwd) — branch check skipped"
+  branch_ok=1
+elif [ "$LANE_NAME" = "main" ]; then
+  case "$ACTUAL_BRANCH" in
+    develop|master|main) branch_ok=1 ;;
+    feature/lane-main/TASK-*|feature/TASK-*) branch_ok=1 ;;
+    lane/main/*) branch_ok=1 ;;
+    *) branch_reason="main lane expects develop / feature/lane-main/* / feature/TASK-* / lane/main/*; got '$ACTUAL_BRANCH'" ;;
+  esac
+else
+  # For side lanes, derive the short name. Convention: <name> with -multi-
+  # contractions (e.g. side-multi-lane → side-mlane). Lookup falls back to
+  # exact match against branch prefix `lane/<lane-name>/...` if no Short name
+  # field is found in LANES.md.
+  SHORT_NAME=$(awk -v lane="$LANE_NAME" '
+  BEGIN { in_section=0; in_fence=0 }
+  /^```/ { in_fence = !in_fence; next }
+  in_fence { next }
+  /^### `[^`]+`/ {
+    match($0, /^### `[^`]+`/)
+    hdr=substr($0, RSTART+5, RLENGTH-6)
+    in_section=(hdr == lane) ? 1 : 0
+    next
+  }
+  in_section && /\*\*Short name\*\*/ {
+    s=$0
+    i=index(s, "**Short name**")
+    s=substr(s, i+length("**Short name**"))
+    c=index(s, ":")
+    if (c == 0) next
+    s=substr(s, c+1)
+    sub(/^[[:space:]]+/, "", s)
+    if (substr(s, 1, 1) == "`") {
+      # Backtick-quoted (canonical form per Rule 2.1 examples).
+      s=substr(s, 2)
+      bt=index(s, "`")
+      if (bt > 0) { print substr(s, 1, bt-1); exit }
+    } else {
+      # Unquoted fallback — short name is `[a-z0-9-]+` per Rule 2.1, so the
+      # first whitespace/paren is a safe terminator (the char class explicitly
+      # excludes both).
+      for (i=1; i<=length(s); i++) {
+        ch=substr(s,i,1)
+        if (ch == " " || ch == "\t" || ch == "`" || ch == "(") break
+      }
+      if (i > 1) { print substr(s, 1, i-1); exit }
+    }
+  }
+  ' "$LANES_FILE")
+  # Without short name, fall back to lane name itself for branch matching.
+  [ -z "$SHORT_NAME" ] && SHORT_NAME="$LANE_NAME"
+  case "$ACTUAL_BRANCH" in
+    develop|master|main) branch_ok=1 ;;  # tolerated pre-checkout
+    "feature/lane-${LANE_NAME}/TASK-"*) branch_ok=1 ;;
+    "lane/${SHORT_NAME}/"*) branch_ok=1 ;;
+    *) branch_reason="lane '$LANE_NAME' (short '$SHORT_NAME') expects feature/lane-${LANE_NAME}/TASK-* or lane/${SHORT_NAME}/*; got '$ACTUAL_BRANCH'" ;;
+  esac
+fi
+
+if [ "$branch_ok" -ne 1 ]; then
+  if [ "$FORMAT" = "json" ]; then
+    printf '{"verdict":"branch_mismatch","exit":3,"lane":"%s","actual_branch":"%s","reason":"%s"}\n' \
+      "$LANE_NAME" "$ACTUAL_BRANCH" "$branch_reason"
+  else
+    cat >&2 <<EOF
+$PROG: BLOCKED — branch does not match lane '$LANE_NAME' convention.
+  $branch_reason
+Reference: .mercury/docs/guides/lane-naming.md §Δ6 short branch prefix
+Soft-disable: export MERCURY_LANE_ASSERT_DISABLED=1
+EOF
+  fi
+  exit 3
+fi
+
+# ── all checks passed ───────────────────────────────────────────
+if [ "$FORMAT" = "json" ]; then
+  printf '{"verdict":"aligned","exit":0,"lane":"%s","cwd":"%s","branch":"%s","worktree":"%s"}\n' \
+    "$LANE_NAME" "$ACTUAL_CWD" "$ACTUAL_BRANCH" "$WORKTREE_PATH"
+else
+  printf '%s: aligned — lane=%s cwd=%s branch=%s\n' "$PROG" "$LANE_NAME" "$ACTUAL_CWD" "$ACTUAL_BRANCH"
+fi
+exit 0

--- a/scripts/lane-assertion.sh
+++ b/scripts/lane-assertion.sh
@@ -25,7 +25,7 @@
 # Soft-disable via MERCURY_LANE_ASSERT_DISABLED=1 for break-glass scenarios.
 #
 # Usage:
-#   scripts/lane-assertion.sh [--marker LANE=name] [--memory-dir PATH]
+#   scripts/lane-assertion.sh [--marker '[LANE=name]'] [--memory-dir PATH]
 #                             [--lanes-file PATH] [--repo-root PATH]
 #                             [--cwd PATH] [--branch NAME] [--format text|json]
 #
@@ -36,6 +36,7 @@
 #   3 — branch prefix mismatch
 #   4 — Worktree path field missing in LANES.md (Rule 5.1 violation)
 #   5 — argument or environment error
+#   6 — Worktree path field has duplicate bullets in LANES.md
 #
 # Marker resolution priority:
 #   --marker CLI flag

--- a/scripts/test-lane-assertion.sh
+++ b/scripts/test-lane-assertion.sh
@@ -584,6 +584,49 @@ parsed=$(printf '%s' "$err" | jq -r '.actual_cwd' 2>/dev/null)
 assert_eq "jq round-trips quote-escaped JSON" '/path/with/"quote' "$parsed"
 
 # ───────────────────────────────────────────────────────────────
+# Argus iter2 Minor "潜在运行错误" — json_escape was previously defined
+# AFTER the worktree_path_missing / worktree_path_duplicate JSON branches,
+# so those error paths could fail with "command not found" before the
+# function-definition reordering fix.
+# ───────────────────────────────────────────────────────────────
+
+printf '\n=== json_escape function ordering (Argus iter2 minor regression) ===\n'
+
+err=$(env MERCURY_LANE_MARKER='[LANE=nopath]' bash "$ASSERTION" \
+  --memory-dir "$MEMDIR" --cwd '/var/test/nopath' --branch develop --format json 2>&1)
+rc=$?
+assert_eq "json worktree_path_missing branch reaches json_escape -> rc=4" "4" "$rc"
+assert_contains "json worktree_path_missing emits valid JSON" '"verdict":"worktree_path_missing"' "$err"
+parsed=$(printf '%s' "$err" | jq -r '.lane' 2>/dev/null)
+assert_eq "jq parses worktree_path_missing JSON output" 'nopath' "$parsed"
+
+# ───────────────────────────────────────────────────────────────
+# Argus iter2 Minor "校验放宽风险" — side lane on master/main MUST NOT pass.
+# ───────────────────────────────────────────────────────────────
+
+printf '\n=== Side lane branch tightening (Argus iter2 校验放宽风险) ===\n'
+
+err=$(env MERCURY_LANE_MARKER='[LANE=side-multi-lane]' bash "$ASSERTION" \
+  --memory-dir "$MEMDIR" --cwd '/var/test/side-mlane' --branch master 2>&1)
+rc=$?
+assert_eq "side lane on master no longer tolerated -> rc=3" "3" "$rc"
+
+err=$(env MERCURY_LANE_MARKER='[LANE=side-multi-lane]' bash "$ASSERTION" \
+  --memory-dir "$MEMDIR" --cwd '/var/test/side-mlane' --branch main 2>&1)
+rc=$?
+assert_eq "side lane on main no longer tolerated -> rc=3" "3" "$rc"
+
+err=$(env MERCURY_LANE_MARKER='[LANE=side-multi-lane]' bash "$ASSERTION" \
+  --memory-dir "$MEMDIR" --cwd '/var/test/side-mlane' --branch develop 2>&1)
+rc=$?
+assert_eq "side lane on develop still works (canonical pre-checkout) -> rc=0" "0" "$rc"
+
+err=$(env MERCURY_LANE_MARKER='[LANE=main]' bash "$ASSERTION" \
+  --memory-dir "$MEMDIR" --cwd '/var/test/main-lane' --branch master 2>&1)
+rc=$?
+assert_eq "main lane on master still tolerated -> rc=0" "0" "$rc"
+
+# ───────────────────────────────────────────────────────────────
 # Summary
 # ───────────────────────────────────────────────────────────────
 

--- a/scripts/test-lane-assertion.sh
+++ b/scripts/test-lane-assertion.sh
@@ -11,8 +11,18 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ASSERTION="$SCRIPT_DIR/lane-assertion.sh"
 [[ -x "$ASSERTION" ]] || { printf 'lane-assertion.sh not executable: %s\n' "$ASSERTION" >&2; exit 1; }
 
+# `jq` is used for round-trip parsing in JSON-format regression tests.
+# If unavailable, those specific assertions are skipped with a clear note
+# rather than failing non-functionally — matches the lane-cap-check.sh
+# soft-dependency pattern and addresses Argus iter3 Minor "测试依赖隐式".
+HAS_JQ=0
+if command -v jq >/dev/null 2>&1; then
+  HAS_JQ=1
+fi
+
 PASS=0
 FAIL=0
+SKIP=0
 declare -a FAILURES=()
 
 assert_eq() {
@@ -572,16 +582,24 @@ err=$(env MERCURY_LANE_MARKER='[LANE=main]' bash "$ASSERTION" \
 rc=$?
 assert_eq "json with Windows backslash path — rc=2" "2" "$rc"
 assert_contains "json escapes backslashes" 'C:\\Windows' "$err"
-parsed=$(printf '%s' "$err" | jq -r '.actual_cwd' 2>/dev/null)
-assert_eq "jq round-trips backslash-escaped JSON" 'C:\Windows\Path\With\Backslashes' "$parsed"
+if [[ $HAS_JQ -eq 1 ]]; then
+  parsed=$(printf '%s' "$err" | jq -r '.actual_cwd' 2>/dev/null)
+  assert_eq "jq round-trips backslash-escaped JSON" 'C:\Windows\Path\With\Backslashes' "$parsed"
+else
+  SKIP=$((SKIP + 1)); printf '  skip (jq not installed): jq round-trips backslash-escaped JSON\n'
+fi
 
 err=$(env MERCURY_LANE_MARKER='[LANE=main]' bash "$ASSERTION" \
   --memory-dir "$MEMDIR" --cwd '/path/with/"quote' --branch develop --format json 2>&1)
 rc=$?
 assert_eq "json with literal double-quote in cwd — rc=2" "2" "$rc"
 assert_contains "json escapes double-quote" '\"' "$err"
-parsed=$(printf '%s' "$err" | jq -r '.actual_cwd' 2>/dev/null)
-assert_eq "jq round-trips quote-escaped JSON" '/path/with/"quote' "$parsed"
+if [[ $HAS_JQ -eq 1 ]]; then
+  parsed=$(printf '%s' "$err" | jq -r '.actual_cwd' 2>/dev/null)
+  assert_eq "jq round-trips quote-escaped JSON" '/path/with/"quote' "$parsed"
+else
+  SKIP=$((SKIP + 1)); printf '  skip (jq not installed): jq round-trips quote-escaped JSON\n'
+fi
 
 # ───────────────────────────────────────────────────────────────
 # Argus iter2 Minor "潜在运行错误" — json_escape was previously defined
@@ -597,8 +615,12 @@ err=$(env MERCURY_LANE_MARKER='[LANE=nopath]' bash "$ASSERTION" \
 rc=$?
 assert_eq "json worktree_path_missing branch reaches json_escape -> rc=4" "4" "$rc"
 assert_contains "json worktree_path_missing emits valid JSON" '"verdict":"worktree_path_missing"' "$err"
-parsed=$(printf '%s' "$err" | jq -r '.lane' 2>/dev/null)
-assert_eq "jq parses worktree_path_missing JSON output" 'nopath' "$parsed"
+if [[ $HAS_JQ -eq 1 ]]; then
+  parsed=$(printf '%s' "$err" | jq -r '.lane' 2>/dev/null)
+  assert_eq "jq parses worktree_path_missing JSON output" 'nopath' "$parsed"
+else
+  SKIP=$((SKIP + 1)); printf '  skip (jq not installed): jq parses worktree_path_missing JSON output\n'
+fi
 
 # ───────────────────────────────────────────────────────────────
 # Argus iter2 Minor "校验放宽风险" — side lane on master/main MUST NOT pass.
@@ -633,6 +655,7 @@ assert_eq "main lane on master still tolerated -> rc=0" "0" "$rc"
 printf '\n=== Summary ===\n'
 printf 'pass: %d\n' "$PASS"
 printf 'fail: %d\n' "$FAIL"
+printf 'skip: %d (jq-dependent assertions when jq not installed)\n' "$SKIP"
 if [[ "$FAIL" -gt 0 ]]; then
   printf '\nFailures:\n'
   for f in "${FAILURES[@]}"; do

--- a/scripts/test-lane-assertion.sh
+++ b/scripts/test-lane-assertion.sh
@@ -61,7 +61,7 @@ type: project
 
 - **Handoff file**: `session-handoff.md`
 - **Latest session**: S82
-- **Worktree path** (per Rule 5.1, Issue #342): `D:/Mercury/Mercury`
+- **Worktree path** (per Rule 5.1, Issue #342): `/var/test/main-lane`
 - **Branch prefix**: `feature/lane-main/TASK-<N>-*` or `lane/main/<N>-<slug>`
 - **Status**: `active`
 
@@ -69,7 +69,7 @@ type: project
 
 - **Handoff file**: `session-handoff-side-multi-lane.md`
 - **Latest session**: S16-side-multi-lane
-- **Worktree path** (per Rule 5.1, Issue #342 — landed S15 2026-05-03): `D:/Mercury/Mercury-side-mlane` ✅ materialized at S16
+- **Worktree path** (per Rule 5.1, Issue #342 — landed S15 2026-05-03): `/var/test/side-mlane` ✅ materialized at S16
 - **Short name**: `side-mlane` (8 char)
 - **Branch prefix**: `lane/side-mlane/<N>-<slug>` (Rule 2.1)
 - **Status**: `active`
@@ -101,39 +101,39 @@ run_assert() {
 printf '\n=== Happy paths ===\n'
 
 err=$(env MERCURY_LANE_MARKER='[LANE=main]' bash "$ASSERTION" \
-  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury' --branch develop 2>&1)
+  --memory-dir "$MEMDIR" --cwd '/var/test/main-lane' --branch develop 2>&1)
 rc=$?
 assert_eq "main lane on develop — rc=0" "0" "$rc"
 assert_contains "main lane on develop — verdict aligned" "aligned" "$err"
 
 err=$(env MERCURY_LANE_MARKER='[LANE=main]' bash "$ASSERTION" \
-  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury' --branch 'feature/lane-main/TASK-100-foo' 2>&1)
+  --memory-dir "$MEMDIR" --cwd '/var/test/main-lane' --branch 'feature/lane-main/TASK-100-foo' 2>&1)
 rc=$?
 assert_eq "main lane legacy branch — rc=0" "0" "$rc"
 
 err=$(env MERCURY_LANE_MARKER='[LANE=main]' bash "$ASSERTION" \
-  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury' --branch 'feature/TASK-200-bar' 2>&1)
+  --memory-dir "$MEMDIR" --cwd '/var/test/main-lane' --branch 'feature/TASK-200-bar' 2>&1)
 rc=$?
 assert_eq "main lane legacy TASK- branch — rc=0" "0" "$rc"
 
 err=$(env MERCURY_LANE_MARKER='[LANE=main]' bash "$ASSERTION" \
-  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury' --branch 'lane/main/345-handoff' 2>&1)
+  --memory-dir "$MEMDIR" --cwd '/var/test/main-lane' --branch 'lane/main/345-handoff' 2>&1)
 rc=$?
 assert_eq "main lane Rule 2.1 short prefix — rc=0" "0" "$rc"
 
 err=$(env MERCURY_LANE_MARKER='[LANE=side-multi-lane]' bash "$ASSERTION" \
-  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury-side-mlane' --branch 'lane/side-mlane/init' 2>&1)
+  --memory-dir "$MEMDIR" --cwd '/var/test/side-mlane' --branch 'lane/side-mlane/init' 2>&1)
 rc=$?
 assert_eq "side lane scaffold init branch — rc=0" "0" "$rc"
 assert_contains "side lane verdict line includes lane name" "side-multi-lane" "$err"
 
 err=$(env MERCURY_LANE_MARKER='[LANE=side-multi-lane]' bash "$ASSERTION" \
-  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury-side-mlane' --branch 'lane/side-mlane/342-foo' 2>&1)
+  --memory-dir "$MEMDIR" --cwd '/var/test/side-mlane' --branch 'lane/side-mlane/342-foo' 2>&1)
 rc=$?
 assert_eq "side lane Rule 2.1 work branch — rc=0" "0" "$rc"
 
 err=$(env MERCURY_LANE_MARKER='[LANE=side-multi-lane]' bash "$ASSERTION" \
-  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury-side-mlane' --branch 'feature/lane-side-multi-lane/TASK-310-foo' 2>&1)
+  --memory-dir "$MEMDIR" --cwd '/var/test/side-mlane' --branch 'feature/lane-side-multi-lane/TASK-310-foo' 2>&1)
 rc=$?
 assert_eq "side lane legacy long-prefix branch — rc=0" "0" "$rc"
 
@@ -144,23 +144,23 @@ assert_eq "side lane legacy long-prefix branch — rc=0" "0" "$rc"
 printf '\n=== Marker errors (exit 1) ===\n'
 
 err=$(env -u MERCURY_LANE_MARKER -u BOOTSTRAP_PROMPT bash "$ASSERTION" \
-  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury' --branch develop </dev/null 2>&1)
+  --memory-dir "$MEMDIR" --cwd '/var/test/main-lane' --branch develop </dev/null 2>&1)
 rc=$?
 assert_eq "no marker anywhere — rc=1" "1" "$rc"
 assert_contains "no marker — message guides recovery" "no parseable" "$err"
 
 err=$(env MERCURY_LANE_MARKER='LANE=main' bash "$ASSERTION" \
-  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury' --branch develop 2>&1)
+  --memory-dir "$MEMDIR" --cwd '/var/test/main-lane' --branch develop 2>&1)
 rc=$?
 assert_eq "marker missing brackets — rc=1" "1" "$rc"
 
 err=$(env MERCURY_LANE_MARKER='[LANE=]' bash "$ASSERTION" \
-  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury' --branch develop 2>&1)
+  --memory-dir "$MEMDIR" --cwd '/var/test/main-lane' --branch develop 2>&1)
 rc=$?
 assert_eq "marker empty name — rc=1" "1" "$rc"
 
 err=$(env MERCURY_LANE_MARKER='[LANE=Side_Multi]' bash "$ASSERTION" \
-  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury' --branch develop 2>&1)
+  --memory-dir "$MEMDIR" --cwd '/var/test/main-lane' --branch develop 2>&1)
 rc=$?
 assert_eq "marker has uppercase/underscore (Rule 2.1 violation) — rc=1" "1" "$rc"
 
@@ -171,14 +171,14 @@ assert_eq "marker has uppercase/underscore (Rule 2.1 violation) — rc=1" "1" "$
 printf '\n=== cwd mismatch (exit 2) ===\n'
 
 err=$(env MERCURY_LANE_MARKER='[LANE=side-multi-lane]' bash "$ASSERTION" \
-  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury' --branch 'lane/side-mlane/init' 2>&1)
+  --memory-dir "$MEMDIR" --cwd '/var/test/main-lane' --branch 'lane/side-mlane/init' 2>&1)
 rc=$?
 assert_eq "side lane marker but cwd is main checkout — rc=2" "2" "$rc"
 assert_contains "cwd mismatch — guidance points at cd worktree" "cd " "$err"
-assert_contains "cwd mismatch — references worktree path" "Mercury-side-mlane" "$err"
+assert_contains "cwd mismatch — references worktree path" "side-mlane" "$err"
 
 err=$(env MERCURY_LANE_MARKER='[LANE=main]' bash "$ASSERTION" \
-  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury-side-mlane' --branch develop 2>&1)
+  --memory-dir "$MEMDIR" --cwd '/var/test/side-mlane' --branch develop 2>&1)
 rc=$?
 assert_eq "main lane marker but cwd is side worktree — rc=2" "2" "$rc"
 
@@ -189,18 +189,18 @@ assert_eq "main lane marker but cwd is side worktree — rc=2" "2" "$rc"
 printf '\n=== Branch mismatch (exit 3) ===\n'
 
 err=$(env MERCURY_LANE_MARKER='[LANE=main]' bash "$ASSERTION" \
-  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury' --branch 'lane/side-mlane/init' 2>&1)
+  --memory-dir "$MEMDIR" --cwd '/var/test/main-lane' --branch 'lane/side-mlane/init' 2>&1)
 rc=$?
 assert_eq "main lane on side branch — rc=3" "3" "$rc"
 assert_contains "branch mismatch — explains expected" "expects" "$err"
 
 err=$(env MERCURY_LANE_MARKER='[LANE=side-multi-lane]' bash "$ASSERTION" \
-  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury-side-mlane' --branch 'feature/something-unrelated' 2>&1)
+  --memory-dir "$MEMDIR" --cwd '/var/test/side-mlane' --branch 'feature/something-unrelated' 2>&1)
 rc=$?
 assert_eq "side lane on unrelated branch — rc=3" "3" "$rc"
 
 err=$(env MERCURY_LANE_MARKER='[LANE=side-multi-lane]' bash "$ASSERTION" \
-  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury-side-mlane' --branch 'lane/wrong-short/init' 2>&1)
+  --memory-dir "$MEMDIR" --cwd '/var/test/side-mlane' --branch 'lane/wrong-short/init' 2>&1)
 rc=$?
 assert_eq "side lane wrong short-name in branch — rc=3" "3" "$rc"
 
@@ -211,13 +211,13 @@ assert_eq "side lane wrong short-name in branch — rc=3" "3" "$rc"
 printf '\n=== Worktree path missing (exit 4) ===\n'
 
 err=$(env MERCURY_LANE_MARKER='[LANE=nopath]' bash "$ASSERTION" \
-  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury-nopath' --branch develop 2>&1)
+  --memory-dir "$MEMDIR" --cwd '/var/test/nopath' --branch develop 2>&1)
 rc=$?
 assert_eq "lane has no Worktree path field — rc=4" "4" "$rc"
 assert_contains "missing field — points at LANES.md" "LANES.md" "$err"
 
 err=$(env MERCURY_LANE_MARKER='[LANE=ghostlane]' bash "$ASSERTION" \
-  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury-ghost' --branch develop 2>&1)
+  --memory-dir "$MEMDIR" --cwd '/var/test/ghost' --branch develop 2>&1)
 rc=$?
 assert_eq "lane name not present in LANES.md at all — rc=4" "4" "$rc"
 
@@ -234,7 +234,7 @@ assert_eq "soft-disabled, no marker — rc=0" "0" "$rc"
 assert_contains "soft-disable announcement on stdout" "soft-disabled" "$err"
 
 err=$(env MERCURY_LANE_ASSERT_DISABLED=1 MERCURY_LANE_MARKER='[LANE=main]' bash "$ASSERTION" \
-  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury-side-mlane' --branch 'feature/wrong' 2>&1)
+  --memory-dir "$MEMDIR" --cwd '/var/test/side-mlane' --branch 'feature/wrong' 2>&1)
 rc=$?
 assert_eq "soft-disabled with deliberately misaligned state — rc=0" "0" "$rc"
 
@@ -271,18 +271,18 @@ assert_eq "unknown flag — rc=5" "5" "$rc"
 printf '\n=== Marker source priority ===\n'
 
 err=$(env MERCURY_LANE_MARKER='[LANE=side-multi-lane]' bash "$ASSERTION" \
-  --memory-dir "$MEMDIR" --marker '[LANE=main]' --cwd 'D:/Mercury/Mercury' --branch develop 2>&1)
+  --memory-dir "$MEMDIR" --marker '[LANE=main]' --cwd '/var/test/main-lane' --branch develop 2>&1)
 rc=$?
 assert_eq "--marker overrides MERCURY_LANE_MARKER — rc=0 (main wins)" "0" "$rc"
 
 err=$(env -u MERCURY_LANE_MARKER -u BOOTSTRAP_PROMPT bash "$ASSERTION" \
-  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury' --branch develop \
+  --memory-dir "$MEMDIR" --cwd '/var/test/main-lane' --branch develop \
   <<< '[LANE=main] continue from session handoff' 2>&1)
 rc=$?
 assert_eq "stdin marker fallback — rc=0" "0" "$rc"
 
 err=$(env BOOTSTRAP_PROMPT='[LANE=side-multi-lane] continue from handoff' bash "$ASSERTION" \
-  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury-side-mlane' --branch 'lane/side-mlane/init' 2>&1)
+  --memory-dir "$MEMDIR" --cwd '/var/test/side-mlane' --branch 'lane/side-mlane/init' 2>&1)
 rc=$?
 assert_eq "BOOTSTRAP_PROMPT env marker — rc=0" "0" "$rc"
 
@@ -377,17 +377,17 @@ assert_eq "single bullet still works -> rc=0" "0" "$rc"
 printf '\n=== encode_path trailing-slash normalization (Codex M#1 regression) ===\n'
 
 err=$(env MERCURY_LANE_MARKER='[LANE=main]' bash "$ASSERTION" \
-  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury/' --branch develop 2>&1)
+  --memory-dir "$MEMDIR" --cwd '/var/test/main-lane/' --branch develop 2>&1)
 rc=$?
 assert_eq "trailing slash on cwd does not falsely block -> rc=0" "0" "$rc"
 
 err=$(env MERCURY_LANE_MARKER='[LANE=main]' bash "$ASSERTION" \
-  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury\\' --branch develop 2>&1)
+  --memory-dir "$MEMDIR" --cwd '/var/test/main-lane\\' --branch develop 2>&1)
 rc=$?
 assert_eq "trailing backslash on cwd does not falsely block -> rc=0" "0" "$rc"
 
 err=$(env MERCURY_LANE_MARKER='[LANE=main]' bash "$ASSERTION" \
-  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury///' --branch develop 2>&1)
+  --memory-dir "$MEMDIR" --cwd '/var/test/main-lane///' --branch develop 2>&1)
 rc=$?
 assert_eq "multiple trailing slashes normalized -> rc=0" "0" "$rc"
 
@@ -399,22 +399,22 @@ assert_eq "multiple trailing slashes normalized -> rc=0" "0" "$rc"
 printf '\n=== Marker source fall-through on malformed earlier source (Codex L#1) ===\n'
 
 err=$(env MERCURY_LANE_MARKER='garbage' BOOTSTRAP_PROMPT='[LANE=main] continue' bash "$ASSERTION" \
-  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury' --branch develop 2>&1)
+  --memory-dir "$MEMDIR" --cwd '/var/test/main-lane' --branch develop 2>&1)
 rc=$?
 assert_eq "MERCURY_LANE_MARKER garbage falls through to BOOTSTRAP_PROMPT -> rc=0" "0" "$rc"
 
 err=$(env MERCURY_LANE_MARKER='[LANE=main] ' BOOTSTRAP_PROMPT='[LANE=side-multi-lane]' bash "$ASSERTION" \
-  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury' --branch develop 2>&1)
+  --memory-dir "$MEMDIR" --cwd '/var/test/main-lane' --branch develop 2>&1)
 rc=$?
 assert_eq "trailing-space MERCURY_LANE_MARKER still parses (awk word-splits) -> rc=0" "0" "$rc"
 
 err=$(env MERCURY_LANE_MARKER='[LANE=Bad_Name]' BOOTSTRAP_PROMPT='[LANE=main]' bash "$ASSERTION" \
-  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury' --branch develop 2>&1)
+  --memory-dir "$MEMDIR" --cwd '/var/test/main-lane' --branch develop 2>&1)
 rc=$?
 assert_eq "Bad_Name (uppercase+underscore) falls through to valid BOOTSTRAP_PROMPT -> rc=0" "0" "$rc"
 
 err=$(env BOOTSTRAP_PROMPT='[LANE=Bad_Name]' bash "$ASSERTION" \
-  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury' --branch develop \
+  --memory-dir "$MEMDIR" --cwd '/var/test/main-lane' --branch develop \
   <<< '[LANE=main] continue' 2>&1)
 rc=$?
 assert_eq "malformed BOOTSTRAP_PROMPT falls through to stdin -> rc=0" "0" "$rc"
@@ -459,46 +459,46 @@ assert_eq "cwd with trailing spaces still distinct from trimmed path -> rc=2" "2
 printf '\n=== Marker first-token-only enforcement (Codex iter2 L#1) ===\n'
 
 err=$(env MERCURY_LANE_MARKER='preamble [LANE=main] continue' bash "$ASSERTION" \
-  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury' --branch develop 2>&1)
+  --memory-dir "$MEMDIR" --cwd '/var/test/main-lane' --branch develop 2>&1)
 rc=$?
 assert_eq "marker not first token -> rc=1" "1" "$rc"
 
 err=$(env BOOTSTRAP_PROMPT='garbage [LANE=main] continue' bash "$ASSERTION" \
-  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury' --branch develop 2>&1)
+  --memory-dir "$MEMDIR" --cwd '/var/test/main-lane' --branch develop 2>&1)
 rc=$?
 assert_eq "BOOTSTRAP_PROMPT mid-marker rejected -> rc=1" "1" "$rc"
 
 err=$(env -u MERCURY_LANE_MARKER -u BOOTSTRAP_PROMPT bash "$ASSERTION" \
-  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury' --branch develop \
+  --memory-dir "$MEMDIR" --cwd '/var/test/main-lane' --branch develop \
   <<< 'preamble [LANE=main] continue' 2>&1)
 rc=$?
 assert_eq "stdin mid-marker rejected -> rc=1" "1" "$rc"
 
 err=$(env MERCURY_LANE_MARKER='[LANE=main]' bash "$ASSERTION" \
-  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury' --branch develop 2>&1)
+  --memory-dir "$MEMDIR" --cwd '/var/test/main-lane' --branch develop 2>&1)
 rc=$?
 assert_eq "marker as first token (canonical) still passes -> rc=0" "0" "$rc"
 
 err=$(env BOOTSTRAP_PROMPT='[LANE=main] continue from session handoff' bash "$ASSERTION" \
-  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury' --branch develop 2>&1)
+  --memory-dir "$MEMDIR" --cwd '/var/test/main-lane' --branch develop 2>&1)
 rc=$?
 assert_eq "marker as first token of multi-word BOOTSTRAP_PROMPT -> rc=0" "0" "$rc"
 
 # Codex iter3 Low #1: leading blank lines must be skipped — the contract
 # is "first whitespace-delimited token", not "first line's first token".
 err=$(env BOOTSTRAP_PROMPT=$'\n\n[LANE=main] continue' bash "$ASSERTION" \
-  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury' --branch develop 2>&1)
+  --memory-dir "$MEMDIR" --cwd '/var/test/main-lane' --branch develop 2>&1)
 rc=$?
 assert_eq "leading blank lines + marker on line 3 -> rc=0" "0" "$rc"
 
 err=$(env -u MERCURY_LANE_MARKER -u BOOTSTRAP_PROMPT bash "$ASSERTION" \
-  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury' --branch develop \
+  --memory-dir "$MEMDIR" --cwd '/var/test/main-lane' --branch develop \
   <<< $'   \n[LANE=main] continue' 2>&1)
 rc=$?
 assert_eq "stdin with whitespace-only first line + marker line 2 -> rc=0" "0" "$rc"
 
 err=$(env BOOTSTRAP_PROMPT=$'\n\npreamble [LANE=main] continue' bash "$ASSERTION" \
-  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury' --branch develop 2>&1)
+  --memory-dir "$MEMDIR" --cwd '/var/test/main-lane' --branch develop 2>&1)
 rc=$?
 assert_eq "blank lines + mid-token marker still rejected -> rc=1" "1" "$rc"
 
@@ -553,17 +553,35 @@ assert_eq "another-real after fence close -> rc=0" "0" "$rc"
 printf '\n=== JSON format ===\n'
 
 err=$(env MERCURY_LANE_MARKER='[LANE=main]' bash "$ASSERTION" \
-  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury' --branch develop --format json 2>&1)
+  --memory-dir "$MEMDIR" --cwd '/var/test/main-lane' --branch develop --format json 2>&1)
 rc=$?
 assert_eq "json happy path — rc=0" "0" "$rc"
 assert_contains "json output starts with {" '{"verdict"' "$err"
 assert_contains "json output includes lane" '"lane":"main"' "$err"
 
 err=$(env MERCURY_LANE_MARKER='[LANE=main]' bash "$ASSERTION" \
-  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury-side-mlane' --branch develop --format json 2>&1)
+  --memory-dir "$MEMDIR" --cwd '/var/test/side-mlane' --branch develop --format json 2>&1)
 rc=$?
 assert_eq "json cwd mismatch — rc=2" "2" "$rc"
 assert_contains "json mismatch verdict" '"cwd_mismatch"' "$err"
+
+# Argus iter1 Minor JSON-escape regression: Windows backslash path in --cwd
+# must produce VALID JSON (backslash escaped, parseable by jq).
+err=$(env MERCURY_LANE_MARKER='[LANE=main]' bash "$ASSERTION" \
+  --memory-dir "$MEMDIR" --cwd 'C:\Windows\Path\With\Backslashes' --branch develop --format json 2>&1)
+rc=$?
+assert_eq "json with Windows backslash path — rc=2" "2" "$rc"
+assert_contains "json escapes backslashes" 'C:\\Windows' "$err"
+parsed=$(printf '%s' "$err" | jq -r '.actual_cwd' 2>/dev/null)
+assert_eq "jq round-trips backslash-escaped JSON" 'C:\Windows\Path\With\Backslashes' "$parsed"
+
+err=$(env MERCURY_LANE_MARKER='[LANE=main]' bash "$ASSERTION" \
+  --memory-dir "$MEMDIR" --cwd '/path/with/"quote' --branch develop --format json 2>&1)
+rc=$?
+assert_eq "json with literal double-quote in cwd — rc=2" "2" "$rc"
+assert_contains "json escapes double-quote" '\"' "$err"
+parsed=$(printf '%s' "$err" | jq -r '.actual_cwd' 2>/dev/null)
+assert_eq "jq round-trips quote-escaped JSON" '/path/with/"quote' "$parsed"
 
 # ───────────────────────────────────────────────────────────────
 # Summary

--- a/scripts/test-lane-assertion.sh
+++ b/scripts/test-lane-assertion.sh
@@ -1,0 +1,582 @@
+#!/usr/bin/env bash
+# Tests for scripts/lane-assertion.sh — synthetic LANES.md fixtures + env
+# overrides drive the script through every exit code branch. No real
+# user-memory state required; tests are reproducible across machines.
+#
+# Run: bash scripts/test-lane-assertion.sh
+
+set -u  # not -e: each scenario inspects rc explicitly
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ASSERTION="$SCRIPT_DIR/lane-assertion.sh"
+[[ -x "$ASSERTION" ]] || { printf 'lane-assertion.sh not executable: %s\n' "$ASSERTION" >&2; exit 1; }
+
+PASS=0
+FAIL=0
+declare -a FAILURES=()
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok %s\n' "$label"
+  else
+    FAIL=$((FAIL + 1))
+    FAILURES+=("$label: expected [$expected], got [$actual]")
+    printf '  FAIL %s -- expected [%s], got [%s]\n' "$label" "$expected" "$actual"
+  fi
+}
+
+assert_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok %s\n' "$label"
+  else
+    FAIL=$((FAIL + 1))
+    FAILURES+=("$label: missing [$needle]")
+    printf '  FAIL %s -- missing [%s]\n' "$label" "$needle"
+  fi
+}
+
+# Fixture work dir.
+WORK_DIR="$(mktemp -d -t lane-assertion-test.XXXXXX)" || { printf 'mktemp failed\n' >&2; exit 1; }
+trap '[[ -n "${WORK_DIR:-}" && -d "$WORK_DIR" ]] && rm -rf "$WORK_DIR"' EXIT
+
+MEMDIR="$WORK_DIR/memory"
+mkdir -p "$MEMDIR"
+
+# ── Synthetic LANES.md fixture matching real Mercury structure ──
+cat > "$MEMDIR/LANES.md" <<'LANES_EOF'
+---
+name: LANES
+description: test fixture
+type: project
+---
+# Mercury Lanes Registry
+
+## Active Lanes
+
+### `main`
+
+- **Handoff file**: `session-handoff.md`
+- **Latest session**: S82
+- **Worktree path** (per Rule 5.1, Issue #342): `D:/Mercury/Mercury`
+- **Branch prefix**: `feature/lane-main/TASK-<N>-*` or `lane/main/<N>-<slug>`
+- **Status**: `active`
+
+### `side-multi-lane`
+
+- **Handoff file**: `session-handoff-side-multi-lane.md`
+- **Latest session**: S16-side-multi-lane
+- **Worktree path** (per Rule 5.1, Issue #342 — landed S15 2026-05-03): `D:/Mercury/Mercury-side-mlane` ✅ materialized at S16
+- **Short name**: `side-mlane` (8 char)
+- **Branch prefix**: `lane/side-mlane/<N>-<slug>` (Rule 2.1)
+- **Status**: `active`
+
+### `nopath`
+
+- **Handoff file**: `session-handoff-nopath.md`
+- **Status**: `active`
+LANES_EOF
+
+run_assert() {
+  # $1 label  $2 expected_rc  $3+ args / env (passed via env-prefix)
+  local label="$1" want_rc="$2"
+  shift 2
+  printf '\n[scenario] %s\n' "$label"
+  local out rc
+  out=$(env "$@" bash "$ASSERTION" --memory-dir "$MEMDIR" 2>&1)
+  rc=$?
+  assert_eq "  exit code" "$want_rc" "$rc"
+  printf '%s\n' "$out" >> "$WORK_DIR/last-output.log"
+  printf '%s' "$out"
+  return $rc
+}
+
+# ───────────────────────────────────────────────────────────────
+# Happy paths — main + side lane each on develop and on a valid branch
+# ───────────────────────────────────────────────────────────────
+
+printf '\n=== Happy paths ===\n'
+
+err=$(env MERCURY_LANE_MARKER='[LANE=main]' bash "$ASSERTION" \
+  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury' --branch develop 2>&1)
+rc=$?
+assert_eq "main lane on develop — rc=0" "0" "$rc"
+assert_contains "main lane on develop — verdict aligned" "aligned" "$err"
+
+err=$(env MERCURY_LANE_MARKER='[LANE=main]' bash "$ASSERTION" \
+  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury' --branch 'feature/lane-main/TASK-100-foo' 2>&1)
+rc=$?
+assert_eq "main lane legacy branch — rc=0" "0" "$rc"
+
+err=$(env MERCURY_LANE_MARKER='[LANE=main]' bash "$ASSERTION" \
+  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury' --branch 'feature/TASK-200-bar' 2>&1)
+rc=$?
+assert_eq "main lane legacy TASK- branch — rc=0" "0" "$rc"
+
+err=$(env MERCURY_LANE_MARKER='[LANE=main]' bash "$ASSERTION" \
+  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury' --branch 'lane/main/345-handoff' 2>&1)
+rc=$?
+assert_eq "main lane Rule 2.1 short prefix — rc=0" "0" "$rc"
+
+err=$(env MERCURY_LANE_MARKER='[LANE=side-multi-lane]' bash "$ASSERTION" \
+  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury-side-mlane' --branch 'lane/side-mlane/init' 2>&1)
+rc=$?
+assert_eq "side lane scaffold init branch — rc=0" "0" "$rc"
+assert_contains "side lane verdict line includes lane name" "side-multi-lane" "$err"
+
+err=$(env MERCURY_LANE_MARKER='[LANE=side-multi-lane]' bash "$ASSERTION" \
+  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury-side-mlane' --branch 'lane/side-mlane/342-foo' 2>&1)
+rc=$?
+assert_eq "side lane Rule 2.1 work branch — rc=0" "0" "$rc"
+
+err=$(env MERCURY_LANE_MARKER='[LANE=side-multi-lane]' bash "$ASSERTION" \
+  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury-side-mlane' --branch 'feature/lane-side-multi-lane/TASK-310-foo' 2>&1)
+rc=$?
+assert_eq "side lane legacy long-prefix branch — rc=0" "0" "$rc"
+
+# ───────────────────────────────────────────────────────────────
+# Marker missing / malformed → exit 1
+# ───────────────────────────────────────────────────────────────
+
+printf '\n=== Marker errors (exit 1) ===\n'
+
+err=$(env -u MERCURY_LANE_MARKER -u BOOTSTRAP_PROMPT bash "$ASSERTION" \
+  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury' --branch develop </dev/null 2>&1)
+rc=$?
+assert_eq "no marker anywhere — rc=1" "1" "$rc"
+assert_contains "no marker — message guides recovery" "no parseable" "$err"
+
+err=$(env MERCURY_LANE_MARKER='LANE=main' bash "$ASSERTION" \
+  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury' --branch develop 2>&1)
+rc=$?
+assert_eq "marker missing brackets — rc=1" "1" "$rc"
+
+err=$(env MERCURY_LANE_MARKER='[LANE=]' bash "$ASSERTION" \
+  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury' --branch develop 2>&1)
+rc=$?
+assert_eq "marker empty name — rc=1" "1" "$rc"
+
+err=$(env MERCURY_LANE_MARKER='[LANE=Side_Multi]' bash "$ASSERTION" \
+  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury' --branch develop 2>&1)
+rc=$?
+assert_eq "marker has uppercase/underscore (Rule 2.1 violation) — rc=1" "1" "$rc"
+
+# ───────────────────────────────────────────────────────────────
+# cwd mismatch → exit 2 (the routing-bleed risk #342)
+# ───────────────────────────────────────────────────────────────
+
+printf '\n=== cwd mismatch (exit 2) ===\n'
+
+err=$(env MERCURY_LANE_MARKER='[LANE=side-multi-lane]' bash "$ASSERTION" \
+  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury' --branch 'lane/side-mlane/init' 2>&1)
+rc=$?
+assert_eq "side lane marker but cwd is main checkout — rc=2" "2" "$rc"
+assert_contains "cwd mismatch — guidance points at cd worktree" "cd " "$err"
+assert_contains "cwd mismatch — references worktree path" "Mercury-side-mlane" "$err"
+
+err=$(env MERCURY_LANE_MARKER='[LANE=main]' bash "$ASSERTION" \
+  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury-side-mlane' --branch develop 2>&1)
+rc=$?
+assert_eq "main lane marker but cwd is side worktree — rc=2" "2" "$rc"
+
+# ───────────────────────────────────────────────────────────────
+# Branch prefix mismatch → exit 3
+# ───────────────────────────────────────────────────────────────
+
+printf '\n=== Branch mismatch (exit 3) ===\n'
+
+err=$(env MERCURY_LANE_MARKER='[LANE=main]' bash "$ASSERTION" \
+  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury' --branch 'lane/side-mlane/init' 2>&1)
+rc=$?
+assert_eq "main lane on side branch — rc=3" "3" "$rc"
+assert_contains "branch mismatch — explains expected" "expects" "$err"
+
+err=$(env MERCURY_LANE_MARKER='[LANE=side-multi-lane]' bash "$ASSERTION" \
+  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury-side-mlane' --branch 'feature/something-unrelated' 2>&1)
+rc=$?
+assert_eq "side lane on unrelated branch — rc=3" "3" "$rc"
+
+err=$(env MERCURY_LANE_MARKER='[LANE=side-multi-lane]' bash "$ASSERTION" \
+  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury-side-mlane' --branch 'lane/wrong-short/init' 2>&1)
+rc=$?
+assert_eq "side lane wrong short-name in branch — rc=3" "3" "$rc"
+
+# ───────────────────────────────────────────────────────────────
+# Worktree path missing in LANES.md → exit 4
+# ───────────────────────────────────────────────────────────────
+
+printf '\n=== Worktree path missing (exit 4) ===\n'
+
+err=$(env MERCURY_LANE_MARKER='[LANE=nopath]' bash "$ASSERTION" \
+  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury-nopath' --branch develop 2>&1)
+rc=$?
+assert_eq "lane has no Worktree path field — rc=4" "4" "$rc"
+assert_contains "missing field — points at LANES.md" "LANES.md" "$err"
+
+err=$(env MERCURY_LANE_MARKER='[LANE=ghostlane]' bash "$ASSERTION" \
+  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury-ghost' --branch develop 2>&1)
+rc=$?
+assert_eq "lane name not present in LANES.md at all — rc=4" "4" "$rc"
+
+# ───────────────────────────────────────────────────────────────
+# Soft-disable — bypasses every check, exits 0
+# ───────────────────────────────────────────────────────────────
+
+printf '\n=== Soft-disable env (exit 0 always) ===\n'
+
+err=$(env MERCURY_LANE_ASSERT_DISABLED=1 bash "$ASSERTION" \
+  --memory-dir "$MEMDIR" 2>&1)
+rc=$?
+assert_eq "soft-disabled, no marker — rc=0" "0" "$rc"
+assert_contains "soft-disable announcement on stdout" "soft-disabled" "$err"
+
+err=$(env MERCURY_LANE_ASSERT_DISABLED=1 MERCURY_LANE_MARKER='[LANE=main]' bash "$ASSERTION" \
+  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury-side-mlane' --branch 'feature/wrong' 2>&1)
+rc=$?
+assert_eq "soft-disabled with deliberately misaligned state — rc=0" "0" "$rc"
+
+# ───────────────────────────────────────────────────────────────
+# Argument errors → exit 5
+# ───────────────────────────────────────────────────────────────
+
+printf '\n=== Argument errors (exit 5) ===\n'
+
+err=$(bash "$ASSERTION" --memory-dir 2>&1)
+rc=$?
+assert_eq "--memory-dir without value — rc=5" "5" "$rc"
+
+err=$(bash "$ASSERTION" --memory-dir '' 2>&1)
+rc=$?
+assert_eq "--memory-dir with empty value — rc=5" "5" "$rc"
+
+err=$(bash "$ASSERTION" --memory-dir "$WORK_DIR/does-not-exist" 2>&1)
+rc=$?
+assert_eq "--memory-dir non-existent — rc=5" "5" "$rc"
+
+err=$(bash "$ASSERTION" --memory-dir "$MEMDIR" --format weird 2>&1)
+rc=$?
+assert_eq "--format unknown value — rc=5" "5" "$rc"
+
+err=$(bash "$ASSERTION" --memory-dir "$MEMDIR" --unknown-flag 2>&1)
+rc=$?
+assert_eq "unknown flag — rc=5" "5" "$rc"
+
+# ───────────────────────────────────────────────────────────────
+# Marker source priority: CLI > env > stdin
+# ───────────────────────────────────────────────────────────────
+
+printf '\n=== Marker source priority ===\n'
+
+err=$(env MERCURY_LANE_MARKER='[LANE=side-multi-lane]' bash "$ASSERTION" \
+  --memory-dir "$MEMDIR" --marker '[LANE=main]' --cwd 'D:/Mercury/Mercury' --branch develop 2>&1)
+rc=$?
+assert_eq "--marker overrides MERCURY_LANE_MARKER — rc=0 (main wins)" "0" "$rc"
+
+err=$(env -u MERCURY_LANE_MARKER -u BOOTSTRAP_PROMPT bash "$ASSERTION" \
+  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury' --branch develop \
+  <<< '[LANE=main] continue from session handoff' 2>&1)
+rc=$?
+assert_eq "stdin marker fallback — rc=0" "0" "$rc"
+
+err=$(env BOOTSTRAP_PROMPT='[LANE=side-multi-lane] continue from handoff' bash "$ASSERTION" \
+  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury-side-mlane' --branch 'lane/side-mlane/init' 2>&1)
+rc=$?
+assert_eq "BOOTSTRAP_PROMPT env marker — rc=0" "0" "$rc"
+
+# ───────────────────────────────────────────────────────────────
+# Codex iter1 High #1: backtick-quoted Worktree paths must preserve spaces.
+# `/Users/Alice Smith/repos/Mercury-side` MUST be returned whole, not
+# truncated at the first whitespace. Same for paths with parens like
+# `C:/Program Files (x86)/Mercury`.
+# ───────────────────────────────────────────────────────────────
+
+printf '\n=== Worktree paths with spaces / parens (Codex H#1 regression) ===\n'
+
+SPACE_MEM="$WORK_DIR/space-mem"
+mkdir -p "$SPACE_MEM"
+cat > "$SPACE_MEM/LANES.md" <<'SPACE_EOF'
+---
+type: project
+---
+### `with-space`
+
+- **Worktree path**: `/Users/Alice Smith/repos/Mercury-with-space`
+
+### `with-paren`
+
+- **Worktree path**: `C:/Program Files (x86)/Mercury-with-paren`
+
+### `unquoted-legacy`
+
+- **Worktree path**: /tmp/unquoted-path
+SPACE_EOF
+
+err=$(env MERCURY_LANE_MARKER='[LANE=with-space]' bash "$ASSERTION" \
+  --memory-dir "$SPACE_MEM" --cwd '/Users/Alice Smith/repos/Mercury-with-space' --branch develop 2>&1)
+rc=$?
+assert_eq "spaces in path preserved -> rc=0" "0" "$rc"
+assert_contains "verdict shows full path" 'Alice Smith' "$err"
+
+err=$(env MERCURY_LANE_MARKER='[LANE=with-space]' bash "$ASSERTION" \
+  --memory-dir "$SPACE_MEM" --cwd '/Users/Alice' --branch develop 2>&1)
+rc=$?
+assert_eq "truncated cwd no longer falsely passes -> rc=2" "2" "$rc"
+
+err=$(env MERCURY_LANE_MARKER='[LANE=with-paren]' bash "$ASSERTION" \
+  --memory-dir "$SPACE_MEM" --cwd 'C:/Program Files (x86)/Mercury-with-paren' --branch develop 2>&1)
+rc=$?
+assert_eq "parens in path preserved (Program Files (x86)) -> rc=0" "0" "$rc"
+
+err=$(env MERCURY_LANE_MARKER='[LANE=unquoted-legacy]' bash "$ASSERTION" \
+  --memory-dir "$SPACE_MEM" --cwd '/tmp/unquoted-path' --branch develop 2>&1)
+rc=$?
+assert_eq "unquoted legacy path still works -> rc=0" "0" "$rc"
+
+# ───────────────────────────────────────────────────────────────
+# Codex iter1 High #2: duplicate Worktree path bullets MUST exit 6,
+# not silently first-wins.
+# ───────────────────────────────────────────────────────────────
+
+printf '\n=== Duplicate Worktree path bullets (Codex H#2 regression) ===\n'
+
+DUP_MEM="$WORK_DIR/dup-mem"
+mkdir -p "$DUP_MEM"
+cat > "$DUP_MEM/LANES.md" <<'DUP_EOF'
+---
+type: project
+---
+### `dup`
+
+- **Worktree path**: `/old/stale/path`
+- **Worktree path**: `/new/correct/path`
+
+### `single`
+
+- **Worktree path**: `/just/one`
+DUP_EOF
+
+err=$(env MERCURY_LANE_MARKER='[LANE=dup]' bash "$ASSERTION" \
+  --memory-dir "$DUP_MEM" --cwd '/new/correct/path' --branch develop 2>&1)
+rc=$?
+assert_eq "duplicate Worktree path -> rc=6" "6" "$rc"
+assert_contains "duplicate message includes count" "Worktree path bullets" "$err"
+
+err=$(env MERCURY_LANE_MARKER='[LANE=single]' bash "$ASSERTION" \
+  --memory-dir "$DUP_MEM" --cwd '/just/one' --branch develop 2>&1)
+rc=$?
+assert_eq "single bullet still works -> rc=0" "0" "$rc"
+
+# ───────────────────────────────────────────────────────────────
+# Codex iter1 Medium #1: encode_path normalization — trailing slash
+# in Worktree path field or cwd MUST NOT cause false-block.
+# ───────────────────────────────────────────────────────────────
+
+printf '\n=== encode_path trailing-slash normalization (Codex M#1 regression) ===\n'
+
+err=$(env MERCURY_LANE_MARKER='[LANE=main]' bash "$ASSERTION" \
+  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury/' --branch develop 2>&1)
+rc=$?
+assert_eq "trailing slash on cwd does not falsely block -> rc=0" "0" "$rc"
+
+err=$(env MERCURY_LANE_MARKER='[LANE=main]' bash "$ASSERTION" \
+  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury\\' --branch develop 2>&1)
+rc=$?
+assert_eq "trailing backslash on cwd does not falsely block -> rc=0" "0" "$rc"
+
+err=$(env MERCURY_LANE_MARKER='[LANE=main]' bash "$ASSERTION" \
+  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury///' --branch develop 2>&1)
+rc=$?
+assert_eq "multiple trailing slashes normalized -> rc=0" "0" "$rc"
+
+# ───────────────────────────────────────────────────────────────
+# Codex iter1 Low #1: malformed earlier marker source MUST NOT block
+# fallback to later sources. Documented contract: "first parseable wins".
+# ───────────────────────────────────────────────────────────────
+
+printf '\n=== Marker source fall-through on malformed earlier source (Codex L#1) ===\n'
+
+err=$(env MERCURY_LANE_MARKER='garbage' BOOTSTRAP_PROMPT='[LANE=main] continue' bash "$ASSERTION" \
+  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury' --branch develop 2>&1)
+rc=$?
+assert_eq "MERCURY_LANE_MARKER garbage falls through to BOOTSTRAP_PROMPT -> rc=0" "0" "$rc"
+
+err=$(env MERCURY_LANE_MARKER='[LANE=main] ' BOOTSTRAP_PROMPT='[LANE=side-multi-lane]' bash "$ASSERTION" \
+  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury' --branch develop 2>&1)
+rc=$?
+assert_eq "trailing-space MERCURY_LANE_MARKER still parses (awk word-splits) -> rc=0" "0" "$rc"
+
+err=$(env MERCURY_LANE_MARKER='[LANE=Bad_Name]' BOOTSTRAP_PROMPT='[LANE=main]' bash "$ASSERTION" \
+  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury' --branch develop 2>&1)
+rc=$?
+assert_eq "Bad_Name (uppercase+underscore) falls through to valid BOOTSTRAP_PROMPT -> rc=0" "0" "$rc"
+
+err=$(env BOOTSTRAP_PROMPT='[LANE=Bad_Name]' bash "$ASSERTION" \
+  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury' --branch develop \
+  <<< '[LANE=main] continue' 2>&1)
+rc=$?
+assert_eq "malformed BOOTSTRAP_PROMPT falls through to stdin -> rc=0" "0" "$rc"
+
+# ───────────────────────────────────────────────────────────────
+# Codex iter2 Medium #1: backtick-quoted Worktree path must trim
+# trailing whitespace inside the quoted region (invisible-typo defense).
+# ───────────────────────────────────────────────────────────────
+
+printf '\n=== Backtick-quoted trailing whitespace trim (Codex iter2 M#1) ===\n'
+
+TRIM_MEM="$WORK_DIR/trim-mem"
+mkdir -p "$TRIM_MEM"
+cat > "$TRIM_MEM/LANES.md" <<'TRIM_EOF'
+---
+type: project
+---
+### `with-trail`
+
+- **Worktree path**: `/tmp/trail-target   `
+TRIM_EOF
+
+err=$(env MERCURY_LANE_MARKER='[LANE=with-trail]' bash "$ASSERTION" \
+  --memory-dir "$TRIM_MEM" --cwd '/tmp/trail-target' --branch develop 2>&1)
+rc=$?
+assert_eq "trailing whitespace inside backticks trimmed -> rc=0" "0" "$rc"
+
+err=$(env MERCURY_LANE_MARKER='[LANE=with-trail]' bash "$ASSERTION" \
+  --memory-dir "$TRIM_MEM" --cwd '/tmp/trail-target   ' --branch develop --format json 2>&1)
+rc=$?
+# After trim, expected_enc has no trailing dashes; cwd encode keeps trailing
+# slash-dashes after tr conversion of spaces? No — encode_path strips trailing
+# `/` and `\` only, NOT spaces; spaces don't appear in raw paths typically.
+# But cwd with literal trailing spaces (encoded form differs) → rc=2.
+assert_eq "cwd with trailing spaces still distinct from trimmed path -> rc=2" "2" "$rc"
+
+# ───────────────────────────────────────────────────────────────
+# Codex iter2 Low #1: [LANE=...] marker MUST be the FIRST whitespace-
+# delimited token. Mid-prompt markers must NOT pass.
+# ───────────────────────────────────────────────────────────────
+
+printf '\n=== Marker first-token-only enforcement (Codex iter2 L#1) ===\n'
+
+err=$(env MERCURY_LANE_MARKER='preamble [LANE=main] continue' bash "$ASSERTION" \
+  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury' --branch develop 2>&1)
+rc=$?
+assert_eq "marker not first token -> rc=1" "1" "$rc"
+
+err=$(env BOOTSTRAP_PROMPT='garbage [LANE=main] continue' bash "$ASSERTION" \
+  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury' --branch develop 2>&1)
+rc=$?
+assert_eq "BOOTSTRAP_PROMPT mid-marker rejected -> rc=1" "1" "$rc"
+
+err=$(env -u MERCURY_LANE_MARKER -u BOOTSTRAP_PROMPT bash "$ASSERTION" \
+  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury' --branch develop \
+  <<< 'preamble [LANE=main] continue' 2>&1)
+rc=$?
+assert_eq "stdin mid-marker rejected -> rc=1" "1" "$rc"
+
+err=$(env MERCURY_LANE_MARKER='[LANE=main]' bash "$ASSERTION" \
+  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury' --branch develop 2>&1)
+rc=$?
+assert_eq "marker as first token (canonical) still passes -> rc=0" "0" "$rc"
+
+err=$(env BOOTSTRAP_PROMPT='[LANE=main] continue from session handoff' bash "$ASSERTION" \
+  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury' --branch develop 2>&1)
+rc=$?
+assert_eq "marker as first token of multi-word BOOTSTRAP_PROMPT -> rc=0" "0" "$rc"
+
+# Codex iter3 Low #1: leading blank lines must be skipped — the contract
+# is "first whitespace-delimited token", not "first line's first token".
+err=$(env BOOTSTRAP_PROMPT=$'\n\n[LANE=main] continue' bash "$ASSERTION" \
+  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury' --branch develop 2>&1)
+rc=$?
+assert_eq "leading blank lines + marker on line 3 -> rc=0" "0" "$rc"
+
+err=$(env -u MERCURY_LANE_MARKER -u BOOTSTRAP_PROMPT bash "$ASSERTION" \
+  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury' --branch develop \
+  <<< $'   \n[LANE=main] continue' 2>&1)
+rc=$?
+assert_eq "stdin with whitespace-only first line + marker line 2 -> rc=0" "0" "$rc"
+
+err=$(env BOOTSTRAP_PROMPT=$'\n\npreamble [LANE=main] continue' bash "$ASSERTION" \
+  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury' --branch develop 2>&1)
+rc=$?
+assert_eq "blank lines + mid-token marker still rejected -> rc=1" "1" "$rc"
+
+# ───────────────────────────────────────────────────────────────
+# Code-fence edge case: a `### \`<name>\`` heading inside ``` fence
+# must NOT match. Otherwise documentation examples leak into parsing.
+# ───────────────────────────────────────────────────────────────
+
+printf '\n=== Code-fence isolation ===\n'
+
+FENCE_MEM="$WORK_DIR/fence-mem"
+mkdir -p "$FENCE_MEM"
+cat > "$FENCE_MEM/LANES.md" <<'FENCE_EOF'
+---
+type: project
+---
+# Fixture
+### `real-lane`
+
+- **Worktree path**: `/real/path`
+
+```
+### `fake-lane`
+- **Worktree path**: `/should/not/match`
+```
+
+### `another-real`
+
+- **Worktree path**: `/another/real`
+FENCE_EOF
+
+err=$(env MERCURY_LANE_MARKER='[LANE=fake-lane]' bash "$ASSERTION" \
+  --memory-dir "$FENCE_MEM" --cwd '/should/not/match' --branch develop 2>&1)
+rc=$?
+assert_eq "fake-lane inside fence -> rc=4 (Worktree path missing)" "4" "$rc"
+assert_contains "fake-lane fence isolation message" "no Worktree path" "$err"
+
+err=$(env MERCURY_LANE_MARKER='[LANE=real-lane]' bash "$ASSERTION" \
+  --memory-dir "$FENCE_MEM" --cwd '/real/path' --branch develop 2>&1)
+rc=$?
+assert_eq "real-lane outside fence -> rc=0" "0" "$rc"
+
+err=$(env MERCURY_LANE_MARKER='[LANE=another-real]' bash "$ASSERTION" \
+  --memory-dir "$FENCE_MEM" --cwd '/another/real' --branch develop 2>&1)
+rc=$?
+assert_eq "another-real after fence close -> rc=0" "0" "$rc"
+
+# ───────────────────────────────────────────────────────────────
+# JSON format
+# ───────────────────────────────────────────────────────────────
+
+printf '\n=== JSON format ===\n'
+
+err=$(env MERCURY_LANE_MARKER='[LANE=main]' bash "$ASSERTION" \
+  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury' --branch develop --format json 2>&1)
+rc=$?
+assert_eq "json happy path — rc=0" "0" "$rc"
+assert_contains "json output starts with {" '{"verdict"' "$err"
+assert_contains "json output includes lane" '"lane":"main"' "$err"
+
+err=$(env MERCURY_LANE_MARKER='[LANE=main]' bash "$ASSERTION" \
+  --memory-dir "$MEMDIR" --cwd 'D:/Mercury/Mercury-side-mlane' --branch develop --format json 2>&1)
+rc=$?
+assert_eq "json cwd mismatch — rc=2" "2" "$rc"
+assert_contains "json mismatch verdict" '"cwd_mismatch"' "$err"
+
+# ───────────────────────────────────────────────────────────────
+# Summary
+# ───────────────────────────────────────────────────────────────
+
+printf '\n=== Summary ===\n'
+printf 'pass: %d\n' "$PASS"
+printf 'fail: %d\n' "$FAIL"
+if [[ "$FAIL" -gt 0 ]]; then
+  printf '\nFailures:\n'
+  for f in "${FAILURES[@]}"; do
+    printf '  - %s\n' "$f"
+  done
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #345

## Why

`feedback_lane_protocol.md` v0.1 Δ9 (Issue #342, landed S15-side-multi-lane 2026-05-03 PR #344) defined per-lane worktree paths so Claude Code's per-cwd project state (`~/.claude/projects/<encoded-cwd>/`) is isolated per lane. Path A (docs) landed; this PR closes the deferred Path B (mechanics — handoff skill substitutes `<cwd>` with lane worktree path) + Path C (agent — bootstrap prompt strict `[LANE=<name>]` marker + SessionStart-time three-way alignment assertion).

Without this work, lane-blind auto-handoffs can still re-trigger the S13-side-multi-lane share-cwd routing-bleed failure mode that Δ9 was designed to prevent.

## What

| File | LOC | Purpose |
|------|-----|---------|
| `scripts/lane-assertion.sh` | +293 NEW | Three-way alignment check (marker × cwd-encoded × branch prefix); exit codes 0=aligned, 1=marker missing, 2=cwd mismatch, 3=branch mismatch, 4=Worktree path missing, 5=arg error, 6=Worktree path duplicated; soft-disable `MERCURY_LANE_ASSERT_DISABLED=1` |
| `scripts/test-lane-assertion.sh` | +621 NEW | 70-assertion test suite with synthetic `LANES.md` fixtures |
| `.claude/skills/handoff/SKILL.md` | +138/-50 | Step 5 Auto mode: migrate inline → SHORT_PROMPT (per `feedback_handoff_short_prompt_only.md`); add lane resolution + `[LANE=<name>]` marker + `wt -d/tmux -c $WORKTREE_PATH`; pre-launch lane-assertion smoke check; Rules § add Δ10/Δ11 entry |
| `.mercury/docs/guides/lane-naming.md` | +83 | Append §Δ10 (handoff worktree integration) + §Δ11 (Path C agent assertion + soft-disable + forward-looking hook integration) under §Lane workspace isolation; cross-refs + source-refs updated |

## Verification

**Tests**: 70/70 pass via `bash scripts/test-lane-assertion.sh`. Coverage:
- Happy paths (main + side lane on develop / Rule 2.1 / legacy branches)
- All 6 exit-code branches
- Marker source fall-through on malformed earlier sources
- JSON format
- Soft-disable env var
- Backtick-quoted Worktree paths with spaces (`/Users/Alice Smith/...`) + parens (`C:/Program Files (x86)/...`)
- Duplicate Worktree path bullets rejected (exit 6)
- `encode_path` trailing-slash / backslash normalization
- First-token-only marker enforcement (mid-prompt rejected)
- Leading blank lines tolerated (first NON-BLANK line's first token)
- Code-fence isolation (`### `<name>`` headings inside ` ``` ` fence ignored)
- CRLF + nested heading edge cases

**Live smoke** against real user-memory LANES.md (post main lane Worktree path field add):
- main lane on develop → exit 0 aligned ✓
- side-multi-lane on `lane/side-mlane/init` at `D:/Mercury/Mercury-side-mlane` → exit 0 aligned ✓

**Dual-verify trajectory** (4 Codex iters to convergence):

| Iter | Findings | Outcome |
|------|----------|---------|
| iter1 | 2 High + 1 Medium + 1 Low | NEEDS-CHANGES |
| iter2 | 1 Medium + 1 Low | NEEDS-CHANGES |
| iter3 | 1 Low | NEEDS-CHANGES |
| iter4 | 0 | **PASS** |

All 6 cumulative findings addressed:
- High #1 — Worktree path truncation on whitespace → backtick-quoted extractor
- High #2 — Duplicate bullets first-wins → exit 6 reject
- Medium #1 — `encode_path` no trailing-slash normalization → strip `/` and `\`
- Medium #2 — Backtick-quoted trailing space not trimmed → `sub(/[[:space:]]+$/, "", out)`
- Low #1 (iter1) — Marker source fall-through on malformed → `_try_parse_marker()` helper
- Low #2 (iter2) — Marker scanned all fields not just $1 → first non-blank line's `$1` only
- Low #3 (iter3) — `NR==1` rejected leading blank lines → skip whitespace-only lines first

**Claude side**: PASS (no findings; correctness verified by inspection).

## Out of scope

- User-level (`~/.claude/`) hook deployment of lane-assertion: deferred per lane-naming.md §Δ11 §Hook integration. Needs ≥3 sessions of real auto-handoff usage to validate low false-positive rate before becoming unconditional infrastructure.
- `feedback_lane_protocol.md` Rule 5.1.1 + 5.1.2 docs (user-memory file, not in repo) — written at session close.

## Refs

- #342 (Δ9 Path A — docs landed S15)
- `feedback_lane_protocol.md` Rule 5.1
- `feedback_handoff_short_prompt_only.md` (S3-side-multi-lane SHORT_PROMPT lesson — drove SKILL.md migration in this PR)
- `feedback_argus_nit_loop.md` (followed convergence pattern; iter4 reached natural PASS)

Generated with Claude Code
