### PR TITLE
fix(notify-hub): #407 security/correctness hardening of IPC + routing

### DIFF
--- a/adapters/mercury-channel-client/lib/mcp-tools.cjs
+++ b/adapters/mercury-channel-client/lib/mcp-tools.cjs
@@ -56,10 +56,16 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
       body: JSON.stringify({ chat_id, text, session_id: SESSION_ID }),
     });
     if (!res.ok) {
+      // Copilot iter-1 hint: drain body even when JSON parse fails so undici
+      // can reuse the connection. `await res.json()` consumes on success.
       let detail = `HTTP ${res.status}`;
-      try { const j = await res.json(); if (j && j.error) detail = `HTTP ${res.status}: ${j.error}`; } catch {}
+      try { const j = await res.json(); if (j && j.error) detail = `HTTP ${res.status}: ${j.error}`; }
+      catch { try { await res.text(); } catch {} }
       return { content: [{ type: 'text', text: `reply rejected by router: ${detail}` }], isError: true };
     }
+    // Drain the success-body so undici releases the keep-alive socket
+    // (Copilot iter-1) — router responds {ok:true} which we don't need to read.
+    try { await res.text(); } catch {}
     routerFetch(`/take-ownership/${SESSION_ID}`, { method: 'POST' }).catch(() => {});
     return { content: [{ type: 'text', text: 'reply sent' }] };
   } catch (e) {

--- a/adapters/mercury-channel-client/lib/mcp-tools.cjs
+++ b/adapters/mercury-channel-client/lib/mcp-tools.cjs
@@ -25,7 +25,9 @@ const mcp = new Server(
   }
 );
 
-// Tool: reply
+// Tool: reply. Issue #407 Codex Low: inputSchema mirrors the router-side
+// validation (lib/ipc.cjs `/reply` — chat_id integer, text non-empty trim) so
+// callers fail at schema-validation time instead of round-tripping a 400.
 mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
   tools: [{
     name: 'reply',
@@ -33,24 +35,31 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
     inputSchema: {
       type: 'object',
       properties: {
-        chat_id: { type: 'number', description: 'Telegram chat_id from the channel tag' },
-        text:    { type: 'string', description: 'Message text (HTML allowed)' },
+        chat_id: { type: 'integer', description: 'Telegram chat_id from the channel tag' },
+        text:    { type: 'string', minLength: 1, pattern: '\\S', description: 'Message text (HTML allowed; must contain non-whitespace)' },
       },
       required: ['chat_id', 'text'],
     },
   }],
 }));
 
+// Issue #407 Codex Medium: the router can now reject /reply with 400/413
+// (F1 + F3). Gate take-ownership on res.ok so a rejected reply does not
+// silently flip the active lane; surface the router's JSON error to MCP.
 mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
   if (req.params.name !== 'reply') throw new Error(`Unknown tool: ${req.params.name}`);
   const { chat_id, text } = req.params.arguments || {};
   try {
-    await routerFetch('/reply', {
+    const res = await routerFetch('/reply', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ chat_id, text, session_id: SESSION_ID }),
     });
-    // take ownership after responding
+    if (!res.ok) {
+      let detail = `HTTP ${res.status}`;
+      try { const j = await res.json(); if (j && j.error) detail = `HTTP ${res.status}: ${j.error}`; } catch {}
+      return { content: [{ type: 'text', text: `reply rejected by router: ${detail}` }], isError: true };
+    }
     routerFetch(`/take-ownership/${SESSION_ID}`, { method: 'POST' }).catch(() => {});
     return { content: [{ type: 'text', text: 'reply sent' }] };
   } catch (e) {
@@ -59,15 +68,21 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
 });
 
 // Outbound permission_request relay (ADR §5.2 step 6 + §7.6)
+// Issue #407 F4: `input_preview` is intentionally NOT forwarded. The router's
+// /permission-request handler (lib/ipc.cjs) only reads tool_name + description
+// + prefixed_request_id; the field used to carry raw tool input that could
+// include secrets (API keys, file contents) and never reached Telegram. Until
+// the router actually needs it, dropping it shrinks the IPC surface area and
+// removes a sensitive-data exfiltration path through router stderr logs.
 mcp.fallbackNotificationHandler = async (notification) => {
   if (notification.method !== 'notifications/claude/channel/permission_request') return;
-  const { tool_name = '', description = '', input_preview = '', request_id = '' } = notification.params || {};
+  const { tool_name = '', description = '', request_id = '' } = notification.params || {};
   const prefixed = `${SESSION_SHORT}-${request_id}`;
   try {
     await routerFetch('/permission-request', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ session_id: SESSION_ID, tool_name, description, input_preview, prefixed_request_id: prefixed }),
+      body: JSON.stringify({ session_id: SESSION_ID, tool_name, description, prefixed_request_id: prefixed }),
     });
   } catch (e) { process.stderr.write(`${TAG} permission-request relay failed: ${e.message}\n`); }
 };

--- a/adapters/mercury-channel-router/lib/body.cjs
+++ b/adapters/mercury-channel-router/lib/body.cjs
@@ -1,0 +1,54 @@
+'use strict';
+
+// Issue #407 F1: per-request body parser with byte cap, split from ipc.cjs to
+// stay under the #303 ≤200 LOC contract. bodyOf writes 413 + destroys the
+// socket on overflow; caller checks res.writableEnded in catch to skip the
+// fall-through 400. Buffer.concat at end-of-stream is mandatory: per-chunk
+// `String += buf` would coerce each chunk independently, emitting U+FFFD for
+// any UTF-8 codepoint split across two TCP frames (Claude dual-verify Medium).
+// Upper-clamp on MAX_BODY_BYTES prevents a misconfigured 1e308 env from
+// silently disabling the cap (Claude dual-verify Low). isSafeInteger is not
+// applicable here — chat_ids are out of scope; this is bytes.
+
+const _MBB_MAX = 16 * 1024 * 1024;                                                            // 16 MB hard ceiling
+const _MBB = Number(process.env.MERCURY_ROUTER_MAX_BODY_BYTES);
+const MAX_BODY_BYTES = Number.isFinite(_MBB) && _MBB >= 1
+  ? Math.min(Math.floor(_MBB), _MBB_MAX) : 65536;
+
+const writeJson = (res, code, obj) => {
+  res.writeHead(code, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(obj));
+};
+
+const bodyOf = (req, res) => new Promise((ok, fail) => {
+  const chunks = [];
+  let bytes = 0;
+  req.on('data', c => {
+    bytes += c.length;
+    if (bytes > MAX_BODY_BYTES) {
+      // writableEnded check covers a future caller that pre-writes headers
+      // before awaiting bodyOf — current ipc.cjs sites are all pre-await.
+      if (res && !res.headersSent && !res.writableEnded) {
+        // Schedule socket destroy AFTER res.end flushes the 413 body so
+        // well-behaved clients still receive the status + JSON before the
+        // connection drops (Claude dual-verify Low). Fallback destroys
+        // immediately if `end` never fires (hostile client streaming forever).
+        res.writeHead(413, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'request body too large', max: MAX_BODY_BYTES }), () => {
+          try { req.socket && req.socket.destroy(); } catch {}
+        });
+      } else {
+        try { req.socket && req.socket.destroy(); } catch {}
+      }
+      return fail(Object.assign(new Error('body too large'), { code: 'BODY_TOO_LARGE' }));
+    }
+    chunks.push(c);
+  });
+  req.on('end', () => {
+    try { ok(JSON.parse(Buffer.concat(chunks).toString('utf8') || '{}')); }
+    catch (e) { fail(e); }
+  });
+  req.on('error', fail);
+});
+
+module.exports = { bodyOf, MAX_BODY_BYTES, writeJson };

--- a/adapters/mercury-channel-router/lib/body.cjs
+++ b/adapters/mercury-channel-router/lib/body.cjs
@@ -23,16 +23,26 @@ const writeJson = (res, code, obj) => {
 const bodyOf = (req, res) => new Promise((ok, fail) => {
   const chunks = [];
   let bytes = 0;
+  let settled = false;
+  // settled flag + listener teardown is Argus iter-2 hardening: prevents
+  // duplicate ok/fail on a hostile client that keeps streaming after the
+  // overflow + 413 (CPU amplification) and prevents the Promise from
+  // hanging if the client aborts mid-stream before `end` fires.
+  const done = (val, err) => {
+    if (settled) return;
+    settled = true;
+    try { req.removeAllListeners('data'); req.removeAllListeners('end'); req.removeAllListeners('error'); req.removeAllListeners('close'); req.pause && req.pause(); } catch {}
+    if (err) fail(err); else ok(val);
+  };
   req.on('data', c => {
     bytes += c.length;
     if (bytes > MAX_BODY_BYTES) {
       // writableEnded check covers a future caller that pre-writes headers
       // before awaiting bodyOf — current ipc.cjs sites are all pre-await.
       if (res && !res.headersSent && !res.writableEnded) {
-        // Schedule socket destroy AFTER res.end flushes the 413 body so
-        // well-behaved clients still receive the status + JSON before the
-        // connection drops (Claude dual-verify Low). Fallback destroys
-        // immediately if `end` never fires (hostile client streaming forever).
+        // socket destroy in res.end callback so well-behaved clients receive
+        // the 413 body (Claude dual-verify Low). Fallback destroys immediately
+        // if `end` never fires (hostile client streaming forever).
         res.writeHead(413, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ error: 'request body too large', max: MAX_BODY_BYTES }), () => {
           try { req.socket && req.socket.destroy(); } catch {}
@@ -40,15 +50,18 @@ const bodyOf = (req, res) => new Promise((ok, fail) => {
       } else {
         try { req.socket && req.socket.destroy(); } catch {}
       }
-      return fail(Object.assign(new Error('body too large'), { code: 'BODY_TOO_LARGE' }));
+      return done(undefined, Object.assign(new Error('body too large'), { code: 'BODY_TOO_LARGE' }));
     }
     chunks.push(c);
   });
   req.on('end', () => {
-    try { ok(JSON.parse(Buffer.concat(chunks).toString('utf8') || '{}')); }
-    catch (e) { fail(e); }
+    try { done(JSON.parse(Buffer.concat(chunks).toString('utf8') || '{}')); }
+    catch (e) { done(undefined, e); }
   });
-  req.on('error', fail);
+  req.on('error', e => done(undefined, e));
+  // Argus iter-2 Medium: client abort fires 'close' with !req.complete before
+  // 'end' if disconnected mid-stream. Reject so callers don't hang forever.
+  req.on('close', () => { if (!req.complete) done(undefined, Object.assign(new Error('client aborted'), { code: 'ABORTED' })); });
 });
 
 module.exports = { bodyOf, MAX_BODY_BYTES, writeJson };

--- a/adapters/mercury-channel-router/lib/ipc.cjs
+++ b/adapters/mercury-channel-router/lib/ipc.cjs
@@ -8,6 +8,7 @@ const http = require('http');
 const fs = require('fs');
 const path = require('path');
 const state = require('./state.cjs');
+const { bodyOf, MAX_BODY_BYTES } = require('./body.cjs');
 
 const { TAG, TOKEN, TOKEN_FILE, LOCK_FILE, MAX_SESS } = state;
 
@@ -78,14 +79,8 @@ function releaseLock() {
   } catch {}
 }
 
-// JSON response helper + body parser.
+// JSON response helper. bodyOf lives in body.cjs (#407 F1 split).
 const json = (res, code, obj) => { res.writeHead(code, { 'Content-Type': 'application/json' }); res.end(JSON.stringify(obj)); };
-const bodyOf = req => new Promise((ok, fail) => {
-  let b = '';
-  req.on('data', c => b += c);
-  req.on('end', () => { try { ok(JSON.parse(b || '{}')); } catch (e) { fail(e); } });
-  req.on('error', fail);
-});
 
 // Factory — http.Server with routes wired against caller-supplied behavior
 // callbacks (deriveLabel/scheduleShutdown → routing.cjs, tgSend/htmlEsc →
@@ -123,7 +118,7 @@ function createServer({ deriveLabel, scheduleShutdown, tgSend, htmlEsc }) {
       return;
     }
     if (m === 'POST' && url === '/register') {
-      let body; try { body = await bodyOf(req); } catch { return json(res, 400, { error: 'bad json' }); }
+      let body; try { body = await bodyOf(req, res); } catch { if (res.writableEnded) return; return json(res, 400, { error: 'bad json' }); }
       // Argus #297 iter-1: session_id is an externally-supplied identifier that
       // flows into stderr logs and Map keys. Restrict to a controlled charset
       // and length to defend against log injection and unbounded memory growth
@@ -165,7 +160,7 @@ function createServer({ deriveLabel, scheduleShutdown, tgSend, htmlEsc }) {
       return json(res, 200, { ok: true });
     }
     if (m === 'POST' && url === '/notify') {
-      let body; try { body = await bodyOf(req); } catch { return json(res, 400, { error: 'bad json' }); }
+      let body; try { body = await bodyOf(req, res); } catch { if (res.writableEnded) return; return json(res, 400, { error: 'bad json' }); }
       const { severity = 'info', title = '', body: mb = '', label: fl } = body;
       const lbl = fl || (state.sessions.get(state.activeId)?.label) || 'mercury';
       const chatId = state.lastChatId || (process.env.MERCURY_TELEGRAM_CHAT_ID ? Number(process.env.MERCURY_TELEGRAM_CHAT_ID) : null);
@@ -173,15 +168,22 @@ function createServer({ deriveLabel, scheduleShutdown, tgSend, htmlEsc }) {
       return json(res, 200, { ok: true });
     }
     if (m === 'POST' && url === '/reply') {
-      let body; try { body = await bodyOf(req); } catch { return json(res, 400, { error: 'bad json' }); }
+      let body; try { body = await bodyOf(req, res); } catch { if (res.writableEnded) return; return json(res, 400, { error: 'bad json' }); }
+      // Issue #407 F3: strict typing on external IPC boundary — pre-#407 truthy
+      // check accepted 0/booleans/arrays/whitespace, surfacing opaque tgSend errors.
+      // isSafeInteger (not isInteger) rejects precision-lossy ids above 2^53-1,
+      // belt-and-braces against IPC callers that build chat_id from a string
+      // (Codex Low). Telegram channels use negative ids — both still pass.
       const { chat_id, text, label } = body;
-      if (!chat_id || !text) return json(res, 400, { error: 'chat_id and text required' });
+      if (!Number.isSafeInteger(chat_id) || typeof text !== 'string' || !text.trim()) {
+        return json(res, 400, { error: 'chat_id must be safe integer; text must be non-empty string' });
+      }
       const s = [...state.sessions.values()].find(x => x.id === body.session_id) || state.sessions.get(state.activeId);
       await tgSend(chat_id, `[${htmlEsc(label || (s?.label) || 'mercury')}] ${htmlEsc(text)}`);
       return json(res, 200, { ok: true });
     }
     if (m === 'POST' && url === '/permission-request') {
-      let body; try { body = await bodyOf(req); } catch { return json(res, 400, { error: 'bad json' }); }
+      let body; try { body = await bodyOf(req, res); } catch { if (res.writableEnded) return; return json(res, 400, { error: 'bad json' }); }
       const { tool_name = '', description = '', prefixed_request_id = '' } = body;
       const chatId = state.lastChatId || (process.env.MERCURY_TELEGRAM_CHAT_ID ? Number(process.env.MERCURY_TELEGRAM_CHAT_ID) : null);
       if (chatId) await tgSend(chatId, `Claude wants to run ${htmlEsc(tool_name)}: ${htmlEsc(description)}\n\nReply 'yes ${htmlEsc(prefixed_request_id)}' or 'no ${htmlEsc(prefixed_request_id)}'`);
@@ -193,5 +195,5 @@ function createServer({ deriveLabel, scheduleShutdown, tgSend, htmlEsc }) {
 
 module.exports = {
   writeToken, cleanupToken, safeUnlinkLock, acquireLock, releaseLock,
-  createServer, LOCK_ACQUIRE_RETRIES,
+  createServer, LOCK_ACQUIRE_RETRIES, MAX_BODY_BYTES,
 };

--- a/adapters/mercury-channel-router/lib/routing.cjs
+++ b/adapters/mercury-channel-router/lib/routing.cjs
@@ -176,11 +176,11 @@ async function routeMessage(msg) {
     await tgSend(chatId, `Verdict needs prefixed ID. Use 'yes &lt;short&gt;-&lt;id&gt;' from the request.`);
     return;
   }
-  const pM = text.match(/^@([\w-]+)\s+(.+)$/s);
+  // Issue #407 F2: resolveLane (ambiguity-aware) instead of startsWith (silent first-match).
+  const pM = text.match(/^@(#?[\w-]+)\s+(.+)$/s);
   if (pM) {
-    const t = [...state.sessions.values()].find(s => s.label.startsWith(pM[1]));
+    const t = await resolveLane(chatId, pM[1].replace(/^#/, ''));
     if (t) sendToInbox(t.id, { type: 'message', content: pM[2], from_chat: chatId });
-    else await tgSend(chatId, `No session matching @${htmlEsc(pM[1])}`);
     return;
   }
   if (!state.activeId || !state.sessions.has(state.activeId)) {

--- a/adapters/mercury-channel-router/test/hardening-407.test.cjs
+++ b/adapters/mercury-channel-router/test/hardening-407.test.cjs
@@ -1,0 +1,286 @@
+'use strict';
+
+// hardening-407.test.cjs — Issue #407 (notify-hub follow-up) regressions for
+// the four pre-existing-logic mitigations Argus flagged on PR #406:
+//   F1: bodyOf max-body cap (lib/body.cjs)        — behavioral 413 + env override
+//   F2: @<label> shorthand uses resolveLane       — structural (routing.cjs)
+//   F3: /reply chat_id integer + text non-empty   — behavioral 400
+//   F4: client drops input_preview IPC payload    — structural (mcp-tools.cjs)
+//
+// F1 and F3 spawn the real router and exercise the HTTP boundary — that is the
+// only place the size cap and validation actually live, and matches the test
+// pattern from register-upsert.test.cjs. F2 and F4 are source-level structural
+// assertions: behavioral coverage for F2 (Telegram message dispatch path) would
+// require booting grammy under test, which the existing suite intentionally
+// avoids (see housekeeping-304.test.cjs:11-14 rationale). The structural check
+// is sufficient to catch a regression that swaps resolveLane back to startsWith.
+
+const { test } = require('node:test');
+const assert  = require('node:assert/strict');
+const { spawn } = require('child_process');
+const path = require('path');
+const fs   = require('fs');
+const os   = require('os');
+
+const ROUTER = path.resolve(__dirname, '..', 'router.cjs');
+
+function pickPort() { return 19000 + Math.floor(Math.random() * 1000); }
+
+// Spawn the router with an isolated HOME (so token/lock files do not collide
+// with the production router) and an optional env overlay. Mirrors the helper
+// in register-upsert.test.cjs — duplicated here so #407 stays self-contained.
+async function withRouter(extraEnv, body) {
+  const PORT = pickPort();
+  const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'mcr-407-'));
+  const tokenFile = path.join(tmpHome, '.mercury', 'router.token');
+  const env = {
+    ...process.env,
+    HOME: tmpHome,
+    USERPROFILE: tmpHome,
+    MERCURY_ROUTER_PORT: String(PORT),
+    MERCURY_NOTIFY_DISABLED: '1',
+    MERCURY_TELEGRAM_BOT_TOKEN: '',
+    MERCURY_TELEGRAM_ALLOWED_USER_IDS: '',
+    ...extraEnv,
+  };
+  const child = spawn(process.execPath, [ROUTER], { env, stdio: ['ignore', 'pipe', 'pipe'] });
+  let listening = false;
+  child.stderr.on('data', d => { if (String(d).includes(`listening on 127.0.0.1:${PORT}`)) listening = true; });
+  for (let i = 0; i < 50 && !listening; i++) await new Promise(r => setTimeout(r, 100));
+  if (!listening) { child.kill('SIGKILL'); throw new Error(`router did not start on ${PORT}`); }
+  for (let i = 0; i < 20 && !fs.existsSync(tokenFile); i++) await new Promise(r => setTimeout(r, 50));
+  const token = fs.readFileSync(tokenFile, 'utf8').trim();
+  try {
+    await body({ PORT, token });
+  } finally {
+    child.kill('SIGTERM');
+    const exited = await new Promise(resolve => {
+      if (child.exitCode !== null || child.signalCode !== null) { resolve(true); return; }
+      const t = setTimeout(() => { child.removeListener('exit', onExit); resolve(false); }, 500);
+      const onExit = () => { clearTimeout(t); resolve(true); };
+      child.once('exit', onExit);
+    });
+    if (!exited) child.kill('SIGKILL');
+    try { fs.rmSync(tmpHome, { recursive: true, force: true }); } catch {}
+  }
+}
+
+const postRaw = (PORT, token, urlPath, body, contentType = 'application/json') =>
+  fetch(`http://127.0.0.1:${PORT}${urlPath}`, {
+    method: 'POST',
+    headers: { 'Content-Type': contentType, Authorization: `Bearer ${token}` },
+    body,
+  });
+
+// ─── F1: bodyOf max-body cap ─────────────────────────────────────────────────
+
+test('F1: POST body over MAX_BODY_BYTES returns 413 (default 64 KB cap)', async () => {
+  await withRouter({}, async ({ PORT, token }) => {
+    // 65 KB of JSON-shaped payload > 64 KB default cap.
+    const big = 'x'.repeat(65 * 1024);
+    const body = JSON.stringify({ session_id: 'sid', project_path: '/p', branch: 'b', pid: 1, short_id: 'aaaaaa', filler: big });
+    const r = await postRaw(PORT, token, '/register', body);
+    assert.equal(r.status, 413, 'oversized body must be rejected with 413');
+    const j = await r.json();
+    assert.equal(j.error, 'request body too large');
+    assert.equal(typeof j.max, 'number');
+  });
+});
+
+test('F1: MERCURY_ROUTER_MAX_BODY_BYTES env override is honored', async () => {
+  // Set a tiny cap; even a small valid body should now overflow.
+  await withRouter({ MERCURY_ROUTER_MAX_BODY_BYTES: '200' }, async ({ PORT, token }) => {
+    const body = JSON.stringify({ session_id: 'sid', project_path: '/p', branch: 'b', pid: 1, short_id: 'aaaaaa', filler: 'x'.repeat(300) });
+    const r = await postRaw(PORT, token, '/register', body);
+    assert.equal(r.status, 413);
+    const j = await r.json();
+    assert.equal(j.max, 200, 'env override must set the documented cap');
+  });
+});
+
+test('F1: small body under cap still routes normally', async () => {
+  await withRouter({}, async ({ PORT, token }) => {
+    const body = JSON.stringify({ session_id: 'sid-ok', project_path: '/p', branch: 'b', pid: 1, short_id: 'okokok' });
+    const r = await postRaw(PORT, token, '/register', body);
+    assert.equal(r.status, 200, 'normal payload must not be affected by the cap');
+  });
+});
+
+// ─── F3: /reply chat_id + text validation ────────────────────────────────────
+
+test('F3: /reply rejects non-integer chat_id with 400', async () => {
+  await withRouter({}, async ({ PORT, token }) => {
+    for (const bad of [{ chat_id: 'abc',  text: 'hi' },
+                       { chat_id: 12.5,   text: 'hi' },
+                       { chat_id: true,   text: 'hi' },
+                       { chat_id: null,   text: 'hi' }]) {
+      const r = await postRaw(PORT, token, '/reply', JSON.stringify(bad));
+      assert.equal(r.status, 400, `chat_id=${JSON.stringify(bad.chat_id)} must be rejected`);
+    }
+  });
+});
+
+test('F3: /reply rejects non-string or empty/whitespace text with 400', async () => {
+  await withRouter({}, async ({ PORT, token }) => {
+    for (const bad of [{ chat_id: 123, text: '' },
+                       { chat_id: 123, text: '   ' },
+                       { chat_id: 123, text: '\t\n' },
+                       { chat_id: 123, text: 42 },
+                       { chat_id: 123, text: null }]) {
+      const r = await postRaw(PORT, token, '/reply', JSON.stringify(bad));
+      assert.equal(r.status, 400, `text=${JSON.stringify(bad.text)} must be rejected`);
+      const j = await r.json();
+      assert.match(j.error, /chat_id.*safe integer.*text.*non-empty/);
+    }
+  });
+});
+
+test('F3: /reply rejects precision-lossy chat_id with 400 (Number.isSafeInteger guard)', async () => {
+  // Codex Low: isInteger accepts 2^53 + 1; isSafeInteger does not. Cheap
+  // defense-in-depth against IPC callers that build chat_id from a string.
+  await withRouter({}, async ({ PORT, token }) => {
+    const r = await postRaw(PORT, token, '/reply', JSON.stringify({ chat_id: Number.MAX_SAFE_INTEGER + 1, text: 'hi' }));
+    assert.equal(r.status, 400, 'chat_id above Number.MAX_SAFE_INTEGER must be rejected');
+  });
+});
+
+test('F3: /reply accepts valid integer chat_id + non-empty text (no Telegram chat known → still 200)', async () => {
+  // No active session + MERCURY_NOTIFY_DISABLED=1 means tgSend is a no-op,
+  // but the validation path must still return 200 for a well-formed body.
+  // Cover positive AND negative (Telegram channels use negative ids).
+  await withRouter({}, async ({ PORT, token }) => {
+    for (const cid of [12345, -1001234567890]) {
+      const r = await postRaw(PORT, token, '/reply', JSON.stringify({ chat_id: cid, text: 'hello' }));
+      assert.equal(r.status, 200, `valid chat_id=${cid} must pass validation`);
+    }
+  });
+});
+
+// ─── F2: structural — @<label> plain-text uses resolveLane ───────────────────
+
+test('F2: routeMessage uses resolveLane for plain @label shorthand', () => {
+  const src = fs.readFileSync(path.join(__dirname, '..', 'lib', 'routing.cjs'), 'utf8');
+  // Strip line comments so a future "// uses startsWith historically" comment
+  // does not get caught by the negative match below.
+  const code = src.split('\n').map(l => l.replace(/\/\/[^\n]*$/, '')).join('\n');
+  // Locate routeMessage and bound the search to its body (until next top-level
+  // declaration). routeMessage is the last named function in routing.cjs.
+  const idx = code.indexOf('async function routeMessage');
+  assert.ok(idx >= 0, 'routeMessage must exist in routing.cjs');
+  const body = code.slice(idx);
+  // Pre-#407: `state.sessions.values()].find(s => s.label.startsWith(pM[1]))`
+  // Post-#407: `resolveLane(chatId, pM[1].replace(/^#/, ''))`
+  assert.match(body, /resolveLane\(chatId,\s*pM\[1\]/,
+    'routeMessage @label shorthand must dispatch through resolveLane');
+  // The old startsWith pattern must not survive on the pM[1] path.
+  assert.doesNotMatch(body, /find\(s\s*=>\s*s\.label\.startsWith\(pM\[1\]\)\)/,
+    'legacy startsWith auto-pick on @label shorthand must be gone');
+});
+
+// ─── F4: structural — client drops input_preview from IPC payload ────────────
+
+test('F4: client mcp-tools.cjs no longer forwards input_preview to router', () => {
+  const clientSrc = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'mercury-channel-client', 'lib', 'mcp-tools.cjs'),
+    'utf8',
+  );
+  // Strip line comments — the file legitimately references input_preview in
+  // its #407 F4 explanation block; what matters is no code path serializes it.
+  const code = clientSrc.split('\n').map(l => l.replace(/\/\/[^\n]*$/, '')).join('\n');
+  assert.doesNotMatch(code, /input_preview/,
+    'client must not destructure or forward input_preview after #407 F4');
+});
+
+// ─── body.cjs sanity: MAX_BODY_BYTES env parsing covers garbage ──────────────
+
+test('body.cjs: MAX_BODY_BYTES parses env, falls back to 64 KB on garbage; clamps oversize', () => {
+  // Spawn a tiny harness that imports body.cjs with assorted env values and
+  // prints the resolved cap. Doing it in-process would not work — body.cjs
+  // reads process.env at require time and gets cached.
+  const MAX_CEIL = 16 * 1024 * 1024;
+  const cases = [
+    { env: undefined, expect: 65536 },
+    { env: 'abc',     expect: 65536 },
+    { env: '-100',    expect: 65536 },
+    { env: '0',       expect: 65536 },
+    { env: '1',       expect: 1 },
+    { env: '128.7',   expect: 128 },
+    { env: '1000000', expect: 1000000 },
+    { env: 'Infinity', expect: 65536 },                                       // non-finite → fallback
+    { env: '1e308',   expect: MAX_CEIL },                                     // Claude Low: oversize clamp
+    { env: String(MAX_CEIL + 1), expect: MAX_CEIL },                          // ceiling exact
+  ];
+  for (const { env, expect } of cases) {
+    const cleanEnv = { ...process.env };
+    delete cleanEnv.MERCURY_ROUTER_MAX_BODY_BYTES;
+    if (env !== undefined) cleanEnv.MERCURY_ROUTER_MAX_BODY_BYTES = env;
+    const out = require('child_process').spawnSync(
+      process.execPath,
+      ['-e', `console.log(require(${JSON.stringify(path.join(__dirname, '..', 'lib', 'body.cjs'))}).MAX_BODY_BYTES)`],
+      { env: cleanEnv, encoding: 'utf8' },
+    );
+    assert.equal(Number(out.stdout.trim()), expect,
+      `MERCURY_ROUTER_MAX_BODY_BYTES=${JSON.stringify(env)} expected ${expect}, got ${out.stdout.trim()}`);
+  }
+});
+
+// ─── body.cjs: Buffer.concat preserves multi-byte UTF-8 across chunk boundaries ──
+
+test('body.cjs: 4-byte emoji split across TCP frames decodes cleanly (Claude dual-verify Medium)', async () => {
+  // Pre-#407 (and pre-Claude-Medium-fix) the per-chunk `b += c` would have
+  // emitted U+FFFD replacement characters when a multi-byte codepoint was
+  // split across two `data` events. Buffer.concat at end-of-stream avoids it.
+  // We spin up the real router and POST a body whose payload includes a
+  // 4-byte emoji. The body is small enough that node typically delivers it
+  // as one chunk on localhost — to actually exercise the split, we send the
+  // body in two halves manually via raw `net` socket, splitting between
+  // bytes 2 and 3 of the emoji's UTF-8 encoding.
+  await withRouter({}, async ({ PORT, token }) => {
+    const net = require('net');
+    const emoji = '😀'; // U+1F600 → 0xF0 0x9F 0x98 0x80 (4 bytes)
+    const body = `{"session_id":"emoji-test","project_path":"/p","branch":"b","pid":1,"short_id":"emojis","label":"${emoji}"}`;
+    const buf = Buffer.from(body, 'utf8');
+    // Find the emoji's first byte (0xF0) and split between its 2nd + 3rd bytes.
+    const emojiStart = buf.indexOf(0xF0);
+    assert.ok(emojiStart >= 0, 'sanity: emoji must be present in test fixture');
+    const split = emojiStart + 2;
+    const head = buf.subarray(0, split);
+    const tail = buf.subarray(split);
+
+    const headers =
+      'POST /register HTTP/1.1\r\n' +
+      'Host: 127.0.0.1\r\n' +
+      `Authorization: Bearer ${token}\r\n` +
+      'Content-Type: application/json\r\n' +
+      `Content-Length: ${buf.length}\r\n` +
+      'Connection: close\r\n\r\n';
+
+    const statusLine = await new Promise((resolve, reject) => {
+      const sock = net.connect(PORT, '127.0.0.1', () => {
+        sock.write(headers);
+        sock.write(head);
+        // Give the server a tick to consume the first chunk so the emoji
+        // boundary is exercised across two `data` events.
+        setTimeout(() => sock.write(tail), 50);
+      });
+      let raw = '';
+      sock.on('data', c => { raw += c.toString('utf8'); });
+      sock.on('end', () => resolve(raw.split('\r\n', 1)[0] || ''));
+      sock.on('error', reject);
+    });
+    // We only need the status code; parsing the chunked body is fragile and
+    // not the point of this test. /sessions below is the actual assertion.
+    assert.match(statusLine, /^HTTP\/1\.1 200 /, `split-chunk register must return 200, got: ${statusLine}`);
+
+    // The label round-trips back via /sessions — must contain the original emoji,
+    // not U+FFFD replacement chars. If body.cjs had used `b += c` per-chunk,
+    // the boundary cut between bytes 2 and 3 of the emoji would have produced
+    // mojibake in the label.
+    const r = await fetch(`http://127.0.0.1:${PORT}/sessions`, { headers: { Authorization: `Bearer ${token}` } });
+    const sess = await r.json();
+    const e = sess.find(s => s.id === 'emoji-test');
+    assert.ok(e, 'session must be registered');
+    assert.equal(e.label, emoji, `label must round-trip cleanly; got ${JSON.stringify(e.label)}`);
+    assert.ok(!e.label.includes('�'), 'no U+FFFD replacement chars allowed');
+  });
+});

--- a/adapters/mercury-channel-router/test/hardening-407.test.cjs
+++ b/adapters/mercury-channel-router/test/hardening-407.test.cjs
@@ -60,7 +60,16 @@ async function withRouter(extraEnv, body) {
       const onExit = () => { clearTimeout(t); resolve(true); };
       child.once('exit', onExit);
     });
-    if (!exited) child.kill('SIGKILL');
+    if (!exited) {
+      child.kill('SIGKILL');
+      // Copilot iter-1: best-effort wait so the OS releases the port + flushes
+      // the child process before the next test (mirrors register-upsert.test.cjs).
+      await new Promise(resolve => {
+        if (child.exitCode !== null || child.signalCode !== null) { resolve(); return; }
+        const t = setTimeout(resolve, 500);
+        child.once('exit', () => { clearTimeout(t); resolve(); });
+      });
+    }
     try { fs.rmSync(tmpHome, { recursive: true, force: true }); } catch {}
   }
 }

--- a/adapters/mercury-channel-router/test/housekeeping-304.test.cjs
+++ b/adapters/mercury-channel-router/test/housekeeping-304.test.cjs
@@ -30,6 +30,9 @@ const stateSrc    = read('lib/state.cjs');
 const telegramSrc = read('lib/telegram.cjs');
 const ipcSrc      = read('lib/ipc.cjs');
 const routingSrc  = read('lib/routing.cjs');
+// Issue #407 F1: body.cjs split off from ipc.cjs to keep both under the
+// #303 ≤200 LOC contract — same structural cap applies.
+const bodySrc     = read('lib/body.cjs');
 
 test('#304 nit 1: magic numbers extracted to named constants in owning submodules', () => {
   // SHUTDOWN_GRACE_MS lives with scheduleShutdown() in routing.cjs.
@@ -99,7 +102,7 @@ test('#304 nit 4: bot init deferred — initBot() exists and runs after acquireL
     '`new Bot` must appear inside or after `function initBot`, never at module scope above it');
   // No other submodule should construct a Bot — that would defeat the
   // lock-gated singleton contract.
-  for (const [name, src] of [['router.cjs', routerSrc], ['lib/ipc.cjs', ipcSrc], ['lib/routing.cjs', routingSrc]]) {
+  for (const [name, src] of [['router.cjs', routerSrc], ['lib/ipc.cjs', ipcSrc], ['lib/routing.cjs', routingSrc], ['lib/body.cjs', bodySrc]]) {
     const stripped2 = src.split('\n').map(l => l.replace(/\/\/[^\n]*$/, '')).join('\n');
     assert.equal((stripped2.match(/new\s+Bot\b/g) || []).length, 0,
       `${name} must not construct a Bot`);
@@ -121,6 +124,7 @@ test('#303 split: router.cjs is wiring only (≤200 LOC) and all submodules ≤2
     'lib/telegram.cjs': lineCount(telegramSrc),
     'lib/ipc.cjs':      lineCount(ipcSrc),
     'lib/routing.cjs':  lineCount(routingSrc),
+    'lib/body.cjs':     lineCount(bodySrc),
   };
   for (const [name, lines] of Object.entries(limits)) {
     assert.ok(lines <= 200, `${name} is ${lines} LOC; #303 acceptance caps each submodule at ≤200`);


### PR DESCRIPTION
## Summary

Carves out the four Argus iter-1 findings on PR #406 (`#303` architectural split) that fell outside the zero-behavior-change refactor contract. Adds defensive hardening for the channel router/client IPC + routing surface area.

**Mitigations**:

- **F1** (`lib/body.cjs` NEW + `lib/ipc.cjs`): `bodyOf` max-body cap. 64 KB default, env-overridable via `MERCURY_ROUTER_MAX_BODY_BYTES` (clamped at 16 MB). Returns 413 + destroys socket on overflow with `res.end`-callback ordering so well-behaved clients receive the full response body before teardown. `Buffer.concat` at end-of-stream fixes a pre-existing UTF-8 chunk-boundary mojibake risk (Claude dual-verify Medium).
- **F2** (`lib/routing.cjs`): `routeMessage` `@<label> text` shorthand dispatches through `resolveLane` instead of legacy `startsWith` auto-pick. Surfaces ambiguity reply when two labels share a prefix (e.g. `@324` with `#324` + `#3247` present) — previously silently routed to insertion-order first match.
- **F3** (`lib/ipc.cjs`): `/reply` requires `Number.isSafeInteger(chat_id)` + non-empty `trim(text)`. Pre-#407 truthy check accepted `0`/booleans/arrays/whitespace, which only surfaced as opaque `tgSend error` log lines.
- **F4** (`mercury-channel-client/lib/mcp-tools.cjs`): drop `input_preview` from `/permission-request` IPC payload — router never read it; it carried potentially sensitive raw tool input (file contents, API keys) into router stderr logs. Also gates `/take-ownership` on `res.ok` so a 400/413 from F1/F3 no longer silently flips the active lane (Codex dual-verify Medium). MCP `inputSchema` tightened to mirror server boundary (Codex Low).

**LOC contract**: all 6 router submodules ≤200 — `router=56, state=38, telegram=153, ipc=199, routing=199, body=54`. `body.cjs` split was necessary to absorb F1's body cap + comment overhead while honoring #303 acceptance.

**Dual-verify**:
- Claude code-reviewer: APPROVED (1 Medium + 4 Low + 2 Nit; all Mediums + Lows addressed inline)
- Codex sync-audit R1 NEEDS-CHANGES (1 Medium + 1 Low) → R2 PASS via `scripts/codex-sync-audit.sh` canonical wrapper

## Test plan
- [x] 38/38 router tests pass + 27/27 client tests pass on Windows + Node 24 locally
- [x] 11 new test cases in `test/hardening-407.test.cjs` cover F1+F2+F3+F4 behaviorally/structurally + body.cjs env parsing (10 cases) + chunk-boundary UTF-8 emoji decode via raw `net` socket
- [x] `housekeeping-304.test.cjs` LOC dict + `new Bot` exclusion loop extended to `lib/body.cjs`
- [ ] Argus iter-1 review converges clean
- [ ] Copilot iter-1 review (if any) resolved

Closes #407