### PR TITLE
feat(skill): sub-agent return-size scoping (Closes #362)

### DIFF
--- a/.claude/agents/acceptance.md
+++ b/.claude/agents/acceptance.md
@@ -1,6 +1,6 @@
 ---
 name: acceptance
-description: Blind acceptance reviewer. Use after a dev agent has completed implementation and pushed code. Receives only the AcceptanceBundle (definition-of-done + acceptance criteria) and a blind receipt (changed files only — NO dev reasoning/narrative). Reads code + runs tests + inspects runtime output. Returns a structured JSON verdict (pass | partial | fail | blocked) with findings + recommendations. MUST NOT read dev agent self-assessment.
+description: Blind acceptance reviewer. Use after a dev agent has completed implementation and pushed code. Receives only the AcceptanceBundle (definition-of-done + acceptance criteria) and a blind receipt (changed files, test results, and a structured dodChecklist of per-criterion citations — NO dev reasoning/narrative). Reads code + runs tests + inspects runtime output. Returns a structured JSON verdict (pass | partial | fail | blocked) with findings + recommendations. MUST NOT read dev agent self-assessment.
 tools: Read, Glob, Grep, Bash
 model: sonnet
 ---

--- a/.claude/agents/acceptance.md
+++ b/.claude/agents/acceptance.md
@@ -1,6 +1,6 @@
 ---
 name: acceptance
-description: Blind acceptance reviewer. Use after a dev agent has completed implementation and pushed code. Receives only the AcceptanceBundle (definition-of-done + acceptance criteria) and a blind receipt (changed files, test results, and a structured dodChecklist of per-criterion citations — NO dev reasoning/narrative). Reads code + runs tests + inspects runtime output. Returns a structured JSON verdict (pass | partial | fail | blocked) with findings + recommendations. MUST NOT read dev agent self-assessment.
+description: Blind acceptance reviewer. Use after a dev agent has completed implementation and pushed code. Receives only the AcceptanceBundle (definition-of-done + acceptance criteria) and a blind receipt (changed-file paths, branch, test results, and a structured dodChecklist of per-criterion citations — NO dev reasoning/narrative). Reads code + runs tests + inspects runtime output. Returns a structured JSON verdict (pass | partial | fail | blocked) with findings + recommendations. MUST NOT read dev agent self-assessment.
 tools: Read, Glob, Grep, Bash
 model: sonnet
 ---

--- a/.claude/agents/dev.md
+++ b/.claude/agents/dev.md
@@ -18,7 +18,7 @@ Read task description, implement within allowed scope, commit code, report compl
 - Read task description and referenced docs
 - Write/modify files within specified scope
 - Run tests relevant to the task
-- Fill structured implementation receipt (`changedFiles`, `commitSha`, `verifyResults`, `dodChecklist` with per-criterion citations)
+- Fill structured implementation receipt — fields: `taskId`, `status`, `branch`, `commitSha`, `changedFiles`, `verifyResults`, `dodChecklist` (per-criterion citations), and `escalationReason` (only when `status != completed`). Schema authority: `.claude/skills/dev-pipeline/SKILL.md` Phase 2 Receipt template.
 - `git add <specific-files>`, `git commit`, `git push` on current branch
 - `git diff`, `git status`, `git log` (read-only)
 - Create Issues when discovering bugs (report only — do not self-fix)

--- a/.claude/agents/dev.md
+++ b/.claude/agents/dev.md
@@ -18,7 +18,7 @@ Read task description, implement within allowed scope, commit code, report compl
 - Read task description and referenced docs
 - Write/modify files within specified scope
 - Run tests relevant to the task
-- Fill implementation receipt (summary, changed files, evidence, risks)
+- Fill structured implementation receipt (`changedFiles`, `commitSha`, `verifyResults`, `dodChecklist` with per-criterion citations)
 - `git add <specific-files>`, `git commit`, `git push` on current branch
 - `git diff`, `git status`, `git log` (read-only)
 - Create Issues when discovering bugs (report only — do not self-fix)

--- a/.claude/skills/autoresearch/SKILL.md
+++ b/.claude/skills/autoresearch/SKILL.md
@@ -118,7 +118,7 @@ When autoresearch terminates and returns control to the calling agent (Mercury m
 
 Concretely, the return MUST include at minimum:
 
-1. **Report file path** — the absolute or repo-relative path to the final research report (e.g. `Mercury_KB/04-research/RESEARCH-topic-001.md` or `.research/reports/RESEARCH-topic-2026-05-09.md`).
+1. **Report file path** — a repo-relative path (or `Mercury_KB/04-research/...`-prefixed path under Mercury orchestration) to the final research report. Do NOT return absolute filesystem paths — they leak host info and are not portable across environments. Example: `Mercury_KB/04-research/RESEARCH-topic-001.md` or `.research/reports/RESEARCH-topic-2026-05-09.md`.
 2. **Verdict + per-metric scores** — the gate metrics from the final round (`question_answer_rate`, `citation_density`, `unverified_rate`) and the verification verdict (PASS / PARTIAL / FAIL / mechanical_only).
 3. **Gap list** — any research questions that remain unanswered or UNVERIFIED after all rounds, or an explicit "None" if none remain.
 4. **Optional one-line topic recap** — a single sentence restating what was researched (omit if the calling context already contains the topic).
@@ -184,9 +184,10 @@ The autoresearch agent ingests only the <500 token summary per worker call. Over
 
 When the autoresearch worker or orchestrator invokes the **Explore subagent** (e.g. for codebase traversal or file discovery), the Explore dispatch prompt MUST include these constraints:
 
-- **Token cap**: cap return at ~5K tokens (caller-stated soft cap). If the response would exceed this, summarize rather than paste.
+- **Token cap**: cap return at ~5K tokens (caller-stated soft cap).
 - **Path-only preference**: when matches exceed 20 files, return file paths only (one per line) — do not include file contents, snippets, or surrounding context beyond the path.
 - **No raw file contents**: never paste raw file contents into the return. Use `file:line` citations with at most a 1-line context excerpt per citation.
+- **Overflow behavior (mandatory fallback)**: if any of the above thresholds are exceeded, the return MUST switch to path-only mode AND emit a single explicit fallback line at the top: `[guardrail-fallback: <reason>; matches=<N>; tokens≈<T>; raw output suppressed — caller may re-dispatch with narrower scope]`. Do not silently truncate or arbitrarily summarize — the caller must know fallback was triggered so they can re-dispatch with tighter scope.
 
 These constraints preserve the main session's context budget. Violation risks are the same as raw-search injection: context pressure and session stops (Issue #215, #101 Gap 4).
 

--- a/.claude/skills/autoresearch/SKILL.md
+++ b/.claude/skills/autoresearch/SKILL.md
@@ -112,6 +112,25 @@ Round N:
                 Round N = max_rounds -> go to VERIFICATION with gaps flagged
 ```
 
+## Return Contract
+
+When autoresearch terminates and returns control to the calling agent (Mercury main session, standalone user, or orchestrator), the completion return message MUST contain ONLY:
+
+1. **Report file path** — the absolute or repo-relative path to the final research report (e.g. `Mercury_KB/04-research/RESEARCH-topic-001.md` or `.research/reports/RESEARCH-topic-2026-05-09.md`).
+2. **Verdict + per-metric scores** — the gate metrics from the final round (`question_answer_rate`, `citation_density`, `unverified_rate`) and the verification verdict (PASS / PARTIAL / FAIL / mechanical_only).
+3. **Gap list** — any research questions that remain unanswered or UNVERIFIED after all rounds, or an explicit "None" if none remain.
+4. **Optional one-line topic recap** — a single sentence restating what was researched (omit if the calling context already contains the topic).
+
+**Explicitly forbidden in the return message:**
+- Raw findings text or raw search result snippets
+- Raw round-by-round log entries or per-round source lists
+- Full report body or large excerpts from the report
+- Full verification checklist content (only the final verdict score, not the checklist rows)
+
+All raw research artifacts live in `.research/reports/` (standalone mode) or `Mercury_KB/04-research/` (Mercury mode) and are addressable by file path. The calling agent reads the file directly if it needs detail — the return message is a pointer + verdict, not a data dump.
+
+> Cross-link: the [Search Worker Protocol](#search-worker-protocol) below enforces the same discipline inside each research round (keeping intermediate search I/O out of the autoresearch agent's context). This section extends that discipline to the final completion return to the calling agent.
+
 ## Search Worker Protocol
 
 **Why**: WebSearch/WebFetch return 1-3K tokens per call. A typical research round runs 9-15 searches, injecting 15-45K tokens of raw HTML/snippet text into the autoresearch agent's own context window. Over 4+ rounds this causes context pressure and has triggered session stops (Issue #215, #101 Gap 4).
@@ -152,6 +171,16 @@ Agent(
 ```
 
 The autoresearch agent ingests only the <500 token summary per worker call. Over 4 rounds × 3 questions × 500 tokens = 6K tokens of search state, versus 60-180K tokens under the old inline pattern.
+
+### Explore guardrail
+
+When the autoresearch worker or orchestrator invokes the **Explore subagent** (e.g. for codebase traversal or file discovery), the Explore dispatch prompt MUST include these constraints:
+
+- **Token cap**: cap return at ~5K tokens (caller-stated soft cap). If the response would exceed this, summarize rather than paste.
+- **Path-only preference**: when matches exceed 20 files, return file paths only (one per line) — do not include file contents, snippets, or surrounding context beyond the path.
+- **No raw file contents**: never paste raw file contents into the return. Use `file:line` citations with at most a 1-line context excerpt per citation.
+
+These constraints preserve the main session's context budget. Violation risks are the same as raw-search injection: context pressure and session stops (Issue #215, #101 Gap 4).
 
 **Fallback** (nested subagent mode, Codex mode, or `Agent()` not available): the primary context protection is much weaker in this mode because the nested agent cannot offload search I/O to a worker. Apply this reduced-budget protocol:
 

--- a/.claude/skills/autoresearch/SKILL.md
+++ b/.claude/skills/autoresearch/SKILL.md
@@ -114,7 +114,9 @@ Round N:
 
 ## Return Contract
 
-When autoresearch terminates and returns control to the calling agent (Mercury main session, standalone user, or orchestrator), the completion return message MUST contain ONLY:
+When autoresearch terminates and returns control to the calling agent (Mercury main session, standalone user, or orchestrator), the completion return message MUST be a **content-kind constraint**, not a literal field list. The constraint is: **no raw findings, no raw search snippets, no full report body** — only summary metadata and pointers.
+
+Concretely, the return MUST include at minimum:
 
 1. **Report file path** — the absolute or repo-relative path to the final research report (e.g. `Mercury_KB/04-research/RESEARCH-topic-001.md` or `.research/reports/RESEARCH-topic-2026-05-09.md`).
 2. **Verdict + per-metric scores** — the gate metrics from the final round (`question_answer_rate`, `citation_density`, `unverified_rate`) and the verification verdict (PASS / PARTIAL / FAIL / mechanical_only).
@@ -126,6 +128,12 @@ When autoresearch terminates and returns control to the calling agent (Mercury m
 - Raw round-by-round log entries or per-round source lists
 - Full report body or large excerpts from the report
 - Full verification checklist content (only the final verdict score, not the checklist rows)
+
+**Permitted summary metadata (conforming to this contract):** The `Rounds: N` line, the per-metric breakdown table, and the orchestrator JSON receipt (Mercury Integration mode) are all allowed — they are summary metadata, not raw findings. The two canonical implementations of this contract are:
+- **`### Final Output` template** (in the Termination & Output section below) — the human-readable summary format used in standalone and interactive invocations.
+- **`## Mercury Integration` JSON receipt** — the machine-readable format used when running under Mercury orchestrator dispatch.
+
+Both satisfy the content-kind constraint. Use whichever matches the invocation context; in Mercury mode, emit both (the human-readable summary for the session transcript and the JSON receipt for the orchestrator `record_receipt` flow).
 
 All raw research artifacts live in `.research/reports/` (standalone mode) or `Mercury_KB/04-research/` (Mercury mode) and are addressable by file path. The calling agent reads the file directly if it needs detail — the return message is a pointer + verdict, not a data dump.
 

--- a/.claude/skills/autoresearch/SKILL.md
+++ b/.claude/skills/autoresearch/SKILL.md
@@ -369,3 +369,26 @@ When running under Mercury orchestrator (auto-detected via `Mercury_KB/04-resear
 - On completion, output a JSON receipt for the orchestrator record_receipt flow
 
 The skill auto-detects this. No manual configuration needed.
+
+### Mercury JSON receipt schema
+
+When running under Mercury orchestrator, emit a final JSON receipt of this shape (this is one canonical implementation of the Return Contract):
+
+```json
+{
+  "topic": "<research topic>",
+  "rounds": "<int>",
+  "report_path": "<repo-relative path under Mercury_KB/04-research/>",
+  "verdict": "PASS|PARTIAL|FAIL|mechanical_only",
+  "metrics": {
+    "question_answer_rate": "<float>",
+    "citation_density": "<float>",
+    "unverified_rate": "<float>",
+    "iteration_depth": "<int>"
+  },
+  "gaps": ["<gap 1>", "..."],
+  "termination_reason": "gate_passed|max_rounds|interrupted"
+}
+```
+
+The `report_path` field MUST be a repo-relative path (no absolute filesystem paths — see Return Contract for rationale). The receipt content is summary metadata only — no raw findings, no raw search snippets, no full report body.

--- a/.claude/skills/dev-pipeline/SKILL.md
+++ b/.claude/skills/dev-pipeline/SKILL.md
@@ -30,7 +30,7 @@ Before invoking this skill, the following must be true:
 | **Acceptance is blind** | The acceptance subagent MUST NOT receive the dev subagent's reasoning, narrative, self-assessment, or risk evaluation. It receives only the AcceptanceBundle (criteria) plus a blindReceipt containing changed-file paths, test results, and a structured `dodChecklist` (per-criterion citations — structured pointers, not narrative reasoning). |
 | **Max 3 dev iterations** | If acceptance returns fail 3 times, escalate to user — do not loop forever. |
 | **Main does not write code** | Main coordinates, reviews receipts, decides next action. Implementation belongs to dev. Verification belongs to acceptance. |
-| **Sub-agents cannot spawn sub-agents** | Per Claude Code documented constraint. Only the Main thread (running this skill) can dispatch dev or acceptance. Dev cannot call acceptance directly. Note: built-in Claude Code tools (Read, Grep, Glob, Explore) are not custom Mercury subagents — they may be invoked by Main per normal Claude Code semantics. The "no sub-agent spawning" rule applies specifically to Mercury's custom dev/acceptance/critic subagents defined under `.claude/agents/`. |
+| **Sub-agents cannot spawn sub-agents** | Per Claude Code documented constraint. Only the Main thread (running this skill) can dispatch dev or acceptance. Dev cannot call acceptance directly. Note: built-in Claude Code search tools (`Read`, `Grep`, `Glob`) and the built-in `Explore` subagent are exempt — they are part of the Claude Code platform, not custom Mercury subagents. Main may dispatch them per normal Claude Code semantics. The "no sub-agent spawning" rule applies specifically to Mercury's custom dev/acceptance/critic subagents defined under `.claude/agents/`. (`Explore` is dispatched via the `Agent` tool with `subagent_type: "Explore"`.) |
 
 ### Receipt return-size discipline
 
@@ -155,6 +155,7 @@ Main checks receipt completeness — NOT correctness (that is acceptance's job).
 Checklist:
 - [ ] All changedFiles exist in the diff
 - [ ] commitSha matches latest commit on the branch
+- [ ] `branch` field is non-empty AND matches the current branch (`git branch --show-current`) — guards against dispatch-time branch confusion or stale receipts.
 - [ ] All verifyCommands listed in the bundle have a verifyResults entry with exitCode 0
 - [ ] dodChecklist has one entry per definitionOfDone item, each with `met: true` and a non-empty `citation` (file:line or test output)
 - [ ] No file outside allowedWriteScope was touched. Use the **task-start SHA** captured before Phase 2 dispatch as the comparison base (`TASK_START_SHA=$(git rev-parse HEAD)` before dispatch, then `git diff --name-only "$TASK_START_SHA..HEAD"` after). Do NOT use `HEAD~1` — it breaks on first commits, squashed commits, and multi-commit dev runs.
@@ -168,6 +169,7 @@ Build the **blindReceipt** by forwarding the structured fields from the dev rece
 ```json
 {
   "taskId": "task-slug",
+  "branch": "<branch name>",
   "changedFiles": ["path/to/file1.ts", "path/to/file2.ts"],
   "commitSha": "abc123def",
   "verifyResults": [

--- a/.claude/skills/dev-pipeline/SKILL.md
+++ b/.claude/skills/dev-pipeline/SKILL.md
@@ -286,9 +286,10 @@ On pass:
 
 When Main dispatches Explore for readScope discovery, scope verification, or general codebase exploration, the Explore prompt MUST cap return at the following constraints:
 
-- **Token cap**: cap return at ~5K tokens (caller-stated soft cap). If the response would exceed this, Explore must summarize rather than paste.
+- **Token cap**: cap return at ~5K tokens (caller-stated soft cap).
 - **Path-only preference**: when matches exceed 20 files, return file paths only (one per line) — no file contents, no snippets, no surrounding context beyond the path.
 - **No raw file contents**: never paste raw file contents into the return. Use `file:line` citations with at most a 1-line context excerpt per citation.
+- **Overflow behavior (mandatory fallback)**: if any of the above thresholds are exceeded, the return MUST switch to path-only mode AND emit a single explicit fallback line at the top: `[guardrail-fallback: <reason>; matches=<N>; tokens≈<T>; raw output suppressed — caller may re-dispatch with narrower scope]`. Do not silently truncate or arbitrarily summarize — the caller must know fallback was triggered so they can re-dispatch with tighter scope.
 
 These constraints preserve the main session's context budget when using Explore for discovery. Violation risks are the same as raw-search injection: context pressure and session stops (Issue #215, #101 Gap 4).
 

--- a/.claude/skills/dev-pipeline/SKILL.md
+++ b/.claude/skills/dev-pipeline/SKILL.md
@@ -27,10 +27,10 @@ Before invoking this skill, the following must be true:
 |---|---|
 | **One task per pipeline run** | Mercury's preset is linear single-task, not parallel multi-task. For parallelism, the user opens multiple sessions. |
 | **TaskBundle is inline JSON, not Obsidian** | This skill is dependency-free. The Memory Layer / Obsidian KB integration ships in Phase 3 — until then, the bundle is constructed inline by Main and passed to the dev subagent in the prompt. |
-| **Acceptance is blind** | The acceptance subagent MUST NOT receive the dev subagent's reasoning, narrative, self-assessment, or risk evaluation. It receives only the AcceptanceBundle (criteria) plus a blindReceipt containing changed-file paths and test results. |
+| **Acceptance is blind** | The acceptance subagent MUST NOT receive the dev subagent's reasoning, narrative, self-assessment, or risk evaluation. It receives only the AcceptanceBundle (criteria) plus a blindReceipt containing changed-file paths, test results, and a structured `dodChecklist` (per-criterion citations — structured pointers, not narrative reasoning). |
 | **Max 3 dev iterations** | If acceptance returns fail 3 times, escalate to user — do not loop forever. |
 | **Main does not write code** | Main coordinates, reviews receipts, decides next action. Implementation belongs to dev. Verification belongs to acceptance. |
-| **Sub-agents cannot spawn sub-agents** | Per Claude Code documented constraint. Only the Main thread (running this skill) can dispatch dev or acceptance. Dev cannot call acceptance directly. |
+| **Sub-agents cannot spawn sub-agents** | Per Claude Code documented constraint. Only the Main thread (running this skill) can dispatch dev or acceptance. Dev cannot call acceptance directly. Note: built-in Claude Code tools (Read, Grep, Glob, Explore) are not custom Mercury subagents — they may be invoked by Main per normal Claude Code semantics. The "no sub-agent spawning" rule applies specifically to Mercury's custom dev/acceptance/critic subagents defined under `.claude/agents/`. |
 
 ### Receipt return-size discipline
 
@@ -120,12 +120,6 @@ You are operating under the dev agent role (.claude/agents/dev.md). Implement th
 6. Commit with format type(scope): summary (Mercury convention).
 7. Push to current branch.
 8. Output the JSON receipt below as your FINAL message.
-
-## Explore guardrail
-When invoking Explore subagent for codebase traversal or file discovery:
-- Cap return at ~5K tokens (caller-stated soft cap).
-- Prefer path-only summaries when matches exceed 20 files — no file contents, no snippets.
-- Never paste raw file contents; use file:line citations with at most 1-line context per citation.
 
 ## Receipt template
 {
@@ -287,6 +281,18 @@ On pass:
 5. After PR merge is confirmed, run the **Phase 5 Cleanup block** as the final action (see Phase 5 above — the retry + `rm -rf` fallback logic is the SoT and is not duplicated here).
 
 **Single source of truth**: the Phase 5 Cleanup block is the only authoritative description of when `$SHA_FILE` is removed. Phase 6 only reaches it via the `pass` branch above. If you find yourself debating "should I clean up here", re-read Phase 5.
+
+## Explore guardrail (Main-side)
+
+When Main dispatches Explore for readScope discovery, scope verification, or general codebase exploration, the Explore prompt MUST cap return at the following constraints:
+
+- **Token cap**: cap return at ~5K tokens (caller-stated soft cap). If the response would exceed this, Explore must summarize rather than paste.
+- **Path-only preference**: when matches exceed 20 files, return file paths only (one per line) — no file contents, no snippets, no surrounding context beyond the path.
+- **No raw file contents**: never paste raw file contents into the return. Use `file:line` citations with at most a 1-line context excerpt per citation.
+
+These constraints preserve the main session's context budget when using Explore for discovery. Violation risks are the same as raw-search injection: context pressure and session stops (Issue #215, #101 Gap 4).
+
+> Note: this section governs Main's use of the built-in Explore tool. Dev subagents operate in isolated worktree contexts and use Read/Grep/Glob directly per their allowed-tools list — they do not dispatch Explore as a subagent.
 
 ## Detachability
 

--- a/.claude/skills/dev-pipeline/SKILL.md
+++ b/.claude/skills/dev-pipeline/SKILL.md
@@ -155,7 +155,7 @@ Main checks receipt completeness — NOT correctness (that is acceptance's job).
 Checklist:
 - [ ] All changedFiles exist in the diff
 - [ ] commitSha matches latest commit on the branch
-- [ ] `branch` field is non-empty AND matches the current branch (`git branch --show-current`) — guards against dispatch-time branch confusion or stale receipts.
+- [ ] `branch` field is non-empty AND matches the `TASK_BRANCH` Main captured in Phase 2 (`echo "$TASK_BRANCH"` if Main saved it, or recover via `git -C "$WORKTREE_PATH" branch --show-current` running in the dev worktree context — NOT `git branch --show-current` from Main's own cwd, which would return Main's parent-branch). Guards against dispatch-time branch confusion or stale receipts.
 - [ ] All verifyCommands listed in the bundle have a verifyResults entry with exitCode 0
 - [ ] dodChecklist has one entry per definitionOfDone item, each with `met: true` and a non-empty `citation` (file:line or test output)
 - [ ] No file outside allowedWriteScope was touched. Use the **task-start SHA** captured before Phase 2 dispatch as the comparison base (`TASK_START_SHA=$(git rev-parse HEAD)` before dispatch, then `git diff --name-only "$TASK_START_SHA..HEAD"` after). Do NOT use `HEAD~1` — it breaks on first commits, squashed commits, and multi-commit dev runs.

--- a/.claude/skills/dev-pipeline/SKILL.md
+++ b/.claude/skills/dev-pipeline/SKILL.md
@@ -202,7 +202,7 @@ You are operating under the acceptance agent role (.claude/agents/acceptance.md)
 ## AcceptanceBundle
 [paste AcceptanceBundle JSON]
 
-## Blind Receipt (changed files only — NO dev narrative)
+## Blind Receipt (changed files, test results, structured dodChecklist — NO dev narrative)
 [paste blindReceipt JSON]
 
 ## Instructions

--- a/.claude/skills/dev-pipeline/SKILL.md
+++ b/.claude/skills/dev-pipeline/SKILL.md
@@ -32,6 +32,9 @@ Before invoking this skill, the following must be true:
 | **Main does not write code** | Main coordinates, reviews receipts, decides next action. Implementation belongs to dev. Verification belongs to acceptance. |
 | **Sub-agents cannot spawn sub-agents** | Per Claude Code documented constraint. Only the Main thread (running this skill) can dispatch dev or acceptance. Dev cannot call acceptance directly. |
 
+### Receipt return-size discipline
+
+Sub-agent return values are the main session's primary context inflation source (typically 5–15K tokens per round). To keep the pipeline sustainable across many iterations, the dev receipt MUST use the structured slim format defined in Phase 2 — no free-form `evidence` or `risks` narrative. The `dodChecklist` array provides structured per-criterion citations that give acceptance everything it needs without prose overhead. See Issue #362 for background and real-world soak targets (<2K tokens avg per receipt).
 
 ## Phase 1: Build TaskBundle
 
@@ -118,17 +121,25 @@ You are operating under the dev agent role (.claude/agents/dev.md). Implement th
 7. Push to current branch.
 8. Output the JSON receipt below as your FINAL message.
 
+## Explore guardrail
+When invoking Explore subagent for codebase traversal or file discovery:
+- Cap return at ~5K tokens (caller-stated soft cap).
+- Prefer path-only summaries when matches exceed 20 files — no file contents, no snippets.
+- Never paste raw file contents; use file:line citations with at most 1-line context per citation.
+
 ## Receipt template
 {
   "taskId": "[copied out of the bundle]",
   "status": "completed|blocked|escalated",
-  "changedFiles": ["path", "..."],
+  "branch": "<current branch name>",
   "commitSha": "sha",
+  "changedFiles": ["path", "..."],
   "verifyResults": [
     {"command": "cmd", "exitCode": 0, "summary": "one line"}
   ],
-  "evidence": "file:line citations supporting definition-of-done",
-  "risks": "known risks or follow-up needed",
+  "dodChecklist": [
+    {"criterion": "<text from definitionOfDone>", "met": true, "citation": "<file:line or test output>"}
+  ],
   "escalationReason": "only if status is not completed"
 }
 
@@ -151,14 +162,14 @@ Checklist:
 - [ ] All changedFiles exist in the diff
 - [ ] commitSha matches latest commit on the branch
 - [ ] All verifyCommands listed in the bundle have a verifyResults entry with exitCode 0
-- [ ] evidence cites at least one file:line per definitionOfDone item
+- [ ] dodChecklist has one entry per definitionOfDone item, each with `met: true` and a non-empty `citation` (file:line or test output)
 - [ ] No file outside allowedWriteScope was touched. Use the **task-start SHA** captured before Phase 2 dispatch as the comparison base (`TASK_START_SHA=$(git rev-parse HEAD)` before dispatch, then `git diff --name-only "$TASK_START_SHA..HEAD"` after). Do NOT use `HEAD~1` — it breaks on first commits, squashed commits, and multi-commit dev runs.
 
 **Gate**: if any check fails, send a correction prompt to dev (still iteration 1) with the specific deficiency. Do not advance to acceptance with an incomplete receipt.
 
 ## Phase 4: Dispatch Acceptance (BLIND)
 
-Build the **blindReceipt** by stripping dev's narrative fields. **Preserve original JSON types** — `changedFiles` and `verifyResults` are arrays in the dev receipt and MUST remain arrays here, not stringified placeholders:
+Build the **blindReceipt** by forwarding the structured fields from the dev receipt. **Preserve original JSON types** — `changedFiles`, `verifyResults`, and `dodChecklist` are arrays in the dev receipt and MUST remain arrays here, not stringified placeholders:
 
 ```json
 {
@@ -168,11 +179,14 @@ Build the **blindReceipt** by stripping dev's narrative fields. **Preserve origi
   "verifyResults": [
     {"command": "pnpm test packages/foo", "exitCode": 0, "summary": "12 passed"},
     {"command": "pnpm lint", "exitCode": 0, "summary": "0 issues"}
+  ],
+  "dodChecklist": [
+    {"criterion": "criterion text from DoD", "met": true, "citation": "file:line or test output"}
   ]
 }
 ```
 
-Note what was REMOVED relative to the dev receipt: `evidence`, `risks`, `escalationReason`. The acceptance agent must form its own conclusions out of code and tests, not out of dev's self-assessment.
+Note what was REMOVED relative to the dev receipt: `escalationReason` (only present when status != completed — not relevant to a completed task's acceptance review). The `dodChecklist` is forwarded because it contains structured per-criterion citations (not dev's narrative reasoning) — acceptance uses it to cross-check each DoD item against actual code. The acceptance agent still forms its own independent conclusions from code and tests; `dodChecklist` citations are starting pointers, not authoritative verdicts.
 
 Build the **AcceptanceBundle** (also preserve original types — `definitionOfDone`, `acceptanceCriteria`, `verifyCommands` are arrays, not strings):
 


### PR DESCRIPTION
## Summary

Mercury Issue #362 (Gap 4 sub-agent return-size scoping, P1 quick-win): mechanical scoping at 3 sub-agent return sites to keep main session context lean.

- **autoresearch return contract** — new `## Return Contract` section + `### Explore guardrail` subsection. Final completion return is a content-kind constraint (no raw findings / no raw search / no full report body); canonical implementations cross-referenced (`### Final Output` + `## Mercury Integration` JSON receipt).
- **dev-pipeline receipt slim** — Phase 2 dev receipt template drops free-form `evidence` + `risks`; adds `branch` + structured `dodChecklist` array (per-criterion citations). Phase 3 review checklist + Phase 4 blind-receipt forwarding updated to match. New `### Receipt return-size discipline` Iron Rule.
- **Explore guardrail (Main-side)** — new top-level dev-pipeline section addressed to Main, governing built-in Explore dispatches (5K token soft cap / path-only > 20 files / no raw file contents). Iron Rule augmented to clarify built-in tools (Read/Grep/Glob/Explore) vs custom Mercury subagents.
- **dev.md / acceptance.md frontmatter** — receipt schema descriptions aligned with new structured form.

## Real-world soak target

Per Issue #362 acceptance criterion 1: 5+ sessions of autoresearch / dev-pipeline real-world use, main session context delta avg < 2K tokens (down from typical 5-15K). Soak verification is post-merge over multi-session period — NOT a PR-landing gate.

## Dual-verify

- Iter 1 (`af50e56`): Claude PASS / Codex NEEDS-CHANGES (1 High + 2 Medium internal-consistency findings)
- Iter 2 (`41d38ef`): all 3 findings addressed surgically — Return Contract reframed as content-kind constraint with canonical implementations cross-ref; Explore guardrail relocated from Phase 2 dispatch prompt to top-level Main-side section; blindReceipt contract aligned in dev-pipeline Iron Rule + acceptance.md frontmatter
- Iter 2 dual-verify: Claude PASS / Codex (re-audit pending — pre-PR gate)

## Test plan

- [x] YAML frontmatter parses for all 4 modified files (`yaml.safe_load` exit 0)
- [x] No file outside scope `[autoresearch/SKILL.md, dev-pipeline/SKILL.md, dev.md, acceptance.md]` modified
- [x] Phase 2 dispatch prompt block no longer contains Explore guardrail (audit `! grep -B1 -A30 '^## Phase 3:' ... | grep Explore guardrail`)
- [x] Top-level `## Explore guardrail` section present in dev-pipeline at heading depth `##`
- [x] Acceptance: dodChecklist forwarded in Phase 4 blindReceipt is structured per-criterion citation, NOT dev narrative — blindness preserved
- [ ] Real-world soak (5+ sessions, post-merge) — out of scope for PR landing per Issue #362 §验收 item 1

## Closes

Closes #362

🤖 Generated with [Claude Code](https://claude.com/claude-code)
