### PR TITLE
docs(lane-naming): cross-repo lane variant (Rule 5.1 extension) (#374)

### DIFF
--- a/.mercury/docs/guides/lane-naming.md
+++ b/.mercury/docs/guides/lane-naming.md
@@ -243,6 +243,54 @@ launched from the lane's session can `cd` to a path that resolves to a
 distinct `~/.claude/projects/<encoded-cwd>/` dir (Mercury team value:
 `~/.claude/projects/D--Mercury-Mercury-<short>/`).
 
+### Cross-repo lane variant (Rule 5.1 extension, Issue [#374](https://github.com/392fyc/Mercury/issues/374))
+
+The default mapping above assumes the lane's worktree is a Mercury checkout
+sibling (`Mercury-<short>`). A **cross-repo lane** points its `Worktree path`
+field at a sibling git repository (a different `.git` root, possibly with
+its own remote / branching convention) and uses Mercury core agents +
+skills + memory mechanics in service of work that lives in that sibling repo.
+
+This is an **extension** of Rule 5.1, not a strict superset: Rule 5.1's
+`Mercury-<short>` SHOULD-recommendation does not apply, and the
+procedural §"Setup at lane open" / §"Cleanup at lane close" Mercury
+`git worktree add/remove` flows below also do **not** apply (the host
+repo manages its own checkout lifecycle). Only the requirement to declare
+a `Worktree path` field per Rule 6 carries over unchanged.
+
+- The worktree path does NOT need to match `<repo-root>/Mercury-<short>` —
+  the `Mercury-<short>` convention is a default for Mercury-checkout
+  sibling lanes, not a hard constraint. The lane MUST still declare a
+  stable `Worktree path` field in its own LANES.md section (Rule 6 binding).
+- The lane's branch convention follows the host repo's git workflow, not
+  Mercury's. Rule 2.1 short-prefix (`lane/<short>/<N>-<slug>`) remains
+  recommended for in-host work-branches that the operator wants Mercury
+  lane-assertion (Δ11) to validate. If host-repo conventions conflict
+  AND the operator accepts the trade-off, `MERCURY_LANE_ASSERT_DISABLED=1`
+  is the operator's escape valve — but it skips **all** assertion checks
+  (marker, cwd-encoded vs Worktree path, branch convention; see soft-disable
+  table in §"Δ11 — Path C" below), not just branch convention. Use
+  sparingly and prefer naming branches per Rule 2.1 where compatible.
+- The lane MUST still claim Mercury Issues via the `lane:<short>` label
+  for any Mercury-side work (e.g. cross-repo coordination tickets);
+  in-host work tracking lives in the host repo's own ledger (KB, Issues,
+  etc.) per host convention and is OPAQUE to Mercury LANES.md.
+- Mercury asset dependency (user-scope agents, skills, hooks) is what
+  makes the cross-repo pattern usable — the lane SHOULD declare a
+  `Mercury asset dependency` field in its own LANES.md section listing
+  the user-scope assets it relies on (e.g. `~/.claude/agents/{main,dev,...}`).
+  This is a documentation-only convention (no schema/tooling enforcement
+  in `scripts/lane-spawn.sh` or fixtures); the field exists so future
+  user-scope asset migrations have a manual audit anchor.
+
+First dogfood: `side-sot` lane (worktree at `D:/ShipOfTheseus/Ship_of_Theseus`,
+opened 2026-05-10 per [#374](https://github.com/392fyc/Mercury/issues/374)).
+The `side-sot` LANES.md section lives in user-memory at
+`~/.claude/projects/D--Mercury-Mercury/memory/LANES.md` (not in the Mercury
+repo), so the dogfood reference cannot be cross-checked against repo
+content from this branch alone — see Issue [#374](https://github.com/392fyc/Mercury/issues/374) for the user-memory LANES.md
+companion edit landed concurrently with this guide change.
+
 ### Setup at lane open
 
 After opening a new lane (LANES.md section added, short name declared):

--- a/.mercury/docs/guides/lane-naming.md
+++ b/.mercury/docs/guides/lane-naming.md
@@ -256,26 +256,33 @@ This is an **extension** of Rule 5.1, not a strict superset: Rule 5.1's
 procedural §"Setup at lane open" / §"Cleanup at lane close" Mercury
 `git worktree add/remove` flows below also do **not** apply (the host
 repo manages its own checkout lifecycle). Only the requirement to declare
-a `Worktree path` field per Rule 6 carries over unchanged.
+a `Worktree path` field per Rule 5.1 (lane workspace isolation) carries
+over unchanged; ownership / per-section editing of LANES.md remains
+governed by Rule 6.
 
 - The worktree path does NOT need to match `<repo-root>/Mercury-<short>` —
   the `Mercury-<short>` convention is a default for Mercury-checkout
   sibling lanes, not a hard constraint. The lane MUST still declare a
-  stable `Worktree path` field in its own LANES.md section (Rule 6 binding).
+  stable `Worktree path` field in its own LANES.md section per Rule 5.1
+  (Worktree path declaration) — and only the owning lane edits its own
+  LANES.md section per Rule 6.
 - The lane's branch convention follows the host repo's git workflow, not
   Mercury's. Rule 2.1 short-prefix (`lane/<short>/<N>-<slug>`) remains
   recommended for in-host work-branches that the operator wants Mercury
   lane-assertion (Δ11) to validate. If host-repo conventions conflict
   AND the operator accepts the trade-off, `MERCURY_LANE_ASSERT_DISABLED=1`
   is the operator's escape valve — but it skips **all** assertion checks
-  (marker, cwd-encoded vs Worktree path, branch convention; see soft-disable
-  table in §"Δ11 — Path C" below), not just branch convention. **Use it
-  only as a one-shot command prefix** (e.g. `MERCURY_LANE_ASSERT_DISABLED=1
-  claude ...`) and `unset MERCURY_LANE_ASSERT_DISABLED` immediately after;
-  do NOT persist in shell profile / `.bashrc` / CI defaults — the assertion
-  bypass is meant for exceptional moments, not steady state. Prefer naming
+  (marker, cwd-encoded vs Worktree path, branch convention; see the
+  soft-disable section in §"Δ11 — Path C" below), not just branch
+  convention. **Use it only as a one-shot command prefix** (e.g.
+  `MERCURY_LANE_ASSERT_DISABLED=1 claude ...`) and
+  `unset MERCURY_LANE_ASSERT_DISABLED` immediately after; do NOT persist
+  in shell profile / `.bashrc` / CI defaults — the assertion bypass is
+  meant for exceptional moments, not steady state. Prefer naming
   branches per Rule 2.1 where compatible.
-- The lane MUST still claim Mercury Issues via the `lane:<short>` label
+- The lane MUST still claim Mercury Issues via the `lane:<name>` label
+  (where `<name>` matches the full lane name in LANES.md, e.g.
+  `lane:side-sot`, `lane:side-bug` — see `.mercury/docs/guides/lane-claim.md`)
   for any Mercury-side work (e.g. cross-repo coordination tickets);
   in-host work tracking lives in the host repo's own ledger (KB, Issues,
   etc.) per host convention and is OPAQUE to Mercury LANES.md.

--- a/.mercury/docs/guides/lane-naming.md
+++ b/.mercury/docs/guides/lane-naming.md
@@ -269,8 +269,12 @@ a `Worktree path` field per Rule 6 carries over unchanged.
   AND the operator accepts the trade-off, `MERCURY_LANE_ASSERT_DISABLED=1`
   is the operator's escape valve — but it skips **all** assertion checks
   (marker, cwd-encoded vs Worktree path, branch convention; see soft-disable
-  table in §"Δ11 — Path C" below), not just branch convention. Use
-  sparingly and prefer naming branches per Rule 2.1 where compatible.
+  table in §"Δ11 — Path C" below), not just branch convention. **Use it
+  only as a one-shot command prefix** (e.g. `MERCURY_LANE_ASSERT_DISABLED=1
+  claude ...`) and `unset MERCURY_LANE_ASSERT_DISABLED` immediately after;
+  do NOT persist in shell profile / `.bashrc` / CI defaults — the assertion
+  bypass is meant for exceptional moments, not steady state. Prefer naming
+  branches per Rule 2.1 where compatible.
 - The lane MUST still claim Mercury Issues via the `lane:<short>` label
   for any Mercury-side work (e.g. cross-repo coordination tickets);
   in-host work tracking lives in the host repo's own ledger (KB, Issues,
@@ -283,13 +287,27 @@ a `Worktree path` field per Rule 6 carries over unchanged.
   in `scripts/lane-spawn.sh` or fixtures); the field exists so future
   user-scope asset migrations have a manual audit anchor.
 
-First dogfood: `side-sot` lane (worktree at `D:/ShipOfTheseus/Ship_of_Theseus`,
+First dogfood: `side-sot` lane (worktree at `<host-repo-root>/<host-repo>`,
 opened 2026-05-10 per [#374](https://github.com/392fyc/Mercury/issues/374)).
 The `side-sot` LANES.md section lives in user-memory at
-`~/.claude/projects/D--Mercury-Mercury/memory/LANES.md` (not in the Mercury
-repo), so the dogfood reference cannot be cross-checked against repo
-content from this branch alone — see Issue [#374](https://github.com/392fyc/Mercury/issues/374) for the user-memory LANES.md
-companion edit landed concurrently with this guide change.
+`<canonical>/LANES.md` (where `<canonical>` resolves per the §"Operational
+expectation" rules above — not in the Mercury repo), so the dogfood
+reference cannot be cross-checked against repo content from this branch
+alone. To verify the companion edit at audit time:
+
+- Read the user-memory LANES.md `### \`side-sot\`` section directly (path
+  resolves via `MERCURY_MEMORY_DIR` or its default — see §"Operational
+  expectation" above);
+- Issue [#374](https://github.com/392fyc/Mercury/issues/374) body links the
+  full side-sot section content as a comment for repo-side audit anchor;
+- This guide change and the user-memory companion edit MUST land in the
+  same Mercury session (atomicity is operator-enforced, not tooling-enforced).
+
+Illustrative team values (one example operator's concrete paths; values
+will differ per operator and platform — trust env resolution at runtime,
+not these literals): `<host-repo-root>/<host-repo>` =
+`D:/ShipOfTheseus/Ship_of_Theseus`, `<canonical>` =
+`~/.claude/projects/D--Mercury-Mercury/memory`.
 
 ### Setup at lane open
 

--- a/.mercury/docs/guides/lane-naming.md
+++ b/.mercury/docs/guides/lane-naming.md
@@ -303,12 +303,6 @@ alone. To verify the companion edit at audit time:
 - This guide change and the user-memory companion edit MUST land in the
   same Mercury session (atomicity is operator-enforced, not tooling-enforced).
 
-Illustrative team values (one example operator's concrete paths; values
-will differ per operator and platform — trust env resolution at runtime,
-not these literals): `<host-repo-root>/<host-repo>` =
-`D:/ShipOfTheseus/Ship_of_Theseus`, `<canonical>` =
-`~/.claude/projects/D--Mercury-Mercury/memory`.
-
 ### Setup at lane open
 
 After opening a new lane (LANES.md section added, short name declared):


### PR DESCRIPTION
## Summary

Documents the **cross-repo lane variant** in `.mercury/docs/guides/lane-naming.md` under §"Lane workspace isolation via git worktree" — the pattern where a lane's `Worktree path` field points at a sibling git repository (different `.git` root) instead of a Mercury checkout sibling. Cross-repo lane is an **extension** of Rule 5.1, not a strict superset:
- `Mercury-<short>` SHOULD-recommendation does not apply
- §"Setup at lane open" / §"Cleanup at lane close" Mercury `git worktree add/remove` flows do not apply
- Only Rule 6 requirement to declare a stable `Worktree path` field carries over unchanged

First dogfood: `side-sot` lane (worktree at `D:/ShipOfTheseus/Ship_of_Theseus`, opened 2026-05-10 per #374), with the user-memory companion LANES.md side-sot section landed concurrently.

## Sub-section content

- Worktree path NOT required to match `<repo-root>/Mercury-<short>`
- Branch convention follows host repo workflow (Rule 2.1 short-prefix recommended for assertion compat)
- `MERCURY_LANE_ASSERT_DISABLED=1` documented as escape valve with **clarified blast radius** (skips ALL assertion checks: marker, cwd-encoded vs Worktree path, branch convention — not branch-only)
- Mercury Issues claimed via `lane:<short>` label for Mercury-side coordination; in-host work tracked in host repo ledger (OPAQUE to Mercury LANES.md)
- `Mercury asset dependency` field SHOULD be declared (documentation-only convention, no `scripts/lane-spawn.sh` / fixture enforcement) for user-scope asset audit anchor

## Dual-verify chain

- **Claude deep-review**: PASS (1 noted softness on Rule 5.1 framing — addressed)
- **Codex code-audit** iter-1: NEEDS-CHANGES (`Critical: 0  High: 0  Medium: 2  Low: 2`)
  - M1: `Mercury asset dependency` MUST field unenforceable → softened to SHOULD + scoped as documentation-only convention
  - M2: `MERCURY_LANE_ASSERT_DISABLED` blast radius understated → clarified skips ALL assertion checks, not branch-only
  - L1: §Setup/Cleanup Mercury worktree flows don't apply to cross-repo → procedural carve-out added
  - L2: side-sot reference not in-branch auditable → disclaimer added that LANES.md side-sot section lives in user-memory companion
- All 4 fixes applied in commit `3781024`

## Test plan

- [x] dual-verify chain documented in commit body
- [x] 3-dot PR diff clean (1 file, +48 LOC, no drift from origin/develop@44a8bce)
- [ ] Argus incremental review APPROVED
- [ ] CI Lint + Docstring + Skill Metadata + Type Check PASS
- [ ] Merge → develop FF + branch deleted

Closes #374

🤖 Generated with [Claude Code](https://claude.com/claude-code)