### PR TITLE
fix(push-guard): quote-aware tokenizer + per-segment evaluation (#349)

### DIFF
--- a/.claude/hooks/push-guard.sh
+++ b/.claude/hooks/push-guard.sh
@@ -1,6 +1,47 @@
 #!/usr/bin/env bash
 # GATE: block direct push to develop/master — all merges must go through PRs.
-# Token cost: ZERO. No external deps.
+# Token cost: ZERO. No external deps beyond awk + bash + grep.
+#
+# Fix history:
+#   Session 1-side-bug / Issue #349 — Bug: greedy regex consumed body text.
+#     The push-args extractor was `sed 's/.*git[[:space:]]\+push[[:space:]]*//'`
+#     applied per-line. When `git commit -m "...heredoc body...with git push
+#     hygiene for develop branch..." && git push origin lane/main/foo` ran,
+#     sed stripped only the line containing the LAST `git push` per-line.
+#     Body lines without `git push` survived intact; bash word-splitting on
+#     PUSH_ARGS exposed standalone `develop`/`master` tokens from those body
+#     lines, mistakenly blocking real push to a non-protected lane branch.
+#
+#     Iter 1 fix mirrored S82 #339 pattern from pr-merge-guard.sh: quote-
+#     aware awk segment splitter + per-segment env-strip + bash token-array
+#     slice from `push` token forward. Body content stays inside the
+#     `git commit -m "..."` segment.
+#
+#     Iter 2 (dual-verify findings): the iter-1 fix retained 6 bypass holes
+#     identified by parallel review (Claude code-reviewer + Codex audit):
+#       - Quoted protected-branch token: `git push origin "develop"` rc=0
+#         (NORMALIZED retained literal quote chars, missed PROTECTED grep)
+#       - 6+ env wrapper chain: `env env env env env env git push origin
+#         develop` rc=0 (5-pass env-strip cap exhausted)
+#       - Subshell/group: `( git push origin develop )` and `{ git push
+#         origin develop; }` rc=0 (awk did not tokenize parens / braces)
+#       - Quoted env values: `A="1 2" git push origin develop` rc=0 (regex
+#         env-strip + bash word-split mangled quoted value with whitespace)
+#       - Quoted -C paths: `git -C "C:/repo with spaces" push origin
+#         develop` rc=0 (same root cause — bash word-split blind to quotes)
+#       - Break-on-first: `git push origin lane/foo && git push origin
+#         develop` rc=0 (first segment matched, second never inspected)
+#       - Codex Medium: parser failure (jq/awk absent) silently exited 0
+#         instead of fail-closing the gate.
+#
+#     Iter 2 fix: replace the regex env-strip + bash word-split combo with a
+#     single quote-aware awk tokenizer that emits one shell token per line
+#     plus `__SEGEND__` markers between separators. Bash reads the stream,
+#     groups tokens per segment, and runs Phase 1/2/3 inline per segment
+#     (no break-on-first). Wrapper-strip is now token-based and unbounded.
+#     Quote-strip in Phase 2 normalization handles literal quote chars
+#     defensively. `(` `)` `{` `}` are tokenized; `(` `{` are skipped during
+#     wrapper-strip. Hard-block on awk failure or unrecoverable extraction.
 
 INPUT=$(cat)
 
@@ -20,17 +61,48 @@ fi
 
 debug_log "INPUT=$INPUT"
 
-# Extract command
-if command -v jq >/dev/null 2>&1; then
+# Detect whether INPUT carries a "command" key BEFORE extraction. Used as a
+# fail-closed signal: if the key exists but COMMAND is empty after extraction,
+# the parser failed and the hook MUST hard-block rather than fall through to
+# exit 0 (codex Medium #349 iter-2).
+if printf '%s' "$INPUT" | grep -q '"command"'; then
+  HAS_CMD_KEY=1
+else
+  HAS_CMD_KEY=0
+fi
+
+# Mercury security policy (Codex iter-2 Critical): jq is required for safe
+# COMMAND extraction. The legacy sed fallback (`[^"]*` capture) truncates at
+# any embedded `"`, so JSON like `"command":"git push origin \"develop\""`
+# extracts as `git push origin \` — non-empty (so the empty-COMMAND check
+# below does not fire), and the truncated tail bypasses the protected-branch
+# grep. Hard-block instead. Test override: MERCURY_PUSH_GUARD_TEST_FORCE_NO_JQ=1
+# forces this branch even when jq is installed (used by scripts/test-push-guard.sh
+# to exercise the path without requiring a Windows-compatible no-jq PATH).
+HAS_JQ=0
+if [ "${MERCURY_PUSH_GUARD_TEST_FORCE_NO_JQ:-0}" != "1" ] && command -v jq >/dev/null 2>&1; then
+  HAS_JQ=1
+fi
+
+if [ "$HAS_JQ" -eq 0 ] && [ "$HAS_CMD_KEY" -eq 1 ]; then
+  # block_parser_fail() defined below — declare it inline to avoid forward-ref
+  # noise. We could hoist, but the body is tiny and the second use site is the
+  # primary one.
+  printf 'BLOCKED: push-guard requires jq for safe command parsing; sed fallback cannot handle escaped quotes inside the command string.\n' >&2
+  printf 'Install jq (https://jqlang.github.io/jq/) on PATH and retry.\n' >&2
+  [ "${GUARD_DEBUG:-0}" = "1" ] && echo "[$(date -Iseconds)] BLOCKED (parser-fail): jq absent" >> "$LOG_FILE"
+  exit 2
+fi
+
+if [ "$HAS_JQ" -eq 1 ]; then
   COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
 else
-  COMMAND=$(echo "$INPUT" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+  # HAS_JQ=0 AND HAS_CMD_KEY=0 — INPUT did not carry a "command" key (e.g.
+  # tool wasn't Bash). Nothing to gate.
+  exit 0
 fi
 
 debug_log "COMMAND=$COMMAND"
-
-# Only intercept git push commands
-printf '%s' "$COMMAND" | grep -qE '\bgit\s+push\b' || exit 0
 
 # Helper: emit the standard BLOCKED message and exit
 block_push() {
@@ -44,62 +116,334 @@ MSG
   exit 2
 }
 
-# ── Phase 1: Detect dangerous flags before token parsing ──
-# --all pushes ALL local branches (including protected ones).
-# --mirror mirrors ALL refs and force-updates + prunes the remote.
-if printf '%s' "$COMMAND" | grep -qE '(^|\s)--(all|mirror)(\s|$)'; then
-  block_push "--all or --mirror flag detected"
+# Helper: emit a parser-failure block and exit (fail-closed semantics).
+block_parser_fail() {
+  local reason="$1"
+  debug_log "BLOCKED (parser-fail): $reason"
+  printf 'BLOCKED: push-guard could not safely parse the command (%s).\n' "$reason" >&2
+  printf 'Aborting to avoid fail-open. Verify the command manually or check that jq is installed.\n' >&2
+  exit 2
+}
+
+# Fail-closed: COMMAND empty but the JSON did contain "command".
+if [ -z "$COMMAND" ]; then
+  if [ "$HAS_CMD_KEY" -eq 1 ]; then
+    block_parser_fail "command extraction returned empty for non-empty input"
+  fi
+  # No command key at all → the bash invocation didn't supply one (e.g. tool
+  # not Bash); nothing to gate.
+  exit 0
 fi
 
-# ── Phase 2: Parse explicit refspec targets ──
-PUSH_ARGS=$(printf '%s' "$COMMAND" | sed 's/.*git[[:space:]]\+push[[:space:]]*//')
-PROTECTED="^(develop|master|main)$"
-SKIPPED_REMOTE=false
-HAS_EXPLICIT_TARGET=false
+# ── Quote-aware awk tokenizer ──────────────────────────────────────────
+# Emits one shell-style token per line, plus a literal `__SEGEND__` marker
+# at every shell separator (`;` `|` `||` `&` `&&`). Inside single or double
+# quotes, separators are buffered as part of the current token and quote
+# delimiters are stripped (mirrors bash word-expansion). Outside quotes,
+# whitespace splits tokens; `(` `)` `{` `}` are emitted as their own
+# single-character tokens so subshell / group prefixes can be wrapper-
+# stripped without bypassing detection.
+#
+# This replaces the previous "regex env-strip + bash word-split" pipeline,
+# which mangled quoted env values (e.g. `A="1 2"`) and quoted -C paths
+# (e.g. `git -C "C:/repo with spaces"`). Token boundaries now match shell
+# semantics for our limited subset (no command substitution, no here-docs
+# — same caveat as the sibling pr-merge-guard.sh).
+_TOK_STREAM=$(printf '%s\n' "$COMMAND" | awk -v SQ="'" '
+BEGIN { in_sq=0; in_dq=0; tok=""; in_tok=0; line_continue=0 }
+function flush_tok() {
+  if (in_tok) { print tok; tok=""; in_tok=0 }
+}
+{
+  line = $0
+  n = length(line)
+  for (i = 1; i <= n; i++) {
+    c = substr(line, i, 1)
+    if (in_sq) {
+      if (c == SQ) { in_sq = 0; continue }
+      tok = tok c
+      continue
+    }
+    if (in_dq) {
+      if (c == "\\") {
+        # POSIX-ish: \" \\ \$ \` are escape sequences inside double quotes;
+        # any other backslash is literal.
+        nc = (i < n) ? substr(line, i+1, 1) : ""
+        if (nc == "\"" || nc == "\\" || nc == "$" || nc == "`") {
+          tok = tok nc; i++; continue
+        }
+        tok = tok c
+        continue
+      }
+      if (c == "\"") { in_dq = 0; continue }
+      tok = tok c
+      continue
+    }
+    # Outside any quotes
+    # Backslash-escape: bash drops the backslash and treats the next char as
+    # literal. So `de\velop` parses as `develop`. Without this, our literal
+    # PROTECTED grep would miss obfuscated targets (Codex iter-2 High #1).
+    if (c == "\\") {
+      nc = (i < n) ? substr(line, i+1, 1) : ""
+      if (nc != "") {
+        tok = tok nc
+        in_tok = 1
+        i++
+        continue
+      }
+      # Trailing backslash at end of line — bash treats this as line
+      # continuation: drop the backslash AND the newline, joining current
+      # token with next line. Set line_continue so the per-line tail block
+      # neither flushes nor emits __SEGEND__ (Codex iter-3 Medium).
+      line_continue = 1
+      continue
+    }
+    if (c == SQ)   { in_sq = 1; in_tok = 1; continue }
+    if (c == "\"") { in_dq = 1; in_tok = 1; continue }
+    if (c == ";")  { flush_tok(); print "__SEGEND__"; continue }
+    if (c == "|") {
+      nc = (i < n) ? substr(line, i+1, 1) : ""
+      flush_tok(); print "__SEGEND__"
+      if (nc == "|") i++
+      continue
+    }
+    if (c == "&") {
+      nc = (i < n) ? substr(line, i+1, 1) : ""
+      flush_tok(); print "__SEGEND__"
+      if (nc == "&") i++
+      continue
+    }
+    # `(` `)` `{` `}` and backtick are statement-grouping / command-substitution
+    # boundaries. Treat them as segment separators so the contents are walked
+    # as their own segment(s). Closes Codex iter-4 High:
+    #   - `( cmd )` subshell bodies
+    #   - `{ cmd; }` brace-group bodies
+    #   - `case x in x) cmd ;; esac` case-pattern bodies (`)` separator)
+    #   - `echo $(git push origin develop)` top-level command-substitution
+    #   - `` echo `git push origin develop` `` legacy backtick form
+    # Limitation: backticks INSIDE double quotes are still buffered (would
+    # need recursive parsing — rare in Claude Code output, accepted).
+    if (c == "(" || c == ")" || c == "{" || c == "}" || c == "`") {
+      flush_tok()
+      print "__SEGEND__"
+      continue
+    }
+    if (c == " " || c == "\t") {
+      flush_tok()
+      continue
+    }
+    tok = tok c
+    in_tok = 1
+  }
+  # End of awk input line.
+  if (in_sq || in_dq) {
+    # Inside a quoted region: preserve the line break as a literal space
+    # (bash semantics for newline inside quotes).
+    tok = tok " "; in_tok = 1
+  } else if (line_continue) {
+    # Backslash-newline line-continuation outside quotes: do not flush, do
+    # not emit __SEGEND__. The current token continues onto the next line.
+    line_continue = 0
+  } else {
+    # Bare newline outside quotes = statement separator (bash semantics).
+    # Closes Codex iter-3 High: `echo ok\ngit push origin develop` previously
+    # stayed one segment, walker exited on `echo`, never inspected the push.
+    flush_tok()
+    print "__SEGEND__"
+  }
+}
+END {
+  flush_tok()
+  print "__SEGEND__"
+}
+') || block_parser_fail "awk tokenizer exited non-zero"
 
-for TOKEN in $PUSH_ARGS; do
-  # Skip flags like --force, -u, --set-upstream
-  case "$TOKEN" in --*|-*) continue ;; esac
+# Group tokens into segments and run Phase 1/2/3 inline per segment.
+# Per-segment phase evaluation closes the iter-1 break-on-first bypass:
+#   `git push origin lane/foo && git push origin develop` evaluates BOTH.
+PROTECTED='^(develop|master|main)$'
 
-  # Skip the first non-flag arg (remote name, e.g. "origin")
-  if [ "$SKIPPED_REMOTE" = false ]; then
-    SKIPPED_REMOTE=true
-    continue
-  fi
+declare -a CUR_SEG=()
 
-  HAS_EXPLICIT_TARGET=true
+process_segment() {
+  local -a tokens=( "$@" )
+  local ntok=${#tokens[@]}
+  local i=0
 
-  # Normalize: strip leading "+" (force-push prefix)
-  NORMALIZED="${TOKEN##+}"
+  # Wrapper-strip: skip leading env-var assignments, command wrappers, and
+  # subshell/group open chars. Loop until no transformation applies — no
+  # iteration cap (closes the iter-1 6+ env wrapper bypass; transforms shrink
+  # the prefix monotonically so termination is bounded by O(ntok)).
+  local _seen_change=1
+  while [ "$_seen_change" -eq 1 ] && [ "$i" -lt "$ntok" ]; do
+    _seen_change=0
+    local tok="${tokens[$i]}"
+    case "$tok" in
+      # Bash logical-NOT (`! cmd` runs cmd, inverts exit code). `(` `{` are
+      # NOT in this list — iter-5 promotes them to segment separators (awk
+      # tokenizer emits __SEGEND__ on those chars), so they never reach the
+      # walker as tokens. Closes Codex iter-2 High #2 + iter-4 case/function/
+      # subshell bypasses uniformly.
+      "!")
+        i=$((i + 1)); _seen_change=1 ;;
+      # Bash control-flow reserved words that can prefix a command in a guarded
+      # segment. After the segment splitter cuts on `;`, a segment like
+      # `if cond; then git push origin develop; fi` produces three segments;
+      # segment 2 starts with `then`, which without this case would stop the
+      # walker before reaching `git`. Closes Codex iter-3 High. Block-closer
+      # words (`fi`/`done`/`esac`) are intentionally absent — they don't
+      # precede a command, but if they did the walker would still exit cleanly.
+      if|then|else|elif|do|while|until)
+        i=$((i + 1)); _seen_change=1 ;;
+      env|command|exec|builtin|nohup|time)
+        i=$((i + 1)); _seen_change=1 ;;
+      # `coproc` and `function` may take an optional/required NAME after the
+      # keyword. Skip the keyword, then peek: if the next token is a plain
+      # identifier (not `git`, not a flag), skip it too. Disambiguation rule:
+      # NEVER skip a literal `git` token — that defeats the walker. The body
+      # of `function f { ... }` is segregated into its own segment by the
+      # `{` separator, so we only need to handle the declaration prefix here.
+      # Closes Codex iter-4 High (`coproc git push ...` + `function f {...}`).
+      coproc|function)
+        i=$((i + 1)); _seen_change=1
+        if [ "$i" -lt "$ntok" ]; then
+          local _next="${tokens[$i]}"
+          case "$_next" in
+            git) ;;  # don't consume, walker needs to match
+            [A-Za-z_][A-Za-z0-9_-]*) i=$((i + 1)) ;;
+          esac
+        fi
+        ;;
+      # env value-taking flags (separate-arg form): skip flag + value.
+      # Long forms `--unset`/`--split-string`/`--chdir` are also separate-arg
+      # value-taking (mirrored from env(1)).
+      -u|-S|-C|--unset|--split-string|--chdir)
+        i=$((i + 2)); _seen_change=1 ;;
+      # Long-form flag with inline value (`--foo=bar`) — single token.
+      --*=*)
+        i=$((i + 1)); _seen_change=1 ;;
+      # Generic flag (long-form `--foo` or short-form `-X[Y...]`) — assume
+      # flag-only. Closes the iter-2 `env --ignore-environment git push ...`
+      # bypass (Codex High #2): the previous pattern `--|-[A-Za-z]*` did NOT
+      # match `--ignore-environment` because `[A-Za-z]` does not match `-`.
+      --|--*|-[A-Za-z]*)
+        i=$((i + 1)); _seen_change=1 ;;
+      # VAR=value assignment (now quote-aware via awk tokenization).
+      [A-Za-z_]*=*)
+        i=$((i + 1)); _seen_change=1 ;;
+    esac
+  done
 
-  # Check refspec RHS if present (e.g. HEAD:develop → develop)
-  if printf '%s' "$NORMALIZED" | grep -q ':'; then
-    REFSPEC_TARGET="${NORMALIZED##*:}"
-    REFSPEC_TARGET="${REFSPEC_TARGET#refs/heads/}"
-    if printf '%s' "$REFSPEC_TARGET" | grep -qE "$PROTECTED"; then
-      block_push "refspec target '$REFSPEC_TARGET' from '$TOKEN'"
+  [ "$i" -lt "$ntok" ] || return 0
+  [ "${tokens[$i]}" = "git" ] || return 0
+  i=$((i + 1))
+
+  # Walk git global options until `push` or non-option non-push token.
+  local push_idx=-1
+  while [ "$i" -lt "$ntok" ]; do
+    local tok="${tokens[$i]}"
+    case "$tok" in
+      push) push_idx=$i; break ;;
+      -C|-c|--git-dir|--work-tree|--namespace|--super-prefix)
+        # value-taking global option: skip flag + value in one step
+        i=$((i + 2)); continue ;;
+      --git-dir=*|--work-tree=*|--namespace=*|--super-prefix=*)
+        # inlined value: skip flag only
+        i=$((i + 1)); continue ;;
+      --help|--version|-h|-v|-p|--paginate|-P|--no-pager|--bare|--no-replace-objects|--literal-pathspecs|--no-optional-locks)
+        i=$((i + 1)); continue ;;
+      -*)
+        # Unknown global option — assume flag-only (best-effort).
+        i=$((i + 1)); continue ;;
+      *)
+        break ;;  # Non-option non-push token → not a push invocation
+    esac
+  done
+
+  [ "$push_idx" -ge 0 ] || return 0
+
+  # Slice push tokens (after the `push` token itself).
+  local -a push_toks=()
+  local j=$((push_idx + 1))
+  while [ "$j" -lt "$ntok" ]; do
+    push_toks+=( "${tokens[$j]}" )
+    j=$((j + 1))
+  done
+
+  # ── Phase 1: dangerous flags ──
+  local t
+  for t in "${push_toks[@]}"; do
+    case "$t" in
+      --all|--mirror) block_push "--all or --mirror flag detected" ;;
+    esac
+  done
+
+  # ── Phase 2: explicit refspec walk ──
+  local SKIPPED_REMOTE=false
+  local HAS_EXPLICIT_TARGET=false
+  for t in "${push_toks[@]}"; do
+    case "$t" in --*|-*) continue ;; esac
+    if [ "$SKIPPED_REMOTE" = false ]; then
+      SKIPPED_REMOTE=true
+      continue
     fi
-    continue
-  fi
+    HAS_EXPLICIT_TARGET=true
 
-  # Strip refs/heads/ prefix (e.g. refs/heads/develop → develop)
-  NORMALIZED="${NORMALIZED#refs/heads/}"
+    # Defensive quote-strip on the push target. Awk strips outer quotes
+    # during tokenization, but mid-token quote chars or repeated escaping
+    # could leak. Mirrors the sibling pr-merge-guard.sh pattern
+    # (REPO_FLAG / PR_SELECTOR strip lines 255-256, 299-300).
+    local NORMALIZED="$t"
+    NORMALIZED="${NORMALIZED%\"}"; NORMALIZED="${NORMALIZED#\"}"
+    NORMALIZED="${NORMALIZED%\'}"; NORMALIZED="${NORMALIZED#\'}"
+    # Strip leading `+` (force-push prefix)
+    NORMALIZED="${NORMALIZED##+}"
 
-  # Check if the normalized token is a protected branch
-  if printf '%s' "$NORMALIZED" | grep -qE "$PROTECTED"; then
-    block_push "direct target '$NORMALIZED' from '$TOKEN'"
-  fi
-done
+    if printf '%s' "$NORMALIZED" | grep -q ':'; then
+      local REFSPEC_TARGET="${NORMALIZED##*:}"
+      REFSPEC_TARGET="${REFSPEC_TARGET#refs/heads/}"
+      REFSPEC_TARGET="${REFSPEC_TARGET%\"}"; REFSPEC_TARGET="${REFSPEC_TARGET#\"}"
+      REFSPEC_TARGET="${REFSPEC_TARGET%\'}"; REFSPEC_TARGET="${REFSPEC_TARGET#\'}"
+      if printf '%s' "$REFSPEC_TARGET" | grep -qE "$PROTECTED"; then
+        block_push "refspec target '$REFSPEC_TARGET' from '$t'"
+      fi
+      continue
+    fi
 
-# ── Phase 3: Handle implicit push (no explicit refspec) ──
-# `git push` or `git push origin` with no refspec uses push.default (typically
-# "simple"), which pushes the current branch to its upstream. If the current
-# branch IS a protected branch, this is an implicit push to develop/master.
-if [ "$HAS_EXPLICIT_TARGET" = false ]; then
-  CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
-  if printf '%s' "$CURRENT_BRANCH" | grep -qE "$PROTECTED"; then
-    block_push "implicit push from current branch '$CURRENT_BRANCH'"
+    NORMALIZED="${NORMALIZED#refs/heads/}"
+    if printf '%s' "$NORMALIZED" | grep -qE "$PROTECTED"; then
+      block_push "direct target '$NORMALIZED' from '$t'"
+    fi
+  done
+
+  # ── Phase 3: implicit push from current branch (no explicit refspec) ──
+  if [ "$HAS_EXPLICIT_TARGET" = false ]; then
+    local CURRENT_BRANCH
+    CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+    if printf '%s' "$CURRENT_BRANCH" | grep -qE "$PROTECTED"; then
+      block_push "implicit push from current branch '$CURRENT_BRANCH'"
+    fi
   fi
+}
+
+# Read the awk-emitted token stream, group tokens into segments, and process.
+while IFS= read -r line; do
+  if [ "$line" = "__SEGEND__" ]; then
+    if [ "${#CUR_SEG[@]}" -gt 0 ]; then
+      process_segment "${CUR_SEG[@]}"
+      CUR_SEG=()
+    fi
+  else
+    CUR_SEG+=( "$line" )
+  fi
+done <<EOF
+$_TOK_STREAM
+EOF
+
+# Defensive flush: awk's END block always emits a trailing __SEGEND__, but
+# guard the case where the stream was empty or truncated.
+if [ "${#CUR_SEG[@]}" -gt 0 ]; then
+  process_segment "${CUR_SEG[@]}"
 fi
 
 exit 0

--- a/.claude/hooks/push-guard.sh
+++ b/.claude/hooks/push-guard.sh
@@ -384,8 +384,27 @@ process_segment() {
   for t in "${push_toks[@]}"; do
     case "$t" in --*|-*) continue ;; esac
     if [ "$SKIPPED_REMOTE" = false ]; then
-      SKIPPED_REMOTE=true
-      continue
+      # First non-flag arg is USUALLY the remote name, but `git push REFSPEC`
+      # (no remote) is also valid bash/git syntax. Git treats an arg as a
+      # refspec rather than a remote when:
+      #   - it contains `:` (LHS:RHS form, e.g. `HEAD:develop`)
+      #   - it starts with `+` (force-push prefix, e.g. `+develop`)
+      #   - it starts with `refs/` (fully-qualified ref, e.g. `refs/heads/develop`)
+      # Without this heuristic, those forms slip past Phase 2 because
+      # SKIPPED_REMOTE eats the refspec as "remote", leaving no target seen.
+      # Trade-off: a remote literally named `refs/heads/develop` would now
+      # produce a false-positive block, but such remote names are virtually
+      # nonexistent (git's remote-name conventions are alphanumeric only).
+      # Closes Argus iter-1 Minor "可能绕过" finding (#352).
+      case "$t" in
+        *:*|+*|refs/*)
+          # Looks like a refspec — fall through to target processing below.
+          ;;
+        *)
+          SKIPPED_REMOTE=true
+          continue
+          ;;
+      esac
     fi
     HAS_EXPLICIT_TARGET=true
 

--- a/.claude/hooks/push-guard.sh
+++ b/.claude/hooks/push-guard.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-# GATE: block direct push to develop/master — all merges must go through PRs.
-# Runtime deps: bash, awk, grep, jq (jq is REQUIRED — Codex iter-2 Critical
-# closed the legacy sed-fallback bypass; the hook hard-blocks if jq is absent).
+# GATE: block direct push to protected branches (develop / master / main) —
+# all merges must go through PRs. Runtime deps: bash, awk, grep, jq (jq is
+# REQUIRED — Codex iter-2 Critical closed the legacy sed-fallback bypass;
+# the hook hard-blocks if jq is absent).
 #
 # Fix history:
 #   Session 1-side-bug / Issue #349 — Bug: greedy regex consumed body text.
@@ -121,7 +122,7 @@ block_push() {
   local reason="$1"
   debug_log "BLOCKED: $reason"
   cat >&2 <<'MSG'
-BLOCKED: Direct push to develop/master is forbidden (CLAUDE.md rule).
+BLOCKED: Direct push to a protected branch (develop / master / main) is forbidden (CLAUDE.md rule).
 All merges into develop must go through a Pull Request.
 Use: git push -u origin <feature-branch> && gh pr create --base develop
 MSG
@@ -190,10 +191,19 @@ function flush_tok() {
     if (in_dq) {
       if (c == "\\") {
         # POSIX-ish: \" \\ \$ \` are escape sequences inside double quotes;
-        # any other backslash is literal.
+        # any other backslash is literal. Trailing `\` at end of line inside
+        # dq is line-continuation (drop both \ and newline) — bash semantics.
+        # Closes Copilot iter-2 line-199 finding: `git push origin "devel\
+        # op"` parses as `git push origin "develop"` in bash, but iter-7 awk
+        # appended literal `\` then space, leaving `devel\ op` token that
+        # missed the PROTECTED grep.
         nc = (i < n) ? substr(line, i+1, 1) : ""
         if (nc == "\"" || nc == "\\" || nc == "$" || nc == "`") {
           tok = tok nc; i++; continue
+        }
+        if (nc == "") {
+          line_continue = 1
+          continue
         }
         tok = tok c
         continue
@@ -258,19 +268,21 @@ function flush_tok() {
     tok = tok c
     in_tok = 1
   }
-  # End of awk input line.
-  if (in_sq || in_dq) {
-    # Inside a quoted region: preserve the line break as a literal space
-    # (bash semantics for newline inside quotes).
-    tok = tok " "; in_tok = 1
-  } else if (line_continue) {
-    # Backslash-newline line-continuation outside quotes: do not flush, do
-    # not emit SEG. The current token continues onto the next line.
+  # End of awk input line. Three cases by precedence:
+  #   1. line_continue is set (trailing `\` at EOL, anywhere — outside quotes
+  #      OR inside double quotes): drop the implicit newline entirely. The
+  #      token continues onto the next line (bash line-continuation).
+  #   2. Inside a quoted region without line_continue: preserve the line
+  #      break as a literal space (bash semantics for unescaped newline
+  #      inside quotes).
+  #   3. Outside quotes: bare newline = statement separator. Closes Codex
+  #      iter-3 High (`echo ok\ngit push origin develop` would stay one
+  #      segment otherwise).
+  if (line_continue) {
     line_continue = 0
+  } else if (in_sq || in_dq) {
+    tok = tok " "; in_tok = 1
   } else {
-    # Bare newline outside quotes = statement separator (bash semantics).
-    # Closes Codex iter-3 High: `echo ok\ngit push origin develop` previously
-    # stayed one segment, walker exited on `echo`, never inspected the push.
     flush_tok()
     print "SEG"
   }

--- a/.claude/hooks/push-guard.sh
+++ b/.claude/hooks/push-guard.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # GATE: block direct push to develop/master — all merges must go through PRs.
-# Token cost: ZERO. No external deps beyond awk + bash + grep.
+# Runtime deps: bash, awk, grep, jq (jq is REQUIRED — Codex iter-2 Critical
+# closed the legacy sed-fallback bypass; the hook hard-blocks if jq is absent).
 #
 # Fix history:
 #   Session 1-side-bug / Issue #349 — Bug: greedy regex consumed body text.
@@ -36,7 +37,7 @@
 #
 #     Iter 2 fix: replace the regex env-strip + bash word-split combo with a
 #     single quote-aware awk tokenizer that emits one shell token per line
-#     plus `__SEGEND__` markers between separators. Bash reads the stream,
+#     plus segment-end markers between separators. Bash reads the stream,
 #     groups tokens per segment, and runs Phase 1/2/3 inline per segment
 #     (no break-on-first). Wrapper-strip is now token-based and unbounded.
 #     Quote-strip in Phase 2 normalization handles literal quote chars
@@ -61,14 +62,32 @@ fi
 
 debug_log "INPUT=$INPUT"
 
-# Detect whether INPUT carries a "command" key BEFORE extraction. Used as a
+# jq availability is the gating discriminator — see Mercury security policy
+# block below for why the sed fallback is unsafe. Test override:
+# MERCURY_PUSH_GUARD_TEST_FORCE_NO_JQ=1 forces the no-jq branch even when jq
+# is installed (used by scripts/test-push-guard.sh).
+HAS_JQ=0
+if [ "${MERCURY_PUSH_GUARD_TEST_FORCE_NO_JQ:-0}" != "1" ] && command -v jq >/dev/null 2>&1; then
+  HAS_JQ=1
+fi
+
+# Detect whether INPUT carries a `command` key BEFORE extraction. Used as a
 # fail-closed signal: if the key exists but COMMAND is empty after extraction,
 # the parser failed and the hook MUST hard-block rather than fall through to
-# exit 0 (codex Medium #349 iter-2).
-if printf '%s' "$INPUT" | grep -q '"command"'; then
+# exit 0 (Codex iter-2 Medium). Use a structured jq check when available so
+# string content inside payload values containing the literal word `command`
+# (e.g. a Write tool's content) does not falsely trigger the hard-block path
+# on machines without jq (Argus iter-2 Medium #1 + Copilot Line 72).
+HAS_CMD_KEY=0
+if [ "$HAS_JQ" -eq 1 ]; then
+  if printf '%s' "$INPUT" | jq -e '(.tool_input // null) | (type=="object") and has("command")' >/dev/null 2>&1; then
+    HAS_CMD_KEY=1
+  fi
+elif printf '%s' "$INPUT" | grep -q '"command"[[:space:]]*:'; then
+  # No-jq fallback — anchor on `"command":` to reduce string-content false
+  # positives. Still imperfect (a value `"\"command\":..."` would match), but
+  # the hard-block below makes this branch a fail-closed gate, not a bypass.
   HAS_CMD_KEY=1
-else
-  HAS_CMD_KEY=0
 fi
 
 # Mercury security policy (Codex iter-2 Critical): jq is required for safe
@@ -76,14 +95,7 @@ fi
 # any embedded `"`, so JSON like `"command":"git push origin \"develop\""`
 # extracts as `git push origin \` — non-empty (so the empty-COMMAND check
 # below does not fire), and the truncated tail bypasses the protected-branch
-# grep. Hard-block instead. Test override: MERCURY_PUSH_GUARD_TEST_FORCE_NO_JQ=1
-# forces this branch even when jq is installed (used by scripts/test-push-guard.sh
-# to exercise the path without requiring a Windows-compatible no-jq PATH).
-HAS_JQ=0
-if [ "${MERCURY_PUSH_GUARD_TEST_FORCE_NO_JQ:-0}" != "1" ] && command -v jq >/dev/null 2>&1; then
-  HAS_JQ=1
-fi
-
+# grep. Hard-block instead.
 if [ "$HAS_JQ" -eq 0 ] && [ "$HAS_CMD_KEY" -eq 1 ]; then
   # block_parser_fail() defined below — declare it inline to avoid forward-ref
   # noise. We could hoist, but the body is tiny and the second use site is the
@@ -136,23 +148,34 @@ if [ -z "$COMMAND" ]; then
 fi
 
 # ── Quote-aware awk tokenizer ──────────────────────────────────────────
-# Emits one shell-style token per line, plus a literal `__SEGEND__` marker
-# at every shell separator (`;` `|` `||` `&` `&&`). Inside single or double
-# quotes, separators are buffered as part of the current token and quote
-# delimiters are stripped (mirrors bash word-expansion). Outside quotes,
-# whitespace splits tokens; `(` `)` `{` `}` are emitted as their own
-# single-character tokens so subshell / group prefixes can be wrapper-
-# stripped without bypassing detection.
+# Emits a typed line-protocol stream:
+#   `TOK\t<value>` — one shell-style token per line
+#   `SEG`          — segment terminator (between `;`, `|`, `||`, `&`, `&&`,
+#                    `(`, `)`, `{`, `}`, backtick, or end-of-line)
+#
+# The `TOK\t` prefix avoids the iter-1..5 token-collision bypass (Argus
+# iter-2 Critical): a real shell token equal to the previous protocol
+# sentinel `__SEGEND__` would have been mis-classified as a separator,
+# splitting `git push origin __SEGEND__ develop` into two segments and
+# letting the protected push slip past the walker. With the prefix, ANY
+# token value (including the literal string `SEG`) is unambiguously a
+# token, not a separator.
+#
+# Inside single or double quotes, separators are buffered as part of the
+# current token and quote delimiters are stripped (mirrors bash word-
+# expansion). Outside quotes, whitespace splits tokens; `(` `)` `{` `}`
+# and backtick are statement-grouping / command-substitution boundaries
+# (emitted as `SEG` so contents are walked as their own segment).
 #
 # This replaces the previous "regex env-strip + bash word-split" pipeline,
 # which mangled quoted env values (e.g. `A="1 2"`) and quoted -C paths
 # (e.g. `git -C "C:/repo with spaces"`). Token boundaries now match shell
-# semantics for our limited subset (no command substitution, no here-docs
-# — same caveat as the sibling pr-merge-guard.sh).
+# semantics for our limited subset (no command substitution recursion into
+# quoted strings, no here-docs — same caveat as the sibling pr-merge-guard.sh).
 _TOK_STREAM=$(printf '%s\n' "$COMMAND" | awk -v SQ="'" '
 BEGIN { in_sq=0; in_dq=0; tok=""; in_tok=0; line_continue=0 }
 function flush_tok() {
-  if (in_tok) { print tok; tok=""; in_tok=0 }
+  if (in_tok) { print "TOK\t" tok; tok=""; in_tok=0 }
 }
 {
   line = $0
@@ -194,22 +217,22 @@ function flush_tok() {
       # Trailing backslash at end of line — bash treats this as line
       # continuation: drop the backslash AND the newline, joining current
       # token with next line. Set line_continue so the per-line tail block
-      # neither flushes nor emits __SEGEND__ (Codex iter-3 Medium).
+      # neither flushes nor emits SEG (Codex iter-3 Medium).
       line_continue = 1
       continue
     }
     if (c == SQ)   { in_sq = 1; in_tok = 1; continue }
     if (c == "\"") { in_dq = 1; in_tok = 1; continue }
-    if (c == ";")  { flush_tok(); print "__SEGEND__"; continue }
+    if (c == ";")  { flush_tok(); print "SEG"; continue }
     if (c == "|") {
       nc = (i < n) ? substr(line, i+1, 1) : ""
-      flush_tok(); print "__SEGEND__"
+      flush_tok(); print "SEG"
       if (nc == "|") i++
       continue
     }
     if (c == "&") {
       nc = (i < n) ? substr(line, i+1, 1) : ""
-      flush_tok(); print "__SEGEND__"
+      flush_tok(); print "SEG"
       if (nc == "&") i++
       continue
     }
@@ -225,7 +248,7 @@ function flush_tok() {
     # need recursive parsing — rare in Claude Code output, accepted).
     if (c == "(" || c == ")" || c == "{" || c == "}" || c == "`") {
       flush_tok()
-      print "__SEGEND__"
+      print "SEG"
       continue
     }
     if (c == " " || c == "\t") {
@@ -242,19 +265,19 @@ function flush_tok() {
     tok = tok " "; in_tok = 1
   } else if (line_continue) {
     # Backslash-newline line-continuation outside quotes: do not flush, do
-    # not emit __SEGEND__. The current token continues onto the next line.
+    # not emit SEG. The current token continues onto the next line.
     line_continue = 0
   } else {
     # Bare newline outside quotes = statement separator (bash semantics).
     # Closes Codex iter-3 High: `echo ok\ngit push origin develop` previously
     # stayed one segment, walker exited on `echo`, never inspected the push.
     flush_tok()
-    print "__SEGEND__"
+    print "SEG"
   }
 }
 END {
   flush_tok()
-  print "__SEGEND__"
+  print "SEG"
 }
 ') || block_parser_fail "awk tokenizer exited non-zero"
 
@@ -281,8 +304,8 @@ process_segment() {
     case "$tok" in
       # Bash logical-NOT (`! cmd` runs cmd, inverts exit code). `(` `{` are
       # NOT in this list — iter-5 promotes them to segment separators (awk
-      # tokenizer emits __SEGEND__ on those chars), so they never reach the
-      # walker as tokens. Closes Codex iter-2 High #2 + iter-4 case/function/
+      # tokenizer emits SEG on those chars), so they never reach the walker
+      # as tokens. Closes Codex iter-2 High #2 + iter-4 case/function/
       # subshell bypasses uniformly.
       "!")
         i=$((i + 1)); _seen_change=1 ;;
@@ -295,7 +318,12 @@ process_segment() {
       # precede a command, but if they did the walker would still exit cleanly.
       if|then|else|elif|do|while|until)
         i=$((i + 1)); _seen_change=1 ;;
-      env|command|exec|builtin|nohup|time)
+      # Sudo/doas added per Copilot iter-1 finding (line 300): `sudo git push
+      # origin develop` previously bypassed because `sudo` led the segment.
+      # Documented limitation: `bash -c "git push origin develop"` is NOT
+      # caught — the inner -c arg would need recursive shell parsing. Rare
+      # in Claude Code output.
+      env|command|exec|builtin|nohup|time|sudo|doas)
         i=$((i + 1)); _seen_change=1 ;;
       # `coproc` and `function` may take an optional/required NAME after the
       # keyword. Skip the keyword, then peek: if the next token is a plain
@@ -445,22 +473,37 @@ process_segment() {
   fi
 }
 
-# Read the awk-emitted token stream, group tokens into segments, and process.
+# Read the awk-emitted typed line-protocol stream, group tokens into segments,
+# and process. Lines beginning with `TOK<TAB>` are tokens (with the TAB-and-
+# everything-before stripped); the bare line `SEG` is a segment terminator.
+# Any other line shape is a protocol violation — ignored to fail closed.
+TAB=$(printf '\t')
+TOK_PREFIX="TOK${TAB}"
 while IFS= read -r line; do
-  if [ "$line" = "__SEGEND__" ]; then
+  if [ "$line" = "SEG" ]; then
     if [ "${#CUR_SEG[@]}" -gt 0 ]; then
       process_segment "${CUR_SEG[@]}"
       CUR_SEG=()
     fi
   else
-    CUR_SEG+=( "$line" )
+    case "$line" in
+      "${TOK_PREFIX}"*)
+        # Strip the TOK\t prefix; the remainder (which may itself equal
+        # the literal string `SEG`) is the token value.
+        CUR_SEG+=( "${line#${TOK_PREFIX}}" )
+        ;;
+      *)
+        # Unrecognized line shape — defensive ignore. The awk tokenizer is
+        # the sole producer; this branch only fires under tampering.
+        ;;
+    esac
   fi
 done <<EOF
 $_TOK_STREAM
 EOF
 
-# Defensive flush: awk's END block always emits a trailing __SEGEND__, but
-# guard the case where the stream was empty or truncated.
+# Defensive flush: awk's END block always emits a trailing SEG, but guard
+# the case where the stream was empty or truncated.
 if [ "${#CUR_SEG[@]}" -gt 0 ]; then
   process_segment "${CUR_SEG[@]}"
 fi

--- a/scripts/test-push-guard.sh
+++ b/scripts/test-push-guard.sh
@@ -94,6 +94,11 @@ chmod +x "$BIN_DIR/git"
 # environment (e.g. 'MOCK_CURRENT_BRANCH=develop'). Pairs are split into an
 # array and passed via `env`, so VALUE may contain spaces or shell
 # metacharacters without being interpreted as code.
+#
+# Limitation (Copilot iter-1 line 96): VALUE cannot contain `;` because that
+# is the pair separator. Tests in this harness do not need semicolons in
+# values; if a future scenario does, switch to a non-semicolon delimiter
+# (e.g. newline-joined pairs) and update the IFS/read accordingly.
 # Returns: stderr text on stdout (so callers can grep it), exit-code in $?.
 #
 # Newline handling: literal newlines in $cmd (e.g. heredoc-style multi-line
@@ -969,6 +974,63 @@ scenario \
 scenario \
   '`git push refs/heads/lane/foo` (no remote, fully-qualified safe ref) -> not blocked' \
   'git push refs/heads/lane/foo' \
+  0 ''
+
+# ===========================================================================
+# Iter-7 bypass closures (Argus iter-2 + Copilot iter-1)
+# ===========================================================================
+
+# Argus iter-2 Critical (token-collision): with the iter-1..6 untyped
+# protocol (`__SEGEND__` literal as separator marker), a real shell token
+# value equal to that literal would mis-classify as a separator. The fix
+# adopts a typed line-protocol: `TOK\t<value>` for tokens, `SEG` for
+# separators. With TOK\t prefix, ANY token value (including literally
+# `SEG` or `__SEGEND__`) is unambiguously a token.
+scenario \
+  '`git push origin __SEGEND__ develop` (legacy-sentinel token-collision) -> blocked' \
+  'git push origin __SEGEND__ develop' \
+  2 'BLOCKED'
+
+scenario \
+  '`git push origin SEG develop` (current-sentinel token-collision) -> blocked' \
+  'git push origin SEG develop' \
+  2 'BLOCKED'
+
+scenario \
+  '`git push origin __SEGEND__:develop` (sentinel inside refspec) -> blocked' \
+  'git push origin __SEGEND__:develop' \
+  2 'BLOCKED'
+
+# Copilot iter-1 line 300: `sudo`/`doas` were missing from wrapper-strip,
+# so `sudo git push origin develop` slipped past as non-git leading token.
+scenario \
+  '`sudo git push origin develop` -> blocked' \
+  'sudo git push origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  '`sudo -E git push origin develop` (preserve env flag) -> blocked' \
+  'sudo -E git push origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  '`sudo -u username git push origin develop` (sudo with -u value) -> blocked' \
+  'sudo -u username git push origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  '`doas git push origin develop` (BSD doas wrapper) -> blocked' \
+  'doas git push origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  '`sudo --preserve-env=PATH git push origin master` (long flag inline value) -> blocked' \
+  'sudo --preserve-env=PATH git push origin master' \
+  2 'BLOCKED'
+
+scenario \
+  '`sudo git push origin lane/foo` (sudo + safe target) -> not blocked' \
+  'sudo git push origin lane/foo' \
   0 ''
 
 # ===========================================================================

--- a/scripts/test-push-guard.sh
+++ b/scripts/test-push-guard.sh
@@ -1,0 +1,935 @@
+#!/usr/bin/env bash
+# Tests for .claude/hooks/push-guard.sh — uses a mock `git` shim placed
+# first in PATH for Phase 3 implicit-push tests. Each scenario synthesises
+# the JSON the hook receives via stdin, captures stderr + exit code, and
+# asserts the parser correctly extracted the push args (or correctly
+# allowed non-push commands and lane-branch pushes).
+#
+# Issue #349 regression: the old per-line greedy regex
+# `sed 's/.*git[[:space:]]\+push[[:space:]]*//'` mangled commit-body lines
+# carrying `develop`/`master` as standalone tokens. The fix uses a
+# quote-aware awk segment splitter + per-segment env-strip + token-array
+# slice from the `push` token forward. Body content stays inside the
+# `git commit -m "..."` segment and never reaches the push-args walker.
+#
+# Run: bash scripts/test-push-guard.sh
+
+set -u  # not -e: we explicitly inspect non-zero exits
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HOOK="$SCRIPT_DIR/../.claude/hooks/push-guard.sh"
+[[ -f "$HOOK" ]] || { printf 'hook not found: %s\n' "$HOOK" >&2; exit 1; }
+
+PASS=0
+FAIL=0
+declare -a FAILURES=()
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok %s\n' "$label"
+  else
+    FAIL=$((FAIL + 1))
+    FAILURES+=("$label: expected [$expected], got [$actual]")
+    printf '  FAIL %s -- expected [%s], got [%s]\n' "$label" "$expected" "$actual"
+  fi
+}
+
+assert_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok %s\n' "$label"
+  else
+    FAIL=$((FAIL + 1))
+    FAILURES+=("$label: missing [$needle] in [$haystack]")
+    printf '  FAIL %s -- missing [%s] in [%s]\n' "$label" "$needle" "$haystack"
+  fi
+}
+
+assert_not_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    PASS=$((PASS + 1))
+    printf '  ok %s\n' "$label"
+  else
+    FAIL=$((FAIL + 1))
+    FAILURES+=("$label: unexpected [$needle] in [$haystack]")
+    printf '  FAIL %s -- unexpected [%s] in [%s]\n' "$label" "$needle" "$haystack"
+  fi
+}
+
+# Per-scenario isolated working dir so each run gets a fresh state dir.
+# Guard mktemp failure explicitly: a missing $WORK_DIR would silently fall
+# through to "$WORK_DIR/..." path concatenation that would resolve to
+# absolute paths under cwd, risking writes outside the temp namespace.
+if ! WORK_DIR="$(mktemp -d -t push-guard-test.XXXXXX)"; then
+  printf 'failed to create temp dir for test\n' >&2
+  exit 1
+fi
+trap '[[ -n "${WORK_DIR:-}" && -d "$WORK_DIR" ]] && rm -rf "$WORK_DIR"' EXIT
+
+BIN_DIR="$WORK_DIR/bin"
+mkdir -p "$BIN_DIR"
+
+# Mock git shim. push-guard.sh only invokes `git rev-parse --abbrev-ref HEAD`
+# during Phase 3 implicit-push detection. The mock returns $MOCK_CURRENT_BRANCH
+# (default `feature/test`) so explicit-target scenarios are unaffected and
+# implicit-push scenarios can exercise both protected and non-protected
+# branch states deterministically.
+cat > "$BIN_DIR/git" <<'MOCK_EOF'
+#!/usr/bin/env bash
+# mock git used by test-push-guard.sh — only emulates rev-parse HEAD
+if [[ "${1:-}" == "rev-parse" && "${2:-}" == "--abbrev-ref" && "${3:-}" == "HEAD" ]]; then
+  printf '%s\n' "${MOCK_CURRENT_BRANCH:-feature/test}"
+  exit 0
+fi
+exit 0
+MOCK_EOF
+chmod +x "$BIN_DIR/git"
+
+# Run hook with given command-string. Captures stderr + exit code.
+# Optional second arg: ';'-separated VAR=VALUE pairs forwarded to the hook
+# environment (e.g. 'MOCK_CURRENT_BRANCH=develop'). Pairs are split into an
+# array and passed via `env`, so VALUE may contain spaces or shell
+# metacharacters without being interpreted as code.
+# Returns: stderr text on stdout (so callers can grep it), exit-code in $?.
+#
+# Newline handling: literal newlines in $cmd (e.g. heredoc-style multi-line
+# commit bodies, exactly the S83 reproducer pattern) are escaped to JSON
+# `\n` sequences so the synthesized JSON is well-formed; jq inside the
+# hook then unescapes them back to literal newlines, matching what the
+# real Claude Code Bash tool would deliver.
+run_hook() {
+  local cmd="$1"
+  local extra_env="${2:-}"
+  # Build JSON input. Escape backslashes, double-quotes, and literal newlines.
+  local esc
+  esc="${cmd//\\/\\\\}"
+  esc="${esc//\"/\\\"}"
+  esc="${esc//$'\n'/\\n}"
+  local input="{\"tool_input\": {\"command\": \"${esc}\"}}"
+  local fake_project="$WORK_DIR/proj-$RANDOM"
+  mkdir -p "$fake_project"
+  local rc
+  local -a extra_env_kv=()
+  if [[ -n "$extra_env" ]]; then
+    IFS=';' read -r -a extra_env_kv <<< "$extra_env"
+  fi
+  env "PATH=$BIN_DIR:$PATH" "CLAUDE_PROJECT_DIR=$fake_project" \
+    "${extra_env_kv[@]}" bash "$HOOK" 2> "$WORK_DIR/stderr.$$" <<<"$input" >/dev/null
+  rc=$?
+  cat "$WORK_DIR/stderr.$$" 2>/dev/null || true
+  rm -f "$WORK_DIR/stderr.$$"
+  return $rc
+}
+
+# Run a scenario: $1 label, $2 cmd, $3 expected exit, $4 stderr-contains needle.
+# Optional $5: stderr-NOT-contains needle. Optional $6: ';'-separated env pairs.
+scenario() {
+  local label="$1" cmd="$2" want_rc="$3" want_msg="$4" not_msg="${5:-}" extra_env="${6:-}"
+  printf '\n[scenario] %s\n' "$label"
+  local err rc
+  err=$(run_hook "$cmd" "$extra_env")
+  rc=$?
+  assert_eq "  exit code" "$want_rc" "$rc"
+  if [[ -n "$want_msg" ]]; then
+    assert_contains "  stderr contains" "$want_msg" "$err"
+  fi
+  if [[ -n "$not_msg" ]]; then
+    assert_not_contains "  stderr does not contain" "$not_msg" "$err"
+  fi
+}
+
+# ===========================================================================
+# Issue #349 — body containing `git push`/`develop`/`master` tokens MUST NOT
+# be parsed as push args (S83 reproducer is the primary acceptance gate)
+# ===========================================================================
+
+# S83 actual reproducer: heredoc-style multi-line body with `git push hygiene`
+# phrase + standalone `develop` and `master` words + real push to lane branch.
+# Pre-fix this BLOCKED with rc=2 because per-line sed left body lines intact
+# and bash word-splitting exposed `develop`/`master` tokens.
+scenario \
+  '#349 S83 heredoc body w/ git-push phrase + develop/master words -> not blocked' \
+  'git commit -m "$(cat <<EOF
+fix: lane-assertion three-way check
+
+refs origin/develop and origin/master
+improves git push hygiene for develop branch
+EOF
+)" && git push origin lane/main/345-handoff-lane-assert' \
+  0 ''
+
+scenario \
+  '#349 single-line body w/ "develop" word + push to lane branch -> not blocked' \
+  'git commit -m "refs develop branch" && git push origin lane/main/foo' \
+  0 ''
+
+scenario \
+  '#349 single-line body w/ "master" word + push to lane branch -> not blocked' \
+  'git commit -m "merge master branch" && git push origin lane/main/foo' \
+  0 ''
+
+scenario \
+  '#349 body literally contains "git push origin develop" + real push to lane -> not blocked' \
+  'git commit -m "avoids git push origin develop bypass" && git push origin lane/main/foo' \
+  0 ''
+
+scenario \
+  '#349 body w/ multiple "git push" mentions + real push to lane -> not blocked' \
+  'git commit -m "fix: handle git push to develop and git push to master" && git push origin lane/main/foo' \
+  0 ''
+
+# ===========================================================================
+# All existing block paths still fire (regression net for the new
+# segment-splitter + token-walker)
+# ===========================================================================
+
+scenario \
+  'plain `git push origin develop` -> blocked' \
+  'git push origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  '`git push origin master` -> blocked' \
+  'git push origin master' \
+  2 'BLOCKED'
+
+scenario \
+  '`git push origin main` -> blocked' \
+  'git push origin main' \
+  2 'BLOCKED'
+
+scenario \
+  '`git push -f origin master` -> blocked (force flag does not bypass)' \
+  'git push -f origin master' \
+  2 'BLOCKED'
+
+scenario \
+  '`git push --force origin develop` -> blocked' \
+  'git push --force origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  '`git push --all` -> blocked (Phase 1 dangerous flag)' \
+  'git push --all' \
+  2 'BLOCKED'
+
+scenario \
+  '`git push --mirror` -> blocked (Phase 1 dangerous flag)' \
+  'git push --mirror' \
+  2 'BLOCKED'
+
+scenario \
+  '`git push origin HEAD:develop` (refspec RHS) -> blocked' \
+  'git push origin HEAD:develop' \
+  2 'BLOCKED'
+
+scenario \
+  '`git push origin lane/main/foo:develop` (refspec RHS) -> blocked' \
+  'git push origin lane/main/foo:develop' \
+  2 'BLOCKED'
+
+scenario \
+  '`git push origin +develop` (force-push prefix) -> blocked' \
+  'git push origin +develop' \
+  2 'BLOCKED'
+
+scenario \
+  '`git push origin refs/heads/develop` (full ref) -> blocked' \
+  'git push origin refs/heads/develop' \
+  2 'BLOCKED'
+
+scenario \
+  '`git push origin HEAD:refs/heads/develop` (full ref RHS) -> blocked' \
+  'git push origin HEAD:refs/heads/develop' \
+  2 'BLOCKED'
+
+# Implicit push from current protected branch (Phase 3)
+scenario \
+  'implicit `git push` from current branch=develop -> blocked' \
+  'git push' \
+  2 'BLOCKED' '' \
+  'MOCK_CURRENT_BRANCH=develop'
+
+scenario \
+  'implicit `git push origin` (remote only) from develop -> blocked' \
+  'git push origin' \
+  2 'BLOCKED' '' \
+  'MOCK_CURRENT_BRANCH=develop'
+
+scenario \
+  'implicit `git push` from current branch=master -> blocked' \
+  'git push' \
+  2 'BLOCKED' '' \
+  'MOCK_CURRENT_BRANCH=master'
+
+scenario \
+  'implicit `git push` from feature branch -> not blocked' \
+  'git push' \
+  0 '' '' \
+  'MOCK_CURRENT_BRANCH=feature/foo'
+
+scenario \
+  'implicit `git push` from lane branch -> not blocked' \
+  'git push' \
+  0 '' '' \
+  'MOCK_CURRENT_BRANCH=lane/side-bug/349'
+
+# ===========================================================================
+# Quote-bypass attempts: separator chars hidden inside quotes must NOT split
+# the segment; separator chars OUTSIDE quotes MUST split.
+# ===========================================================================
+
+scenario \
+  '`echo ok && git push origin develop` -> blocked (segment 2 fires)' \
+  'echo ok && git push origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  '`echo ok || git push origin develop` -> blocked' \
+  'echo ok || git push origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  '`echo ok ; git push origin develop` -> blocked' \
+  'echo ok ; git push origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  '`true | git push origin develop` -> blocked' \
+  'true | git push origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  '`git commit -m "; git push origin develop"` (separator inside quotes) -> not blocked' \
+  'git commit -m "; git push origin develop"' \
+  0 ''
+
+scenario \
+  "git commit with single-quoted body containing 'git push origin develop' -> not blocked" \
+  "git commit -m 'git push origin develop content'" \
+  0 ''
+
+scenario \
+  '`git commit -m "&& git push origin master"` -> not blocked' \
+  'git commit -m "&& git push origin master"' \
+  0 ''
+
+# ===========================================================================
+# Env-var prefix + command-wrapper bypass attempts
+# ===========================================================================
+
+scenario \
+  '`GIT_TRACE=1 git push origin develop` -> blocked' \
+  'GIT_TRACE=1 git push origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  '`env GIT_TRACE=1 git push origin develop` -> blocked' \
+  'env GIT_TRACE=1 git push origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  '`command git push origin develop` -> blocked' \
+  'command git push origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  '`exec git push origin develop` -> blocked' \
+  'exec git push origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  '`nohup git push origin master` -> blocked' \
+  'nohup git push origin master' \
+  2 'BLOCKED'
+
+scenario \
+  '`A=1 B=2 git push origin develop` -> blocked (multiple env vars)' \
+  'A=1 B=2 git push origin develop' \
+  2 'BLOCKED'
+
+# ===========================================================================
+# Lane-branch defense (false-positive guards: substring-but-not-token matches)
+# ===========================================================================
+
+scenario \
+  '`git push origin lane/main/345-handoff-lane-assert` -> not blocked' \
+  'git push origin lane/main/345-handoff-lane-assert' \
+  0 ''
+
+scenario \
+  '`git push origin lane/side-bug/349-push-guard-regex` -> not blocked' \
+  'git push origin lane/side-bug/349-push-guard-regex' \
+  0 ''
+
+scenario \
+  '`git push -u origin lane/side-bug/349` -> not blocked (-u flag)' \
+  'git push -u origin lane/side-bug/349' \
+  0 ''
+
+scenario \
+  '`git push --set-upstream origin lane/side-bug/349` -> not blocked' \
+  'git push --set-upstream origin lane/side-bug/349' \
+  0 ''
+
+scenario \
+  '`git push origin feature/develop-feat` (substring not exact) -> not blocked' \
+  'git push origin feature/develop-feat' \
+  0 ''
+
+scenario \
+  '`git push origin develop-typo` (substring not exact) -> not blocked' \
+  'git push origin develop-typo' \
+  0 ''
+
+scenario \
+  '`git push origin master-backup` (substring not exact) -> not blocked' \
+  'git push origin master-backup' \
+  0 ''
+
+scenario \
+  '`git push origin HEAD:lane/side-bug/349` (refspec to non-protected) -> not blocked' \
+  'git push origin HEAD:lane/side-bug/349' \
+  0 ''
+
+scenario \
+  '`git push -f -u origin lane/main/foo` (multiple flags) -> not blocked' \
+  'git push -f -u origin lane/main/foo' \
+  0 ''
+
+# ===========================================================================
+# Negative path: non-push commands MUST NOT fire the intercept
+# ===========================================================================
+
+scenario \
+  '`git commit -m "fix: push to develop"` (no real push) -> not intercepted' \
+  'git commit -m "fix: push to develop"' \
+  0 ''
+
+scenario \
+  '`git fetch origin develop` -> not intercepted (not a push)' \
+  'git fetch origin develop' \
+  0 ''
+
+scenario \
+  '`git pull origin develop` -> not intercepted (not a push)' \
+  'git pull origin develop' \
+  0 ''
+
+scenario \
+  '`echo "git push origin develop"` -> not intercepted (echo, not git push)' \
+  'echo "git push origin develop"' \
+  0 ''
+
+scenario \
+  '`gh pr view 5` -> not intercepted (not git push)' \
+  'gh pr view 5' \
+  0 ''
+
+scenario \
+  '`pushd /tmp` -> not intercepted (substring "push" not "git push")' \
+  'pushd /tmp' \
+  0 ''
+
+# ===========================================================================
+# git global options (-C, -c) before the push subcommand
+# ===========================================================================
+
+scenario \
+  '`git -C /repo push origin develop` -> blocked' \
+  'git -C /repo push origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  '`git -c user.name=foo push origin develop` -> blocked' \
+  'git -c user.name=foo push origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  '`git -C /repo push origin lane/main/foo` -> not blocked' \
+  'git -C /repo push origin lane/main/foo' \
+  0 ''
+
+scenario \
+  '`git --git-dir=/repo/.git push origin develop` -> blocked' \
+  'git --git-dir=/repo/.git push origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  '`git --no-pager push origin develop` -> blocked' \
+  'git --no-pager push origin develop' \
+  2 'BLOCKED'
+
+# ===========================================================================
+# Multi-segment + env-prefix interaction
+# ===========================================================================
+
+scenario \
+  '`echo ok && GIT_TRACE=1 git push origin develop` -> blocked' \
+  'echo ok && GIT_TRACE=1 git push origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  '`git commit -m "develop" && env GIT_TRACE=1 git push origin lane/main/foo` -> not blocked' \
+  'git commit -m "develop" && env GIT_TRACE=1 git push origin lane/main/foo' \
+  0 ''
+
+scenario \
+  '`git commit -m "ok" && git push origin develop` -> blocked (real push to develop wins)' \
+  'git commit -m "ok" && git push origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  '`git status && git push origin develop` -> blocked (segment 2 fires)' \
+  'git status && git push origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  '`git push origin lane/foo && git status` -> not blocked (lane push first)' \
+  'git push origin lane/foo && git status' \
+  0 ''
+
+# ===========================================================================
+# Edge cases
+# ===========================================================================
+
+# Empty COMMAND with "command" key in JSON = parser-fail signal → fail-closed.
+# Real Claude Code Bash invocations always carry a non-empty command, so this
+# code path only fires under parser malfunction / malformed input.
+scenario \
+  'empty command WITH command key -> hard-block (parser-fail safety)' \
+  '' \
+  2 'BLOCKED'
+
+scenario \
+  '`git` (just git, no subcommand) -> not intercepted' \
+  'git' \
+  0 ''
+
+scenario \
+  '`git push` from feature branch (mock) -> not blocked' \
+  'git push' \
+  0 '' '' \
+  'MOCK_CURRENT_BRANCH=feature/foo'
+
+# ===========================================================================
+# Iter-2 bypass closures (dual-verify findings: claude-only + codex-only)
+# ===========================================================================
+
+# CRITICAL #1: literal-quote token in protected-branch position must NOT bypass.
+# Awk strips outer quotes during tokenization; defensive quote-strip in Phase 2
+# handles any leakage from mid-token quotes / repeated escaping.
+scenario \
+  '`git push origin "develop"` (double-quoted protected) -> blocked' \
+  'git push origin "develop"' \
+  2 'BLOCKED'
+
+scenario \
+  "git push origin 'develop' (single-quoted protected) -> blocked" \
+  "git push origin 'develop'" \
+  2 'BLOCKED'
+
+scenario \
+  '`git push origin "+develop"` (quoted force-prefix) -> blocked' \
+  'git push origin "+develop"' \
+  2 'BLOCKED'
+
+scenario \
+  '`git push origin "HEAD:develop"` (quoted refspec RHS) -> blocked' \
+  'git push origin "HEAD:develop"' \
+  2 'BLOCKED'
+
+scenario \
+  '`git push origin "refs/heads/develop"` (quoted full ref) -> blocked' \
+  'git push origin "refs/heads/develop"' \
+  2 'BLOCKED'
+
+# CRITICAL #2: 6+ chained env wrappers must NOT bypass (was capped at 5 passes).
+# Token-based wrapper-strip is now unbounded.
+scenario \
+  '`env env env env env env git push origin develop` (6× env) -> blocked' \
+  'env env env env env env git push origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  '10× env chain -> blocked' \
+  'env env env env env env env env env env git push origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  'mixed wrapper chain (env+command+exec×3 alternating) -> blocked' \
+  'env command exec env command exec env command exec git push origin develop' \
+  2 'BLOCKED'
+
+# HIGH (Claude): subshell `( ... )` and group `{ ...; }` must NOT bypass.
+# Awk now tokenizes parens/braces; wrapper-strip skips leading `(` `{`.
+scenario \
+  '`( git push origin develop )` (subshell) -> blocked' \
+  '( git push origin develop )' \
+  2 'BLOCKED'
+
+scenario \
+  '`{ git push origin develop ; }` (brace group) -> blocked' \
+  '{ git push origin develop ; }' \
+  2 'BLOCKED'
+
+scenario \
+  '`( env GIT_TRACE=1 git push origin master )` (subshell + env) -> blocked' \
+  '( env GIT_TRACE=1 git push origin master )' \
+  2 'BLOCKED'
+
+scenario \
+  '`( git push origin lane/foo )` (subshell + safe target) -> not blocked' \
+  '( git push origin lane/foo )' \
+  0 ''
+
+# HIGH (Codex): quoted env values + quoted -C paths must NOT mistokenize.
+# Awk produces a single token for `A="1 2"` (the value-with-space); previous
+# bash word-split + sed regex produced two malformed tokens.
+scenario \
+  '`A="1 2" git push origin develop` (quoted env value w/ space) -> blocked' \
+  'A="1 2" git push origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  '`A="" git push origin develop` (empty quoted env value) -> blocked' \
+  'A="" git push origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  "A='1 2' git push origin develop (single-quoted env value w/ space) -> blocked" \
+  "A='1 2' git push origin develop" \
+  2 'BLOCKED'
+
+scenario \
+  '`env A="1 2" git push origin develop` -> blocked (env wrapper + quoted value)' \
+  'env A="1 2" git push origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  '`git -C "C:/repo with spaces" push origin develop` (quoted -C path) -> blocked' \
+  'git -C "C:/repo with spaces" push origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  "git -c 'user.name=A B' push origin develop (quoted -c value w/ space) -> blocked" \
+  "git -c 'user.name=A B' push origin develop" \
+  2 'BLOCKED'
+
+scenario \
+  '`git -C "C:/repo with spaces" push origin lane/main/foo` (quoted -C, safe target) -> not blocked' \
+  'git -C "C:/repo with spaces" push origin lane/main/foo' \
+  0 ''
+
+# CRITICAL (Codex): break-on-first segment match must be replaced by
+# evaluate-all-segments. `git push origin lane/foo && git push origin develop`
+# was rc=0 in iter-1 because only the first segment was inspected.
+scenario \
+  '`git push origin lane/foo && git push origin develop` -> blocked (segment 2 fires)' \
+  'git push origin lane/foo && git push origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  '`git push origin develop && git push origin lane/foo` -> blocked (segment 1 fires)' \
+  'git push origin develop && git push origin lane/foo' \
+  2 'BLOCKED'
+
+scenario \
+  '`git push origin lane/a && git push origin lane/b` (both safe) -> not blocked' \
+  'git push origin lane/a && git push origin lane/b' \
+  0 ''
+
+scenario \
+  'three pushes, last protected -> blocked' \
+  'git push origin lane/a && git push origin lane/b && git push origin master' \
+  2 'BLOCKED'
+
+scenario \
+  'three pushes, middle protected -> blocked' \
+  'git push origin lane/a && git push origin develop && git push origin lane/b' \
+  2 'BLOCKED'
+
+# ===========================================================================
+# Iter-3 bypass closures (codex iter-2 audit)
+# ===========================================================================
+
+# Codex Critical: jq absent + escaped quotes in JSON command bypass via
+# truncating sed fallback. Fix hard-blocks when jq is unavailable. Test via
+# MERCURY_PUSH_GUARD_TEST_FORCE_NO_JQ=1 env override (Windows-portable —
+# avoids fragile copy-system-utils-without-jq PATH gymnastics).
+scenario \
+  'jq absent + non-empty command -> hard-block (parser-fail)' \
+  'git push origin lane/foo' \
+  2 'BLOCKED' '' \
+  'MERCURY_PUSH_GUARD_TEST_FORCE_NO_JQ=1'
+
+scenario \
+  'jq absent + would-be-allowed safe push still blocks (fail-closed)' \
+  'git push origin lane/main/345' \
+  2 'BLOCKED' '' \
+  'MERCURY_PUSH_GUARD_TEST_FORCE_NO_JQ=1'
+
+# Codex High #1: backslash escape outside double quotes. Bash parses
+# `git push origin de\velop` as `git push origin develop`. The iter-2 awk
+# tokenizer treated `\` as a literal char, leaving `de\velop` in the token,
+# missing the protected-branch grep. Iter-3 awk now consumes the backslash
+# and appends the escaped char.
+scenario \
+  '`git push origin de\velop` (outside-quote backslash escape) -> blocked' \
+  'git push origin de\velop' \
+  2 'BLOCKED'
+
+scenario \
+  '`git push origin maste\r` (outside-quote backslash escape) -> blocked' \
+  'git push origin maste\r' \
+  2 'BLOCKED'
+
+scenario \
+  '`git push origin HEAD:de\velop` (escaped refspec RHS) -> blocked' \
+  'git push origin HEAD:de\velop' \
+  2 'BLOCKED'
+
+scenario \
+  '`git push origin lane\/main\/foo` (gratuitous escapes on safe target) -> not blocked' \
+  'git push origin lane\/main\/foo' \
+  0 ''
+
+# Codex High #2: prefix-grammar bypasses via `!` (bash logical NOT) and
+# `--longopt` after a wrapper (`env --ignore-environment ...`).
+scenario \
+  '`! git push origin develop` (bash NOT) -> blocked' \
+  '! git push origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  '`! ! git push origin develop` (double NOT) -> blocked' \
+  '! ! git push origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  '`env --ignore-environment git push origin develop` -> blocked' \
+  'env --ignore-environment git push origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  '`env -i git push origin develop` (short-form) -> blocked' \
+  'env -i git push origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  '`env --null git push origin develop` (long flag-only) -> blocked' \
+  'env --null git push origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  '`env --chdir=/tmp git push origin develop` (--longopt=value inline) -> blocked' \
+  'env --chdir=/tmp git push origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  '`env --unset PATH git push origin develop` (separate-arg long value) -> blocked' \
+  'env --unset PATH git push origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  '`env --chdir /tmp git push origin develop` (separate-arg --chdir) -> blocked' \
+  'env --chdir /tmp git push origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  '`! ( env --ignore-environment git push origin master )` (combined !) -> blocked' \
+  '! ( env --ignore-environment git push origin master )' \
+  2 'BLOCKED'
+
+# ===========================================================================
+# Iter-4 bypass closures (codex iter-3 audit)
+# ===========================================================================
+
+# Codex iter-3 High: bare newlines outside quotes were not segment separators.
+# `echo ok\ngit push origin develop` stayed one segment (echo, ok, git, push,
+# origin, develop), walker exited on `echo`, the develop push was never
+# inspected. Iter-4 awk emits __SEGEND__ at end-of-line outside quotes.
+scenario \
+  $'newline-separated `echo ok` + `git push origin develop` -> blocked' \
+  $'echo ok\ngit push origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  $'newline-separated `git push origin lane/foo` + `git push origin develop` -> blocked' \
+  $'git push origin lane/foo\ngit push origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  $'two-line both-safe pushes -> not blocked' \
+  $'git push origin lane/a\ngit push origin lane/b' \
+  0 ''
+
+scenario \
+  $'commit + newline + push to lane (S83-style minus heredoc) -> not blocked' \
+  $'git commit -m "fix: develop master refs"\ngit push origin lane/main/foo' \
+  0 ''
+
+# Codex iter-3 High: bash control-flow reserved words (`if`/`then`/`else`/
+# `elif`/`do`/`while`/`until`) added to wrapper-strip so guarded segments
+# starting with these words still walk into the inner command.
+scenario \
+  '`if true; then git push origin develop; fi` (then-prefix) -> blocked' \
+  'if true; then git push origin develop; fi' \
+  2 'BLOCKED'
+
+scenario \
+  '`while true; do git push origin master; done` (do-prefix) -> blocked' \
+  'while true; do git push origin master; done' \
+  2 'BLOCKED'
+
+scenario \
+  '`if x; then echo safe; else git push origin develop; fi` (else-prefix) -> blocked' \
+  'if x; then echo safe; else git push origin develop; fi' \
+  2 'BLOCKED'
+
+scenario \
+  '`if x; then echo a; elif y; then git push origin develop; fi` (elif-prefix) -> blocked' \
+  'if x; then echo a; elif y; then git push origin develop; fi' \
+  2 'BLOCKED'
+
+scenario \
+  '`until git push origin develop; do : ; done` (until-prefix) -> blocked' \
+  'until git push origin develop; do : ; done' \
+  2 'BLOCKED'
+
+scenario \
+  '`if true; then git push origin lane/foo; fi` (then-prefix, safe target) -> not blocked' \
+  'if true; then git push origin lane/foo; fi' \
+  0 ''
+
+# Codex iter-3 Medium: trailing backslash line-continuation outside quotes.
+# `git push origin devel\<NL>op` should parse as `git push origin develop`
+# (bash drops both `\` and newline, joining lines). Iter-3 awk dropped the
+# backslash but flushed the token at end-of-line, so `devel` and `op` became
+# separate tokens, missing the PROTECTED grep. Iter-4 awk tracks
+# line_continue state to suppress the end-of-line flush + __SEGEND__.
+scenario \
+  $'`git push origin devel\\<NL>op` (line-continuation across develop) -> blocked' \
+  $'git push origin devel\\\nop' \
+  2 'BLOCKED'
+
+scenario \
+  $'`git push origin maste\\<NL>r` (line-continuation across master) -> blocked' \
+  $'git push origin maste\\\nr' \
+  2 'BLOCKED'
+
+scenario \
+  $'`git \\<NL>push origin develop` (line-cont across cmd boundary) -> blocked' \
+  $'git \\\npush origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  $'`git push origin lane/\\<NL>main/foo` (line-cont safe target) -> not blocked' \
+  $'git push origin lane/\\\nmain/foo' \
+  0 ''
+
+# ===========================================================================
+# Iter-5 bypass closures (codex iter-4 audit)
+# ===========================================================================
+
+# Codex iter-4 High: `coproc` keyword unhandled. `coproc git push origin
+# develop` previously had `coproc` as leading token → walker exit before git.
+scenario \
+  '`coproc git push origin develop` (coproc unnamed) -> blocked' \
+  'coproc git push origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  '`coproc CO git push origin develop` (coproc named) -> blocked' \
+  'coproc CO git push origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  '`coproc git push origin lane/foo` (coproc safe target) -> not blocked' \
+  'coproc git push origin lane/foo' \
+  0 ''
+
+# Codex iter-4 High: top-level command substitution `$(...)` and backtick
+# `` `...` `` previously buffered as opaque tokens → inner `git push` invisible.
+# Iter-5 awk treats `(` `)` `{` `}` and backtick as segment separators;
+# inner content becomes its own segment.
+scenario \
+  '`echo $(git push origin develop)` (command substitution dollar-paren) -> blocked' \
+  'echo $(git push origin develop)' \
+  2 'BLOCKED'
+
+scenario \
+  '`echo $(git push origin lane/foo)` (cmdsub safe target) -> not blocked' \
+  'echo $(git push origin lane/foo)' \
+  0 ''
+
+scenario \
+  'backtick command substitution with protected target -> blocked' \
+  'echo `git push origin develop`' \
+  2 'BLOCKED'
+
+scenario \
+  'backtick command substitution with safe target -> not blocked' \
+  'echo `git push origin lane/foo`' \
+  0 ''
+
+# Codex iter-4 High: `case ... in PAT) CMD ;; esac` compound-command body.
+# Iter-5 `)` separator makes the body a clean segment.
+scenario \
+  '`case x in x) git push origin develop ;; esac` -> blocked' \
+  'case x in x) git push origin develop ;; esac' \
+  2 'BLOCKED'
+
+scenario \
+  '`case x in x) git push origin lane/foo ;; esac` (safe target) -> not blocked' \
+  'case x in x) git push origin lane/foo ;; esac' \
+  0 ''
+
+# Codex iter-4 High: `function f { ... }; f` and `f() { ... }; f` body.
+# Iter-5: `{` separator splits body out; `function`+name skip handles
+# declaration prefix.
+scenario \
+  '`function f { git push origin develop; }; f` -> blocked' \
+  'function f { git push origin develop; }; f' \
+  2 'BLOCKED'
+
+scenario \
+  '`f() { git push origin develop; }; f` (no function keyword) -> blocked' \
+  'f() { git push origin develop; }; f' \
+  2 'BLOCKED'
+
+scenario \
+  '`function f { git push origin lane/foo; }; f` (safe target) -> not blocked' \
+  'function f { git push origin lane/foo; }; f' \
+  0 ''
+
+# Combined obfuscation patterns
+scenario \
+  '`( ! coproc env --ignore-environment git push origin master )` (max obfuscation) -> blocked' \
+  '( ! coproc env --ignore-environment git push origin master )' \
+  2 'BLOCKED'
+
+scenario \
+  'nested `( ( git push origin develop ) )` -> blocked' \
+  '( ( git push origin develop ) )' \
+  2 'BLOCKED'
+
+# ===========================================================================
+# Summary
+# ===========================================================================
+
+printf '\n=== Summary ===\n'
+printf 'pass: %d\n' "$PASS"
+printf 'fail: %d\n' "$FAIL"
+if [[ "$FAIL" -gt 0 ]]; then
+  printf '\nFailures:\n'
+  for f in "${FAILURES[@]}"; do
+    printf '  - %s\n' "$f"
+  done
+  exit 1
+fi
+exit 0

--- a/scripts/test-push-guard.sh
+++ b/scripts/test-push-guard.sh
@@ -919,6 +919,59 @@ scenario \
   2 'BLOCKED'
 
 # ===========================================================================
+# Iter-6 bypass closure (Argus iter-1 finding on PR #352)
+# ===========================================================================
+
+# Argus Minor #1: `git push REFSPEC` (no remote arg) is valid syntax —
+# git treats `HEAD:develop` as a refspec, not a remote name. Iter-5
+# SKIPPED_REMOTE eat-first-non-flag heuristic missed this case and let
+# Phase 3 fall through to current-branch check.
+scenario \
+  '`git push HEAD:develop` (no remote, refspec only) -> blocked' \
+  'git push HEAD:develop' \
+  2 'BLOCKED'
+
+scenario \
+  '`git push HEAD:master` (no remote, refspec) -> blocked' \
+  'git push HEAD:master' \
+  2 'BLOCKED'
+
+scenario \
+  '`git push +develop` (no remote, force prefix) -> blocked' \
+  'git push +develop' \
+  2 'BLOCKED'
+
+scenario \
+  '`git push +HEAD:develop` (no remote, force + refspec) -> blocked' \
+  'git push +HEAD:develop' \
+  2 'BLOCKED'
+
+scenario \
+  '`git push refs/heads/develop` (no remote, fully-qualified ref) -> blocked' \
+  'git push refs/heads/develop' \
+  2 'BLOCKED'
+
+scenario \
+  '`git push refs/heads/master` (no remote, fully-qualified ref) -> blocked' \
+  'git push refs/heads/master' \
+  2 'BLOCKED'
+
+scenario \
+  '`git push HEAD:lane/foo` (no remote, refspec to safe target) -> not blocked' \
+  'git push HEAD:lane/foo' \
+  0 ''
+
+scenario \
+  '`git push +lane/foo` (force-push to safe target, no remote) -> not blocked' \
+  'git push +lane/foo' \
+  0 ''
+
+scenario \
+  '`git push refs/heads/lane/foo` (no remote, fully-qualified safe ref) -> not blocked' \
+  'git push refs/heads/lane/foo' \
+  0 ''
+
+# ===========================================================================
 # Summary
 # ===========================================================================
 

--- a/scripts/test-push-guard.sh
+++ b/scripts/test-push-guard.sh
@@ -109,12 +109,18 @@ chmod +x "$BIN_DIR/git"
 run_hook() {
   local cmd="$1"
   local extra_env="${2:-}"
-  # Build JSON input. Escape backslashes, double-quotes, and literal newlines.
-  local esc
-  esc="${cmd//\\/\\\\}"
-  esc="${esc//\"/\\\"}"
-  esc="${esc//$'\n'/\\n}"
-  local input="{\"tool_input\": {\"command\": \"${esc}\"}}"
+  # Build JSON via jq -n so all JSON escape rules are handled correctly
+  # (closes Copilot iter-2 line-117 finding: the previous manual escape
+  # only covered \\, ", and \n; control chars like \r, \t, and 0x00..0x1f
+  # would have produced malformed JSON). jq is required by the hook
+  # itself, so the dependency was already implicit; making it explicit in
+  # the harness is a robustness no-op for our environment but eliminates
+  # a class of test-side input encoding bugs.
+  local input
+  input=$(jq -nc --arg cmd "$cmd" '{tool_input: {command: $cmd}}') || {
+    printf 'run_hook: jq -n failed to encode JSON input\n' >&2
+    return 1
+  }
   local fake_project="$WORK_DIR/proj-$RANDOM"
   mkdir -p "$fake_project"
   local rc
@@ -1031,6 +1037,44 @@ scenario \
 scenario \
   '`sudo git push origin lane/foo` (sudo + safe target) -> not blocked' \
   'sudo git push origin lane/foo' \
+  0 ''
+
+# ===========================================================================
+# Iter-8 bypass closures (Argus iter-3 + Copilot iter-2)
+# ===========================================================================
+
+# Copilot iter-2 line-199 (real bypass): backslash-newline INSIDE double
+# quotes is bash line-continuation (drops both `\` and newline). Iter-7 awk
+# only handled this OUTSIDE quotes. Inside dq, `\` was appended as literal
+# and the implicit EOL inserted a space, splitting `develop` into
+# `devel\<space>op` — missing the PROTECTED grep.
+scenario \
+  $'`git push origin "devel\\<NL>op"` (dq line-cont across develop) -> blocked' \
+  $'git push origin "devel\\\nop"' \
+  2 'BLOCKED'
+
+scenario \
+  $'`git push origin "maste\\<NL>r"` (dq line-cont across master) -> blocked' \
+  $'git push origin "maste\\\nr"' \
+  2 'BLOCKED'
+
+scenario \
+  $'`git push origin "lane/\\<NL>main/foo"` (dq line-cont safe target) -> not blocked' \
+  $'git push origin "lane/\\\nmain/foo"' \
+  0 ''
+
+# Carriage-return + tab in command (regression for Copilot iter-2 line-117
+# JSON-escaping). Pre-fix: harness escaped only \, ", \n; \r and \t in cmd
+# would have produced malformed JSON. With jq -n encoding, any literal
+# byte is encoded correctly.
+scenario \
+  $'`git push origin lane/foo\\twith-tab` (literal tab in target — JSON encoding) -> not blocked' \
+  $'git push origin lane/foo\twith-tab' \
+  0 ''
+
+scenario \
+  $'CR in body (literal \\r) does not crash JSON encoding — not blocked' \
+  $'git commit -m "develop\\rmaster" && git push origin lane/foo' \
   0 ''
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

Fixes Issue #349 — `.claude/hooks/push-guard.sh` greedy-regex bypass that caused S83 main lane PR #346 commit + push compound chain to be incorrectly BLOCKED. Pattern parallel to S82 #339 fix on `pr-merge-guard.sh` (commit `818415d`).

The hook's per-line `sed 's/.*git[[:space:]]\+push[[:space:]]*//'` extractor stripped only the LAST line containing `git push`. Body lines from heredoc commit messages survived intact; bash word-splitting on `PUSH_ARGS` exposed standalone `develop`/`master` tokens from those body lines as protected-branch matches.

**Fix**: full rewrite of the hook using a quote-aware awk tokenizer that emits one shell-style token per line plus `__SEGEND__` markers between separators. Per-segment Phase 1/2/3 evaluation (no break-on-first), unbounded fixed-point wrapper-strip, jq-required policy with hard-block on absence, defensive quote-strip in Phase 2.

## Components

- **`.claude/hooks/push-guard.sh`** (rewrite, +395/-46): quote-aware awk tokenizer + per-segment phase evaluation
- **`scripts/test-push-guard.sh`** (NEW, 935 lines): 217-assertion harness with mock `git` shim for Phase 3 implicit-push tests

## Verification

- `bash scripts/test-push-guard.sh` → 217/217 PASS
- `bash -n` clean on both files
- Live S83 reproducer (heredoc body w/ "develop"/"master"/"git push hygiene" + push to lane branch) → exit 0 (allowed)
- Real `git push origin develop` → exit 2 (blocked)
- Self-test: this PR's commit + push chain (containing many "git push origin develop" references in commit body) passed through cleanly without false-positive

## Dual-verify trajectory

5 iterations of parallel review (Claude code-reviewer + Codex sync-audit) closed **14 progressively-obscure bypass classes**:

| Iter | Codex side | Claude side | Closures |
|------|-----------|-------------|----------|
| 1 | NEEDS-CHANGES (1C/1H/1M) | NEEDS-CHANGES (2C/1H/2M/2L) | break-on-first segment, quoted env values, fail-open parser, quoted protected token, 5-pass env cap, subshell `( ... )` |
| 2 | NEEDS-CHANGES (1C/2H) | PASS | jq-absent + escaped quotes (Critical), outside-quote `\` escape, bash `!`, long-form flag |
| 3 | NEEDS-CHANGES (1H/1M) | PASS | bare-newline as separator, trailing-`\` line continuation, control-flow words (`if`/`then`/`else`/`elif`/`do`/`while`/`until`) |
| 4 | NEEDS-CHANGES (3H, increasingly esoteric) | (not re-run, iter-3 PASS standing) | `coproc`, command substitution `$(...)` and backtick, `case`/`function` compound bodies via `(`/`)`/`{`/`}`/`` ` `` as segment separators |
| 5 | not run — escape-hatch per `feedback_argus_nit_loop.md` after 4 audit cycles on a P3 hook fix | — | — |

## Test coverage by category

- S83 reproducer: 5
- Existing block paths (develop/master/main, refspec RHS, `+`force, `refs/heads/`, `--all`/`--mirror`, Phase 3): 15
- Quote-bypass attempts: 7
- Env-prefix + wrapper bypass: 6
- Lane-branch defense (substring not exact): 9
- Negative path (commit/fetch/pull/echo/gh/pushd): 6
- Git global options (`-C`/`-c`/`--git-dir=`/`--no-pager`): 5
- Multi-segment + env-prefix interaction: 5
- Edge cases (empty, bare git, feature branch implicit): 3
- **Iter-2 closures** (24): quoted protected (5), multi-env wrappers (3), subshell/group (4), quoted env values + `-C` paths (7), multi-segment evaluation (5), parser-fail (1)
- **Iter-3 closures** (15): jq-absent (2), `\`-escape outside quotes (4), bash `!` (2), env long flags (6, including separate-arg value forms), combined obfuscation (1)
- **Iter-4 closures** (15): newline as separator (4), control-flow words (6), trailing `\` line cont (4), regression (1)
- **Iter-5 closures** (13): `coproc` (3), command substitution (4), `case` body (2), `function` body (3), max obfuscation + nested (2)

## Known limits (documented, not regressions)

- **Backtick command substitution INSIDE double-quoted strings**: `"...echo \`git push origin develop\`..."` would not be recursively parsed. Real shell parser would be needed for full coverage. Rare in Claude Code output; no realistic accident vector.
- **Whitespace inside quoted refspec** (`"develop "`): git rejects refnames with whitespace at network layer; not exploitable.
- **Unknown long flag with separate-arg value** (`env --xxx yyy git push ...`): OS env rejects unknown flags before git push runs; not a real protected-branch push.

## Test plan

- [x] `bash scripts/test-push-guard.sh` → 217/217
- [x] Live S83 reproducer rc=0
- [x] Real `git push origin develop` rc=2
- [x] PR's own commit + push chain (heredoc body w/ many `git push origin develop` references) passes through without false-positive
- [x] `bash -n` clean

Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)