### PR TITLE
research(phase6): #411 GUI MVP scoping + Mode A decision landed

### DIFF
--- a/.mercury/docs/research/phase6-gui-mvp-agentview-backend-schema-2026-05.md
+++ b/.mercury/docs/research/phase6-gui-mvp-agentview-backend-schema-2026-05.md
@@ -8,8 +8,7 @@
 
 **Companion ADR**: `phase6-gui-mvp-tech-stack-2026-05.md`
 
-**Prior art**: [`agent-view-multi-lane-adaptation-2026-05.md`](agent-view-multi-lane-adaptation-2026-05.md) (PR #387, Closes #386) Phase 1+2 docs+empirical
-| [`agent-view-phase6-empirical-2026-05.md`](agent-view-phase6-empirical-2026-05.md) (PR #391, Closes #391) Phase 6 empirical
+**Prior art**: [`agent-view-multi-lane-adaptation-2026-05.md`](agent-view-multi-lane-adaptation-2026-05.md) (PR #387, Closes #386) Phase 1+2 docs+empirical; [`agent-view-phase6-empirical-2026-05.md`](agent-view-phase6-empirical-2026-05.md) (PR #391, Closes #391) Phase 6 empirical
 
 ---
 
@@ -96,7 +95,7 @@ Empirical inspection of 4 sample `~/.claude/jobs/<id>/state.json` files + `~/.cl
 |-------|------|-------|
 | `proto` | int | schema version (currently 1) |
 | `supervisorPid` | int | per-user supervisor process pid |
-| `updatedAt` | unix ms | 最后 supervisor heartbeat — staleness 指标 (e.g. >1h → 1h-timeout 已 fire, supervisor process 释放) |
+| `updatedAt` | unix ms | 最后 supervisor heartbeat — staleness 指标 (e.g. >1h → 1h-timeout 已 fire, supervisor process 释放). **Time-format note**: roster.json `updatedAt` uses unix milliseconds (e.g. `1778822198033`), while state.json `createdAt`/`updatedAt`/`firstTerminalAt` use ISO 8601 (`"2026-05-14T16:42:55.110Z"`). GUI parsers MUST dispatch on file source — do NOT assume uniform time format across Mercury read-side data sources. |
 | `workers` | object (map) | active worker process map; key 推断是 daemonShort / sessionId, 当前为空 (no active session at inspection time) |
 
 **关系**: `roster.json.workers[<key>]` ↔ `jobs/<id>/state.json` 1:1 (active sessions); jobs/<id>/state.json 在 supervisor 释放后 persist (1h timeout 后 process die 但 state.json 留盘). Mercury GUI 用 `roster.json.workers` 判断 "live" vs "stopped" sessions。

--- a/.mercury/docs/research/phase6-gui-mvp-agentview-backend-schema-2026-05.md
+++ b/.mercury/docs/research/phase6-gui-mvp-agentview-backend-schema-2026-05.md
@@ -1,0 +1,228 @@
+# Phase 6 GUI MVP — Agent view backend data source schema (empirical)
+
+**Issue**: [#411](https://github.com/392fyc/Mercury/issues/411) (research-front, sub-task 1-3 + 5)
+
+**Status**: Phase 1 — empirical schema record (S120, 2026-05-19)
+
+**Session**: S120 (main lane)
+
+**Companion ADR**: `phase6-gui-mvp-tech-stack-2026-05.md`
+
+**Prior art**: [`agent-view-multi-lane-adaptation-2026-05.md`](agent-view-multi-lane-adaptation-2026-05.md) (PR #387, Closes #386) Phase 1+2 docs+empirical
+| [`agent-view-phase6-empirical-2026-05.md`](agent-view-phase6-empirical-2026-05.md) (PR #391, Closes #391) Phase 6 empirical
+
+---
+
+## TL;DR
+
+Empirical inspection of 4 sample `~/.claude/jobs/<id>/state.json` files + `~/.claude/daemon/roster.json` + `~/.claude/jobs/pins.json` + `claude agents` CLI 验证 + `timeline.jsonl` 新发现, 为 #411 GUI MVP 的 read-side data layer 建立 schema baseline。
+
+**3 个关键发现矫正 #411 body 描述**:
+
+1. **state.json `state` 字段实际枚举值** ≠ 6-value display taxonomy (Working / Needs input / Idle / Completed / Failed / Stopped). 4 samples 全部 `state: "done"` — 推断 docs taxonomy 是 GUI display layer, raw state.json 用底层 token。Mercury GUI 不能简单 string match docs taxonomy, 需建立 state-token → display-label 映射。
+2. **`claude agents` CLI 不可在 non-interactive shell parse** — 报错 `"requires an interactive terminal (stdout is not a TTY)"`. Filter primitives `a:<agent>` / `s:<state>` / `#<PR>` 报错 `"too many arguments for 'agents'. Expected 0 arguments but got 1."` → 推断这些是 interactive REPL 输入, 不是 CLI flag。**Mercury GUI 不能 spawn `claude agents` parse stdout** — 必须直接读 `~/.claude/jobs/*/state.json` + `~/.claude/daemon/roster.json` 自己构建 view。
+3. **新发现 `timeline.jsonl` 字段** — 同目录 sibling file, 含 `{at, state, detail, text}` 转换历史, 适合 GUI 时间轴 (scenario 2 of #411 body)。**`~/.claude/jobs/<id>/timeline.jsonl` 应纳入 read-side data source list**。
+
+---
+
+## state.json 字段 schema (4 samples, 2026-05-14 ~ 2026-05-15)
+
+### Sample identification
+
+| Sample id | template | intent | cliVersion |
+|-----------|----------|--------|------------|
+| `1baace78` | `bg` (--help respawn) | (empty) | (absent — older session) |
+| `40726463` | `research` (subagent) | `What is 2+2? Answer in one sentence then stop.` | `2.1.142` |
+| `a06e1416` | `bg` | `echo from-bg-probe-test` | `2.1.141` |
+| `a8c58664` | `bg` (Edit tool fire) | `Use the Edit tool to modify ... probe1-target.txt ...` | `2.1.142` |
+
+### Field schema — required (present in all 4)
+
+| Field | Type | Sample value | Notes |
+|-------|------|--------------|-------|
+| `state` | string | `"done"` (all 4) | **底层 token, NOT display taxonomy**. 推断其它 token: `working` / `idle` / `needs_input` / `failed` / `stopped` — 需 empirical capture (Phase 2). |
+| `detail` | string | `"answered 2+2=4 in one sentence"`, `"echoed from-bg-probe-test"`, `"(idle — send a prompt to start)"`, `"Edit applied to probe1-target.txt in worktree; file written with both target lines; worktree preserved on worktree-phase6-probe-1 branch; session returned to main"` | 一句话总结, 适合 GUI list item subtitle |
+| `tempo` | string | `"idle"` (all 4) | 似 state 的延迟版 — 推断有 `"active"` / `"slow"` 等 token (UNVERIFIED) |
+| `output` | object\|null | `{"result": "2+2 = 4"}`, `{"result": "from-bg-probe-test"}`, `{"result": "probe1-target.txt edited and written; worktree phase6-probe-1 preserved"}`, `null` | 终态 output payload; null = 未完成 OR template 不产出 |
+| `children` | null | `null` (all 4) | 推断 subagent nested dispatch 才填 — agent-teams 原语 |
+| `linkScanOffset` | int | `0`, `17321`, `53522`, `142682` | byte offset 进 transcript jsonl, internal pagination cursor |
+| `template` | string | `"bg"` (3), `"research"` (1) | dispatch template — `bg` (`claude --bg`) vs `research`/`dev`/etc (`claude --bg --agent <name>`) |
+| `respawnFlags` | string[] | `["--help"]`, `["--agent", "research"]`, `[]` (2) | restart 时复用的 CLI args |
+| `intent` | string | first-line prompt | 适合 GUI list item title |
+| `sessionId` | string (UUID) | `1baace78-6b3a-478b-829b-0def2187745c` | full UUID, daemonShort 是 8-char prefix |
+| `resumeSessionId` | string (UUID) | == sessionId | resume target — 多数 case 等于 sessionId, 但理论可不同 (`claude --resume <id>`) |
+| `daemonShort` | string | `"1baace78"` (8 hex) | UUID prefix; `claude agents` filter 用这个 |
+| `cwd` | string | `"D:\\Mercury\\Mercury"` (all 4) | Windows backslash (JSON-escaped), **NOT POSIX**. GUI 需 normalize 用于 LANES.md cross-reference |
+| `createdAt` | ISO 8601 | `"2026-05-14T16:42:55.110Z"` | UTC, ms precision |
+| `updatedAt` | ISO 8601 | 同上 | 最近字段写入时间 |
+| `firstTerminalAt` | ISO 8601 | 同上 | 第一次 reach terminal state — elapsed = firstTerminalAt - createdAt |
+| `backend` | string | `"daemon"` (all 4) | supervisor backend; 推断有 `"local"` 等 token (UNVERIFIED) |
+
+### Field schema — optional (newer sessions only, cliVersion 2.1.141+)
+
+| Field | Type | Sample value | Notes |
+|-------|------|--------------|-------|
+| `inFlight` | object | `{"tasks": 0, "queued": 0, "kinds": []}` | mid-flight task counter; idle session = all zeros. 3/4 samples 含, 最老 `1baace78` 缺 (pre-2.1.141) |
+| `linkScanPath` | string | `"C:\\Users\\392fy\\.claude\\projects\\D--Mercury-Mercury\\<id>.jsonl"` | transcript file path; linkScanOffset 进该文件 |
+| `cliVersion` | string | `"2.1.141"` / `"2.1.142"` | CLI version when session created |
+| `name` | string | `"math calculation response"`, `"from-bg-probe-test"`, `"phase6-probe file editing"` | auto-generated display name (LLM-sourced from intent) |
+| `nameSource` | string | `"auto"` (all 3 with name field) | 推断有 `"manual"` token if user supplies via `claude --bg --name <x>` |
+
+### Field schema — mid-flight only (per #386 ADR Phase 6 §state worktreePath empirical)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `worktreePath` | string | 仅 PreToolUse-trigger Edit + EnterWorktree path 之间 mid-flight 期间出现 (per `agent-view-phase6-empirical-2026-05.md`); terminal state 时移除 (S120 4 samples 全 terminal, 故全部 absent) |
+| `worktreeBranch` | string | 同上 mid-flight only |
+
+**Schema-tolerant parsing 必须**: Mercury GUI 读 state.json 必须 defensive (missing inFlight / linkScanPath / cliVersion / name / nameSource on older sessions; missing worktreePath / worktreeBranch on terminal sessions; potentially missing children / output / respawnFlags on edge cases)。
+
+---
+
+## roster.json 字段 schema
+
+```json
+{
+  "proto": 1,
+  "supervisorPid": 2240,
+  "updatedAt": 1778822198033,
+  "workers": {}
+}
+```
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `proto` | int | schema version (currently 1) |
+| `supervisorPid` | int | per-user supervisor process pid |
+| `updatedAt` | unix ms | 最后 supervisor heartbeat — staleness 指标 (e.g. >1h → 1h-timeout 已 fire, supervisor process 释放) |
+| `workers` | object (map) | active worker process map; key 推断是 daemonShort / sessionId, 当前为空 (no active session at inspection time) |
+
+**关系**: `roster.json.workers[<key>]` ↔ `jobs/<id>/state.json` 1:1 (active sessions); jobs/<id>/state.json 在 supervisor 释放后 persist (1h timeout 后 process die 但 state.json 留盘). Mercury GUI 用 `roster.json.workers` 判断 "live" vs "stopped" sessions。
+
+---
+
+## pins.json 字段 schema
+
+```json
+[]
+```
+
+`~/.claude/jobs/pins.json` 当前为空 array。推断: user pin 操作 (e.g. `claude agents` 内 pin shortcut) 将 sessionId / daemonShort 加入。**Mercury GUI v1 可忽略**, v2+ 若实现 pin 功能再纳入。
+
+---
+
+## timeline.jsonl 字段 schema (新发现, NOT in #411 body)
+
+`~/.claude/jobs/<id>/timeline.jsonl` — 每行 1 个 JSON event:
+
+```json
+{"at":"2026-05-15T05:10:53.100Z","state":"done","detail":"answered 2+2=4 in one sentence","text":"2+2 等于 4。"}
+{"at":"2026-05-15T05:12:10.337Z","state":"done","detail":"Edit applied to probe1-target.txt in worktree; ...","text":"Edit applied in isolated worktree at `.claude/worktrees/phase6-probe-1/.tmp/phase6-probe/probe1-target.txt`. Exiting per instruction.\n\nProbe-1 complete. ..."}
+{"at":"2026-05-14T16:43:12.094Z","state":"done","detail":"echoed from-bg-probe-test","text":"from-bg-probe-test"}
+```
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `at` | ISO 8601 | event timestamp |
+| `state` | string | state token at event (匹配 state.json.state) |
+| `detail` | string | 同 state.json.detail |
+| `text` | string | full LLM output (state.json.output.result 是缩略, text 是 raw) |
+
+**3 samples 全部仅含 terminal event** — 推断仅 terminal transitions logged (没有 mid-flight `state: "working"` event). UNVERIFIED — 需 catch mid-flight session 验证。
+
+**Mercury GUI relevance**: timeline.jsonl 适合 #411 scenario 2 "跨 session 时间轴" 视觉化 — per-session event log → tree/timeline UI. **MUST add to read-side data source list**。
+
+---
+
+## `claude agents` CLI 验证 — 关键负面发现
+
+| Command | Result | Implication |
+|---------|--------|-------------|
+| `claude agents` | `'claude agents' requires an interactive terminal (stdout is not a TTY) — open a new terminal and run it there.` | non-TTY 不可调用; Mercury GUI 不能 spawn-and-parse |
+| `claude agents a:dev` | `error: too many arguments for 'agents'. Expected 0 arguments but got 1.` | filter 不是 CLI arg |
+| `claude agents s:idle` | 同上 | 同上 |
+
+**结论**: `claude agents` 是 interactive TUI / REPL 命令, 不是 batch CLI。**Mercury GUI 的读 path 必须 bypass 该 CLI**, 直接读 `~/.claude/jobs/*/state.json` + `~/.claude/daemon/roster.json` + `~/.claude/jobs/<id>/timeline.jsonl` 自己 aggregate。Filter primitives `a:` / `s:` / `#` 由 Mercury GUI 自己实现 (用 state.json.template / state.json.state / state.json.intent regex 等)。
+
+**对 #389 (lane-status.sh POC) 的 implication**: #389 已正确选择 "read state.json + roster.json group by cwd" 路径 (不依赖 `claude agents` CLI). 该路径已 docs-evidence 验证 (无 CLI 可用) — #389 仍 strictly viable, NOT 被 `claude agents` CLI replace。
+
+---
+
+## #389 prior-art audit
+
+`gh issue view 389` 检查 (S120 2026-05-19):
+
+| Aspect | #389 (shell POC) | #411 (GUI MVP) |
+|--------|------------------|----------------|
+| 标题 | "(optional) lane-status.sh POC: read state.json + roster.json group by cwd" | "Phase 6 GUI MVP — Mercury self-built GUI consuming agent view backend as data source" |
+| 数据源 | `~/.claude/jobs/*/state.json` + `~/.claude/daemon/roster.json` | **同左** + timeline.jsonl + LANES.md + cost-tracker jsonl + mem0 + gh CLI |
+| 分组 key | by `cwd` field | by lane (cross-ref LANES.md.Worktree path) |
+| 输出 | 终端表格 (shell stdout) | GUI (form factor TBD) |
+| Scope | shell script POC | full Mode A planning + ADR + implementation Issue chain |
+| Priority | P3 OPTIONAL | P2 research |
+| State | OPEN | OPEN |
+
+**Verdict**: **#389 NOT superseded by #411**. 关系是 layered:
+
+- **#389 = #411 的 data-layer POC / CLI-fallback alternative**
+- 若 #411 GUI 落地, #389 仍价值 (shell-script monitor for headless / SSH session use case)
+- 若 #389 先落地 (e.g. autorun-safe shell-only path), 可作为 #411 GUI 的 backend data adapter
+
+**S120 recommendation**: keep #389 OPEN as P3 OPTIONAL. **不 close**, **不 fold into #411**. 在 #411 implementation Issue chain file 时 ([未来 sub-Issue]), 可引用 #389 作为 prior-art / CLI 副产品。
+
+---
+
+## 综合 — Mercury GUI read-side data source 清单 (per v1 scope user decision 2026-05-20)
+
+User S120 Mode A 决策 (2026-05-20): v1 scope = scenarios **1 + 5 only** (cross-lane snapshot + Issue/PR dashboard); scenarios 2 + 3 + 4 推迟 v2+。
+
+### v1 in-scope data sources (scenarios 1 + 5)
+
+```
+~/.claude/jobs/<id>/state.json       — per-session 主状态 (22 fields, schema-tolerant 必需) — scenario 1
+~/.claude/daemon/roster.json          — supervisor heartbeat + active-worker registry — scenario 1
+LANES.md                              — Mercury lane registry (group key = cwd → lane) — scenario 1
+gh CLI (Issue/PR state)               — scenario 5
+```
+
+### v2+ deferred data sources (scenarios 2 / 3 / 4)
+
+```
+~/.claude/jobs/<id>/timeline.jsonl    — per-session 事件流 (4 fields, NEW finding S120) — scenario 2 跨 session 时间轴
+memory/sessions/S<N>(-<lane>)?.md     — per-session SoT (Mercury 自建) — scenario 2
+memory/session-handoff(-<lane>)?.md   — handoff doc (跨 session 持久态) — scenario 2
+~/.claude/scripts/cost-tracker/<id>.jsonl — cost-tracker (#361) — scenario 4 cost trend chart
+[Phase 5 Notify Hub IPC]              — scenario 3 桌面端反向控制台
+~/.claude/jobs/pins.json              — pin 列表 (v1 可忽略, v2+ 若实现 pin 功能再纳入)
+```
+
+**read-only 严格**: 所有 `~/.claude/` 下文件 Anthropic owned, Mercury GUI **不可 write/delete**。Mercury 自建文件 (memory/, .mercury/) Mercury owned, GUI 可 read/edit (但 v1 推荐 read-only)。
+
+**Polling vs file-watcher** (Mode A blocker, 留 user 决策):
+- chokidar (npm, ESM-only v5 from Nov 2025, node 20+ min) 是 cross-platform 标准方案
+- Windows recursive watching 已 native support (chokidar README)
+- 备选: 5-15s polling — 简单但 CPU/IO 浪费
+- 推荐预选: chokidar 监听 `~/.claude/jobs/*/state.json` + `~/.claude/jobs/*/timeline.jsonl` + `~/.claude/daemon/roster.json` (3 path glob, debounce 200-500ms)
+
+---
+
+## Open questions (carry into tech stack ADR)
+
+1. state.json `state` 完整 token 集 (除 `"done"` 外的 `"working"` / `"idle"` / `"failed"` / 等具体字符串) — 需 mid-flight + failed + stopped session 各 capture 1 个。S120 仅 4 terminal samples, 不充分。
+2. `tempo` 字段除 `"idle"` 外的其它 token (推断 `"active"` / `"slow"` 但 UNVERIFIED)
+3. `backend` 字段除 `"daemon"` 外的 token (UNVERIFIED)
+4. timeline.jsonl mid-flight events 是否 logged (S120 3 samples 全 terminal-only)
+5. roster.json.workers map 结构 (S120 captured 时全空, 需 active session 期间 capture)
+
+**这些 UNVERIFIED 项不阻塞 #411 Mode A 决策** — GUI 设计阶段 schema-tolerant 即可。Phase 2+ 实现期间 empirical capture 补全。
+
+---
+
+## References
+
+- [`agent-view-multi-lane-adaptation-2026-05.md`](agent-view-multi-lane-adaptation-2026-05.md) — Phase 1+2 docs+empirical, PR #387 Closes #386
+- [`agent-view-phase6-empirical-2026-05.md`](agent-view-phase6-empirical-2026-05.md) — Phase 6 empirical, PR #391 Closes #391
+- [Anthropic docs: agent view](https://code.claude.com/docs/en/agent-view) — official agent view docs
+- [Issue #389](https://github.com/392fyc/Mercury/issues/389) — lane-status.sh POC (prior-art / CLI alternative, OPEN, keep)
+- [Issue #411](https://github.com/392fyc/Mercury/issues/411) — Phase 6 GUI MVP scoping (本 ADR target)
+- 4 sample state.json files inspected: `1baace78` / `40726463` / `a06e1416` / `a8c58664` (2026-05-14 ~ 2026-05-15)

--- a/.mercury/docs/research/phase6-gui-mvp-agentview-backend-schema-2026-05.md
+++ b/.mercury/docs/research/phase6-gui-mvp-agentview-backend-schema-2026-05.md
@@ -29,6 +29,8 @@ Empirical inspection of 4 sample `~/.claude/jobs/<id>/state.json` files + `~/.cl
 
 ### Sample identification
 
+> **PII note**: Raw JSON sample values below preserve `D:\Mercury\Mercury` (project-wide Mercury convention path, not user-specific) but mask Windows user directory `C:\Users\<user>\` (originally `C:\Users\392fy\`) per Mercury PII redaction convention. Mercury GUI implementation should normalize to `${HOME}` / `${CLAUDE_CONFIG_DIR}` / `${USERPROFILE}` env-vars rather than hardcoding any specific user path.
+
 | Sample id | template | intent | cliVersion |
 |-----------|----------|--------|------------|
 | `1baace78` | `bg` (--help respawn) | (empty) | (absent — older session) |
@@ -63,7 +65,7 @@ Empirical inspection of 4 sample `~/.claude/jobs/<id>/state.json` files + `~/.cl
 | Field | Type | Sample value | Notes |
 |-------|------|--------------|-------|
 | `inFlight` | object | `{"tasks": 0, "queued": 0, "kinds": []}` | mid-flight task counter; idle session = all zeros. 3/4 samples 含, 最老 `1baace78` 缺 (pre-2.1.141) |
-| `linkScanPath` | string | `"C:\\Users\\392fy\\.claude\\projects\\D--Mercury-Mercury\\<id>.jsonl"` | transcript file path; linkScanOffset 进该文件 |
+| `linkScanPath` | string | `"C:\\Users\\<user>\\.claude\\projects\\D--Mercury-Mercury\\<id>.jsonl"` | transcript file path; linkScanOffset 进该文件 |
 | `cliVersion` | string | `"2.1.141"` / `"2.1.142"` | CLI version when session created |
 | `name` | string | `"math calculation response"`, `"from-bg-probe-test"`, `"phase6-probe file editing"` | auto-generated display name (LLM-sourced from intent) |
 | `nameSource` | string | `"auto"` (all 3 with name field) | 推断有 `"manual"` token if user supplies via `claude --bg --name <x>` |

--- a/.mercury/docs/research/phase6-gui-mvp-agentview-backend-schema-2026-05.md
+++ b/.mercury/docs/research/phase6-gui-mvp-agentview-backend-schema-2026-05.md
@@ -182,7 +182,10 @@ User S120 Mode A 决策 (2026-05-20): v1 scope = scenarios **1 + 5 only** (cross
 ```
 ~/.claude/jobs/<id>/state.json       — per-session 主状态 (22 fields, schema-tolerant 必需) — scenario 1
 ~/.claude/daemon/roster.json          — supervisor heartbeat + active-worker registry — scenario 1
-LANES.md                              — Mercury lane registry (group key = cwd → lane) — scenario 1
+${MERCURY_MEMORY_DIR:-${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/D--Mercury-Mercury/memory}/LANES.md
+                                      — Mercury lane registry (group key = cwd → lane) — scenario 1
+                                        canonical path per `scripts/lane-assertion.sh:128-131` (user-memory, NOT repo file).
+                                        Override env: `MERCURY_MEMORY_DIR`. NO repo-root `LANES.md` exists.
 gh CLI (Issue/PR state)               — scenario 5
 ```
 
@@ -203,7 +206,7 @@ memory/session-handoff(-<lane>)?.md   — handoff doc (跨 session 持久态) �
 - chokidar (npm, ESM-only v5 from Nov 2025, node 20+ min) 是 cross-platform 标准方案
 - Windows recursive watching 已 native support (chokidar README)
 - 备选: 5-15s polling — 简单但 CPU/IO 浪费
-- 推荐预选: chokidar 监听 `~/.claude/jobs/*/state.json` + `~/.claude/jobs/*/timeline.jsonl` + `~/.claude/daemon/roster.json` (3 path glob, debounce 200-500ms)
+- 推荐预选 (**v1 scope only — scenarios 1+5**): chokidar 监听 `~/.claude/jobs/*/state.json` + `~/.claude/daemon/roster.json` + LANES.md (2-3 path glob, debounce 200-500ms). **`timeline.jsonl` NOT watched in v1** — scenario 2 deferred to v2+ per Mode A scope
 
 ---
 

--- a/.mercury/docs/research/phase6-gui-mvp-tech-stack-2026-05.md
+++ b/.mercury/docs/research/phase6-gui-mvp-tech-stack-2026-05.md
@@ -21,8 +21,8 @@
 | **Tauri** | v2.11.1 (2026-05-06) | ~10-30 MB | Rust + Web | Linux/macOS/Win + Android/iOS | **GA stable** | ★★★★★ (推荐 desktop primary) |
 | **Electron** | v42.1.0 (3 days pre-S120, ~2026-05-16) | ~100-150 MB | JS + Web | Linux/macOS/Win | **GA, hugely mature** | ★★★★ (bundle 大但 zero-friction) |
 | **Wails** | v3.0.0-alpha.93 (2026-05-17), v2 GA | ~20-50 MB | Go + Web | Linux/macOS/Win | **v3 alpha** (v2 GA OK) | ★★★ (Mercury 已 JS-heavy, Go 引入新 lang) |
-| **Textual** | **UNVERIFIED** (v3+ inferred from pypi; search 未给出 2026 specific version) | n/a (TUI) | Python | Linux/macOS/Win | **GA, Textualize active** | ★★★ (TUI 适合 dev/SSH 场景, 但 GUI 形态弱) |
-| **Pure Web (Next.js localhost)** | Next.js 15-16 **UNVERIFIED**, chokidar v5 (Nov 2025) | n/a (browser) | JS + Web | 任意 browser | **GA, hugely mature** | ★★★★ (但需用户开 browser, port 占用) |
+| **Textual** | v8.2.7 (2026-05-19) | n/a (TUI) | Python | Linux/macOS/Win | **GA, Textualize active** | ★★★ (TUI 适合 dev/SSH 场景, 但 GUI 形态弱) |
+| **Pure Web (Next.js localhost)** | Next.js 16.2.6 (16.2 release 2026-03-18), chokidar v5 (Nov 2025) | n/a (browser) | JS + Web | 任意 browser | **GA, hugely mature** | ★★★★ (但需用户开 browser, port 占用) |
 
 **预初步预排** (S120 不决策, 仅供 user Mode A 决策时参考):
 
@@ -153,7 +153,7 @@
 
 ### Verified facts (2026-05-19)
 
-- **Latest version**: UNVERIFIED (search 未给出 2026 specific version; [Textualize GitHub](https://github.com/Textualize/textual) 持续 active dev, 当前推断 v3.x — 需 `pip show textual` 验证)
+- **Latest version**: **v8.2.7** (released 2026-05-19) per [textual · PyPI](https://pypi.org/project/textual/) + [textual.textualize.io](https://textual.textualize.io/)
 - **License**: MIT
 - **Language**: Python (3.8+ typical)
 - **Cross-platform**: macOS + Linux + Windows
@@ -188,7 +188,7 @@
 
 ### Verified facts (2026-05-19)
 
-- **Next.js**: 15-16 (**UNVERIFIED** — 具体 latest version 未 pin via `npm view next version`; [vercel/next.js](https://github.com/vercel/next.js) active dev. Mode A 已选 Tauri 2, Next.js 仅作 alternative-not-chosen 参考)
+- **Next.js**: **v16.2.6** (16.2 major release 2026-03-18) per [nextjs.org/blog/next-16-2](https://nextjs.org/blog/next-16-2) + [Releases · vercel/next.js](https://github.com/vercel/next.js/releases). Mode A 已选 Tauri 2, Next.js 仅作 alternative-not-chosen 参考
 - **chokidar**: **v5** (Nov 2025), ESM-only, Node 20+ min — per [paulmillr/chokidar](https://github.com/paulmillr/chokidar) + [chokidar - npm](https://www.npmjs.com/package/chokidar)
 - **License**: chokidar MIT, Next.js MIT
 - **Languages**: JavaScript / TypeScript
@@ -278,20 +278,20 @@ S120 完成 5 sub-tasks + surface 4 axes to user via AskUserQuestion. User 选�
 - **Read-side data sources v1** (per companion schema ADR):
   - `~/.claude/jobs/<id>/state.json` (22 fields, schema-tolerant)
   - `~/.claude/daemon/roster.json` (4 fields)
-  - LANES.md (Mercury lane registry → cwd group key)
+  - `${MERCURY_MEMORY_DIR:-${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/D--Mercury-Mercury/memory}/LANES.md` (Mercury lane registry → cwd group key; canonical path per `scripts/lane-assertion.sh:128-131` — user-memory, NOT repo file. Override env: `MERCURY_MEMORY_DIR`)
   - gh CLI Issue/PR state (scenario 5)
 - **Read-side data sources DEFERRED v2+** (scenarios 2/3/4):
   - `~/.claude/jobs/<id>/timeline.jsonl` (scenario 2 跨 session 时间轴)
   - `~/.claude/scripts/cost-tracker/<id>.jsonl` (scenario 4 cost trend chart)
-- **System tray**: Tauri tray-icon plugin v1 desirable (close-to-tray UX)
-- **Single-instance lock**: Tauri single-instance plugin v1 (avoid multi-launch)
+- **System tray**: Tauri **core feature** `features = ["tray-icon"]` in Cargo.toml (NOT a plugin — renamed from `system-tray` in Tauri 2.0) per [System Tray | Tauri v2](https://v2.tauri.app/learn/system-tray/) — close-to-tray UX
+- **Single-instance lock**: Tauri `single-instance` **plugin** v1 (separate plugin, avoid multi-launch)
 
 ### Implementation Issue chain (filed post-decision)
 
 实施 work 由 dev-pipeline 跟进, 不在 S120 scope。建议 split 为:
 
 - **#411-A** (P2, lane:main, enhancement): Tauri 2 project scaffold + Mercury Windows MSI build + system tray + single-instance — bare app skeleton, no scenarios yet
-- **#411-B** (P2, lane:main, enhancement): Read-side data layer (state.json + roster.json + LANES.md parser; chokidar/notify file-watcher) — IPC commands defined
+- **#411-B** (P2, lane:main, enhancement): Read-side data layer (state.json + roster.json + user-memory `LANES.md` parser at `${MERCURY_MEMORY_DIR:-...}/LANES.md`; chokidar/notify file-watcher) — IPC commands defined
 - **#411-C** (P2, lane:main, enhancement): UI scenario 1 — cross-lane snapshot (4 active lanes + active PR + 5h usage marker)
 - **#411-D** (P2, lane:main, enhancement): UI scenario 5 — Issue/PR dashboard (gh CLI integration + label/lane/Phase filter)
 - **#411 itself**: closes with this ADR PR (research + decision finalized)

--- a/.mercury/docs/research/phase6-gui-mvp-tech-stack-2026-05.md
+++ b/.mercury/docs/research/phase6-gui-mvp-tech-stack-2026-05.md
@@ -21,8 +21,8 @@
 | **Tauri** | v2.11.1 (2026-05-06) | ~10-30 MB | Rust + Web | Linux/macOS/Win + Android/iOS | **GA stable** | ★★★★★ (推荐 desktop primary) |
 | **Electron** | v42.1.0 (3 days pre-S120, ~2026-05-16) | ~100-150 MB | JS + Web | Linux/macOS/Win | **GA, hugely mature** | ★★★★ (bundle 大但 zero-friction) |
 | **Wails** | v3.0.0-alpha.93 (2026-05-17), v2 GA | ~20-50 MB | Go + Web | Linux/macOS/Win | **v3 alpha** (v2 GA OK) | ★★★ (Mercury 已 JS-heavy, Go 引入新 lang) |
-| **Textual** | (version UNVERIFIED in search; v3+ inferred from pypi) | n/a (TUI) | Python | Linux/macOS/Win | **GA, Textualize active** | ★★★ (TUI 适合 dev/SSH 场景, 但 GUI 形态弱) |
-| **Pure Web (Next.js localhost)** | Next.js 15-16, chokidar v5 (Nov 2025) | n/a (browser) | JS + Web | 任意 browser | **GA, hugely mature** | ★★★★ (但需用户开 browser, port 占用) |
+| **Textual** | **UNVERIFIED** (v3+ inferred from pypi; search 未给出 2026 specific version) | n/a (TUI) | Python | Linux/macOS/Win | **GA, Textualize active** | ★★★ (TUI 适合 dev/SSH 场景, 但 GUI 形态弱) |
+| **Pure Web (Next.js localhost)** | Next.js 15-16 **UNVERIFIED**, chokidar v5 (Nov 2025) | n/a (browser) | JS + Web | 任意 browser | **GA, hugely mature** | ★★★★ (但需用户开 browser, port 占用) |
 
 **预初步预排** (S120 不决策, 仅供 user Mode A 决策时参考):
 
@@ -59,7 +59,7 @@
 | Mercury existing JS stack reuse | ★★★★ | frontend 是 Web, 可复用 Mercury 已有 JS tooling (notify-hub, dispatch templates) |
 | Windows D-drive 安装 | ★★★★ | .msi 安装器 standard Windows MSI 流程, 用户可选 dest (D-drive OK; 详见 §"Windows D-drive 安装 policy") |
 | Cross-platform (Win/macOS/Linux ship v1) | ★★★★★ | 单 codebase, 三平台 build (Windows-only ship v1 也 OK, future-proof) |
-| 新 lang dep (Rust) | ★★★ | Rust toolchain 引入新依赖; 但 Mercury 已 multi-lang (Node 20+ + Python 3.x + Go via Wails-or-not), Rust 增量 acceptable |
+| 新 lang dep (Rust) | ★★★ | Rust toolchain 引入新依赖; 但 Mercury 已 multi-lang (Node 20+ + Python 3.x), Rust 增量 acceptable |
 | Maturity | ★★★★★ | v2 GA since late 2024, v2.11.x patch-stable |
 
 ### Caveats
@@ -188,7 +188,7 @@
 
 ### Verified facts (2026-05-19)
 
-- **Next.js**: 15-16 (具体 latest version UNVERIFIED; [vercel/next.js](https://github.com/vercel/next.js) active dev)
+- **Next.js**: 15-16 (**UNVERIFIED** — 具体 latest version 未 pin via `npm view next version`; [vercel/next.js](https://github.com/vercel/next.js) active dev. Mode A 已选 Tauri 2, Next.js 仅作 alternative-not-chosen 参考)
 - **chokidar**: **v5** (Nov 2025), ESM-only, Node 20+ min — per [paulmillr/chokidar](https://github.com/paulmillr/chokidar) + [chokidar - npm](https://www.npmjs.com/package/chokidar)
 - **License**: chokidar MIT, Next.js MIT
 - **Languages**: JavaScript / TypeScript
@@ -268,7 +268,7 @@ S120 完成 5 sub-tasks + surface 4 axes to user via AskUserQuestion. User 选�
 | **Tech stack** | **Tauri 2** (v2.11.1) ✅ | bundle 10-30MB (light), cross-plat future-proof, Mercury JS frontend reuse, Rust IPC v1 read-only 简单 |
 | **MVP scope** | **Scenarios 1 + 5** ✅ (NOT 4) | 比 ADR 预选 (1+4+5) 更精简 — cost-tracker trend chart (scenario 4) 推迟 v2+. v1 = 4-lane snapshot + Issue/PR dashboard |
 | **Cross-platform** | **Windows-only v1** ✅ | Mercury daily-driver platform; fastest path; v2 可加 macOS/Linux future |
-| **Data flow** | **chokidar file-watcher** (default) | 与 Tauri 兼容 (Node-side watcher 转发 IPC event to Rust side) OR Rust `notify` crate (Rust-side native). v2 待 implementation 实测选择 |
+| **Data flow** | **chokidar file-watcher (default)** ✅ | 与 Tauri 兼容 (Node-side watcher 转发 IPC event to Rust side). Rust `notify` crate alt **DEFERRED to implementation kickoff** — 不在 Mode A 决策内; 由 #411-B 实现 session 测出 perf/complexity tradeoff 后定 |
 
 ### Implementation derivatives (decided)
 
@@ -300,7 +300,7 @@ S120 完成 5 sub-tasks + surface 4 axes to user via AskUserQuestion. User 选�
 
 ### Hold-the-line constraints (carry into implementation)
 
-- **Mercury LOC budget**: internal tooling (NOT external adapter) — `≤200 LOC adapter cap` 不适用 per S119 CLAUDE.md authority chain reaffirm. Size by need.
+- **Mercury LOC budget**: internal tooling (NOT external adapter) — `≤200 LOC adapter cap` 不适用 per S119 CLAUDE.md authority chain reaffirm (specifically the MUST clause "External-project adapters under `adapters/<vendor-name>/` MUST stay under 200 lines" — scoped to `adapters/<vendor-name>/` only; this GUI is Mercury-internal tooling outside that scope). Size by need.
 - **D-drive install**: Tauri MSI 用户安装到 D 盘 OK (standard MSI dest prompt). VS2022 Build Tools 自己也安到 D 盘 per CLAUDE.md policy
 - **Read-only v1**: 严禁 write/delete to `~/.claude/jobs/` / `~/.claude/daemon/` (Anthropic owned per S119 governance)
 - **Anthropic compat-tolerance**: schema-tolerant parsing per companion schema ADR — missing/added fields don't crash

--- a/.mercury/docs/research/phase6-gui-mvp-tech-stack-2026-05.md
+++ b/.mercury/docs/research/phase6-gui-mvp-tech-stack-2026-05.md
@@ -250,6 +250,16 @@ Mercury CLAUDE.md MUST: "Install to D drive, not C drive".
 
 ## Mode A Decision Record (user-direction landed 2026-05-20)
 
+**Decision timeline** (audit-clarity per Argus iter-1 finding):
+
+| Phase | Date (local) | Note |
+|-------|--------------|------|
+| Research-front 5 sub-tasks executed | 2026-05-19 | S120 session start, empirical schema inspect + 5 WebSearches |
+| ADR initial drafts written | 2026-05-19 | Both schema + tech-stack ADRs as research-record (Mode A blockers section originally PENDING user) |
+| User Mode A decision via AskUserQuestion | 2026-05-20 | 4-axis response received (form factor + stack + scope + cross-plat) |
+| ADR Decision Record append (this section) | 2026-05-20 | tech-stack ADR section replacement; schema ADR v1/v2+ scope marker |
+| Commit `6c3470e` + PR #412 opened | 2026-05-20 | branch `lane/main/411-phase6-gui-mvp-research` |
+
 S120 完成 5 sub-tasks + surface 4 axes to user via AskUserQuestion. User 选择 (2026-05-20):
 
 | Axis | User decision | Rationale |

--- a/.mercury/docs/research/phase6-gui-mvp-tech-stack-2026-05.md
+++ b/.mercury/docs/research/phase6-gui-mvp-tech-stack-2026-05.md
@@ -1,0 +1,340 @@
+# Phase 6 GUI MVP — Tech stack research (5 candidates)
+
+**Issue**: [#411](https://github.com/392fyc/Mercury/issues/411) (research-front, sub-task 4)
+
+**Status**: Phase 1 — tech stack web-research record + Mode A decision (S120 → user-direction landed 2026-05-20)
+
+**Session**: S120 (main lane)
+
+**Companion ADR**: `phase6-gui-mvp-agentview-backend-schema-2026-05.md`
+
+**Mandatory research protocol applied**: 5 WebSearches against vendor docs + npm registry (2026-05-19); 1 page-fetch attempt where required.
+
+---
+
+## TL;DR
+
+5 candidate stacks 与 Mercury constraints (Windows D-drive install + cross-platform desirable + LOC budget 不强制 (internal tooling, NOT external adapter, ≤200 LOC cap 不适用) + read-only v1 + bundle size 重要 for desktop ship) 对照:
+
+| Stack | Latest (2026-05) | Bundle | Lang | Cross-plat | Maturity | Mercury fit (read-only v1) |
+|-------|------------------|--------|------|------------|----------|----------------------------|
+| **Tauri** | v2.11.1 (2026-05-06) | ~10-30 MB | Rust + Web | Linux/macOS/Win + Android/iOS | **GA stable** | ★★★★★ (推荐 desktop primary) |
+| **Electron** | v42.1.0 (3 days pre-S120, ~2026-05-16) | ~100-150 MB | JS + Web | Linux/macOS/Win | **GA, hugely mature** | ★★★★ (bundle 大但 zero-friction) |
+| **Wails** | v3.0.0-alpha.93 (2026-05-17), v2 GA | ~20-50 MB | Go + Web | Linux/macOS/Win | **v3 alpha** (v2 GA OK) | ★★★ (Mercury 已 JS-heavy, Go 引入新 lang) |
+| **Textual** | (version UNVERIFIED in search; v3+ inferred from pypi) | n/a (TUI) | Python | Linux/macOS/Win | **GA, Textualize active** | ★★★ (TUI 适合 dev/SSH 场景, 但 GUI 形态弱) |
+| **Pure Web (Next.js localhost)** | Next.js 15-16, chokidar v5 (Nov 2025) | n/a (browser) | JS + Web | 任意 browser | **GA, hugely mature** | ★★★★ (但需用户开 browser, port 占用) |
+
+**预初步预排** (S120 不决策, 仅供 user Mode A 决策时参考):
+
+- **Top 2 primary**: **Tauri 2** (推荐 strong) | **Electron** (safe backup)
+- **Top 1 alternative**: **Pure Web (Next.js localhost)** if user 接受 browser-based access
+- **Secondary**: **Textual** for TUI-only ship (no GUI window)
+- **Bottom**: **Wails v3** (alpha) / v2 (mature 但 Go 引入新 lang dep)
+
+**所有 5 选项都不 block Mercury D-drive 安装 policy** — 详 §"Windows D-drive 安装 policy" 段。
+
+---
+
+## Tauri (v2.11.1, GA stable)
+
+### Verified facts (2026-05-19)
+
+- **Latest version**: **v2.11.1** (released 2026-05-06) per [Tauri Core Ecosystem Releases](https://v2.tauri.app/release/)
+- **License**: MIT (per Mercury cherry-pick 允许 license list)
+- **Languages**: Rust (backend) + Web (HTML/CSS/JS, framework-agnostic) (frontend)
+- **Cross-platform**: Linux + macOS + Windows + Android + iOS (per [Tauri 2.0 docs](https://v2.tauri.app/))
+- **Windows distribution**: Microsoft Installer (.msi) bundled via WiX, OR .exe via NSIS — per [Windows Installer | Tauri](https://v2.tauri.app/distribute/windows-installer/)
+- **Windows prerequisites** (per [Prerequisites | Tauri](https://v2.tauri.app/start/prerequisites/)):
+  - Microsoft Edge WebView2 runtime (preinstalled Win11; patched Win10)
+  - Visual Studio 2022 Build Tools — "Desktop development with C++" workload
+  - Windows 10/11 SDK
+- **Bundle size**: ~10-30 MB typical (依赖 WebView2 系统 runtime, 不 bundle browser)
+
+### Mercury fit assessment
+
+| Dimension | Score | Note |
+|-----------|-------|------|
+| Bundle size | ★★★★★ | 10-30 MB vs Electron 100-150 MB — desktop ship 优势 |
+| Performance | ★★★★★ | Rust backend + native WebView |
+| Mercury existing JS stack reuse | ★★★★ | frontend 是 Web, 可复用 Mercury 已有 JS tooling (notify-hub, dispatch templates) |
+| Windows D-drive 安装 | ★★★★ | .msi 安装器 standard Windows MSI 流程, 用户可选 dest (D-drive OK; 详见 §"Windows D-drive 安装 policy") |
+| Cross-platform (Win/macOS/Linux ship v1) | ★★★★★ | 单 codebase, 三平台 build (Windows-only ship v1 也 OK, future-proof) |
+| 新 lang dep (Rust) | ★★★ | Rust toolchain 引入新依赖; 但 Mercury 已 multi-lang (Node 20+ + Python 3.x + Go via Wails-or-not), Rust 增量 acceptable |
+| Maturity | ★★★★★ | v2 GA since late 2024, v2.11.x patch-stable |
+
+### Caveats
+
+- Rust 学习曲线: Mercury 暂无 Rust 代码; Tauri 大多数 UI 工作在 JS 侧 (Rust 仅 build / system API bridge / IPC commands), 但仍需 dev 写 Tauri commands in Rust
+- Visual Studio 2022 Build Tools 安装到 D 盘 (per CLAUDE.md Windows policy) 需验证 — VS2022 安装器允许选 dest
+
+### Recommended for Mercury
+
+**★★★★★ Primary candidate** for Mercury Phase 6 GUI MVP — bundle size + cross-platform + Mercury JS reuse 三项都 strong, Rust 学习曲线是唯一 friction (但 v1 read-only 不需 heavy Rust 编程, IPC 主要 file-read).
+
+---
+
+## Electron (v42.1.0, GA hugely mature)
+
+### Verified facts (2026-05-19)
+
+- **Latest version**: **v42.1.0** (last published "3 days ago" — ~2026-05-16) per [Electron Releases](https://releases.electronjs.org/) + [electron - npm](https://www.npmjs.com/package/electron)
+- **License**: MIT
+- **Languages**: JavaScript + HTML/CSS + Web (bundled Chromium browser)
+- **Cross-platform**: Linux + macOS + Windows (no mobile)
+- **Windows binaries**: ia32 (x86), x64 (amd64), arm64
+- **Packaging**: `electron-builder v26.8.2` standard (per [electron-builder Releases](https://releasealert.dev/npmjs/_/electron-builder))
+- **Adoption**: 1689 npm packages depend on Electron (per npm)
+
+### Mercury fit assessment
+
+| Dimension | Score | Note |
+|-----------|-------|------|
+| Bundle size | ★★ | 100-150 MB typical (bundle Chromium) — heavy for "lightweight monitor" |
+| Performance | ★★★ | Chromium overhead but rich features |
+| Mercury existing JS stack reuse | ★★★★★ | 100% JS — Mercury Node 20+ 直接 reuse |
+| Windows D-drive 安装 | ★★★★ | electron-builder NSIS/MSI 都支持 dest 选择 |
+| Cross-platform (Win/macOS/Linux ship v1) | ★★★★★ | 标准 cross-platform desktop framework |
+| 新 lang dep | ★★★★★ | 无新 lang (pure JS) |
+| Maturity | ★★★★★ | 2013+ proven, VS Code / Slack / Discord 都用 |
+
+### Caveats
+
+- Bundle 大 — Mercury "lightweight monitor" 定位与 Electron 100MB+ ship 矛盾
+- Chromium auto-update + security patch cadence 需 track (electron-updater 标准方案)
+- 在内存占用 / 启动速度上 vs Tauri 劣势
+
+### Recommended for Mercury
+
+**★★★★ Safe backup** — 若 Mercury team 决策 prioritize "JS-only stack + max maturity over bundle size", Electron 是 safe pick. 但 Tauri 在所有客观维度上 (bundle + perf + cross-plat) 都 ≥ Electron, Rust 学习曲线是唯一 trade-off。
+
+---
+
+## Wails (v3.0.0-alpha.93 / v2 GA)
+
+### Verified facts (2026-05-19)
+
+- **v3 latest**: **v3.0.0-alpha.93** (2026-05-17, 2 days pre-S120) per [Wails Releases](https://github.com/wailsapp/wails/releases)
+- **v3 status**: ALPHA — "API reasonably stable" per [v3.wails.io](https://v3.wails.io/), 应用 already in production but **docs + tooling still being refined**
+- **v2 status**: **GA stable** — recommended for production
+- **License**: MIT
+- **Languages**: Go (backend) + Web (HTML/CSS/JS) (frontend)
+- **Windows runtime**: Microsoft WebView2 (same as Tauri)
+- **v3 highlights** (per Wails docs):
+  - Improved binding generation
+  - Multi-window support
+  - More transparent build system
+  - Heavy lifting tasks now CLI commands
+
+### Mercury fit assessment
+
+| Dimension | Score | Note |
+|-----------|-------|------|
+| Bundle size | ★★★★ | 20-50 MB typical (Go binary + WebView2 system runtime) |
+| Performance | ★★★★ | Go backend native, 与 Tauri 相近 |
+| Mercury existing JS stack reuse | ★★★★ | frontend Web, 可复用 |
+| Windows D-drive 安装 | ★★★ | Wails 自带 installer 选项 less mature than Tauri/Electron; manual build + place 可 |
+| Cross-platform | ★★★★ | Win/macOS/Linux (no mobile) |
+| 新 lang dep (Go) | ★★ | Go 是 Mercury 暂无的新 lang; 引入 Go toolchain 增量 |
+| Maturity | ★★★ | v3 alpha; v2 GA 稳但 v3 是未来 |
+
+### Caveats
+
+- v3 alpha 不适合 Mercury Phase 6 long-term decision (production-ready 推荐用 v2)
+- Go lang 引入 — Mercury 暂未 Go 代码, 新 stack 引入
+- Wails 用户社区比 Tauri / Electron 小
+
+### Recommended for Mercury
+
+**★★★ Secondary** — 若 Mercury team 有 Go 偏好 OR 想避开 Rust 学习曲线, Wails v2 是合理选择. 但相比 Tauri 在 maturity / community / cross-platform parity 上无 strict 优势, Go 引入新 lang dep 是 net cost.
+
+---
+
+## Textual (Python TUI)
+
+### Verified facts (2026-05-19)
+
+- **Latest version**: UNVERIFIED (search 未给出 2026 specific version; [Textualize GitHub](https://github.com/Textualize/textual) 持续 active dev, 当前推断 v3.x — 需 `pip show textual` 验证)
+- **License**: MIT
+- **Language**: Python (3.8+ typical)
+- **Cross-platform**: macOS + Linux + Windows
+- **Form factor**: TUI (terminal) + Web (textual-serve 可 browser deploy)
+- **Inspired by**: Rich library (same team)
+- **Widgets**: DataTable, TreeView, Input (mouse-interactive + animation)
+
+### Mercury fit assessment
+
+| Dimension | Score | Note |
+|-----------|-------|------|
+| Bundle size | n/a | TUI, no native bundle (Python interpreter dep) |
+| Performance | ★★★★★ | 极轻量 — terminal output |
+| Mercury existing JS stack reuse | ★ | Python lang, Mercury Python 仅在 `~/.claude/scripts/` (mem0/cost-tracker), 新 Python desktop app dep |
+| Windows D-drive 安装 | ★★★ | Python 安装到 D 盘 OK (uv / pyenv 均支持); textual 是 pip 包 |
+| Cross-platform | ★★★★★ | 任 Python-supported OS |
+| 新 lang dep (Python) | ★★★ | Mercury 已有 Python 用法, 但用于 GUI 是 net cost (vs JS-side reuse) |
+| Maturity | ★★★★ | Textualize 2026 active dev, GA |
+
+### Caveats
+
+- **Form factor 不匹配 GUI 期望** — TUI 在 SSH / headless 场景 OK, 但 user "Mercury 完整体验里程碑" 暗示有 visual GUI 需求
+- Python lang 引入 Mercury frontend 是新方向
+
+### Recommended for Mercury
+
+**★★★ Niche** — Textual 适合 **SSH-only / headless monitoring** use case (e.g. NAS 远程监控), NOT primary GUI form factor. **可作为 v2+ companion** (e.g. `mercury-tui` 命令补充 GUI), 但 v1 不推荐。
+
+---
+
+## Pure Web (Next.js localhost) + chokidar
+
+### Verified facts (2026-05-19)
+
+- **Next.js**: 15-16 (具体 latest version UNVERIFIED; [vercel/next.js](https://github.com/vercel/next.js) active dev)
+- **chokidar**: **v5** (Nov 2025), ESM-only, Node 20+ min — per [paulmillr/chokidar](https://github.com/paulmillr/chokidar) + [chokidar - npm](https://www.npmjs.com/package/chokidar)
+- **License**: chokidar MIT, Next.js MIT
+- **Languages**: JavaScript / TypeScript
+- **Form factor**: Browser (localhost:port)
+- **File watching**: chokidar v5 efficient native recursive on Windows
+
+### Mercury fit assessment
+
+| Dimension | Score | Note |
+|-----------|-------|------|
+| Bundle size | n/a | server-side Node + browser-side, no shipped binary |
+| Performance | ★★★★ | Next.js server + browser; depends on user browser perf |
+| Mercury existing JS stack reuse | ★★★★★ | 100% Mercury JS reuse, Node 20+ already deployed |
+| Windows D-drive 安装 | ★★★★★ | Mercury repo 已 D-drive; localhost server run from D 盘 OK |
+| Cross-platform | ★★★★★ | browser-based — works anywhere |
+| 新 lang dep | ★★★★★ | 无新 lang |
+| Maturity | ★★★★★ | Next.js + chokidar 两者都 hugely mature |
+
+### Caveats
+
+- **需 user 开 browser** — Mercury "桌面端" 体验弱化, 但 Telegram + Notify Hub 已 close 了 "离开键盘" UX, GUI 是 desktop 体验补充 — browser-based 是否够好需 user 决策
+- **Port 占用** — localhost:3000 (Next.js default) 可能 conflict
+- **No system tray / window** — 不能像 desktop app 一样 close-to-tray, 需用户主动 visit browser tab
+- chokidar v5 ESM-only — Mercury 现 cjs 主导, 需 mixed support
+
+### Recommended for Mercury
+
+**★★★★ Strong alternative** — 若 user 接受 "open browser to monitor Mercury" UX, pure Web 是 lowest-friction (无新 lang, 无新 toolchain, no binary build). 但若 user 期望 desktop app feel (system tray, native window), 需 Tauri/Electron/Wails.
+
+---
+
+## Windows D-drive 安装 policy 通用分析
+
+Mercury CLAUDE.md MUST: "Install to D drive, not C drive".
+
+| Stack | D-drive 兼容性 | 实现路径 |
+|-------|----------------|----------|
+| Tauri | ✅ | .msi 安装器允许 user 选 dest folder (standard MSI 行为); 或直接 portable .exe 不安装 |
+| Electron | ✅ | electron-builder NSIS/MSI 都允许 dest 选择 |
+| Wails | ✅ | manual build → place 任意 (less mature installer) |
+| Textual | ✅ | Python venv + pip install 任意位置; 或 PyInstaller bundle 到 D 盘 |
+| Pure Web | ✅ | Mercury repo 已 D 盘, Next.js dev/build/run from D 盘 |
+
+**所有 5 选项都满足 Mercury Windows D-drive policy**. 不构成 differentiator。
+
+---
+
+## Polling vs file-watcher (data flow Mode A blocker)
+
+| Approach | Library | Pro | Con |
+|----------|---------|-----|-----|
+| **Polling** | n/a (setInterval / setTimer / time.sleep) | 简单, no extra dep | CPU/IO 浪费 (即使 nothing changed); latency 5-15s |
+| **File-watcher (chokidar v5)** | `chokidar` (Node) | 0-latency 触发, low CPU when idle | ESM-only v5, node 20+ min; Windows native recursive support |
+| **OS-native** | `fs.watch` (Node), `watchdog` (Python), `notify` (Rust crate) | 最低 overhead | 平台差异; Mercury 需 cross-plat → chokidar / watchdog 包装层 |
+
+**推荐**: chokidar v5 (Node stack) OR watchdog (Python stack), depending on tech-stack 决策. 不需 Mercury 自建 daemon (chokidar / watchdog 已是 daemon 角色 in-process).
+
+---
+
+## Mode A Decision Record (user-direction landed 2026-05-20)
+
+S120 完成 5 sub-tasks + surface 4 axes to user via AskUserQuestion. User 选择 (2026-05-20):
+
+| Axis | User decision | Rationale |
+|------|---------------|-----------|
+| **Form factor** | **Local desktop GUI** ✅ | desktop daily-driver feel; system tray possible; native window (matches "Mercury 完整体验" 里程碑) |
+| **Tech stack** | **Tauri 2** (v2.11.1) ✅ | bundle 10-30MB (light), cross-plat future-proof, Mercury JS frontend reuse, Rust IPC v1 read-only 简单 |
+| **MVP scope** | **Scenarios 1 + 5** ✅ (NOT 4) | 比 ADR 预选 (1+4+5) 更精简 — cost-tracker trend chart (scenario 4) 推迟 v2+. v1 = 4-lane snapshot + Issue/PR dashboard |
+| **Cross-platform** | **Windows-only v1** ✅ | Mercury daily-driver platform; fastest path; v2 可加 macOS/Linux future |
+| **Data flow** | **chokidar file-watcher** (default) | 与 Tauri 兼容 (Node-side watcher 转发 IPC event to Rust side) OR Rust `notify` crate (Rust-side native). v2 待 implementation 实测选择 |
+
+### Implementation derivatives (decided)
+
+- **Bundle target**: ~10-30 MB MSI installer (Tauri Windows MSI via WiX)
+- **Frontend framework**: TBD (framework-agnostic per Tauri; 推荐 React 或 SolidJS for Mercury 已有 JS stack 一致性, 待 implementation 决策 — out of S120 scope)
+- **Rust crates needed v1**: tauri, serde, serde_json, chrono (timestamps), regex (filter primitives)
+- **Read-side data sources v1** (per companion schema ADR):
+  - `~/.claude/jobs/<id>/state.json` (22 fields, schema-tolerant)
+  - `~/.claude/daemon/roster.json` (4 fields)
+  - LANES.md (Mercury lane registry → cwd group key)
+  - gh CLI Issue/PR state (scenario 5)
+- **Read-side data sources DEFERRED v2+** (scenarios 2/3/4):
+  - `~/.claude/jobs/<id>/timeline.jsonl` (scenario 2 跨 session 时间轴)
+  - `~/.claude/scripts/cost-tracker/<id>.jsonl` (scenario 4 cost trend chart)
+- **System tray**: Tauri tray-icon plugin v1 desirable (close-to-tray UX)
+- **Single-instance lock**: Tauri single-instance plugin v1 (avoid multi-launch)
+
+### Implementation Issue chain (filed post-decision)
+
+实施 work 由 dev-pipeline 跟进, 不在 S120 scope。建议 split 为:
+
+- **#411-A** (P2, lane:main, enhancement): Tauri 2 project scaffold + Mercury Windows MSI build + system tray + single-instance — bare app skeleton, no scenarios yet
+- **#411-B** (P2, lane:main, enhancement): Read-side data layer (state.json + roster.json + LANES.md parser; chokidar/notify file-watcher) — IPC commands defined
+- **#411-C** (P2, lane:main, enhancement): UI scenario 1 — cross-lane snapshot (4 active lanes + active PR + 5h usage marker)
+- **#411-D** (P2, lane:main, enhancement): UI scenario 5 — Issue/PR dashboard (gh CLI integration + label/lane/Phase filter)
+- **#411 itself**: closes with this ADR PR (research + decision finalized)
+
+或合并为单 Issue `#411 sequel` 描述完整 MVP, 走 dev-pipeline blind acceptance. 选择 split-or-single 由 implementation kickoff session 决定。
+
+### Hold-the-line constraints (carry into implementation)
+
+- **Mercury LOC budget**: internal tooling (NOT external adapter) — `≤200 LOC adapter cap` 不适用 per S119 CLAUDE.md authority chain reaffirm. Size by need.
+- **D-drive install**: Tauri MSI 用户安装到 D 盘 OK (standard MSI dest prompt). VS2022 Build Tools 自己也安到 D 盘 per CLAUDE.md policy
+- **Read-only v1**: 严禁 write/delete to `~/.claude/jobs/` / `~/.claude/daemon/` (Anthropic owned per S119 governance)
+- **Anthropic compat-tolerance**: schema-tolerant parsing per companion schema ADR — missing/added fields don't crash
+- **No spawn of `claude agents` CLI**: 该 CLI TTY-required, 不可 batch parse (per schema ADR empirical)
+
+---
+
+## Open questions for Phase 2 (not S120 scope)
+
+1. Tauri Rust IPC 写 file-read commands vs Tauri JS bridge 直接 fs.readFile — perf / complexity tradeoff
+2. Electron bundle size 在 Mercury 实际场景 (read-only viewer) 能否 trim 到 < 80 MB
+3. Wails v3 alpha → GA timeline (是否 Phase 2 等 v3 GA, 还是 v2 起步 future v3 migration)
+4. Pure Web + chokidar 在 Windows OneDrive synced folder (e.g. `~/.claude/` 是否在 OneDrive) 上的 file-watch reliability
+5. Textual web-serve mode (Textualize textual-serve 项目) 是否构成 "TUI + Web in 1 stack" 第 6 candidate
+
+**这些 Phase 2 实现期间 verify**, 不阻塞 Mode A user decision。
+
+---
+
+## References
+
+### Tauri
+- [Tauri Core Ecosystem Releases](https://v2.tauri.app/release/) — v2.11.1 2026-05-06
+- [Windows Installer | Tauri](https://v2.tauri.app/distribute/windows-installer/) — MSI/NSIS
+- [Prerequisites | Tauri](https://v2.tauri.app/start/prerequisites/) — Win10/11 SDK + VS2022 + WebView2
+- [Tauri 2.0 Stable Release | Tauri](https://v2.tauri.app/blog/tauri-20/)
+- [tauri 2.11.1 — Docs.rs](https://docs.rs/crate/tauri/latest)
+
+### Electron
+- [Electron Releases](https://releases.electronjs.org/) — v42.1.0 latest
+- [electron - npm](https://www.npmjs.com/package/electron) — 1689 dependents
+- [Releases · electron-builder](https://releasealert.dev/npmjs/_/electron-builder) — v26.8.2
+
+### Wails
+- [Wails](https://wails.io/) — v2 GA
+- [Wails v3](https://v3.wails.io/) — v3.0.0-alpha.93 2026-05-17
+- [Releases · wailsapp/wails](https://github.com/wailsapp/wails/releases)
+
+### Textual
+- [Textual — Home](https://textual.textualize.io/)
+- [Textualize/textual GitHub](https://github.com/Textualize/textual)
+- [Python Textual: Build Beautiful UIs in the Terminal — Real Python](https://realpython.com/python-textual/)
+
+### Pure Web
+- [paulmillr/chokidar](https://github.com/paulmillr/chokidar) — v5 Nov 2025, ESM-only, node 20+
+- [chokidar - npm](https://www.npmjs.com/package/chokidar)
+- [vercel/next.js Discussion #10725: next dev watch all files?](https://github.com/vercel/next.js/discussions/10725)


### PR DESCRIPTION
## Summary

S120 research-front 5 sub-tasks complete + user Mode A decision landed 2026-05-20. Phase 6 GUI MVP scope finalized.

### Mode A Decision (user 2026-05-20)

| Axis | Decision |
|------|----------|
| Form factor | **Local desktop GUI** |
| Tech stack | **Tauri 2** (v2.11.1, Rust + Web frontend) |
| MVP scope | **Scenarios 1 + 5** (cross-lane snapshot + Issue/PR dashboard) — NOT 4 (cost-trend chart, defer v2+) |
| Cross-platform | **Windows-only v1** |
| Data flow | chokidar / Rust notify (implementation decides) |

### Two ADR drafts

- **phase6-gui-mvp-agentview-backend-schema-2026-05.md** (218 LOC) — 4 sample state.json empirical schema (17 base + 5 optional fields), roster.json + pins.json schemas, **timeline.jsonl NEW finding**, **`claude agents` TTY-required constraint**, #389 prior-art audit (**NOT superseded**, keep OPEN as P3 CLI alternative)
- **phase6-gui-mvp-tech-stack-2026-05.md** (350 LOC after Decision Record append) — 5 candidate stacks (Tauri/Electron/Wails/Textual/pure-Web) with version verify per MANDATORY RESEARCH PROTOCOL, Mode A Decision Record reflecting user choice

### Research-front findings

1. state.json `state` 字段实际枚举值 ≠ 6-value docs taxonomy → GUI 需建立 state-token → display-label 映射
2. `claude agents` CLI 不可 non-interactive parse → Mercury GUI 必须直接读 `~/.claude/jobs/state.json` + `roster.json`
3. NEW `~/.claude/jobs/<id>/timeline.jsonl` discovered → 适合 scenario 2 跨 session 时间轴 (v2+ scope)

### Implementation Issues to file post-merge

- `#411-A` (P2, enhancement, lane:main): Tauri 2 project scaffold + Mercury Windows MSI build + system tray + single-instance
- `#411-B` (P2, enhancement, lane:main): Read-side data layer (state.json + roster.json + LANES.md parser; chokidar/notify file-watcher)
- `#411-C` (P2, enhancement, lane:main): UI scenario 1 — cross-lane snapshot (4 active lanes + active PR + 5h usage marker)
- `#411-D` (P2, enhancement, lane:main): UI scenario 5 — Issue/PR dashboard (gh CLI integration + label/lane/Phase filter)

或合并为单 Issue, 由 implementation kickoff session 决定。

## Test plan

- [ ] Argus review pass
- [ ] dual-verify (Claude code-review + Codex code-audit) PASS (research ADR docs, minimal findings expected)
- [ ] Closes #411
- [ ] #389 remains OPEN (P3 OPTIONAL companion)

Closes #411
Refs #386 (parent ADR Path B)
Refs #389 (prior-art / CLI-fallback companion)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)