### PR TITLE
fix(notify-hub): #298 strict truthy semantics for MERCURY_NOTIFY_DISABLED

### DIFF
--- a/adapters/mercury-channel-router/README.md
+++ b/adapters/mercury-channel-router/README.md
@@ -28,7 +28,7 @@ MERCURY_TELEGRAM_BOT_TOKEN=<token> node adapters/mercury-channel-router/router.c
 | `MERCURY_TELEGRAM_ALLOWED_USER_IDS` | **REQUIRED for inbound** | Comma-separated Telegram user IDs (sender allowlist). Empty = all inbound messages dropped (fail-closed). |
 | `MERCURY_TELEGRAM_CHAT_ID` | No | Default chat_id for `/notify` when no session has chatted yet |
 | `MERCURY_ROUTER_PORT` | No | IPC port (default: 8788) |
-| `MERCURY_NOTIFY_DISABLED` | No | Disables Telegram polling entirely; IPC still works |
+| `MERCURY_NOTIFY_DISABLED` | No | Truthy → disables Telegram polling entirely (IPC still works). Accepted truthy values (case-insensitive, whitespace trimmed): `1`, `true`, `yes`, `on`. Any other value (incl. `0`, `false`, `no`, `off`, empty, unset) leaves Telegram enabled. See Issue #298. |
 
 ## User Setup
 
@@ -89,3 +89,4 @@ Rationale: confusing internal agent telemetry with user-facing notifications flo
 - Lock file at `~/.mercury/router.lock` prevents duplicate instances.
 - Requires `node-telegram-bot-api` (installed via pnpm at project root).
 - Long Telegram messages are truncated via `lib/truncate.cjs` to keep within the 4096-UTF-16-code-unit cap while preserving surrogate pairs (#300).
+- `MERCURY_NOTIFY_DISABLED` env flag is parsed via `lib/env.cjs` strict truthy helper to match the `=== '1'` convention used elsewhere in Mercury (`mercury-loop-detector`, `mercury-test-gate`); see Issue #298.

--- a/adapters/mercury-channel-router/lib/env.cjs
+++ b/adapters/mercury-channel-router/lib/env.cjs
@@ -1,0 +1,19 @@
+'use strict';
+
+// Issue #298: strict env-flag parsing for MERCURY_NOTIFY_DISABLED (and any future
+// boolean env flag in this adapter). Accepts '1'/'true'/'yes'/'on' (case-insensitive,
+// surrounding whitespace trimmed). Returns false for unset, empty, '0', 'false', etc.
+// Loose `if (process.env.X)` checks were truthy for any non-empty string including
+// the literal '0', diverging from the strict `=== '1'` pattern used elsewhere in
+// Mercury (mercury-loop-detector, mercury-test-gate).
+//
+// Sibling of adapters/mercury-notify/lib/env.cjs — kept in-tree per CLAUDE.md
+// "modular design" (every adapter independently detachable; no cross-adapter
+// require()). Both copies must stay in sync.
+const TRUTHY = new Set(['1', 'true', 'yes', 'on']);
+function isEnvTruthy(v) {
+  if (v == null) return false;
+  return TRUTHY.has(String(v).trim().toLowerCase());
+}
+
+module.exports = { isEnvTruthy };

--- a/adapters/mercury-channel-router/router.cjs
+++ b/adapters/mercury-channel-router/router.cjs
@@ -10,6 +10,7 @@ const os     = require('os');
 const path   = require('path');
 const crypto = require('crypto');
 const { truncateForTelegram } = require('./lib/truncate.cjs');
+const { isEnvTruthy } = require('./lib/env.cjs');
 
 const PORT       = Number(process.env.MERCURY_ROUTER_PORT) || 8788;
 const LOCK_FILE  = path.join(os.homedir(), '.mercury', 'router.lock');
@@ -48,7 +49,8 @@ function releaseLock() { try { const pid=parseInt(fs.readFileSync(LOCK_FILE,'utf
 // Telegram bot
 let bot = null;
 const BOT_TOKEN = process.env.MERCURY_TELEGRAM_BOT_TOKEN;
-if (!process.env.MERCURY_NOTIFY_DISABLED && BOT_TOKEN) {
+// Issue #298: strict truthy check — '0', 'false', 'no', 'off', '', unset → enabled.
+if (!isEnvTruthy(process.env.MERCURY_NOTIFY_DISABLED) && BOT_TOKEN) {
   try {
     const TelegramBot = require('node-telegram-bot-api');
     bot = new TelegramBot(BOT_TOKEN, { polling: true });

--- a/adapters/mercury-channel-router/test/env.test.cjs
+++ b/adapters/mercury-channel-router/test/env.test.cjs
@@ -1,0 +1,54 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { isEnvTruthy } = require('../lib/env.cjs');
+
+test('isEnvTruthy: canonical truthy strings', () => {
+  for (const v of ['1', 'true', 'yes', 'on']) {
+    assert.strictEqual(isEnvTruthy(v), true, `expected ${JSON.stringify(v)} truthy`);
+  }
+});
+
+test('isEnvTruthy: case-insensitive', () => {
+  for (const v of ['TRUE', 'True', 'Yes', 'YES', 'On', 'ON']) {
+    assert.strictEqual(isEnvTruthy(v), true, `expected ${JSON.stringify(v)} truthy`);
+  }
+});
+
+test('isEnvTruthy: whitespace trimmed', () => {
+  for (const v of [' 1', '1 ', '  true  ', '\tyes\n', '\non\t']) {
+    assert.strictEqual(isEnvTruthy(v), true, `expected trim(${JSON.stringify(v)}) truthy`);
+  }
+});
+
+test('isEnvTruthy: literal 0 is NOT truthy (Issue #298 core bug)', () => {
+  assert.strictEqual(isEnvTruthy('0'), false);
+  assert.strictEqual(isEnvTruthy(' 0 '), false);
+});
+
+test('isEnvTruthy: explicit falsy strings', () => {
+  for (const v of ['false', 'False', 'FALSE', 'no', 'No', 'NO', 'off', 'Off']) {
+    assert.strictEqual(isEnvTruthy(v), false, `expected ${JSON.stringify(v)} falsy`);
+  }
+});
+
+test('isEnvTruthy: arbitrary strings falsy', () => {
+  for (const v of ['random', 'enable', 'disable', '2', '-1', 'truthy', 'y', 'n']) {
+    assert.strictEqual(isEnvTruthy(v), false, `expected ${JSON.stringify(v)} falsy`);
+  }
+});
+
+test('isEnvTruthy: empty / null / undefined are falsy', () => {
+  assert.strictEqual(isEnvTruthy(''), false);
+  assert.strictEqual(isEnvTruthy('   '), false);
+  assert.strictEqual(isEnvTruthy(null), false);
+  assert.strictEqual(isEnvTruthy(undefined), false);
+});
+
+test('isEnvTruthy: non-string inputs coerced via String()', () => {
+  assert.strictEqual(isEnvTruthy(1), true);
+  assert.strictEqual(isEnvTruthy(0), false);
+  assert.strictEqual(isEnvTruthy(true), true);
+  assert.strictEqual(isEnvTruthy(false), false);
+});

--- a/adapters/mercury-notify/README.md
+++ b/adapters/mercury-notify/README.md
@@ -32,7 +32,7 @@ No startup needed. `require` directly from any skill/hook emitting a user-action
 | Variable | Required | Description |
 |---|---|---|
 | `MERCURY_ROUTER_PORT` | No | IPC port (default: 8788) |
-| `MERCURY_NOTIFY_DISABLED` | No | Set to any value to skip all notifications silently |
+| `MERCURY_NOTIFY_DISABLED` | No | Truthy → skip all notifications silently. Accepted truthy values (case-insensitive, whitespace trimmed): `1`, `true`, `yes`, `on`. Any other value (incl. `0`, `false`, `no`, `off`, empty, unset) keeps notifications enabled. See Issue #298. |
 
 ## Setup
 
@@ -56,3 +56,4 @@ Logs to stderr only.
 
 - Bun is optional — Node 18+ works fine.
 - This module has no dependencies beyond Node built-ins.
+- `MERCURY_NOTIFY_DISABLED` env flag is parsed via `lib/env.cjs` strict truthy helper to match the `=== '1'` convention used elsewhere in Mercury (`mercury-loop-detector`, `mercury-test-gate`); see Issue #298.

--- a/adapters/mercury-notify/lib/env.cjs
+++ b/adapters/mercury-notify/lib/env.cjs
@@ -1,0 +1,15 @@
+'use strict';
+
+// Issue #298: strict env-flag parsing for MERCURY_NOTIFY_DISABLED (and any future
+// boolean env flag in this adapter). Accepts '1'/'true'/'yes'/'on' (case-insensitive,
+// surrounding whitespace trimmed). Returns false for unset, empty, '0', 'false', etc.
+// Loose `if (process.env.X)` checks were truthy for any non-empty string including
+// the literal '0', diverging from the strict `=== '1'` pattern used elsewhere in
+// Mercury (mercury-loop-detector, mercury-test-gate).
+const TRUTHY = new Set(['1', 'true', 'yes', 'on']);
+function isEnvTruthy(v) {
+  if (v == null) return false;
+  return TRUTHY.has(String(v).trim().toLowerCase());
+}
+
+module.exports = { isEnvTruthy };

--- a/adapters/mercury-notify/notify.cjs
+++ b/adapters/mercury-notify/notify.cjs
@@ -11,6 +11,7 @@
 const fs   = require('fs');
 const os   = require('os');
 const path = require('path');
+const { isEnvTruthy } = require('./lib/env.cjs');
 
 const PORT       = process.env.MERCURY_ROUTER_PORT || 8788;
 const TOKEN_FILE = path.join(os.homedir(), '.mercury', 'router.token');
@@ -20,7 +21,8 @@ function readToken() {
 }
 
 async function notify(severity, title, body, options = {}) {
-  if (process.env.MERCURY_NOTIFY_DISABLED) return { ok: true, skipped: true };
+  // Issue #298: strict truthy check — '0', 'false', 'no', 'off', '', unset → enabled.
+  if (isEnvTruthy(process.env.MERCURY_NOTIFY_DISABLED)) return { ok: true, skipped: true };
   const token = readToken();
   if (!token) return { ok: false, error: 'no_token' };
   try {

--- a/adapters/mercury-notify/test/env.test.cjs
+++ b/adapters/mercury-notify/test/env.test.cjs
@@ -1,0 +1,54 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { isEnvTruthy } = require('../lib/env.cjs');
+
+test('isEnvTruthy: canonical truthy strings', () => {
+  for (const v of ['1', 'true', 'yes', 'on']) {
+    assert.strictEqual(isEnvTruthy(v), true, `expected ${JSON.stringify(v)} truthy`);
+  }
+});
+
+test('isEnvTruthy: case-insensitive', () => {
+  for (const v of ['TRUE', 'True', 'Yes', 'YES', 'On', 'ON']) {
+    assert.strictEqual(isEnvTruthy(v), true, `expected ${JSON.stringify(v)} truthy`);
+  }
+});
+
+test('isEnvTruthy: whitespace trimmed', () => {
+  for (const v of [' 1', '1 ', '  true  ', '\tyes\n', '\non\t']) {
+    assert.strictEqual(isEnvTruthy(v), true, `expected trim(${JSON.stringify(v)}) truthy`);
+  }
+});
+
+test('isEnvTruthy: literal 0 is NOT truthy (Issue #298 core bug)', () => {
+  assert.strictEqual(isEnvTruthy('0'), false);
+  assert.strictEqual(isEnvTruthy(' 0 '), false);
+});
+
+test('isEnvTruthy: explicit falsy strings', () => {
+  for (const v of ['false', 'False', 'FALSE', 'no', 'No', 'NO', 'off', 'Off']) {
+    assert.strictEqual(isEnvTruthy(v), false, `expected ${JSON.stringify(v)} falsy`);
+  }
+});
+
+test('isEnvTruthy: arbitrary strings falsy', () => {
+  for (const v of ['random', 'enable', 'disable', '2', '-1', 'truthy', 'y', 'n']) {
+    assert.strictEqual(isEnvTruthy(v), false, `expected ${JSON.stringify(v)} falsy`);
+  }
+});
+
+test('isEnvTruthy: empty / null / undefined are falsy', () => {
+  assert.strictEqual(isEnvTruthy(''), false);
+  assert.strictEqual(isEnvTruthy('   '), false);
+  assert.strictEqual(isEnvTruthy(null), false);
+  assert.strictEqual(isEnvTruthy(undefined), false);
+});
+
+test('isEnvTruthy: non-string inputs coerced via String()', () => {
+  assert.strictEqual(isEnvTruthy(1), true);
+  assert.strictEqual(isEnvTruthy(0), false);
+  assert.strictEqual(isEnvTruthy(true), true);
+  assert.strictEqual(isEnvTruthy(false), false);
+});


### PR DESCRIPTION
## Summary
- Replace loose `if (process.env.MERCURY_NOTIFY_DISABLED)` truthy-on-any-non-empty-value checks at `adapters/mercury-notify/notify.cjs:23` and `adapters/mercury-channel-router/router.cjs:51` with a strict `isEnvTruthy()` helper (Set membership on `{'1','true','yes','on'}`, case-insensitive, whitespace-trimmed).
- Aligns notify-hub adapters with the `=== '1'` convention already used elsewhere in Mercury (`mercury-loop-detector/report.cjs:37`, `mercury-test-gate/hook.cjs:12`).
- Core bug fix: literal `'0'` was previously truthy and surprisingly disabled notifications. After this PR, `'0'`, `'false'`, `'no'`, `'off'`, empty, and unset all keep notifications enabled. Only the four canonical truthy strings disable.
- Helper duplicated per adapter (parallel `lib/env.cjs`) per CLAUDE.md "modular design" rule — each adapter must remain independently detachable, with no cross-adapter `require()`. Both copies cross-reference each other and must stay in sync.

## Scope
- 8 files: 152 insertions / 4 deletions
  - NEW `adapters/mercury-notify/lib/env.cjs` (15 LOC pure DI helper)
  - NEW `adapters/mercury-notify/test/env.test.cjs` (54 LOC, 8 node:test cases)
  - NEW `adapters/mercury-channel-router/lib/env.cjs` (19 LOC, sibling-sync comment)
  - NEW `adapters/mercury-channel-router/test/env.test.cjs` (54 LOC, parallel copy)
  - MOD `adapters/mercury-notify/notify.cjs` (require + wire helper at the one call site)
  - MOD `adapters/mercury-channel-router/router.cjs` (require + wire helper at the one call site)
  - MOD `adapters/mercury-notify/README.md` (document accepted truthy values + helper pointer)
  - MOD `adapters/mercury-channel-router/README.md` (document accepted truthy values + helper pointer)

## Verification
- ✅ 32/32 `node --test` PASS locally (8 env + 11 truncate + 13 register-upsert) — no regression
- ✅ dual-verify Claude PASS 0/0/0/0 + Codex PASS 0/0/0/0 (Codex job `task-mp9jlx2b-qtixz1`)
- ✅ `'1'` call site behavior preserved (existing `MERCURY_NOTIFY_DISABLED=1` users unaffected — same skip)
- ✅ Codex `git diff --check` clean (no whitespace/EOL issues)
- ✅ `.mercury/state/review-passed` set before commit

## Test plan
- [ ] Argus review iteration(s) on PR
- [ ] Fix per Argus findings if any (prefer reply-classification ACCEPT path)
- [ ] Merge after APPROVED + threads resolved + CI PASS
- [ ] Issue #298 auto-closes via `Closes #298` tag in commit body
- [ ] Post comprehensive close-comment on #298 with merge SHA

Closes #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)