### PR TITLE
feat(harness): cost-tracker user-level layer + CLAUDE.md governance (Closes #361)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ Mercury 的部分功能跨仓库运作。以下表格记录外部仓库与 Mercu
 
 | Repo | Location | Purpose | 关系 |
 |------|----------|---------|------|
-| **Memory layer (user-level)** | `~/.claude/hooks/` + `~/.claude/scripts/` | mem0 adapter + bridge + flush + session-start/end hooks | 运行时独立于任何 git 仓库；mem0 Qdrant 数据在 `~/.claude/scripts/mem0-state/` |
+| **Memory layer (user-level)** | `~/.claude/hooks/` + `~/.claude/scripts/` | mem0 adapter + bridge + flush + session-start/end hooks + cost tracker (#361) | 运行时独立于任何 git 仓库；mem0 Qdrant 数据在 `~/.claude/scripts/mem0-state/`；cost-tracker per-session jsonl 在 `~/.claude/scripts/cost-tracker/` |
 | **claude-handoff** | 插件仓库 <https://github.com/392fyc/claude-handoff> | Session handoff / 续接 + `session_chain` SQLite | 作为本地插件挂载在 `~/.claude/settings.json` marketplace |
 | **AgentKB (archival-pending)** | `$AGENTKB_DIR` | 旧 Memory 层（Karpathy-style KB），Mercury #252 后被 mem0 取代 | 待归档；salvage 审计见 `.mercury/docs/research/agentkb-fork-salvage-audit-2026-04-17.md` |
 | **Mercury_KB** | *(archived)* | 项目专属 Obsidian vault (archived) | 已归档，早于 AgentKB 被取代 |
@@ -37,9 +37,10 @@ Mercury 的部分功能跨仓库运作。以下表格记录外部仓库与 Mercu
 **跨仓库开发注意事项：**
 - `dev-pipeline` 等 skill 假设单仓库工作，跨仓库任务需直接实现
 - 用户级 hooks / scripts 变更不走 Mercury PR 流程。相关路径里 `~/.claude` 等价于 `${CLAUDE_CONFIG_DIR:-$HOME/.claude}`；命令示例可任选一种书写，env 形式在多账户 / CI 下更可移植
-- 新环境验证: 运行 `ls "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/" "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/scripts/"` 看到 `pre-compact.py`/`session-end.py`/`flush.py`/`mem0_hooks.py`/`mem0_bridge.py` 即为 #259 后状态；`grep AGENTKB "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json"` 应返回 0 行
+- 新环境验证: 运行 `ls "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/" "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/scripts/"` 看到 `pre-compact.py`/`session-end.py`/`flush.py`/`mem0_hooks.py`/`mem0_bridge.py`/`cost_tracker.py` 即为 #361 后状态；`grep AGENTKB "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json"` 应返回 0 行
 - 安装依赖: `cd "${CLAUDE_CONFIG_DIR:-$HOME/.claude}" && uv sync` 建立 `.venv/` 并装 mem0ai + qdrant-client
-- 回滚通道: `MERCURY_MEM0_DISABLED=1` / `AGENTKB_MEM0_DISABLED=1` / `uv remove mem0ai` 任一即可 no-op mem0 写入路径
+- 回滚通道: `MERCURY_MEM0_DISABLED=1` / `AGENTKB_MEM0_DISABLED=1` / `MERCURY_COST_TRACKER_DISABLED=1` / `uv remove mem0ai` 任一即可 no-op 对应路径
+- Cost tracker (#361) env vars: `MERCURY_SESSION_COST_CEILING_USD=NN.NN` 触发 statusline 颜色阶梯 (绿 <70% / 黄 70-89% / 红 ≥90%)；`MERCURY_TIER_MISUSE_THRESHOLD` (默认 2000) 控制 opus 小任务 advisory 阈值
 
 **用户级变更治理（避免"仓库外漂移"）：**
 - **变更记录位置**: 每次修改 `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/`、`.../scripts/`、`.../settings.json` 时，在 Mercury 内开对应 Issue（类似 #259），在 Issue 下记录"命令清单 + 最终 diff 摘要 + 验证步骤"。Issue 关闭即成为该用户级变更的权威记录

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,10 +37,13 @@ Mercury 的部分功能跨仓库运作。以下表格记录外部仓库与 Mercu
 **跨仓库开发注意事项：**
 - `dev-pipeline` 等 skill 假设单仓库工作，跨仓库任务需直接实现
 - 用户级 hooks / scripts 变更不走 Mercury PR 流程。相关路径里 `~/.claude` 等价于 `${CLAUDE_CONFIG_DIR:-$HOME/.claude}`；命令示例可任选一种书写，env 形式在多账户 / CI 下更可移植
-- 新环境验证: 运行 `ls "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/" "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/scripts/"` 看到 `pre-compact.py`/`session-end.py`/`flush.py`/`mem0_hooks.py`/`mem0_bridge.py`/`cost_tracker.py` 即为 #361 后状态；`grep AGENTKB "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json"` 应返回 0 行
+- 新环境验证: 文件存在性 + 钩子注册 + 库可导入三层检查：
+  1. `ls "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/" "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/scripts/"` 看到 `pre-compact.py`/`session-end.py`/`flush.py`/`mem0_hooks.py`/`mem0_bridge.py`/`cost_tracker.py` 即为 #361 后状态
+  2. `grep -c session-end.py "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json"` 应返回 ≥1（钩子在 SessionEnd matcher 注册）；`grep AGENTKB "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json"` 应返回 0 行
+  3. `python -c "import sys; sys.path.insert(0, r'${CLAUDE_CONFIG_DIR:-$HOME/.claude}/scripts'); import cost_tracker; print(cost_tracker.session_log_path('verify-smoke'))"` 应打印 `cost-tracker/verify-smoke.jsonl` 路径（导入 + 路径解析 OK）
 - 安装依赖: `cd "${CLAUDE_CONFIG_DIR:-$HOME/.claude}" && uv sync` 建立 `.venv/` 并装 mem0ai + qdrant-client
 - 回滚通道: `MERCURY_MEM0_DISABLED=1` / `AGENTKB_MEM0_DISABLED=1` / `MERCURY_COST_TRACKER_DISABLED=1` / `uv remove mem0ai` 任一即可 no-op 对应路径
-- Cost tracker (#361) env vars: `MERCURY_SESSION_COST_CEILING_USD=NN.NN` 触发 statusline 颜色阶梯 (绿 <70% / 黄 70-89% / 红 ≥90%)；`MERCURY_TIER_MISUSE_THRESHOLD` (默认 2000) 控制 opus 小任务 advisory 阈值
+- Cost tracker (#361) env vars (canonical 实现见 `~/.claude/scripts/cost_tracker.py` `PRICING` / `_disabled()` / `ceiling_advisory()` / `detect_tier_misuse()`)：`MERCURY_SESSION_COST_CEILING_USD=NN.NN` 触发 statusline 颜色阶梯 (绿 <70% / 黄 70-89% / 红 ≥90%)；`MERCURY_TIER_MISUSE_THRESHOLD` (默认 2000) 控制 opus 小任务 advisory 阈值；`MERCURY_COST_TRACKER_DISABLED=1` 软关 `write_session_summary()` 写路径（statusline 段落另在 hook 内独立 gate）
 
 **用户级变更治理（避免"仓库外漂移"）：**
 - **变更记录位置**: 每次修改 `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/`、`.../scripts/`、`.../settings.json` 时，在 Mercury 内开对应 Issue（类似 #259），在 Issue 下记录"命令清单 + 最终 diff 摘要 + 验证步骤"。Issue 关闭即成为该用户级变更的权威记录


### PR DESCRIPTION
## Summary

- **Implements Mercury #361 (P2)** — Gap 3 cost control follow-up to long-running-agent baseline #101. Companion to already-merged #362 (Gap 4 sub-agent return scoping).
- **Cross-repo PR** — most files target `~/.claude/` (user-level scripts + hooks). This PR is the in-repo **CLAUDE.md governance update + audit trail** per #259 pattern.
- **DoD per #361 — all 4 criteria met**:
  1. ✅ Per-session cost log at `~/.claude/scripts/cost-tracker/<session_id>.jsonl`
  2. ✅ Statusline integration (cumulative session cost + 5h window cost + ceiling color tier)
  3. ✅ Tier misuse detection (opus turns with low effective input → advisory only, NOT blocking)
  4. ✅ Per-session ceiling alert via `MERCURY_SESSION_COST_CEILING_USD`

## In-repo change

- `CLAUDE.md` Memory layer row + cross-repo verification + rollback channel + new env var docs (4+/3-)

## User-level changes (out-of-repo, recorded here per #259 governance pattern)

| Path | Change | LOC |
|------|--------|-----|
| `~/.claude/scripts/cost_tracker.py` | NEW — pricing math + transcript parse + session log + window aggregation + tier-misuse + ceiling | 430 |
| `~/.claude/scripts/cost_tracker_test.py` | NEW — 35 tests | 395 |
| `~/.claude/hooks/statusline-context.sh` | EDIT — append cost segment + ceiling color tier (+45 lines net) | (existing 36 → 81) |
| `~/.claude/hooks/session-end.py` | EDIT — piggyback `write_session_summary()` non-blocking call (+18 lines) | (existing 257 → 275) |

## Module entry points

- Library: `cost_tracker.py` standalone (only stdlib + a transcript path; no Mercury imports)
- CLI: `python cost_tracker.py <transcript.jsonl> [session_id] [project]` writes summary to per-session jsonl
- CLI: `python cost_tracker.py --window-total [seconds]` prints rolling-window total USD
- CLI: `python cost_tracker.py --session-total <session_id>` prints session total USD

## Verified pricing (2026-05 Anthropic official, sources cited below)

| Model | Input ($/MTok) | Output ($/MTok) |
|-------|---------------|-----------------|
| Haiku 4.5 | $1 | $5 |
| Sonnet 4.6 | $3 | $15 |
| Opus 4.7 | $5 | $25 |

Cache 5m write = 1.25× / 1h write = 2× / cache read = 0.10× input rate. Batch service tier = 0.5× total.

## Schema (empirically verified from S91 transcript)

`message.usage.{input_tokens, output_tokens, cache_creation_input_tokens, cache_read_input_tokens, service_tier}` + `usage.cache_creation.{ephemeral_5m_input_tokens, ephemeral_1h_input_tokens}` breakdown. Statusline stdin has native `cost.total_cost_usd` consumed directly.

## Env vars

- `MERCURY_COST_TRACKER_DISABLED=1` — soft-disable all writes (rollback channel)
- `MERCURY_SESSION_COST_CEILING_USD=NN.NN` — statusline ceiling color (green <70% / yellow 70-89% / red ≥90%)
- `MERCURY_TIER_MISUSE_THRESHOLD` — default 2000 input tokens; opus turns under threshold flagged as advisory

## Backup files (rollback path)

- `~/.claude/settings.json.backup-pre-361-20260509`
- `~/.claude/hooks/statusline-context.sh.backup-pre-361`
- `~/.claude/hooks/session-end.py.backup-pre-361`

Settings.json was NOT modified — backup is precautionary only.

## #259 governance validation checklist (all PASS)

- [x] `settings.json` JSON valid: `python -c "import json; json.load(open(r'C:/Users/392fy/.claude/settings.json'))"` → OK
- [x] `statusline-context.sh` smoke under synthesized stdin (plain) → exit 0, output includes `¤2.34`
- [x] `statusline-context.sh` smoke under synthesized stdin (ceiling 90% red branch) → exit 0, output includes red `¤4.50/5.00`
- [x] `session-end.py` smoke against real S91 transcript (227 turns) → exit 0, summary written
- [x] `cost_tracker_test.py` 35/35 PASS
- [x] Cost number matches manual calc: $74.32 from real transcript (0% delta, well within ±5% target)
- [x] Window aggregation correct: `window_total_usd()` returns same as `session_total_usd()` for sole session

## Dual-verify (Mercury MUST pre-commit gate)

- **Claude Code critic**: APPROVED with non-blocking comments (no Critical/High; H1+M2 fixed inline before commit)
- **Codex iter-3**: APPROVED clean — all Critical/High/Medium clear

Iter chain:
- Critic identified H1 (dead-code key in misuse heuristic) + M2 (unverified priority tier multiplier) → fixed in deployed code
- Codex iter-1 identified 3 Mediums (replay window inflation, parse robustness, misuse undercount on cache writes) → fixed
- Codex iter-2 confirmed 2/3 Mediums clear, last (5h window recency by mtime) flagged → fixed via summary-timestamp keying
- Codex iter-3 APPROVED — gate clean

## Sources (web-research verified before code)

- https://platform.claude.com/docs/en/about-claude/pricing
- https://code.claude.com/docs/en/statusline (statusline JSON schema with `cost.total_cost_usd` native)
- https://www.claude-dev.tools/docs/transcripts (transcript JSONL anatomy)
- https://www.finout.io/blog/anthropic-api-pricing (cache write multipliers, batch tier)
- https://devtk.ai/en/blog/claude-api-pricing-guide-2026/ (2026-05 pricing matrix)

## Test plan

- [x] Run `cd ~/.claude/scripts && python cost_tracker_test.py` → 35/35 PASS
- [x] Smoke `statusline-context.sh` with synthesized stdin (plain + ceiling)
- [x] Smoke `session-end.py` with real transcript → cost-tracker dir + jsonl created
- [x] Window aggregation cross-checked against manual calc

## Rollback

```bash
# Soft-disable (env var, no file changes):
export MERCURY_COST_TRACKER_DISABLED=1

# Full revert (file-level):
mv ~/.claude/hooks/statusline-context.sh.backup-pre-361 ~/.claude/hooks/statusline-context.sh
mv ~/.claude/hooks/session-end.py.backup-pre-361 ~/.claude/hooks/session-end.py
rm ~/.claude/scripts/cost_tracker.py ~/.claude/scripts/cost_tracker_test.py
rm -rf ~/.claude/scripts/cost-tracker/
```

Closes #361

🤖 Generated with [Claude Code](https://claude.com/claude-code)
