### PR TITLE
fix(notify): revert loop-detector stall → notify wire (Closes #316)

### DIFF
--- a/.mercury/docs/EXECUTION-PLAN.md
+++ b/.mercury/docs/EXECUTION-PLAN.md
@@ -326,7 +326,7 @@ adapters/         # 适配层
 - ✅ sliding window 循环检测已实现并交付 (PR #229, #231, merged)
 - ✅ 增强 A: 多级超时 (soft → idle → hard) — Issue #290 落地
 - ✅ 增强 B: 卡死后诊断报告 → 写文件 (.mercury/state/stall-reports/) — Issue #290 落地
-- ⏳ 增强 C (Phase 5 依赖): 卡死后推送通知给用户（随 Phase 5 Notify Hub 落地）
+- ❌ ~~增强 C (Phase 5 依赖): 卡死后推送通知给用户~~ — **已 revert (Issue #316, 2026-05-09)**: stall 事件 agent-self-consumed via `writeStallReport()`，不属于 user-actionable scope。Phase 5-3 通知 scope 只限 user-actionable 事件（详见 §5-3）
 
 **产出**: agent 可以自动跨 session 继续工作
 **人类干预点**: ~~技术方案选择（已完成，Option D）~~；首次 session 接力时确认状态传递完整性

--- a/.mercury/docs/EXECUTION-PLAN.md
+++ b/.mercury/docs/EXECUTION-PLAN.md
@@ -354,7 +354,8 @@ adapters/         # 适配层
 - ✅ Addresses Issue #91 ("IM Bot Bridge — LINE/Telegram 托管 Main Agent 远程对话") — closed manually post-merge
 
 ### 5-3. 与其他模块集成 — 🟡 Partial
-- ✅ Quality Gate: loop-detector stall → notify wire 已落地 (PR #295)
+- **Scope (user-actionable only)**: Phase 5-3 wire targets are limited to events with meaningful user response — Dev Pipeline complete, handoff session-switch, permission relay, critical security events. Internal agent state (loop-detector, hook failures, autocompact, heartbeat) **never** wires to notify.
+- ❌ Quality Gate: loop-detector stall → notify wire **已 revert** (Issue #316, 2026-05-09) — stall events are agent-self-consumed via `writeStallReport()`. Telegram reserved for user-actionable events only.
 - ⏳ Session Continuity: handoff session 切换时通知 — 待 `CLAUDE_HANDOFF_AUTO_LAUNCH_FLAGS` env var 在 claude-handoff plugin merge 后启用 (跨仓库: [`392fyc/claude-handoff#11`](https://github.com/392fyc/claude-handoff/pull/11))
 - ⏳ Dev Pipeline: dev/acceptance subagent 完成时通知 — 后续接入
 - 🔜 自然语言意图解析（"取消刚才那个"等口语命令）DEFER — MVP 用 deterministic `@<label>` + `/cmd` 已够用；远期 Phase 5-3 加 OpenAI gpt-4o-mini direct intent parser（ADR §11 Phase 5-3 + `router-llm-backend-2026-04-25.md`）

--- a/.mercury/docs/research/phase5-mvp-telegram-adr-2026-04-25.md
+++ b/.mercury/docs/research/phase5-mvp-telegram-adr-2026-04-25.md
@@ -542,11 +542,13 @@ tmux new-session -d -s handoff "claude ${MERCURY_CHANNELS_FLAGS:-} -- '$SHORT_PR
 
 ### Phase 5-1: notify.cjs + router skeleton（首 PR）
 
+> **Historical note (Issue #316 correction, 2026-05-09)**: 原 Phase 5-1 plan 提议 wire `mercury-loop-detector/hook.cjs` stall → notify 并以 Telegram stall alert 作 demo。该 wire 已 revert（PR #295 commit `bb8a458` 引入，Issue #316 移除），因为 stall 事件 agent-self-consumed 不属于 user-actionable scope（详见 §6.3）。Phase 5-1 实际 ship 的 demo 改为 user-actionable 事件（如 Dev Pipeline 完成提示）。
+
 - `mercury-notify/notify.cjs` 30 LOC
 - `mercury-channel-router/router.cjs` 仅 outbound 部分（接 `/notify` 转 Telegram，~80 LOC）
-- Wire `mercury-loop-detector/hook.cjs` 卡死后调 notify
+- ~~Wire `mercury-loop-detector/hook.cjs` 卡死后调 notify~~ — **REVERTED per #316**: stall 事件 agent-self-consumed via `writeStallReport()`，不 wire notify
 - 用户在 `~/.claude/settings.json` 设 `MERCURY_TELEGRAM_BOT_TOKEN`
-- **Demo**：触发卡死 → 手机收到 `[#NNN] Mercury stall: no_progress`
+- **Demo (corrected)**：user-actionable 事件触发 → 手机收到 `[#NNN] <severity> <title>`（loop-detector stall 不再作为示例 demo）
 - 关 #293 一半 scope
 
 ### Phase 5-2: router 完整 + channel-client（次 PR）

--- a/.mercury/docs/research/phase5-mvp-telegram-adr-2026-04-25.md
+++ b/.mercury/docs/research/phase5-mvp-telegram-adr-2026-04-25.md
@@ -375,9 +375,21 @@ async function notify(severity, title, body, options = {}) {
 module.exports = { notify };
 ```
 
-### 6.3 Caller wire（不变）
+### 6.3 Caller wire（user-actionable only — corrected per #316）
 
-`adapters/mercury-loop-detector/hook.cjs` 在 stall 触发后调 `notify('error', 'Mercury stall: <type>', stallReason)`，fire-and-forget。
+**正确的 caller pattern**：notify 仅用于 user 在 Telegram 上有 actionable response 的事件。
+
+**示例（user-actionable）**：
+- Dev Pipeline subagent 完成长任务后 `notify('info', 'Dev pipeline complete', '<verdict + next step prompt>')` → 用户决定继续 / cancel / handoff
+- Handoff skill spawn 新 session 时 `notify('info', 'Handoff: new session spawned', '<branch + label>')` → 用户切换到新 tab
+- Permission relay：MCP `permission_request` → router → Telegram inline keyboard
+
+**反例（DO NOT wire — agent self-consumed）**：
+- ❌ loop-detector stall 触发：原 PR #295 wire 已 revert（Issue #316），agent 通过 `writeStallReport()` 自处理
+- ❌ Hook script failure：agent 自恢复，无需 Telegram
+- ❌ Autocompact / heartbeat：内部状态事件
+
+**设计原则**：confusing internal agent telemetry with user-facing notifications floods the channel. Reserve Telegram for events that genuinely require human attention.
 
 ---
 

--- a/adapters/mercury-channel-router/README.md
+++ b/adapters/mercury-channel-router/README.md
@@ -85,6 +85,6 @@ Rationale: confusing internal agent telemetry with user-facing notifications flo
 
 ## Notes
 
-- Bun is optional — Node 18+ works fine.
+- Bun is optional — Node 20+ required (per repo `package.json` engines + Phase 5 ADR §9.1).
 - Lock file at `~/.mercury/router.lock` prevents duplicate instances.
 - Requires `node-telegram-bot-api` (installed via pnpm at project root).

--- a/adapters/mercury-channel-router/README.md
+++ b/adapters/mercury-channel-router/README.md
@@ -65,6 +65,24 @@ Or set `CLAUDE_HANDOFF_AUTO_LAUNCH_FLAGS` in your environment to propagate this 
 | GET | `/sessions` | List registered sessions |
 | GET | `/inbox/:id` | SSE stream of inbound events for a session |
 
+## Acceptable Callers (notify endpoint)
+
+The `/notify` IPC endpoint is for **user-actionable events only** — events where the user on Telegram has a meaningful action to take (decide next step, approve permission, acknowledge milestone).
+
+**✅ Acceptable**:
+- Dev Pipeline task complete → user decides next step (continue / cancel / handoff)
+- Handoff session-switch → user is aware new tab spawned, can switch focus
+- Permission relay → user approves/denies tool call
+- Critical security event → token leak attempt, unusual sender
+
+**❌ Anti-patterns (never wire to /notify)**:
+- `loop-detector` stall events → agent self-consumes (writeStallReport file is the agent-internal channel) — see Issue #316
+- Hook script failures → agent self-recovers
+- Autocompact / heartbeat / periodic state events
+- Any event where the user has no actionable response on Telegram
+
+Rationale: confusing internal agent telemetry with user-facing notifications floods the channel and trains the user to ignore it. Reserve Telegram for events that genuinely require human attention.
+
 ## Notes
 
 - Bun is optional — Node 18+ works fine.

--- a/adapters/mercury-loop-detector/hook.cjs
+++ b/adapters/mercury-loop-detector/hook.cjs
@@ -174,7 +174,7 @@ function main() {
       const fullReason = `Mercury loop detector: ${tr.message}\n(Buffer reset. If this is a false positive, resume your work.)`;
       writeStallReport(cwd, session_id, 'timeout_hard', fullReason, state,
         { name: tool_name, input_hash: ihash, errored, err_sig });
-      try { const { notify } = require('../mercury-notify/notify.cjs'); notify('error', `Mercury stall: timeout_hard`, tr.message).catch(() => {}); } catch { /* notify load failure non-fatal */ }
+      // stall events are agent-internal — no Telegram wire (#316).
       Object.assign(state, EMPTY_STATE()); state.session_id = session_id; saveState(statePath, state);
       block(fullReason);
     }
@@ -186,7 +186,7 @@ function main() {
     const fullReason = `Mercury loop detector: ${stall.reason}\n(Buffer reset. If this is a false positive, resume your work.)`;
     writeStallReport(cwd, session_id, stall.type, fullReason, state,
       { name: tool_name, input_hash: ihash, errored, err_sig });
-    try { const { notify } = require('../mercury-notify/notify.cjs'); notify('error', `Mercury stall: ${stall.type}`, stall.reason).catch(() => {}); } catch { /* notify load failure non-fatal */ }
+    // stall events are agent-internal — no Telegram wire (#316).
     Object.assign(state, EMPTY_STATE()); state.session_id = session_id; saveState(statePath, state);
     block(fullReason);
   }


### PR DESCRIPTION
## Summary

Revert the `mercury-loop-detector/hook.cjs` → `mercury-notify` → Telegram wire introduced by PR #295 (`bb8a458`). Stall events are agent-self-consumed via `writeStallReport()`; Telegram is reserved for **user-actionable events only** (Dev Pipeline complete, handoff session-switch, permission relay, critical security events).

Per user design philosophy 2026-04-26 (recorded in `feedback_notify_user_actionable_only.md`):
> loop-detector 触发 → notify('error', 'stall', ...) 这类不需要提示，因为这类提示一般是面向 agent 自身。用户在 Telegram 需要的是实质的交互。

## Changes (4 files, 2 commits)

### Commit 1 (`e0a831e`) — initial revert + 3 doc updates
- `adapters/mercury-loop-detector/hook.cjs`: remove 2 `notify(...)` try/catch blocks (lines 177 + 189), keep `writeStallReport()` calls intact, add one-line comment at each site explaining `agent-internal — no Telegram wire (#316)`
- `adapters/mercury-channel-router/README.md`: add **Acceptable Callers** section enumerating user-actionable targets (Dev Pipeline / handoff / permission relay / critical security) + anti-patterns (loop-detector / hook failures / autocompact / heartbeat) + rationale
- `.mercury/docs/research/phase5-mvp-telegram-adr-2026-04-25.md` §6.3: replace caller wire example with user-actionable-only guidance + 3 examples + 3 anti-patterns + design principle
- `.mercury/docs/EXECUTION-PLAN.md` Phase 5-3: revert first bullet from ✅ to ❌ with #316 reference + add **Scope (user-actionable only)** lead bullet excluding internal events

### Commit 2 (`b6619cd`) — Codex iter-1 ADR §11 consistency fix
- `.mercury/docs/research/phase5-mvp-telegram-adr-2026-04-25.md` §11 Phase 5-1: add historical note + strike-through `Wire mercury-loop-detector/hook.cjs 卡死后调 notify` bullet + replace stall demo with corrected user-actionable demo example. Resolves doc inconsistency between §11 (planning) and §6.3 (corrected) caught by Codex audit.

## Dual-Verify

- **Claude deep-review**: PASS (0 findings on initial diff)
- **Codex iter-1**: NEEDS-CHANGES (1 Medium — §11 Phase 5-1 doc inconsistency; resolved in commit 2)
- **Codex iter-2**: PASS (0 findings; cross-doc consistency verified across §6.3, §11, EXECUTION-PLAN, README)

## Test plan

- [x] `node adapters/mercury-loop-detector/hook.test.cjs` → 44/45 pass, 1 skipped (Unix-only file-mode test, expected on Windows), 0 fail
- [x] `grep "mercury-notify\|require.*notify" adapters/mercury-loop-detector/hook.cjs` → empty (0 lines, notify references fully removed)
- [x] `writeStallReport()` calls preserved on both stall paths (timeout_hard line 175 + detectStall line 187)
- [x] State cleanup `Object.assign(state, EMPTY_STATE())` still runs on both paths after revert
- [x] No new platform-specific syntax introduced
- [x] Docs cross-consistent: README + ADR §6.3 + ADR §11 + EXECUTION-PLAN Phase 5-3 all align on user-actionable-only principle

## Acceptance per Issue #316

- [x] Action 1: revert 2 notify blocks in `hook.cjs`, keep `writeStallReport()`
- [x] Action 2: update `mercury-channel-router/README.md` § acceptable callers
- [x] Action 3: update phase5 ADR §6.3 caller wire example
- [x] Action 4: update EXECUTION-PLAN Phase 5-3 scope statement
- [x] Action 5: smoke verifies loop-detector triggers no Telegram message + writeStallReport intact

Closes #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)