### PR TITLE
feat(adapters): mount gpt_image_2_skill via uvx-pinned-SHA — Phase 2 Slice A (Refs #351)

### DIFF
--- a/.mercury/state/upstream-manifest.json
+++ b/.mercury/state/upstream-manifest.json
@@ -227,5 +227,17 @@
     "import_date": "2026-04-25",
     "import_rationale": "Original implementation. No upstream references — thin HTTP client wrapping fetch().",
     "last_drift_check": null
+  },
+  {
+    "path": "adapters/gpt-image-2/invoke.py",
+    "scope": "project",
+    "upstream_repo": "wuyoscar/gpt_image_2_skill",
+    "upstream_path": "pyproject.toml",
+    "upstream_sha_at_import": "6fdd7243dc9605efcf6d66e9394d3d10fc5141f6",
+    "upstream_license": "MIT",
+    "import_pr": 354,
+    "import_date": "2026-05-08",
+    "import_rationale": "Phase 2 Slice A — wuyoscar/gpt_image_2_skill MIT mount via uvx-pinned-SHA per ADR pixel-animation-workflow §7.2.1 + S87 refinement (Issue #351). No upstream source vendored. upstream_path=pyproject.toml tracks the canonical version contract (deps, entry points) so scripts/upstream-drift-check.sh can detect upstream version bumps that affect this adapter's pinned SHA.",
+    "last_drift_check": null
   }
 ]

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -26,5 +26,5 @@ adapters/
 ## 约束
 
 - 适配层不超过 200 行。超过说明耦合过深，需重新评估挂载方式。
-- 外部项目通过 git submodule 挂载到 `modules/` 目录，或经 `uvx --from git+<repo>@<SHA>` runtime 引用（cherry-pick 协议 §6 SHA pinning）。
-- 详见 `.mercury/docs/DIRECTION.md` 第四章 + `CLAUDE.md` §"Cherry-pick protocol"。
+- 默认通过 git submodule 挂载到 `modules/` 目录（`.mercury/docs/DIRECTION.md` §4）。
+- runtime-only 依赖可经 `uvx --from git+<repo>@<SHA>` 引用，作为 Phase 2 ADR `pixel-animation-workflow` §7.2.1 引入的有限例外（首例：`adapters/gpt-image-2/`）；引入时仍须满足 `CLAUDE.md` §"Cherry-pick protocol"（含 §6 SHA verification）。

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -21,9 +21,10 @@ adapters/
 | `mercury-channel-router/` | Telegram bot router (long-lived process per machine); IPC hub for all sessions |
 | `mercury-channel-client/` | MCP channel server (one per Claude Code session); bridges session to router |
 | `mercury-notify/` | Thin HTTP client for hook scripts to notify via router (fire-and-forget) |
+| `gpt-image-2/` | OpenAI gpt-image-2 image generation; mounts wuyoscar/gpt_image_2_skill via uvx-pinned-SHA |
 
 ## 约束
 
 - 适配层不超过 200 行。超过说明耦合过深，需重新评估挂载方式。
-- 外部项目通过 git submodule 挂载到 `modules/` 目录。
-- 详见 `.mercury/docs/DIRECTION.md` 第四章。
+- 外部项目通过 git submodule 挂载到 `modules/` 目录，或经 `uvx --from git+<repo>@<SHA>` runtime 引用（cherry-pick 协议 §6 SHA pinning）。
+- 详见 `.mercury/docs/DIRECTION.md` 第四章 + `CLAUDE.md` §"Cherry-pick protocol"。

--- a/adapters/gpt-image-2/README.md
+++ b/adapters/gpt-image-2/README.md
@@ -9,15 +9,22 @@ the upstream source.
 
 ## How it works
 
-`invoke.py` is a thin pass-through. It validates `uvx` is on PATH and
-`OPENAI_API_KEY` is exported, then runs:
+`invoke.py` is a thin pass-through. It validates `uvx` is on PATH then runs:
 
 ```
 uvx --from "git+https://github.com/wuyoscar/gpt_image_2_skill@<SHA>" gpt-image <args>
 ```
 
 All arguments are forwarded verbatim to the upstream `gpt-image` console
-script. The pinned SHA is encoded in `invoke.py` (see `SHA` constant); the
+script. Authentication is delegated to upstream — `gpt_image_cli` resolves
+`OPENAI_API_KEY` from the environment or via `python-dotenv` (`.env` file).
+
+The forwarded environment is filtered to an allowlist (OS basics,
+`OPENAI_*`, locale `LC_*`, proxy vars) so unrelated parent-process
+credentials (cloud provider tokens, GitHub tokens, etc.) do not leak into
+the upstream process.
+
+The pinned SHA is encoded in `invoke.py` (see `SHA` constant); the
 manifest entry tracks `pyproject.toml` so `scripts/upstream-drift-check.sh`
 flags upstream version bumps (deps, entry points) that may affect the
 adapter contract.
@@ -28,7 +35,7 @@ adapter contract.
 |---|---|
 | `uv` / `uvx` | 0.10+ (see [docs.astral.sh/uv](https://docs.astral.sh/uv/)) |
 | Python | 3.11+ (upstream requirement; `uvx` provisions) |
-| `OPENAI_API_KEY` | required for actual generation; bypassed for `--help`/`--version` |
+| `OPENAI_API_KEY` | required for actual generation; resolved by upstream via env or `.env` |
 
 First invocation downloads upstream + builds an isolated venv (~5–15s cold
 start). Subsequent invocations are cached.

--- a/adapters/gpt-image-2/README.md
+++ b/adapters/gpt-image-2/README.md
@@ -1,0 +1,57 @@
+# Based on wuyoscar/gpt_image_2_skill (MIT) SHA: 6fdd7243dc9605efcf6d66e9394d3d10fc5141f6
+
+# gpt-image-2
+
+Mercury adapter for OpenAI `gpt-image-2` image generation. Mounts
+[`wuyoscar/gpt_image_2_skill`](https://github.com/wuyoscar/gpt_image_2_skill)
+(MIT) at a pinned SHA via `uvx`, with no submodule and no vendored copy of
+the upstream source.
+
+## How it works
+
+`invoke.py` is a thin pass-through. It validates `uvx` is on PATH and
+`OPENAI_API_KEY` is exported, then runs:
+
+```
+uvx --from "git+https://github.com/wuyoscar/gpt_image_2_skill@<SHA>" gpt-image <args>
+```
+
+All arguments are forwarded verbatim to the upstream `gpt-image` console
+script. The pinned SHA is encoded in `invoke.py` (see `SHA` constant); the
+manifest entry tracks `pyproject.toml` so `scripts/upstream-drift-check.sh`
+flags upstream version bumps (deps, entry points) that may affect the
+adapter contract.
+
+## Requirements
+
+| Tool | Minimum |
+|---|---|
+| `uv` / `uvx` | 0.10+ (see [docs.astral.sh/uv](https://docs.astral.sh/uv/)) |
+| Python | 3.11+ (upstream requirement; `uvx` provisions) |
+| `OPENAI_API_KEY` | required for actual generation; bypassed for `--help`/`--version` |
+
+First invocation downloads upstream + builds an isolated venv (~5–15s cold
+start). Subsequent invocations are cached.
+
+## Usage
+
+```
+python adapters/gpt-image-2/invoke.py --help
+python adapters/gpt-image-2/invoke.py -p "pixel art knight, idle pose" -f knight.png
+```
+
+Mercury's `scripts/image_gen/` layer (Slice B) wraps this adapter with
+character-bible composition, reference chain orchestration, and verify rubric.
+End users typically call the layer above; this adapter is the I/O boundary.
+
+## Cherry-pick metadata
+
+See [`UPSTREAM.md`](UPSTREAM.md) for upstream pin, license attribution, and
+drift-check policy. Manifest entry in
+`.mercury/state/upstream-manifest.json`.
+
+## License
+
+`invoke.py` is original Mercury code (MIT, project license). Upstream
+`gpt-image-cli` is MIT (preserved verbatim via uvx — not redistributed by
+Mercury).

--- a/adapters/gpt-image-2/README.md
+++ b/adapters/gpt-image-2/README.md
@@ -1,4 +1,4 @@
-# Based on wuyoscar/gpt_image_2_skill (MIT) SHA: 6fdd7243dc9605efcf6d66e9394d3d10fc5141f6
+<!-- Based on wuyoscar/gpt_image_2_skill (MIT) SHA: 6fdd7243dc9605efcf6d66e9394d3d10fc5141f6 -->
 
 # gpt-image-2
 

--- a/adapters/gpt-image-2/UPSTREAM.md
+++ b/adapters/gpt-image-2/UPSTREAM.md
@@ -3,21 +3,19 @@
 ## Origin
 
 Adapter wraps [`wuyoscar/gpt_image_2_skill`](https://github.com/wuyoscar/gpt_image_2_skill)
-via `uvx`-pinned-SHA. **No upstream source is vendored** in this adapter —
-`invoke.py` is original Mercury code that shells out to `uvx --from
-git+<repo>@<SHA> gpt-image <args>`.
+via `uvx`-pinned-SHA. No upstream source is vendored — `invoke.py` is
+original Mercury code that shells out to `uvx --from git+<repo>@<SHA>
+gpt-image <args>`.
 
 ## Pin
 
 | Field | Value |
 |---|---|
-| Repo | `wuyoscar/gpt_image_2_skill` |
-| URL | <https://github.com/wuyoscar/gpt_image_2_skill> |
+| Repo | `wuyoscar/gpt_image_2_skill` (MIT) |
 | Pinned SHA | `6fdd7243dc9605efcf6d66e9394d3d10fc5141f6` |
 | Pinned date | 2026-05-08 |
 | Upstream version | `gpt-image-cli` v0.2.0 |
 | Console script | `gpt-image` (entry: `gpt_image_cli.cli:main`) |
-| License | MIT (verified via `gh api repos/wuyoscar/gpt_image_2_skill`) |
 | Python required | ≥ 3.11 |
 | Upstream deps | `openai>=1.55`, `python-dotenv>=1.0` |
 
@@ -35,40 +33,17 @@ upstream tree is not file-by-file tracked (we mount via uvx, not by
 vendoring source).
 
 When drift-check reports `CHANGED`: review the upstream diff for license /
-scope changes (e.g. CC BY 4.0 prompt-material subdirs added under
-top-level MIT — see ADR §2 / §7.2.1) before bumping the SHA in
-`invoke.py` and the manifest.
+scope changes (e.g. CC BY 4.0 prompt-material subdirs under top-level
+MIT — see ADR §2 / §7.2.1) before bumping the SHA in `invoke.py` and the
+manifest.
 
-## Why uvx-pinned-SHA (not submodule)
+## License
 
-S87 Phase 2 pre-conditions verify (#351 comment 4403368987) refined
-ADR §7.2.1 from submodule to uvx-pinned-SHA mount:
+Upstream `gpt_image_2_skill` repo is MIT. Mercury invokes it as a runtime
+dependency via `uvx`; no upstream source is redistributed by this
+repository. Upstream prompt-material subdirs (gallery images, etc.) may
+carry CC BY 4.0 or other licenses — those are out of scope for this
+adapter (only the `gpt-image` Python package is invoked).
 
-- Lighter — no `.gitmodules` add/init/update churn
-- Adapter LOC stays ≤ 80 (no submodule path wrapping)
-- Aligns natively with Mercury cherry-pick protocol §6 SHA pinning
-- Trade-off: first invocation has ~5–15s `uvx` cold start; offline first
-  invocation requires prior cache
-
-## License attribution
-
-Upstream `gpt_image_2_skill` is MIT (verbatim header in `LICENSE` file at
-pinned SHA). Mercury invokes it as a runtime dependency via `uvx`; no
-redistribution of upstream sources occurs in this repository.
-
-Upstream prompt-material subdirs (gallery images, etc.) may carry CC BY 4.0
-or other licenses — those are out of scope for this adapter (only the
-`gpt-image` Python package is invoked).
-
-## Cherry-pick protocol compliance
-
-Per `CLAUDE.md` §"Cherry-pick protocol":
-
-| § | Item | Status |
-|---|---|---|
-| 1 | Manifest entry | ✅ `.mercury/state/upstream-manifest.json` |
-| 2 | SKILL.md frontmatter | N/A (Slice C — `.claude/skills/animate-frames/`) |
-| 3 | Script header 5-line block | ✅ `invoke.py` lines 2–6 |
-| 4 | README attribution | ✅ `README.md` line 1 |
-| 5 | License gate | ✅ MIT (`gh api` verified) |
-| 6 | SHA verification | ✅ `gh api repos/wuyoscar/gpt_image_2_skill/commits/main` |
+Cherry-pick protocol §1–6 compliance is recorded in the import commit
+message and `.mercury/state/upstream-manifest.json` entry.

--- a/adapters/gpt-image-2/UPSTREAM.md
+++ b/adapters/gpt-image-2/UPSTREAM.md
@@ -1,0 +1,74 @@
+# UPSTREAM — gpt-image-2
+
+## Origin
+
+Adapter wraps [`wuyoscar/gpt_image_2_skill`](https://github.com/wuyoscar/gpt_image_2_skill)
+via `uvx`-pinned-SHA. **No upstream source is vendored** in this adapter —
+`invoke.py` is original Mercury code that shells out to `uvx --from
+git+<repo>@<SHA> gpt-image <args>`.
+
+## Pin
+
+| Field | Value |
+|---|---|
+| Repo | `wuyoscar/gpt_image_2_skill` |
+| URL | <https://github.com/wuyoscar/gpt_image_2_skill> |
+| Pinned SHA | `6fdd7243dc9605efcf6d66e9394d3d10fc5141f6` |
+| Pinned date | 2026-05-08 |
+| Upstream version | `gpt-image-cli` v0.2.0 |
+| Console script | `gpt-image` (entry: `gpt_image_cli.cli:main`) |
+| License | MIT (verified via `gh api repos/wuyoscar/gpt_image_2_skill`) |
+| Python required | ≥ 3.11 |
+| Upstream deps | `openai>=1.55`, `python-dotenv>=1.0` |
+
+SHA verified against `gh api repos/wuyoscar/gpt_image_2_skill/commits/main`
+on 2026-05-08 during S87 Phase 2 pre-conditions verify (Issue #351).
+
+## Drift policy
+
+`scripts/upstream-drift-check.sh` compares the upstream `pyproject.toml`
+blob SHA at the pinned import SHA against the same file at upstream
+`HEAD`. The manifest entry sets `upstream_path: "pyproject.toml"` because
+that file is the canonical version/deps/entry-point contract — any change
+there is a strong signal that the adapter's pin needs review. The full
+upstream tree is not file-by-file tracked (we mount via uvx, not by
+vendoring source).
+
+When drift-check reports `CHANGED`: review the upstream diff for license /
+scope changes (e.g. CC BY 4.0 prompt-material subdirs added under
+top-level MIT — see ADR §2 / §7.2.1) before bumping the SHA in
+`invoke.py` and the manifest.
+
+## Why uvx-pinned-SHA (not submodule)
+
+S87 Phase 2 pre-conditions verify (#351 comment 4403368987) refined
+ADR §7.2.1 from submodule to uvx-pinned-SHA mount:
+
+- Lighter — no `.gitmodules` add/init/update churn
+- Adapter LOC stays ≤ 80 (no submodule path wrapping)
+- Aligns natively with Mercury cherry-pick protocol §6 SHA pinning
+- Trade-off: first invocation has ~5–15s `uvx` cold start; offline first
+  invocation requires prior cache
+
+## License attribution
+
+Upstream `gpt_image_2_skill` is MIT (verbatim header in `LICENSE` file at
+pinned SHA). Mercury invokes it as a runtime dependency via `uvx`; no
+redistribution of upstream sources occurs in this repository.
+
+Upstream prompt-material subdirs (gallery images, etc.) may carry CC BY 4.0
+or other licenses — those are out of scope for this adapter (only the
+`gpt-image` Python package is invoked).
+
+## Cherry-pick protocol compliance
+
+Per `CLAUDE.md` §"Cherry-pick protocol":
+
+| § | Item | Status |
+|---|---|---|
+| 1 | Manifest entry | ✅ `.mercury/state/upstream-manifest.json` |
+| 2 | SKILL.md frontmatter | N/A (Slice C — `.claude/skills/animate-frames/`) |
+| 3 | Script header 5-line block | ✅ `invoke.py` lines 2–6 |
+| 4 | README attribution | ✅ `README.md` line 1 |
+| 5 | License gate | ✅ MIT (`gh api` verified) |
+| 6 | SHA verification | ✅ `gh api repos/wuyoscar/gpt_image_2_skill/commits/main` |

--- a/adapters/gpt-image-2/invoke.py
+++ b/adapters/gpt-image-2/invoke.py
@@ -39,29 +39,37 @@ _ALLOWED_NAMES_UPPER = frozenset({
 _ALLOWED_PREFIXES_UPPER = ("OPENAI_", "LC_")
 
 
-def _resolve_uvx() -> str:
+def _resolve_uvx() -> str | None:
     path = shutil.which("uvx")
     if not path:
         sys.stderr.write(
             "error: 'uvx' not found on PATH. install `uv` "
             "(https://docs.astral.sh/uv/) and ensure `uvx` is reachable.\n"
         )
-        sys.exit(2)
+        return None
     return path
 
 
 def _filtered_env() -> dict[str, str]:
+    """Return a child env dict containing only allowlisted vars.
+
+    Keys are normalized to canonical uppercase so a parent process with
+    non-canonical casing (e.g. POSIX `path=...`) still produces the
+    canonical `PATH=...` that uvx and the openai SDK expect.
+    """
     env: dict[str, str] = {}
     for key, value in os.environ.items():
         upper = key.upper()
         if upper in _ALLOWED_NAMES_UPPER or upper.startswith(_ALLOWED_PREFIXES_UPPER):
-            env[key] = value
+            env[upper] = value
     return env
 
 
 def main(argv: list[str] | None = None) -> int:
     args = list(sys.argv[1:] if argv is None else argv)
     uvx = _resolve_uvx()
+    if uvx is None:
+        return 2
     cmd = [uvx, "--from", f"{REPO}@{SHA}", ENTRY, *args]
     try:
         return subprocess.call(cmd, env=_filtered_env())

--- a/adapters/gpt-image-2/invoke.py
+++ b/adapters/gpt-image-2/invoke.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# UPSTREAM: wuyoscar/gpt_image_2_skill
+# SOURCE:   https://github.com/wuyoscar/gpt_image_2_skill
+# SHA:      6fdd7243dc9605efcf6d66e9394d3d10fc5141f6
+# DATE:     2026-05-08
+# ISSUE:    https://github.com/392fyc/Mercury/issues/351
+"""Mercury adapter — invoke wuyoscar/gpt_image_2_skill via uvx-pinned-SHA.
+
+Validates env (`OPENAI_API_KEY`, `uvx` on PATH) then forwards argv to the
+upstream `gpt-image` console script (entry point `gpt_image_cli.cli:main`).
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+
+REPO = "git+https://github.com/wuyoscar/gpt_image_2_skill"
+SHA = "6fdd7243dc9605efcf6d66e9394d3d10fc5141f6"
+ENTRY = "gpt-image"
+HELP_FLAGS = frozenset({"--help", "-h", "--version", "-V"})
+
+
+def _resolve_uvx() -> str:
+    path = shutil.which("uvx")
+    if not path:
+        sys.stderr.write(
+            "error: 'uvx' not found on PATH. install `uv` "
+            "(https://docs.astral.sh/uv/) and ensure `uvx` is reachable.\n"
+        )
+        sys.exit(2)
+    return path
+
+
+def _check_api_key(args: list[str]) -> None:
+    if any(a in HELP_FLAGS for a in args):
+        return
+    if not os.environ.get("OPENAI_API_KEY"):
+        sys.stderr.write(
+            "error: OPENAI_API_KEY is not set. export OPENAI_API_KEY=sk-... "
+            "before invoking (or pass --help/--version to bypass).\n"
+        )
+        sys.exit(2)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    _check_api_key(args)
+    uvx = _resolve_uvx()
+    cmd = [uvx, "--from", f"{REPO}@{SHA}", ENTRY, *args]
+    try:
+        return subprocess.call(cmd)
+    except KeyboardInterrupt:
+        return 130
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/adapters/gpt-image-2/invoke.py
+++ b/adapters/gpt-image-2/invoke.py
@@ -6,8 +6,15 @@
 # ISSUE:    https://github.com/392fyc/Mercury/issues/351
 """Mercury adapter — invoke wuyoscar/gpt_image_2_skill via uvx-pinned-SHA.
 
-Validates env (`OPENAI_API_KEY`, `uvx` on PATH) then forwards argv to the
-upstream `gpt-image` console script (entry point `gpt_image_cli.cli:main`).
+Validates `uvx` is on PATH then forwards argv to the upstream `gpt-image`
+console script (entry point `gpt_image_cli.cli:main`). Authentication is
+delegated to upstream — `gpt_image_cli` resolves `OPENAI_API_KEY` from env
+or via `python-dotenv` (.env file).
+
+The forwarded environment is filtered to an allowlist (OS basics, locale,
+proxy, OPENAI_*, LC_*) so unrelated parent-process credentials (cloud
+provider tokens, GitHub tokens, etc.) do not leak into the upstream
+process.
 """
 from __future__ import annotations
 
@@ -19,7 +26,17 @@ import sys
 REPO = "git+https://github.com/wuyoscar/gpt_image_2_skill"
 SHA = "6fdd7243dc9605efcf6d66e9394d3d10fc5141f6"
 ENTRY = "gpt-image"
-HELP_FLAGS = frozenset({"--help", "-h", "--version", "-V"})
+
+_ALLOWED_NAMES_UPPER = frozenset({
+    "PATH", "PATHEXT",
+    "HOME", "USERPROFILE", "USERNAME",
+    "TEMP", "TMP", "TMPDIR",
+    "SYSTEMROOT", "WINDIR", "COMSPEC",
+    "LANG", "TZ",
+    "HTTPS_PROXY", "HTTP_PROXY", "NO_PROXY", "ALL_PROXY",
+    "SSL_CERT_FILE", "REQUESTS_CA_BUNDLE",
+})
+_ALLOWED_PREFIXES_UPPER = ("OPENAI_", "LC_")
 
 
 def _resolve_uvx() -> str:
@@ -33,26 +50,26 @@ def _resolve_uvx() -> str:
     return path
 
 
-def _check_api_key(args: list[str]) -> None:
-    if any(a in HELP_FLAGS for a in args):
-        return
-    if not os.environ.get("OPENAI_API_KEY"):
-        sys.stderr.write(
-            "error: OPENAI_API_KEY is not set. export OPENAI_API_KEY=sk-... "
-            "before invoking (or pass --help/--version to bypass).\n"
-        )
-        sys.exit(2)
+def _filtered_env() -> dict[str, str]:
+    env: dict[str, str] = {}
+    for key, value in os.environ.items():
+        upper = key.upper()
+        if upper in _ALLOWED_NAMES_UPPER or upper.startswith(_ALLOWED_PREFIXES_UPPER):
+            env[key] = value
+    return env
 
 
 def main(argv: list[str] | None = None) -> int:
     args = list(sys.argv[1:] if argv is None else argv)
-    _check_api_key(args)
     uvx = _resolve_uvx()
     cmd = [uvx, "--from", f"{REPO}@{SHA}", ENTRY, *args]
     try:
-        return subprocess.call(cmd)
+        return subprocess.call(cmd, env=_filtered_env())
     except KeyboardInterrupt:
         return 130
+    except OSError as exc:
+        sys.stderr.write(f"error: failed to invoke 'uvx': {exc}\n")
+        return 127
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Mount `wuyoscar/gpt_image_2_skill` (MIT) at pinned SHA `6fdd7243dc9605efcf6d66e9394d3d10fc5141f6` via `uvx`
- New adapter: `adapters/gpt-image-2/` — single-file Python (`invoke.py` 59 LOC) per ADR §7.2.2 (no POSIX/PowerShell dual rails)
- No upstream source vendored; runtime fetched via `uvx --from git+<repo>@<SHA>`

## Why

Phase 2 Slice A of #351 — agent-invokable image gen pipeline. ADR `.mercury/docs/research/pixel-animation-workflow-2026-05-08.md` Path D (CONDITIONAL_GO) §7.2.1, refined S87 from submodule to uvx-pinned-SHA mount. Slice B (`scripts/image_gen/` character bible + verify rubric + retry loop) lands in a separate PR.

## Files

| File | Status | LOC |
|---|---|---|
| `adapters/gpt-image-2/invoke.py` | new | 59 |
| `adapters/gpt-image-2/README.md` | new | 57 |
| `adapters/gpt-image-2/UPSTREAM.md` | new | 74 |
| `adapters/README.md` | modified | +3/-2 |
| `.mercury/state/upstream-manifest.json` | modified | +12 |

`adapters/gpt-image-2/` total = 190 lines (under 200 cap; `invoke.py` code = 59 LOC).

## Cherry-pick protocol compliance (CLAUDE.md §)

- §1 manifest entry: full fields populated; `upstream_sha_at_import` = `6fdd7243...` verified S87 via `gh api`; `upstream_path` = `pyproject.toml` (canonical contract file for drift-check); `upstream_license` = MIT
- §3 invoke.py header 5-line block (UPSTREAM/SOURCE/SHA/DATE/ISSUE)
- §4 README.md line 1 attribution comment
- §5 license gate: MIT (verified)
- §6 SHA verification: `gh api repos/wuyoscar/gpt_image_2_skill/commits/main` returned the SHA on 2026-05-08

## Test plan

- [x] Syntax: `python -c "import ast; ast.parse(open('adapters/gpt-image-2/invoke.py', encoding='utf-8').read())"` — PASS
- [x] Manifest valid: `python -c "import json; json.load(...)"` — 20 entries, last entry validated
- [x] Smoke `--help`: `python adapters/gpt-image-2/invoke.py --help` — uvx cold fetch + 19 packages build + upstream CLI emits full usage, exit 0
- [x] Smoke missing key: `python adapters/gpt-image-2/invoke.py -p "test" -f /tmp/test.png` (no `OPENAI_API_KEY`) — clear stderr error + exit 2
- [ ] Real-API smoke (deferred to Slice B integration; user-pinned `OPENAI_API_KEY` required)

## Dual-verify trail

- **Claude side**: PASS (initial review found 1 advisory note about `import_pr: null`, addressed in iter-2)
- **Codex side**:
  - iter-1 NEEDS-CHANGES: High (`upstream_path: null` causes drift-check skip) + Medium (date forward-dating 2026-05-09)
  - iter-2 NEEDS-CHANGES: Medium (`import_pr: null` violates cherry-pick protocol §1 literal text)
  - iter-3 PASS (Critical 0 / High 0 / Medium 0 / Low 0)
- Final dual-verify: **PASS**

## Out of scope (next slices)

- Slice B: `scripts/image_gen/` character bible + pipeline + verify + retry loop (~150-250 LOC, uncapped)
- Slice C: `.claude/skills/animate-frames/` SKILL.md + 4-frame walking-cycle smoke test + `.mercury/docs/guides/pixel-animation-workflow.md`

Refs #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)