### PR TITLE
feat(handoff): canonical wt/tmux launcher script (Closes #377)

### DIFF
--- a/.claude/skills/handoff/SKILL.md
+++ b/.claude/skills/handoff/SKILL.md
@@ -431,10 +431,13 @@ mechanism for `/handoff auto` and is dual-verify-tested (Mercury Issue #377).
 
 **SHORT_PROMPT metacharacter rationale** (kept here for human readers — the
 launcher enforces this automatically): SHORT_PROMPT must remain free of
-`;` (command separator), `&` (background), `|` (pipe), `\` outside quotes,
-`$()` (command substitution). The `[LANE=<name>]` marker only contains
-`[a-z0-9-]+` per Rule 2.1 + the literal `[`/`]`/`=` brackets, none of
-which are wt/tmux metacharacters.
+`;` (command separator), `&` (background), `|` (pipe), `$()` (command
+substitution), and `` ` `` (backtick). The launcher does NOT reject `\`:
+on Windows, the canonical handoff-doc path contains backslashes
+(`C:\Users\...\session-handoff.md`), and bash double-quoting preserves
+`\<char>` literally for non-special chars. The `[LANE=<name>]` marker
+only contains `[a-z0-9-]+` per Rule 2.1 + the literal `[`/`]`/`=`
+brackets, none of which are wt/tmux metacharacters.
 
 The positional argument after `--` is the session's first user message —
 documented at <https://code.claude.com/docs/en/cli-reference>. The `--`

--- a/.claude/skills/handoff/SKILL.md
+++ b/.claude/skills/handoff/SKILL.md
@@ -397,37 +397,47 @@ fi
 
 (Soft-disable via `MERCURY_LANE_ASSERT_DISABLED=1` if break-glass.)
 
-**Windows** (Windows Terminal, new tab) — `wt`'s `-- ...` passes argv
-directly to `CreateProcess`, so the prompt is one argv element with no
-shell re-parse; no extra quoting needed:
-```bash
-wt -w 0 nt --title "Handoff: $LANE_NAME" -d "$WORKTREE_PATH" -- claude -- "$SHORT_PROMPT"
-```
-
-**macOS / Linux with tmux** (real new window, detached from current TTY) —
-`tmux new-window <cmd>` runs `<cmd>` via `/bin/sh -c`. Bash's `printf %q`
-can emit `$'...'` ANSI-C quoting for some inputs, which is a bash extension
-not recognized by POSIX sh (dash on Debian/Ubuntu, busybox sh) — so we
-explicitly route through `bash -c` to ensure the quoted form is parsed by
-bash regardless of what `/bin/sh` resolves to. The outer `sh` only sees a
-plain `bash -c "..."` invocation, which is POSIX-portable. Closes Copilot
-iter3 finding on PR #346 (printf %q × dash sh portability):
-```bash
-SHORT_PROMPT_QUOTED=$(printf '%q' "$SHORT_PROMPT")
-tmux new-window -n handoff -c "$WORKTREE_PATH" \
-  "bash -c \"claude -- $SHORT_PROMPT_QUOTED\""
-```
-
-**macOS / Linux without tmux** — there is no portable "new terminal"
-primitive. Use `tmux new-session -d` or the terminal emulator's own CLI
-(`osascript -e 'tell app "Terminal" to do script ...'` on macOS,
-`gnome-terminal --` on Linux). Otherwise fall back to manual mode.
+**Required**: Do NOT construct the wt/tmux command inline. Call the
+canonical launcher:
 
 ```bash
-SHORT_PROMPT_QUOTED=$(printf '%q' "$SHORT_PROMPT")
-tmux new-session -d -s handoff -c "$WORKTREE_PATH" \
-  "bash -c \"claude -- $SHORT_PROMPT_QUOTED\""
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+bash "$REPO_ROOT/scripts/handoff-launch.sh" \
+  --lane "$LANE_NAME" \
+  --worktree "$WORKTREE_PATH" \
+  --handoff-doc "$HANDOFF_PATH"
 ```
+
+This script:
+- Constructs SHORT_PROMPT canonically with `[LANE=<name>]` marker preserved
+- Validates no wt/tmux metacharacters (`;` `&` `|` `$(` `` ` ``) in SHORT_PROMPT
+- Invokes wt directly from bash (Windows) or tmux (macOS/Linux) without
+  going through `Start-Process` or `ShellExecute` shim
+
+**Do NOT** invoke wt via PowerShell `Start-Process -FilePath "<concatenated string>"` —
+Windows Shell will treat the entire commandline string as the executable
+path and produce `0x80070002 ERROR_FILE_NOT_FOUND`. Mercury Issue #377
+forensic record:
+```
+[出现错误 2147942402 (0x80070002) (启动"S5 -d D:\Mercury\Mercury-side-bug
+-- C:\Users\392fy\.local\bin\claude.exe -- LANE=side-bug Continue from
+session handoff. Read ...
+```
+
+**Do NOT** use the literal bash command
+`wt -w 0 nt ... -- claude -- "$SHORT_PROMPT"` directly from agent code —
+even though that pattern works from a properly invoked bash shell, agent
+freeform construction has been observed to introduce escape errors
+(e.g. `[LANE=...]` brackets dropped by PowerShell wildcard expansion,
+title overridden by decorative agent string). The launcher script is the
+single supported entry point.
+
+**SHORT_PROMPT metacharacter rationale** (kept here for human readers — the
+launcher enforces this automatically): SHORT_PROMPT must remain free of
+`;` (command separator), `&` (background), `|` (pipe), `\` outside quotes,
+`$()` (command substitution). The `[LANE=<name>]` marker only contains
+`[a-z0-9-]+` per Rule 2.1 + the literal `[`/`]`/`=` brackets, none of
+which are wt/tmux metacharacters.
 
 The positional argument after `--` is the session's first user message —
 documented at <https://code.claude.com/docs/en/cli-reference>. The `--`

--- a/.claude/skills/handoff/SKILL.md
+++ b/.claude/skills/handoff/SKILL.md
@@ -424,13 +424,10 @@ forensic record:
 session handoff. Read ...
 ```
 
-**Do NOT** use the literal bash command
-`wt -w 0 nt ... -- claude -- "$SHORT_PROMPT"` directly from agent code —
-even though that pattern works from a properly invoked bash shell, agent
-freeform construction has been observed to introduce escape errors
-(e.g. `[LANE=...]` brackets dropped by PowerShell wildcard expansion,
-title overridden by decorative agent string). The launcher script is the
-single supported entry point.
+**ONLY entry point**: `scripts/handoff-launch.sh`. No exceptions. Do not call
+`wt`, `tmux`, `Start-Process`, or any direct terminal-spawn primitive from
+your agent code under any circumstances. The launcher is the only supported
+mechanism for `/handoff auto` and is dual-verify-tested (Mercury Issue #377).
 
 **SHORT_PROMPT metacharacter rationale** (kept here for human readers — the
 launcher enforces this automatically): SHORT_PROMPT must remain free of

--- a/.mercury/docs/guides/lane-naming.md
+++ b/.mercury/docs/guides/lane-naming.md
@@ -490,6 +490,7 @@ as the new tab's cwd:
 3. The path is passed to the canonical launcher (Mercury Issue #377; do not
    freeform-construct wt/tmux commands):
    ```bash
+   REPO_ROOT="$(git rev-parse --show-toplevel)"
    bash "$REPO_ROOT/scripts/handoff-launch.sh" \
      --lane <lane> --worktree <worktree> --handoff-doc <doc>
    ```

--- a/.mercury/docs/guides/lane-naming.md
+++ b/.mercury/docs/guides/lane-naming.md
@@ -487,9 +487,14 @@ as the new tab's cwd:
 2. `LANES.md` is read for that lane's `Worktree path` bullet (this §
    Worktree path convention table). awk extraction is bounded by the
    `### \`<lane-name>\`` heading scope so cross-lane bleed is impossible.
-3. The path is substituted into the spawn command:
-   - Windows: `wt -w 0 nt --title "Handoff: <lane>" -d "<worktree>" -- claude -- "$SHORT_PROMPT"`
-   - tmux:    `tmux new-window -n handoff -c "<worktree>" "claude -- '$SHORT_PROMPT'"`
+3. The path is passed to the canonical launcher (Mercury Issue #377; do not
+   freeform-construct wt/tmux commands):
+   ```bash
+   bash "$REPO_ROOT/scripts/handoff-launch.sh" \
+     --lane <lane> --worktree <worktree> --handoff-doc <doc>
+   ```
+   The launcher handles platform detection (Windows → wt, macOS/Linux → tmux)
+   and constructs SHORT_PROMPT with `[LANE=<name>]` marker preserved.
 4. If the `Worktree path` field is missing → spawn aborts with explicit
    `Rule 5.1` guidance pointing at `LANES.md`.
 

--- a/scripts/handoff-launch.sh
+++ b/scripts/handoff-launch.sh
@@ -176,7 +176,7 @@ if [ "$DRY_RUN" -eq 1 ]; then
     echo "COMMAND: wt -w 0 nt --title \"$TITLE_PREFIX $LANE\" -d \"$WORKTREE\" -- claude -- \"$SHORT_PROMPT\""
   else
     SHORT_PROMPT_QUOTED=$(printf '%q' "$SHORT_PROMPT")
-    echo "COMMAND: tmux new-window -n handoff -c \"$WORKTREE\" \"bash -c \\\"claude -- $SHORT_PROMPT_QUOTED\\\"\""
+    echo "COMMAND: tmux new-window -n handoff -c \"$WORKTREE\" \"bash -c 'claude -- \\\"\\\$1\\\"' _ $SHORT_PROMPT_QUOTED\""
   fi
   exit 0
 fi
@@ -202,9 +202,20 @@ else
   # Unix path (macOS / Linux): use tmux new-window.
   # Route through bash -c so printf %q output is interpreted by bash,
   # not POSIX sh (dash/busybox), which doesn't support $'...' quoting.
+  # Pass SHORT_PROMPT as a positional arg ($1) to the inner bash invocation
+  # rather than interpolating it into the command string.  Defense-in-depth:
+  # even though the metachar guard above rejects ;/&/|/$(`), routing through
+  # $1 means the prompt never enters the bash -c command-text re-parsing path.
+  #
+  # Parsing layers:
+  #   Layer 1 — tmux dispatches via /bin/sh -c "<outer-string>".
+  #             printf %q escapes SHORT_PROMPT for this sh layer.
+  #   Layer 2 — sh sees: bash -c 'claude -- "$1"' _ <quoted-prompt>
+  #             single-quoted literal is the bash script; prompt is argv[1].
+  #   Layer 3 — bash expands "$1" → prompt value; no re-parsing occurs.
   SHORT_PROMPT_QUOTED=$(printf '%q' "$SHORT_PROMPT")
   if tmux new-window -n handoff -c "$WORKTREE" \
-       "bash -c \"claude -- $SHORT_PROMPT_QUOTED\""; then
+       "bash -c 'claude -- \"\$1\"' _ $SHORT_PROMPT_QUOTED"; then
     EXIT_CODE=0
   else
     EXIT_CODE=$?

--- a/scripts/handoff-launch.sh
+++ b/scripts/handoff-launch.sh
@@ -182,22 +182,33 @@ if [ "$DRY_RUN" -eq 1 ]; then
 fi
 
 # ── Spawn ─────────────────────────────────────────────────────────────────
+# Use if-then-else form so the ERR trap (set -e / trap ERR) is suppressed
+# for the wt/tmux call per bash spec: commands in the test position of an
+# if statement are exempt from the ERR trap.  This ensures a real launch
+# failure reaches the EXIT_CODE branch and exits 1 (launch failure) rather
+# than 2 (unhandled error) via the trap.
 if [ "$TARGET" = "windows" ]; then
   # Windows path: invoke wt directly via bash exec — each argument is a
   # separate token, bypassing ShellExecute single-string trap (Issue #377).
   # Do NOT route through PowerShell Start-Process: that receives the full
   # commandline as -FilePath and passes it to ShellExecute as one string,
   # producing 0x80070002 ERROR_FILE_NOT_FOUND.
-  wt -w 0 nt --title "$TITLE_PREFIX $LANE" -d "$WORKTREE" -- claude -- "$SHORT_PROMPT"
-  EXIT_CODE=$?
+  if wt -w 0 nt --title "$TITLE_PREFIX $LANE" -d "$WORKTREE" -- claude -- "$SHORT_PROMPT"; then
+    EXIT_CODE=0
+  else
+    EXIT_CODE=$?
+  fi
 else
   # Unix path (macOS / Linux): use tmux new-window.
   # Route through bash -c so printf %q output is interpreted by bash,
   # not POSIX sh (dash/busybox), which doesn't support $'...' quoting.
   SHORT_PROMPT_QUOTED=$(printf '%q' "$SHORT_PROMPT")
-  tmux new-window -n handoff -c "$WORKTREE" \
-    "bash -c \"claude -- $SHORT_PROMPT_QUOTED\""
-  EXIT_CODE=$?
+  if tmux new-window -n handoff -c "$WORKTREE" \
+       "bash -c \"claude -- $SHORT_PROMPT_QUOTED\""; then
+    EXIT_CODE=0
+  else
+    EXIT_CODE=$?
+  fi
 fi
 
 if [ "$EXIT_CODE" -ne 0 ]; then

--- a/scripts/handoff-launch.sh
+++ b/scripts/handoff-launch.sh
@@ -188,11 +188,12 @@ fi
 # failure reaches the EXIT_CODE branch and exits 1 (launch failure) rather
 # than 2 (unhandled error) via the trap.
 if [ "$TARGET" = "windows" ]; then
-  # Windows path: invoke wt directly via bash exec — each argument is a
-  # separate token, bypassing ShellExecute single-string trap (Issue #377).
-  # Do NOT route through PowerShell Start-Process: that receives the full
-  # commandline as -FilePath and passes it to ShellExecute as one string,
-  # producing 0x80070002 ERROR_FILE_NOT_FOUND.
+  # Windows path: invoke wt as a foreground bash command. Each argument
+  # is a separate token in argv (CreateProcess form), bypassing the
+  # ShellExecute single-string trap (Issue #377). Do NOT route through
+  # PowerShell Start-Process: that receives the full commandline as
+  # -FilePath and passes it to ShellExecute as one string, producing
+  # 0x80070002 ERROR_FILE_NOT_FOUND.
   if wt -w 0 nt --title "$TITLE_PREFIX $LANE" -d "$WORKTREE" -- claude -- "$SHORT_PROMPT"; then
     EXIT_CODE=0
   else

--- a/scripts/handoff-launch.sh
+++ b/scripts/handoff-launch.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# handoff-launch.sh — Canonical wt/tmux launcher for /handoff auto mode.
+#
+# Purpose: Wrap wt (Windows) or tmux (macOS/Linux) invocation so agents never
+#          freeform-construct the command line. Prevents the 0x80070002
+#          ERROR_FILE_NOT_FOUND failure caused by ShellExecute receiving the
+#          entire commandline as a single concatenated string (program path).
+#
+# Mercury Issue #377 — forensic: side-bug spawn failed with
+#   "S5 -d D:\Mercury\Mercury-side-bug -- claude.exe -- LANE=side-bug ..."
+#   passed as a single string to ShellExecute. Fix: bash exec form to
+#   CreateProcess (Windows) / tmux new-window (macOS/Linux).
+#
+# Usage:
+#   bash scripts/handoff-launch.sh \
+#     --lane <name> \
+#     --worktree <path> \
+#     --handoff-doc <path> \
+#     [--title-prefix <str>] \
+#     [--dry-run]
+#
+# Exit codes:
+#   0  success (spawned or dry-run)
+#   1  launch failed (wt/tmux returned nonzero)
+#   2  argument / environment error (bad args, path not found, etc.)
+
+set -u
+
+# ── Trap unhandled errors ──────────────────────────────────────────────────
+_on_error() {
+  local lineno="${1:-?}"
+  echo "ERROR: unhandled error at line $lineno" >&2
+  exit 2
+}
+trap '_on_error $LINENO' ERR
+
+# ── Defaults ──────────────────────────────────────────────────────────────
+LANE=""
+WORKTREE=""
+HANDOFF_DOC=""
+TITLE_PREFIX="Handoff:"
+DRY_RUN=0
+
+# ── Usage ─────────────────────────────────────────────────────────────────
+usage() {
+  cat <<EOF
+Usage: bash scripts/handoff-launch.sh OPTIONS
+
+Required:
+  --lane <name>          Lane name (matches ^[a-z0-9][a-z0-9-]*$)
+  --worktree <path>      Directory for wt -d / tmux -c (must exist)
+  --handoff-doc <path>   Handoff markdown file (must exist)
+
+Optional:
+  --title-prefix <str>   wt window title prefix (default: "Handoff:")
+  --dry-run              Print intended command + SHORT_PROMPT, do not spawn
+  -h, --help             Show this help and exit
+
+Exit codes:
+  0  success (spawned or dry-run)
+  1  launch failed (wt/tmux returned nonzero)
+  2  argument / environment error
+EOF
+}
+
+# ── Argument parsing ───────────────────────────────────────────────────────
+if [ $# -eq 0 ]; then
+  usage
+  exit 2
+fi
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --lane)
+      shift
+      LANE="${1:-}"
+      ;;
+    --worktree)
+      shift
+      WORKTREE="${1:-}"
+      ;;
+    --handoff-doc)
+      shift
+      HANDOFF_DOC="${1:-}"
+      ;;
+    --title-prefix)
+      shift
+      TITLE_PREFIX="${1:-Handoff:}"
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+# ── Validate required args ─────────────────────────────────────────────────
+if [ -z "$LANE" ]; then
+  echo "ERROR: --lane is required" >&2
+  exit 2
+fi
+if [ -z "$WORKTREE" ]; then
+  echo "ERROR: --worktree is required" >&2
+  exit 2
+fi
+if [ -z "$HANDOFF_DOC" ]; then
+  echo "ERROR: --handoff-doc is required" >&2
+  exit 2
+fi
+
+# ── Validate lane name format ──────────────────────────────────────────────
+if ! echo "$LANE" | grep -qE '^[a-z0-9][a-z0-9-]*$'; then
+  echo "ERROR: invalid lane name '$LANE' — must match ^[a-z0-9][a-z0-9-]*\$" >&2
+  exit 2
+fi
+
+# ── Validate worktree path ─────────────────────────────────────────────────
+if [ ! -d "$WORKTREE" ]; then
+  echo "ERROR: worktree path does not exist or is not a directory: $WORKTREE" >&2
+  exit 2
+fi
+
+# ── Validate handoff-doc path ──────────────────────────────────────────────
+if [ ! -f "$HANDOFF_DOC" ]; then
+  echo "ERROR: handoff-doc does not exist or is not a file: $HANDOFF_DOC" >&2
+  exit 2
+fi
+
+# ── Construct SHORT_PROMPT canonically (Δ11 contract) ─────────────────────
+SHORT_PROMPT="[LANE=${LANE}] Continue from session handoff. Read ${HANDOFF_DOC} as your first action."
+
+# ── Validate SHORT_PROMPT contains no wt/tmux metacharacters ─────────────
+# Check for: ; & | $( ` (command separator, background, pipe, subst, backtick)
+if echo "$SHORT_PROMPT" | grep -qE '[;|&]|\$\(|`'; then
+  echo "ERROR: SHORT_PROMPT contains forbidden metacharacters (; & | \$( \`)" >&2
+  echo "       SHORT_PROMPT: $SHORT_PROMPT" >&2
+  exit 2
+fi
+
+# ── Detect platform ───────────────────────────────────────────────────────
+PLATFORM="$(uname -s 2>/dev/null || echo "unknown")"
+
+case "$PLATFORM" in
+  MINGW*|MSYS*|CYGWIN*)
+    TARGET="windows"
+    ;;
+  Darwin|Linux)
+    TARGET="unix"
+    ;;
+  *)
+    echo "ERROR: unsupported platform '$PLATFORM' — cannot determine wt/tmux path" >&2
+    exit 2
+    ;;
+esac
+
+# ── Dry-run: print and exit ────────────────────────────────────────────────
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "=== handoff-launch dry-run ==="
+  echo "LANE:          $LANE"
+  echo "WORKTREE:      $WORKTREE"
+  echo "HANDOFF_DOC:   $HANDOFF_DOC"
+  echo "TITLE_PREFIX:  $TITLE_PREFIX"
+  echo "SHORT_PROMPT:  $SHORT_PROMPT"
+  echo "PLATFORM:      $PLATFORM ($TARGET)"
+  echo ""
+  if [ "$TARGET" = "windows" ]; then
+    echo "COMMAND: wt -w 0 nt --title \"$TITLE_PREFIX $LANE\" -d \"$WORKTREE\" -- claude -- \"$SHORT_PROMPT\""
+  else
+    SHORT_PROMPT_QUOTED=$(printf '%q' "$SHORT_PROMPT")
+    echo "COMMAND: tmux new-window -n handoff -c \"$WORKTREE\" \"bash -c \\\"claude -- $SHORT_PROMPT_QUOTED\\\"\""
+  fi
+  exit 0
+fi
+
+# ── Spawn ─────────────────────────────────────────────────────────────────
+if [ "$TARGET" = "windows" ]; then
+  # Windows path: invoke wt directly via bash exec — each argument is a
+  # separate token, bypassing ShellExecute single-string trap (Issue #377).
+  # Do NOT route through PowerShell Start-Process: that receives the full
+  # commandline as -FilePath and passes it to ShellExecute as one string,
+  # producing 0x80070002 ERROR_FILE_NOT_FOUND.
+  wt -w 0 nt --title "$TITLE_PREFIX $LANE" -d "$WORKTREE" -- claude -- "$SHORT_PROMPT"
+  EXIT_CODE=$?
+else
+  # Unix path (macOS / Linux): use tmux new-window.
+  # Route through bash -c so printf %q output is interpreted by bash,
+  # not POSIX sh (dash/busybox), which doesn't support $'...' quoting.
+  SHORT_PROMPT_QUOTED=$(printf '%q' "$SHORT_PROMPT")
+  tmux new-window -n handoff -c "$WORKTREE" \
+    "bash -c \"claude -- $SHORT_PROMPT_QUOTED\""
+  EXIT_CODE=$?
+fi
+
+if [ "$EXIT_CODE" -ne 0 ]; then
+  echo "ERROR: launch failed (exit $EXIT_CODE)" >&2
+  exit 1
+fi
+
+echo "handoff-launch: spawned new tab for lane '$LANE' at '$WORKTREE'"
+exit 0

--- a/scripts/handoff-launch.test.sh
+++ b/scripts/handoff-launch.test.sh
@@ -231,6 +231,124 @@ assert_exit_and_contains \
     --handoff-doc "$FAKE_HANDOFF" \
     --dry-run
 
+# ── Metachar guard tests (via --handoff-doc path injection) ───────────────
+# The lane-name regex rejects hostile chars in --lane before they reach the
+# metachar grep. To exercise the metachar guard directly we need a path
+# whose resolved SHORT_PROMPT contains the forbidden character. The guard
+# checks SHORT_PROMPT which embeds the --handoff-doc path literally. So we
+# pass a real file whose PATH itself contains a metachar.
+# NTFS forbids: \ / : * ? " < > |  — so | is NOT creatable on Windows.
+# NTFS allows:  & ; ( ) are fine on NTFS but rejected by some shells.
+# Strategy: try to create fixture files; skip individual sub-test if the
+# filesystem rejects the name (|| true pattern).
+
+# 16. handoff-doc path containing '&' — metachar guard rejects if creatable
+FAKE_HANDOFF_AMP="$TMPDIR_FIXTURE/bad&name.md"
+(echo "fake" > "$FAKE_HANDOFF_AMP") 2>/dev/null || true
+if [ -f "$FAKE_HANDOFF_AMP" ]; then
+  assert_exit_and_contains \
+    "metachar in handoff-doc '&' rejected by metachar guard (exit 2)" \
+    2 "forbidden metacharacters" \
+    bash "$LAUNCH_SCRIPT" \
+      --lane "test" \
+      --worktree "$FAKE_WORKTREE" \
+      --handoff-doc "$FAKE_HANDOFF_AMP" \
+      --dry-run
+else
+  echo "SKIP: test 16 — filesystem rejected '&' in filename (NTFS/platform)"
+fi
+
+# 17. handoff-doc path containing backtick — metachar guard rejects if creatable
+FAKE_HANDOFF_BT="$TMPDIR_FIXTURE/bad\`name.md"
+(echo "fake" > "$FAKE_HANDOFF_BT") 2>/dev/null || true
+if [ -f "$FAKE_HANDOFF_BT" ]; then
+  assert_exit_and_contains \
+    "metachar in handoff-doc backtick rejected by metachar guard (exit 2)" \
+    2 "forbidden metacharacters" \
+    bash "$LAUNCH_SCRIPT" \
+      --lane "test" \
+      --worktree "$FAKE_WORKTREE" \
+      --handoff-doc "$FAKE_HANDOFF_BT" \
+      --dry-run
+else
+  echo "SKIP: test 17 — filesystem rejected backtick in filename (NTFS/platform)"
+fi
+
+# ── Argv-capture stub test ─────────────────────────────────────────────────
+# Verify the launcher invokes wt (Windows) or tmux (Unix) with > 1 separate
+# argv tokens — the regression surface of Mercury Issue #377 (single-string
+# ShellExecute path). We stub the native executable so no real spawn happens.
+
+STUB_DIR="$TMPDIR_FIXTURE/stub-bin"
+ARGV_LOG="$TMPDIR_FIXTURE/wt-argv.log"
+mkdir -p "$STUB_DIR"
+
+# Detect which stub to install based on current platform
+CURRENT_PLATFORM="$(uname -s 2>/dev/null || echo "unknown")"
+case "$CURRENT_PLATFORM" in
+  MINGW*|MSYS*|CYGWIN*)
+    STUB_EXEC="wt"
+    ;;
+  Darwin|Linux)
+    STUB_EXEC="tmux"
+    ;;
+  *)
+    STUB_EXEC=""
+    ;;
+esac
+
+if [ -n "$STUB_EXEC" ]; then
+  ARGV_LOG_PATH_FOR_STUB="$ARGV_LOG"
+  cat > "$STUB_DIR/$STUB_EXEC" <<STUB
+#!/usr/bin/env bash
+echo "argc=\$#" > "\$ARGV_LOG_PATH"
+for i in "\$@"; do
+  echo "argv: \$i" >> "\$ARGV_LOG_PATH"
+done
+exit 0
+STUB
+  chmod +x "$STUB_DIR/$STUB_EXEC"
+
+  # Run launcher with PATH prepended so the stub intercepts the call.
+  # Do NOT pass --dry-run here — we want the spawn path to execute.
+  stub_output=$(ARGV_LOG_PATH="$ARGV_LOG_PATH_FOR_STUB" \
+    PATH="$STUB_DIR:$PATH" \
+    bash "$LAUNCH_SCRIPT" \
+      --lane "test" \
+      --worktree "$FAKE_WORKTREE" \
+      --handoff-doc "$FAKE_HANDOFF" 2>&1)
+  stub_exit=$?
+
+  # 18. Launcher exits 0 when stub wt/tmux succeeds
+  if [ "$stub_exit" -eq 0 ]; then
+    echo "PASS: stub-argv — launcher exits 0 with stub $STUB_EXEC"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: stub-argv — launcher exited $stub_exit (expected 0); output: $stub_output"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    FAILURES+=("stub-argv launcher exit 0")
+  fi
+
+  # 19. Stub captured > 1 argv tokens (separate-token, not single-string form)
+  if [ -f "$ARGV_LOG" ]; then
+    captured_argc=$(grep -E '^argc=' "$ARGV_LOG" | cut -d= -f2)
+    if [ -n "$captured_argc" ] && [ "$captured_argc" -gt 1 ]; then
+      echo "PASS: stub-argv — $STUB_EXEC invoked with $captured_argc separate argv tokens (not single string)"
+      PASS_COUNT=$((PASS_COUNT + 1))
+    else
+      echo "FAIL: stub-argv — $STUB_EXEC argc=$captured_argc (expected > 1); log: $(cat "$ARGV_LOG" 2>/dev/null)"
+      FAIL_COUNT=$((FAIL_COUNT + 1))
+      FAILURES+=("stub-argv argc > 1")
+    fi
+  else
+    echo "FAIL: stub-argv — argv log not created (stub did not run or ARGV_LOG_PATH not honoured)"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    FAILURES+=("stub-argv log created")
+  fi
+else
+  echo "SKIP: tests 18-19 — unsupported platform for stub-argv test"
+fi
+
 # ── Summary ───────────────────────────────────────────────────────────────
 TOTAL=$((PASS_COUNT + FAIL_COUNT))
 echo ""

--- a/scripts/handoff-launch.test.sh
+++ b/scripts/handoff-launch.test.sh
@@ -349,6 +349,82 @@ else
   echo "SKIP: tests 18-19 — unsupported platform for stub-argv test"
 fi
 
+# ── Positional-arg form tests ─────────────────────────────────────────────
+# Argus iter-1 finding #3: ensure tmux receives the prompt as a positional
+# arg to bash -c (defense-in-depth, never enters command-text re-parsing).
+
+# 20. Dry-run COMMAND output contains the positional-arg form (Unix only):
+#     bash -c 'claude -- "$1"' _ <prompt>  (not bash -c "claude -- <prompt>")
+#     On Windows the dry-run COMMAND shows the wt path, not tmux — skip there.
+_PLATFORM_TEST20="$(uname -s 2>/dev/null || echo "unknown")"
+case "$_PLATFORM_TEST20" in
+  Darwin|Linux)
+    assert_exit_and_contains \
+      "dry-run COMMAND uses positional-arg form (claude -- \"\$1\")" \
+      0 'claude -- "$1"' \
+      bash "$LAUNCH_SCRIPT" \
+        --lane "test" \
+        --worktree "$FAKE_WORKTREE" \
+        --handoff-doc "$FAKE_HANDOFF" \
+        --dry-run
+    ;;
+  *)
+    echo "SKIP: test 20 — Windows platform, dry-run shows wt path (tmux line absent)"
+    ;;
+esac
+
+# 21. On Unix: stub tmux argv log shows the prompt as a SEPARATE token
+#     (after the '_' placeholder), not interpolated into the command string.
+#     We reuse the stub-bin path written during tests 18-19 if on Unix.
+CURRENT_PLATFORM2="$(uname -s 2>/dev/null || echo "unknown")"
+case "$CURRENT_PLATFORM2" in
+  Darwin|Linux)
+    ARGV_LOG2="$TMPDIR_FIXTURE/tmux-argv2.log"
+    STUB_DIR2="$TMPDIR_FIXTURE/stub-bin2"
+    mkdir -p "$STUB_DIR2"
+    # Stub tmux: log every argv token separately.
+    cat > "$STUB_DIR2/tmux" <<'STUB2'
+#!/usr/bin/env bash
+echo "argc=$#" > "$ARGV_LOG_PATH"
+for i in "$@"; do
+  echo "argv: $i" >> "$ARGV_LOG_PATH"
+done
+exit 0
+STUB2
+    chmod +x "$STUB_DIR2/tmux"
+
+    ARGV_LOG_PATH="$ARGV_LOG2" PATH="$STUB_DIR2:$PATH" \
+      bash "$LAUNCH_SCRIPT" \
+        --lane "test" \
+        --worktree "$FAKE_WORKTREE" \
+        --handoff-doc "$FAKE_HANDOFF" 2>/dev/null
+    stub2_exit=$?
+
+    if [ -f "$ARGV_LOG2" ]; then
+      # The last argv token must be the quoted SHORT_PROMPT value
+      # (i.e. the prompt was passed as a separate token, not baked into
+      # the command string).  We check that one of the tokens IS the
+      # literal tmux command string containing the single-quoted script
+      # 'claude -- "$1"' (meaning $1 was NOT expanded there).
+      if grep -qF 'claude -- "$1"' "$ARGV_LOG2"; then
+        echo "PASS: stub-argv-positional — tmux command string contains literal '\$1' (prompt not interpolated)"
+        PASS_COUNT=$((PASS_COUNT + 1))
+      else
+        echo "FAIL: stub-argv-positional — tmux command string did not contain literal '\$1'; log: $(cat "$ARGV_LOG2")"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+        FAILURES+=("stub-argv-positional prompt not interpolated")
+      fi
+    else
+      echo "FAIL: stub-argv-positional — argv log not created"
+      FAIL_COUNT=$((FAIL_COUNT + 1))
+      FAILURES+=("stub-argv-positional log created")
+    fi
+    ;;
+  *)
+    echo "SKIP: test 21 — not a Unix platform, skipping tmux positional-arg stub test"
+    ;;
+esac
+
 # ── Summary ───────────────────────────────────────────────────────────────
 TOTAL=$((PASS_COUNT + FAIL_COUNT))
 echo ""

--- a/scripts/handoff-launch.test.sh
+++ b/scripts/handoff-launch.test.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 # handoff-launch.test.sh — Smoke tests for handoff-launch.sh
 #
-# Uses --dry-run mode exclusively: never spawns wt/tmux.
+# Mostly uses --dry-run mode. Tests 18-21 run the spawn path with a
+# PATH-stubbed wt/tmux to verify argv-token semantics — they never reach
+# real wt/tmux because the stub takes precedence on PATH.
 # Exit 0 if all tests pass, 1 if any fail.
 #
 # Mercury Issue #377
@@ -16,7 +18,7 @@ FAIL_COUNT=0
 FAILURES=()
 
 # ── Fixtures ──────────────────────────────────────────────────────────────
-TMPDIR_FIXTURE="$(mktemp -d)"
+TMPDIR_FIXTURE="$(mktemp -d "${TMPDIR:-/tmp}/handoff-launch-test.XXXXXX")"
 FAKE_WORKTREE="$TMPDIR_FIXTURE/worktree"
 FAKE_HANDOFF="$TMPDIR_FIXTURE/session-handoff-test.md"
 mkdir -p "$FAKE_WORKTREE"

--- a/scripts/handoff-launch.test.sh
+++ b/scripts/handoff-launch.test.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+# handoff-launch.test.sh — Smoke tests for handoff-launch.sh
+#
+# Uses --dry-run mode exclusively: never spawns wt/tmux.
+# Exit 0 if all tests pass, 1 if any fail.
+#
+# Mercury Issue #377
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LAUNCH_SCRIPT="$SCRIPT_DIR/handoff-launch.sh"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+FAILURES=()
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+TMPDIR_FIXTURE="$(mktemp -d)"
+FAKE_WORKTREE="$TMPDIR_FIXTURE/worktree"
+FAKE_HANDOFF="$TMPDIR_FIXTURE/session-handoff-test.md"
+mkdir -p "$FAKE_WORKTREE"
+echo "# Fake handoff doc" > "$FAKE_HANDOFF"
+
+# Clean up on exit
+trap 'rm -rf "$TMPDIR_FIXTURE"' EXIT
+
+# ── Helpers ───────────────────────────────────────────────────────────────
+assert_exit() {
+  local test_name="$1"
+  local expected_exit="$2"
+  shift 2
+  local output
+  output=$("$@" 2>&1)
+  local actual_exit=$?
+  if [ "$actual_exit" -eq "$expected_exit" ]; then
+    echo "PASS: $test_name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $test_name — expected exit $expected_exit, got $actual_exit"
+    echo "      output: $output"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    FAILURES+=("$test_name")
+  fi
+}
+
+assert_output_contains() {
+  local test_name="$1"
+  local needle="$2"
+  shift 2
+  local output
+  output=$("$@" 2>&1)
+  if echo "$output" | grep -qF -- "$needle"; then
+    echo "PASS: $test_name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $test_name — expected output to contain: $needle"
+    echo "      actual output: $output"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    FAILURES+=("$test_name")
+  fi
+}
+
+assert_exit_and_contains() {
+  local test_name="$1"
+  local expected_exit="$2"
+  local needle="$3"
+  shift 3
+  local output
+  output=$("$@" 2>&1)
+  local actual_exit=$?
+  local exit_ok=1
+  local content_ok=1
+  if [ "$actual_exit" -ne "$expected_exit" ]; then
+    exit_ok=0
+  fi
+  if ! echo "$output" | grep -qF -- "$needle"; then
+    content_ok=0
+  fi
+  if [ "$exit_ok" -eq 1 ] && [ "$content_ok" -eq 1 ]; then
+    echo "PASS: $test_name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $test_name"
+    if [ "$exit_ok" -eq 0 ]; then
+      echo "      expected exit $expected_exit, got $actual_exit"
+    fi
+    if [ "$content_ok" -eq 0 ]; then
+      echo "      expected output to contain: $needle"
+    fi
+    echo "      actual output: $output"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    FAILURES+=("$test_name")
+  fi
+}
+
+# ── Tests ─────────────────────────────────────────────────────────────────
+
+# 1. --help exits 0 and outputs usage
+assert_exit_and_contains \
+  "--help exits 0 with usage" \
+  0 "Usage:" \
+  bash "$LAUNCH_SCRIPT" --help
+
+# 2. Missing --lane exits 2
+assert_exit_and_contains \
+  "missing --lane exits 2" \
+  2 "--lane is required" \
+  bash "$LAUNCH_SCRIPT" \
+    --worktree "$FAKE_WORKTREE" \
+    --handoff-doc "$FAKE_HANDOFF"
+
+# 3. Missing --worktree exits 2
+assert_exit_and_contains \
+  "missing --worktree exits 2" \
+  2 "--worktree is required" \
+  bash "$LAUNCH_SCRIPT" \
+    --lane "test" \
+    --handoff-doc "$FAKE_HANDOFF"
+
+# 4. Missing --handoff-doc exits 2
+assert_exit_and_contains \
+  "missing --handoff-doc exits 2" \
+  2 "--handoff-doc is required" \
+  bash "$LAUNCH_SCRIPT" \
+    --lane "test" \
+    --worktree "$FAKE_WORKTREE"
+
+# 5. Invalid lane name exits 2
+assert_exit_and_contains \
+  "invalid lane name exits 2" \
+  2 "invalid lane name" \
+  bash "$LAUNCH_SCRIPT" \
+    --lane "Bad-Lane!" \
+    --worktree "$FAKE_WORKTREE" \
+    --handoff-doc "$FAKE_HANDOFF"
+
+# 6. Nonexistent worktree dir exits 2
+assert_exit_and_contains \
+  "nonexistent worktree exits 2" \
+  2 "not exist or is not a directory" \
+  bash "$LAUNCH_SCRIPT" \
+    --lane "test" \
+    --worktree "/nonexistent/path/worktree" \
+    --handoff-doc "$FAKE_HANDOFF"
+
+# 7. Nonexistent handoff-doc exits 2
+assert_exit_and_contains \
+  "nonexistent handoff-doc exits 2" \
+  2 "not exist or is not a file" \
+  bash "$LAUNCH_SCRIPT" \
+    --lane "test" \
+    --worktree "$FAKE_WORKTREE" \
+    --handoff-doc "/nonexistent/session-handoff.md"
+
+# 8. Valid args + --dry-run exits 0 and prints [LANE=...] SHORT_PROMPT
+assert_exit_and_contains \
+  "dry-run exits 0 with [LANE=test]" \
+  0 "[LANE=test]" \
+  bash "$LAUNCH_SCRIPT" \
+    --lane "test" \
+    --worktree "$FAKE_WORKTREE" \
+    --handoff-doc "$FAKE_HANDOFF" \
+    --dry-run
+
+# 9. Verify SHORT_PROMPT canonical format in dry-run
+assert_exit_and_contains \
+  "dry-run SHORT_PROMPT contains 'Continue from session handoff'" \
+  0 "Continue from session handoff" \
+  bash "$LAUNCH_SCRIPT" \
+    --lane "test" \
+    --worktree "$FAKE_WORKTREE" \
+    --handoff-doc "$FAKE_HANDOFF" \
+    --dry-run
+
+# 10. Valid args + --dry-run + custom --title-prefix exits 0 and uses custom prefix
+assert_exit_and_contains \
+  "dry-run with custom title-prefix uses custom prefix" \
+  0 "custom" \
+  bash "$LAUNCH_SCRIPT" \
+    --lane "test" \
+    --worktree "$FAKE_WORKTREE" \
+    --handoff-doc "$FAKE_HANDOFF" \
+    --title-prefix "custom" \
+    --dry-run
+
+# 11. Lane name with uppercase letters (invalid) exits 2
+assert_exit_and_contains \
+  "lane name with uppercase exits 2" \
+  2 "invalid lane name" \
+  bash "$LAUNCH_SCRIPT" \
+    --lane "SideLane" \
+    --worktree "$FAKE_WORKTREE" \
+    --handoff-doc "$FAKE_HANDOFF"
+
+# 12. Lane name starting with hyphen (invalid) exits 2
+assert_exit_and_contains \
+  "lane name starting with hyphen exits 2" \
+  2 "invalid lane name" \
+  bash "$LAUNCH_SCRIPT" \
+    --lane "-badlane" \
+    --worktree "$FAKE_WORKTREE" \
+    --handoff-doc "$FAKE_HANDOFF"
+
+# 13. Lane name with semicolon exits 2 (caught at name validation before metachar check)
+assert_exit \
+  "lane name with semicolon exits 2" \
+  2 \
+  bash "$LAUNCH_SCRIPT" \
+    --lane "bad;lane" \
+    --worktree "$FAKE_WORKTREE" \
+    --handoff-doc "$FAKE_HANDOFF"
+
+# 14. Dry-run output includes WORKTREE path
+assert_exit_and_contains \
+  "dry-run output includes worktree path" \
+  0 "$FAKE_WORKTREE" \
+  bash "$LAUNCH_SCRIPT" \
+    --lane "test" \
+    --worktree "$FAKE_WORKTREE" \
+    --handoff-doc "$FAKE_HANDOFF" \
+    --dry-run
+
+# 15. Dry-run output includes handoff-doc path in SHORT_PROMPT
+assert_exit_and_contains \
+  "dry-run SHORT_PROMPT includes handoff-doc path" \
+  0 "$FAKE_HANDOFF" \
+  bash "$LAUNCH_SCRIPT" \
+    --lane "test" \
+    --worktree "$FAKE_WORKTREE" \
+    --handoff-doc "$FAKE_HANDOFF" \
+    --dry-run
+
+# ── Summary ───────────────────────────────────────────────────────────────
+TOTAL=$((PASS_COUNT + FAIL_COUNT))
+echo ""
+echo "$PASS_COUNT/$TOTAL tests passed"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  echo "Failed tests:"
+  for f in "${FAILURES[@]}"; do
+    echo "  - $f"
+  done
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

Mercury Issue #377 fix — close the wt/tmux invocation regression that caused side-bug S5 handoff:auto to fail with `0x80070002 ERROR_FILE_NOT_FOUND` while sister main lane S97 spawn succeeded (S96 → S97 cross-lane forensic record).

**Root cause**: agents were freeform-constructing wt commandlines and (in some cases) routing through PowerShell `Start-Process -FilePath "<entire concatenated string>"`, which makes Windows Shell treat the entire string as the executable path. Sister to #359 / #360, which fixed SHORT_PROMPT *content* but did not enforce *invocation pattern*.

**Fix shape**:
- New canonical `scripts/handoff-launch.sh` (~210 LOC) — single supported entry point for `/handoff auto` spawn
- Validates lane name (`^[a-z0-9][a-z0-9-]*$`), worktree dir, handoff-doc file, SHORT_PROMPT metachar guard
- Constructs `[LANE=<name>]` SHORT_PROMPT canonically (Δ11 contract preserved)
- Invokes wt (Windows) / tmux (macOS/Linux) with each arg as a separate token via bash `exec` — bypasses ShellExecute single-string trap
- 19 smoke tests including stubbed wt/tmux argv-capture (mechanically locks down the regression surface — `argc=11 > 1` on real run)
- SKILL.md tightened to "ONLY entry point: scripts/handoff-launch.sh. No exceptions." with explicit ban on `wt` / `tmux` / `Start-Process` direct calls
- `.mercury/docs/guides/lane-naming.md` Δ10 step 3 updated to reference launcher

## Test plan

- [x] `bash scripts/handoff-launch.test.sh` — 19/19 tests pass (validation + dry-run + metachar guard + argv capture)
- [x] Manual wt-failure smoke (PATH-stubbed wt returning 42) — launcher exits 1 with `ERROR: launch failed (exit 42)` (was incorrectly exit 2 in iter-0 due to ERR trap)
- [x] Stub argv capture — `argc=11` separate tokens (vs broken single-string form would be `argc=1`)
- [x] dual-verify: Claude PASS + Codex PASS (iter-2, 0/0/0/0 findings)
- [x] No external SDK references introduced — only existing wt.exe + tmux + bash POSIX coreutils

## Review iters

- iter-0 (`7b23409`): initial impl, 15/15 tests, dual-verify NEEDS-CHANGES (1 High + 2 Medium)
- iter-1 (`0949569`): ERR trap fix (if-then-else wrap) + metachar guard tests via `--handoff-doc` + stubbed-wt argv capture + SKILL.md "ONLY entry point" wording. 19/19 tests, dual-verify PASS.

## Out of scope

- `~/.claude/skills/handoff/SKILL.md` (user-level) — separate sync after PR merge
- `memory/feedback_handoff_short_prompt_only.md` — main lane updates separately to add ShellExecute single-string failure mode forensic
- Recovery of S5-side-bug session — done manually after this PR merges via the new launcher

🤖 Generated with [Claude Code](https://claude.com/claude-code)