### PR TITLE
docs(direction): #396 P2 §模块 2 mem0+Qdrant rewrite (Closes #396)

### DIFF
--- a/.mercury/docs/DIRECTION.md
+++ b/.mercury/docs/DIRECTION.md
@@ -103,21 +103,22 @@ Mercury 的核心价值不在代码里，在方法论里。
 
 ### 模块 2: Memory Layer（长期记忆层）
 
-**解决的问题**: Claude Code 内置 memory 容量有限、不可结构化查询、不跨项目。
+**解决的问题**: Claude Code 内置 memory 容量有限、不可结构化查询、不跨 session、不跨项目、不跨 vendor。
 
 **职责**:
-- NAS 上的 Obsidian vault 作为中心化知识库
-- 遵循 Karpathy 模式: raw data → LLM compile → structured wiki → LLM Q&A → incrementally enhance
-- 跨项目共享: 不绑定 Mercury，任何项目均可接入
-- LLM 自维护: agent 负责写入和维护 wiki，人类只读/查询
-- 周期健康检查: LLM lint 检测不一致、缺失、过时内容
+- 跨 session 语义召回: SessionStart 注入相关历史 / SessionEnd flush 总结 / PreCompact 压缩前 snapshot
+- 跨项目共享（§P3 模块可拆卸的体现）: 不绑定 Mercury，用户级 hook 链（`~/.claude/hooks/`）使任何 Claude Code / Codex CLI 项目均可接入
+- 跨 vendor 可移植（§P5 向上兼容的核心收益）: 持久层 user-controlled，不依赖任何 Anthropic / OpenAI runtime；Anthropic Claude Managed Agents Memory / OpenAI `/responses/compact` 评估见 [Issue #384 ADR](research/cma-memory-vs-mem0-2026-05.md)（Verdict (a) status quo + monitor 配 4 个 re-eval trigger）
+- LLM 自维护: agent 全自动写入 + dedup，人类只读 / 查询
+- 失败安全 kill-switch: `AGENTKB_MEM0_DISABLED=1`（或 alias `MERCURY_MEM0_DISABLED=1`）软关；全路径 no-op-safe fail-falsy（mem0 缺失 / API key 缺失 / store 错误均不阻塞主流程）
 
-**技术方向**:
-- MCP server 提供读写接口（需评估当前可用的 Obsidian MCP server 方案）
-- NAS SSH 直接访问底层文件
-- 周期维护 Agent (Issue #92) 作为 health check skill
+**技术方向** (当前实装):
+- Adapter — [PR #258](https://github.com/392fyc/Mercury/pull/258) `599d313` 2026-04-17（Mercury Issue #252 **Phase A**，in-repo `scripts/`，仅 adapter prototype，hook 接线延后）: `mem0ai.Memory` 包装 + 4 个上游 P1 bug guard（mem0ai [#4099](https://github.com/mem0ai/mem0/issues/4099) empty-payload / [#4799](https://github.com/mem0ai/mem0/issues/4799) list-content / [#4453](https://github.com/mem0ai/mem0/issues/4453) threshold-filter / [#4536](https://github.com/mem0ai/mem0/issues/4536) contradiction-dedup 0.92 cosine fails-closed） + telemetry-off forced
+- Bridge + Hook 触发 + Vector store — user-level cross-repo 落地（post-Phase A，per CLAUDE.md §"用户级变更治理" + #259 governance pattern）: `~/.claude/scripts/mem0_bridge.py` no-op-safe `ingest_session()` / `recall()` + `~/.claude/hooks/{session-start.py,session-end.py,pre-compact.py}` hook 触发 + `~/.claude/scripts/mem0-state/qdrant/` + `history.db`（on-disk Qdrant + SQLite history，user-controlled）
+- Karpathy 模式 (raw → compile → wiki → Q&A → enhance) 映射: `add_safe()` → Qdrant + SQLite → `search_safe()` cosine + entity graph → `dedup_guard` 阈值拒绝矛盾或重复
+- 历史演进: Mercury_KB Obsidian vault（早期，已废）→ AgentKB-fork（Karpathy-style file KB，已归档详见 [`agentkb-fork-salvage-audit-2026-04-17.md`](research/agentkb-fork-salvage-audit-2026-04-17.md)）→ mem0 + Qdrant（当前实装）
 
-**自研理由**: 知识库结构、领域模板、编译流程是 Mercury 特有的。底层存储通过 MCP 生态解决。
+**自研理由**: adapter + bridge + 4 P1 bug guard 是 Mercury 特有；底层 vector store + LLM compile loop 通过 mem0ai + Qdrant 上游解决。
 
 ---
 

--- a/.mercury/docs/DIRECTION.md
+++ b/.mercury/docs/DIRECTION.md
@@ -112,7 +112,7 @@ Mercury 的核心价值不在代码里，在方法论里。
 - LLM 自维护: agent 全自动写入 + dedup，人类只读 / 查询
 - 失败安全 kill-switch: `AGENTKB_MEM0_DISABLED=1`（或 alias `MERCURY_MEM0_DISABLED=1`）软关；全路径 no-op-safe fail-falsy（mem0 缺失 / API key 缺失 / store 错误均不阻塞主流程）
 
-**技术方向** (当前实装):
+**技术方向** (当前实装；路径约定: `~/.claude/...` 等价于 `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/...`，沿用 CLAUDE.md §"Related Repositories" 约定，二者可任选一种书写，env 形式在多账户 / CI 下更可移植):
 - Adapter — [PR #258](https://github.com/392fyc/Mercury/pull/258) `599d313` 2026-04-17（Mercury Issue #252 **Phase A**，in-repo `scripts/`，仅 adapter prototype，hook 接线延后）: `mem0ai.Memory` 包装 + 4 个上游 P1 bug guard（mem0ai [#4099](https://github.com/mem0ai/mem0/issues/4099) empty-payload / [#4799](https://github.com/mem0ai/mem0/issues/4799) list-content / [#4453](https://github.com/mem0ai/mem0/issues/4453) threshold-filter / [#4536](https://github.com/mem0ai/mem0/issues/4536) contradiction-dedup 0.92 cosine fails-closed） + telemetry-off forced
 - Bridge + Hook 触发 + Vector store — user-level cross-repo 落地（post-Phase A，per CLAUDE.md §"用户级变更治理" + #259 governance pattern）: `~/.claude/scripts/mem0_bridge.py` no-op-safe `ingest_session()` / `recall()` + `~/.claude/hooks/{session-start.py,session-end.py,pre-compact.py}` hook 触发 + `~/.claude/scripts/mem0-state/qdrant/` + `history.db`（on-disk Qdrant + SQLite history，user-controlled）
 - Karpathy 模式 (raw → compile → wiki → Q&A → enhance) 映射: `add_safe()` → Qdrant + SQLite → `search_safe()` cosine + entity graph → `dedup_guard` 阈值拒绝矛盾或重复


### PR DESCRIPTION
## Summary

`.mercury/docs/DIRECTION.md` §模块 2「Memory Layer」 rewrite — replace pre-[#258](https://github.com/392fyc/Mercury/pull/258) Obsidian-vault / NAS-SSH / Karpathy-wiki description with current **mem0 + Qdrant** stack.

Surfaced by [PR #395](https://github.com/392fyc/Mercury/pull/395) / Issue #384 research (CMA Memory + `/responses/compact` re-eval, S102 2026-05-16) and tracked at [Issue #396](https://github.com/392fyc/Mercury/issues/396) (S102 follow-up).

## Closes

Closes #396

## Changes (single file, +14 / -13 lines)

`.mercury/docs/DIRECTION.md` §模块 2 only:

- **解决的问题**: 加入 cross-session / cross-vendor 维度
- **职责** (5 bullets): SessionStart/End/PreCompact 召回链 + §P3 (跨项目共享) + §P5 (跨 vendor 可移植) commitments folded inline + LLM 自维护 + kill-switch
- **技术方向** (4 bullets, properly split between Phase A in-repo vs post-Phase A user-level):
  - Adapter (PR #258 `599d313` 2026-04-17, Mercury Issue #252 **Phase A**, in-repo `scripts/mem0_hooks.py` adapter prototype) + 4 mem0 upstream P1 bug guards ([#4099](https://github.com/mem0ai/mem0/issues/4099) / [#4799](https://github.com/mem0ai/mem0/issues/4799) / [#4453](https://github.com/mem0ai/mem0/issues/4453) / [#4536](https://github.com/mem0ai/mem0/issues/4536)) + 0.92 cosine fails-closed
  - Bridge + Hook + Vector store (user-level cross-repo post-Phase A, per CLAUDE.md §"用户级变更治理" + #259 governance): `~/.claude/scripts/mem0_bridge.py` + `~/.claude/hooks/{session-start.py,session-end.py,pre-compact.py}` + `~/.claude/scripts/mem0-state/qdrant/` + `history.db`
  - Karpathy 模式映射: `add_safe()` → Qdrant + SQLite → `search_safe()` → `dedup_guard`
  - 历史演进: Mercury_KB Obsidian → AgentKB-fork (archived) → mem0 + Qdrant
- **自研理由**: adapter + bridge + 4 P1 guard 是 Mercury 特有；底层 mem0ai + Qdrant 上游解决
- Drops bare `Issue #92` (CLOSED) reference from §模块 2 — no living memory-layer health-check role

## Acceptance check (per Issue #396)

- [x] §模块 2 rewritten to match mem0 + Qdrant current state with explicit reference to PR #258 + Issue #384 ADR
- [x] No removal of §P3 / §P5 architectural commitments (only data-layer descriptions updated; §P3 + §P5 now inline in 职责 bullets 2 + 3)
- [x] Cross-reference Issue #92 if periodic-maintenance Agent still has a role somewhere — §模块 6 skill catalog (line ~197) keeps the listing as a Detachable Skill; §模块 2 incorrect attribution (as memory-layer health-check) removed
- [x] DIRECTION.md is a "supreme reference" doc — main lane PR + main-lane approval required

## Dual-verify

**Claude Code deep review: PASS** — all factual claims verified against actual implementation (`history.db` line 58/93 of `mem0_hooks.py`; `dedup_guard` line 148; `0.92` cosine line 37; kill-switch env vars `mem0_bridge.py` line 33 + docstring line 8; PR #258 SHA `599d313bb29f...` + mergedAt `2026-04-17T05:18:07Z` via `gh pr view 258`).

**Codex audit: NEEDS-CHANGES (iter 1) → PASS (post-fix, iter 1 in-thread)**

| Severity | Finding | Action |
|----------|---------|--------|
| High | "Adapter + Bridge + Hook + Vector store" all attributed to PR #258 Phase A, but Phase A is adapter-only; bridge/hook/state are post-Phase A user-level | **FIXED** — split 技术方向 into 2 bullets per actual landing timeline + governance |
| Medium | Bare `#92` ref still exists at §模块 6 line 197 (`periodic-maintenance (#92)`) | **DISAGREE** — out of #396 scope per acceptance #3 conditional reading: "if periodic-maintenance Agent still has a role somewhere" — §模块 6 is the "somewhere" mention (legitimate skill catalog entry). #396 only required removing the §模块 2 wrong-attribution (memory-layer health-check), which is done |
| Low | New `架构合规` + `历史` sections break 4-part template (解决的问题 / 职责 / 技术方向 / 自研理由) | **FIXED** — §P3/§P5 folded into 职责 bullets 2+3; 历史演进 become 技术方向 bullet 4; 4-part template restored |

Final Verdict: PASS (one Medium DISAGREE-documented, all in-scope findings addressed).

## Test plan

- [x] Markdown link integrity (relative paths from `.mercury/docs/DIRECTION.md` to `research/cma-memory-vs-mem0-2026-05.md` + `research/agentkb-fork-salvage-audit-2026-04-17.md` both resolve)
- [x] §P3 / §P5 cited in 职责 bullets 2 + 3 (preserved per acceptance #2)
- [x] §模块 2 4-part template matches §模块 1 / 3 / 4 / 5 / 6 style
- [x] Adjacent §模块 1 + §模块 3 unaffected (`git diff --stat` = single file)
- [x] No staged secrets / .env / credentials