### PR TITLE
docs(claude-md): scope 200-LOC adapter rule to external-project adapters (#348)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,7 @@ Mercury 的部分功能跨仓库运作。以下表格记录外部仓库与 Mercu
 - **PR to develop**: all code merges into develop must go through a PR. Direct push to develop is forbidden.
 - **Install to D drive**: install software to `D:\Program Files`, not C drive.
 - **Modular design**: every new feature must be independently detachable. If it cannot be used outside Mercury, the coupling is too deep.
+- **External-project adapters under `adapters/<vendor-name>/` MUST stay under 200 lines.** If an external integration needs more than that, rethink the mounting approach. This rule does NOT apply to Mercury-internal tooling under `scripts/` — internal tooling implements the protocol that lives in this repo and isn't trying to mount anything external, so it has no LOC cap (size by need). Empirical drivers: PR #338 (`scripts/codex-sync-audit.sh` ~360 LOC) and PR #346 (`scripts/lane-assertion.sh` ~440 LOC) both hit Argus nit-loops on the adapter-size finding, requiring iter-3+ escape-hatch / disagree replies before APPROVED.
 - **No self-research**: if an external project can solve the problem, mount it via submodule rather than reimplementing.
 
 ## DO NOT
@@ -72,7 +73,7 @@ Mercury 的部分功能跨仓库运作。以下表格记录外部仓库与 Mercu
 - Do not commit without running `/dual-verify`.
 - Do not create PRs without an associated GitHub Issue.
 - Do not build features that assume the model is weak — design for upward compatibility.
-- Do not create adapters exceeding 200 lines — rethink the mounting approach if this happens.
+- Do not create **external-project adapters** under `adapters/<vendor-name>/` exceeding 200 lines — rethink the mounting approach if this happens. (Mercury-internal tooling under `scripts/` is exempt — see MUST §"External-project adapters" carve-out.)
 
 ## Cherry-pick protocol
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ Mercury 的部分功能跨仓库运作。以下表格记录外部仓库与 Mercu
 - **PR to develop**: all code merges into develop must go through a PR. Direct push to develop is forbidden.
 - **Install to D drive**: install software to `D:\Program Files`, not C drive.
 - **Modular design**: every new feature must be independently detachable. If it cannot be used outside Mercury, the coupling is too deep.
-- **External-project adapters under `adapters/<vendor-name>/` MUST stay under 200 lines.** If an external integration needs more than that, rethink the mounting approach. This rule does NOT apply to Mercury-internal tooling under `scripts/` — internal tooling implements the protocol that lives in this repo and isn't trying to mount anything external, so it has no LOC cap (size by need). Empirical drivers: PR #338 (`scripts/codex-sync-audit.sh` ~360 LOC) and PR #346 (`scripts/lane-assertion.sh` ~440 LOC) both hit Argus nit-loops on the adapter-size finding, requiring iter-3+ escape-hatch / disagree replies before APPROVED.
+- **External-project adapters under `adapters/<vendor-name>/` MUST stay under 200 lines.** If an external integration needs more than that, rethink the mounting approach. This rule does NOT apply to Mercury-internal tooling under `scripts/` — internal tooling implements the protocol that lives in this repo and isn't trying to mount anything external, so it has no LOC cap (size by need). Aligns with `.mercury/docs/DIRECTION.md` §"适配层规范" line 240 (scopes the 200-line rule to the `adapters/{project-name}/` layer) and §8-2 line 385 (calls "adapter ≤200 LOC 是硬约束" specifically about the `mercury-test-gate` adapter); CLAUDE.md previously had a loose phrasing that Argus mis-applied to `scripts/`. Empirical drivers: PR #338 (`scripts/codex-sync-audit.sh` ~360 LOC) and PR #346 (`scripts/lane-assertion.sh` ~440 LOC) both hit Argus nit-loops on the adapter-size finding, requiring iter-3+ escape-hatch / disagree replies before APPROVED.
 - **No self-research**: if an external project can solve the problem, mount it via submodule rather than reimplementing.
 
 ## DO NOT
@@ -73,7 +73,7 @@ Mercury 的部分功能跨仓库运作。以下表格记录外部仓库与 Mercu
 - Do not commit without running `/dual-verify`.
 - Do not create PRs without an associated GitHub Issue.
 - Do not build features that assume the model is weak — design for upward compatibility.
-- Do not create **external-project adapters** under `adapters/<vendor-name>/` exceeding 200 lines — rethink the mounting approach if this happens. (Mercury-internal tooling under `scripts/` is exempt — see MUST §"External-project adapters" carve-out.)
+- Do not create **external-project adapters** under `adapters/<vendor-name>/` exceeding 200 lines — rethink the mounting approach if this happens. (Mercury-internal tooling under `scripts/` is exempt — see the MUST bullet "External-project adapters under `adapters/<vendor-name>/` MUST stay under 200 lines" above for the carve-out and authority chain.)
 
 ## Cherry-pick protocol
 


### PR DESCRIPTION
## Summary

Argus repeatedly mis-applies CLAUDE.md `Do not create adapters exceeding 200 lines` to Mercury-internal tooling under `scripts/`, producing nit-loops on PR #338 (`scripts/codex-sync-audit.sh` ~360 LOC) and PR #346 (`scripts/lane-assertion.sh` ~440 LOC) that each required iter-3+ escape-hatch / disagree replies before APPROVED.

This PR adds an explicit carve-out scoping the 200-LOC cap to external-project adapters under `adapters/<vendor-name>/` only.

## Changes

- **MUST §"External-project adapters"** (new): `adapters/<vendor-name>/` MUST stay under 200 lines; `scripts/` is exempt (no LOC cap, size by need); empirical drivers cited
- **DO NOT §"adapters exceeding 200 lines"** (rewritten): mirrors MUST scope; cross-references the carve-out
- **`feedback_argus_nit_loop.md`** (canonical user-memory, NOT in this PR diff): canonical-rebuttal section appended for cross-session continuity

## Test plan

- [x] Dual-verify: Claude deep-review PASS (0 findings); Codex sync audit (initial) flagged 1 Medium on overstated iter count → addressed by softening "4× nit-loop" → "iter-3+ escape-hatch / disagree replies"
- [x] Diff is minimal (2 hunks in CLAUDE.md, 1 file)
- [x] MUST and DO NOT bullets mirror scope without contradiction
- [x] Reviewer reading `scripts/foo.sh` at 300 LOC will know it's exempt by spec
- [x] Cited PRs (#338, #346) verified MERGED via `gh pr view`

## Refs

- Closes #348
- Empirical evidence: PR #338, PR #346
- `feedback_argus_nit_loop.md` (user-memory) cross-references this carve-out

🤖 Generated with [Claude Code](https://claude.com/claude-code)