### PR TITLE
fix(skill): handoff auto-mode bootstrap direct-Read fallback (#359)

### DIFF
--- a/.claude/skills/handoff/SKILL.md
+++ b/.claude/skills/handoff/SKILL.md
@@ -284,13 +284,20 @@ Optional: offer to launch if the user later says so (Step 6).
 After Step 5.1 + 5.2, and Pre-Termination Checklist passed:
 
 **Required launch pattern — use a SHORT reference prompt, never inline the
-full handoff content into the command line.** The SessionStart hook already
-injects the full handoff document as `additionalContext`, so the new session
-receives everything automatically. Inlining multi-line/multi-KB content into
-`wt`/`tmux`/shell commands causes catastrophic failures on Windows
-(multi-line expansion breaks argument parsing → error 0x80070002, multiple
-ghost terminal windows; see `feedback_handoff_short_prompt_only.md` —
-S3-side-multi-lane 2026-04-26 forensic record).
+full handoff content into the command line.** Inlining multi-line/multi-KB
+content into `wt`/`tmux`/shell commands causes catastrophic failures on
+Windows (multi-line expansion breaks argument parsing → error 0x80070002,
+multiple ghost terminal windows; see `feedback_handoff_short_prompt_only.md`
+— S3-side-multi-lane 2026-04-26 forensic record).
+
+The SHORT_PROMPT directs the new session to `Read` the handoff doc
+explicitly as its first action. A SessionStart hook (e.g. the
+`claude-handoff` plugin's `hooks/session-start.py`) MAY additionally inject
+the doc as `additionalContext`, but the prompt MUST NOT assume that
+injection happened — plugin install scope may not cover the new session's
+cwd (Mercury #359 / claude-handoff #12 forensic record), the plugin may
+not be installed, or the runtime may have failed silently. The explicit
+`Read` directive guarantees handoff visibility regardless of hook state.
 
 **SHORT_PROMPT contract (Δ11 — Path C lane assertion)**:
 
@@ -358,7 +365,7 @@ if [ "$WORKTREE_COUNT" -gt 1 ]; then
 fi
 WORKTREE_PATH="$WORKTREE_PATH_RAW"
 
-SHORT_PROMPT="[LANE=${LANE_NAME}] Continue from session handoff. The SessionStart hook injects the full document. Fallback: read ${HANDOFF_PATH}"
+SHORT_PROMPT="[LANE=${LANE_NAME}] Continue from session handoff. Read ${HANDOFF_PATH} as your first action."
 ```
 
 `<encoded_cwd>` for the handoff doc path uses the same `encode_project_path()`

--- a/.mercury/docs/guides/lane-naming.md
+++ b/.mercury/docs/guides/lane-naming.md
@@ -446,7 +446,7 @@ name (e.g. `side-mlane`) instead would yield exit 4 (Worktree path
 missing) because no lane section heading matches.
 
 ```
-[LANE=side-multi-lane] Continue from session handoff. The SessionStart hook injects the full document. Fallback: read <HANDOFF_PATH>
+[LANE=side-multi-lane] Continue from session handoff. Read <HANDOFF_PATH> as your first action.
 ```
 
 For the `main` lane the section name and short name happen to be


### PR DESCRIPTION
## Summary

- Replaces unconditional "SessionStart hook injects" assertion in handoff skill auto-mode SHORT_PROMPT and design block with explicit Read-first directive
- Acknowledges hook injection as best-effort layer (plugin install scope, plugin presence, runtime silent failure can all break it)
- Read directive guarantees handoff visibility regardless of hook state

## Forensic context

S3-side-bug session 2026-05-08 traced bootstrap silent breakage to: `claude-handoff` plugin install scope=local pinned to AgentKB project → plugin's `hooks/session-start.py` never fires for Mercury cwd → bootstrap promises injected context that never arrives. Plugin hook is functional (manual invocation 完整输出 valid `additionalContext` JSON), but plugin runtime gates invocation by install scope.

## Constraints preserved

- SHORT_PROMPT still leads with `[LANE=...]` marker (Δ11 contract, lane-assertion three-way alignment)
- No `wt`/`tmux` metacharacters in the prompt string (`;` `&` `|` `\` outside quotes, `$()`)
- Rules section consistency (Starting Prompt self-contained — Read path + doc content satisfy this)

## Test plan

- [x] Diff scope: 1 file `.claude/skills/handoff/SKILL.md` (+15/-8 lines), doc-only
- [x] Dual-verify PASS (Claude: 0/0/0/0, Codex: 0/0/0/0 — both PASS)
- [x] grep "injects the full document" → 0 matches (stale wording fully removed)
- [x] SHORT_PROMPT after bash expansion: regular ASCII text + `[LANE=...]` marker + path; no shell metachars
- [ ] Manual smoke (out of CI scope): next `/handoff:auto` cycle would direct new session to Read the doc as first action

## Cross-repo

- `392fyc/claude-handoff#12` tracks the upstream skill copy + plugin self-check / install-scope warnings
- Mercury skill is independently maintained (not in `.mercury/state/upstream-manifest.json`); this fix is Mercury-side only

Closes #359