### PR TITLE
feat(mercury-gui): #414 read-side data layer (4 IPC commands + notify watcher)

### DIFF
--- a/mercury-gui/src-tauri/Cargo.lock
+++ b/mercury-gui/src-tauri/Cargo.lock
@@ -460,8 +460,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link 0.2.1",
 ]
 
@@ -704,11 +706,32 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.4.6",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -719,7 +742,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
 ]
 
@@ -1023,6 +1046,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1721,6 +1753,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
+dependencies = [
+ "bitflags 2.11.1",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1864,6 +1916,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1984,12 +2056,16 @@ dependencies = [
 name = "mercury-gui"
 version = "0.1.0"
 dependencies = [
+ "chrono",
+ "dirs 5.0.1",
+ "notify",
  "serde",
  "serde_json",
  "tauri",
  "tauri-build",
  "tauri-plugin-opener",
  "tauri-plugin-single-instance",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2015,6 +2091,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -2069,6 +2146,33 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.11.1",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.11.1",
+]
 
 [[package]]
 name = "num-conv"
@@ -2667,6 +2771,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.11.1",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3326,7 +3441,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "cookie",
- "dirs",
+ "dirs 6.0.0",
  "dunce",
  "embed_plist",
  "getrandom 0.3.4",
@@ -3376,7 +3491,7 @@ checksum = "4aa1f9055fc23919a54e4e125052bed16ed04aef0487086e758fe01a67b451c7"
 dependencies = [
  "anyhow",
  "cargo_toml",
- "dirs",
+ "dirs 6.0.0",
  "glob",
  "heck 0.5.0",
  "json-patch",
@@ -3932,7 +4047,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15edbb0d80583e85ee8df283410038e17314df5cba30da2087a54a85216c0773"
 dependencies = [
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "libappindicator",
  "muda",
  "objc2",
@@ -4559,6 +4674,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
@@ -4597,6 +4721,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -4658,6 +4797,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -4676,6 +4821,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4691,6 +4842,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4724,6 +4881,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -4739,6 +4902,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4760,6 +4929,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -4775,6 +4950,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4932,7 +5113,7 @@ dependencies = [
  "block2",
  "cookie",
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "dom_query",
  "dpi",
  "dunce",

--- a/mercury-gui/src-tauri/Cargo.toml
+++ b/mercury-gui/src-tauri/Cargo.toml
@@ -22,6 +22,10 @@ tauri = { version = "2", features = ["tray-icon"] }
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+chrono = { version = "0.4", features = ["serde"] }
+dirs = "5"
+notify = "8"
+thiserror = "2"
 
 [target.'cfg(any(target_os = "macos", windows, target_os = "linux"))'.dependencies]
 tauri-plugin-single-instance = "2.4.2"

--- a/mercury-gui/src-tauri/src/data/commands.rs
+++ b/mercury-gui/src-tauri/src/data/commands.rs
@@ -3,6 +3,11 @@ use super::paths;
 use super::DataError;
 use std::collections::HashMap;
 use std::fs;
+use std::io::ErrorKind;
+
+/// state.json files in the wild are typically 1-10 KB. Cap reads at 2 MB so a
+/// pathological file can't OOM the GUI process (#414 Argus iter-1 Critical 5).
+const MAX_STATE_JSON_BYTES: u64 = 2 * 1024 * 1024;
 
 #[tauri::command]
 pub fn read_jobs() -> Result<Vec<JobState>, DataError> {
@@ -20,10 +25,19 @@ pub fn read_jobs() -> Result<Vec<JobState>, DataError> {
         if !state_path.is_file() {
             continue;
         }
-        // Schema-tolerant: skip unreadable / malformed files rather than failing the whole call.
-        // GUI surfaces "0 jobs" instead of an error if every file is corrupt.
+        // Schema-tolerant: skip unreadable / malformed / oversized files rather
+        // than failing the whole call. GUI surfaces "0 jobs" instead of an error
+        // if every file is corrupt.
+        let Ok(meta) = fs::metadata(&state_path) else { continue };
+        if meta.len() > MAX_STATE_JSON_BYTES {
+            continue;
+        }
         let Ok(bytes) = fs::read(&state_path) else { continue };
-        let Ok(job) = serde_json::from_slice::<JobState>(&bytes) else { continue };
+        let Ok(mut job) = serde_json::from_slice::<JobState>(&bytes) else { continue };
+        // Strip home prefix from path-bearing fields so the JS frontend never
+        // sees `C:\Users\<name>\...` literals (defense in depth — `redact_home`
+        // is also applied to surfaced error strings in DataError).
+        job.sanitize_paths();
         out.push(job);
     }
     Ok(out)
@@ -35,10 +49,17 @@ pub fn read_roster() -> Result<RosterSnapshot, DataError> {
     if !p.exists() {
         return Ok(RosterSnapshot::default());
     }
-    let bytes = fs::read(&p)?;
+    let bytes = match fs::read(&p) {
+        Ok(b) => b,
+        // Transient NotFound (e.g. supervisor file rotation) should not flash
+        // an error to the GUI; degrade to default and resync on the next watcher
+        // tick (matches the lenient pattern of read_jobs).
+        Err(e) if e.kind() == ErrorKind::NotFound => return Ok(RosterSnapshot::default()),
+        Err(e) => return Err(e.into()),
+    };
     // roster.json is written by an external supervisor process; mid-write reads
     // can yield truncated JSON. Degrade to default rather than surfacing a
-    // transient parse error (matches read_jobs lenient pattern).
+    // transient parse error.
     Ok(serde_json::from_slice(&bytes).unwrap_or_default())
 }
 
@@ -147,7 +168,7 @@ pub(crate) fn group_jobs_by_lane(
             .find(|l| {
                 l.worktree_path
                     .as_ref()
-                    .map(|wp| normalize_path(wp).eq_ignore_ascii_case(&job_norm))
+                    .map(|wp| normalize_path(wp) == job_norm)
                     .unwrap_or(false)
             })
             .map(|l| l.name.clone())

--- a/mercury-gui/src-tauri/src/data/commands.rs
+++ b/mercury-gui/src-tauri/src/data/commands.rs
@@ -1,0 +1,307 @@
+use super::models::{JobState, Lane, RosterSnapshot};
+use super::paths;
+use super::DataError;
+use std::collections::HashMap;
+use std::fs;
+
+#[tauri::command]
+pub fn read_jobs() -> Result<Vec<JobState>, DataError> {
+    let dir = paths::jobs_dir();
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+    let mut out = Vec::new();
+    for entry in fs::read_dir(&dir)? {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+        let state_path = entry.path().join("state.json");
+        if !state_path.is_file() {
+            continue;
+        }
+        // Schema-tolerant: skip unreadable / malformed files rather than failing the whole call.
+        // GUI surfaces "0 jobs" instead of an error if every file is corrupt.
+        let Ok(bytes) = fs::read(&state_path) else { continue };
+        let Ok(job) = serde_json::from_slice::<JobState>(&bytes) else { continue };
+        out.push(job);
+    }
+    Ok(out)
+}
+
+#[tauri::command]
+pub fn read_roster() -> Result<RosterSnapshot, DataError> {
+    let p = paths::roster_path();
+    if !p.exists() {
+        return Ok(RosterSnapshot::default());
+    }
+    let bytes = fs::read(&p)?;
+    // roster.json is written by an external supervisor process; mid-write reads
+    // can yield truncated JSON. Degrade to default rather than surfacing a
+    // transient parse error (matches read_jobs lenient pattern).
+    Ok(serde_json::from_slice(&bytes).unwrap_or_default())
+}
+
+#[tauri::command]
+pub fn read_lanes() -> Result<Vec<Lane>, DataError> {
+    let p = paths::lanes_path();
+    if !p.exists() {
+        return Ok(Vec::new());
+    }
+    let text = fs::read_to_string(&p)?;
+    Ok(parse_lanes_md(&text))
+}
+
+#[tauri::command]
+pub fn read_jobs_by_lane() -> Result<HashMap<String, Vec<JobState>>, DataError> {
+    // Propagate lane-resolution failures so the GUI can surface a degraded state
+    // explicitly instead of silently filing every job under `__unassigned__`.
+    // `read_lanes` already returns `Ok(empty)` when LANES.md is simply absent.
+    let jobs = read_jobs()?;
+    let lanes = read_lanes()?;
+    Ok(group_jobs_by_lane(jobs, &lanes))
+}
+
+/// Parse the `## Active Lanes` section of LANES.md.
+///
+/// Format (canonical per the user-memory file):
+///   ## Active Lanes
+///   ### `<name>` (... description ...)
+///   - **Worktree path** (...): `<path>` — annotations
+///   - **Status**: `<status>`
+///   ...
+///   ## Closed Lanes
+///
+/// The first backticked group on a worktree/status bullet is the value;
+/// bullets without backticks (e.g. the `health` lane's N/A variant) yield `None`.
+pub(crate) fn parse_lanes_md(text: &str) -> Vec<Lane> {
+    let mut lanes: Vec<Lane> = Vec::new();
+    let mut current: Option<Lane> = None;
+    let mut in_active = false;
+
+    for raw in text.lines() {
+        let line = raw.trim_end();
+        if let Some(stripped) = line.strip_prefix("## ") {
+            if stripped.starts_with("Active") {
+                in_active = true;
+            } else {
+                if let Some(l) = current.take() {
+                    lanes.push(l);
+                }
+                in_active = false;
+            }
+            continue;
+        }
+        if !in_active {
+            continue;
+        }
+        if line.starts_with("### ") {
+            if let Some(l) = current.take() {
+                lanes.push(l);
+            }
+            if let Some(name) = first_backticked(line) {
+                current = Some(Lane {
+                    name,
+                    worktree_path: None,
+                    status: None,
+                });
+            }
+            continue;
+        }
+        let Some(ref mut lane) = current else { continue };
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("- **Worktree path**") {
+            lane.worktree_path = first_backticked(trimmed);
+        } else if trimmed.starts_with("- **Status**") {
+            lane.status = first_backticked(trimmed);
+        }
+    }
+    if let Some(l) = current.take() {
+        lanes.push(l);
+    }
+    lanes
+}
+
+/// First substring enclosed by a matched pair of backticks, or None.
+fn first_backticked(s: &str) -> Option<String> {
+    let start = s.find('`')?;
+    let rest = &s[start + 1..];
+    let end = rest.find('`')?;
+    Some(rest[..end].to_string())
+}
+
+/// Group jobs by lane via case-insensitive normalized-path match of `cwd` against
+/// `lane.worktree_path`. Jobs whose cwd doesn't match any lane fall under `__unassigned__`.
+pub(crate) fn group_jobs_by_lane(
+    jobs: Vec<JobState>,
+    lanes: &[Lane],
+) -> HashMap<String, Vec<JobState>> {
+    let mut out: HashMap<String, Vec<JobState>> = HashMap::new();
+    for lane in lanes {
+        out.entry(lane.name.clone()).or_default();
+    }
+    for job in jobs {
+        let job_norm = normalize_path(&job.cwd);
+        let matched = lanes
+            .iter()
+            .find(|l| {
+                l.worktree_path
+                    .as_ref()
+                    .map(|wp| normalize_path(wp).eq_ignore_ascii_case(&job_norm))
+                    .unwrap_or(false)
+            })
+            .map(|l| l.name.clone())
+            .unwrap_or_else(|| "__unassigned__".to_string());
+        out.entry(matched).or_default().push(job);
+    }
+    out
+}
+
+/// Normalize: backslashes → forward slashes, strip trailing slash, lowercase.
+/// Path comparison only — not used for filesystem access.
+fn normalize_path(s: &str) -> String {
+    s.replace('\\', "/")
+        .trim_end_matches('/')
+        .to_ascii_lowercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE_LANES_MD: &str = r#"# Mercury Lanes Registry
+
+## Active Lanes
+
+### `main` (default lane)
+
+- **Handoff file**: `session-handoff.md`
+- **Worktree path** (per Rule 5.1, Issue #342): `D:/Mercury/Mercury` — main lane canonical
+- **Status**: `active`
+
+### `side-bug` (peripheral bug-fix lane)
+
+- **Handoff file**: `session-handoff-side-bug.md`
+- **Worktree path** (per Rule 5.1): `D:/Mercury/Mercury-side-bug` (materialized 2026-05-04)
+- **Status**: `active`
+
+### `health` (personal health discussions)
+
+- **Worktree path** (per Rule 5.1, **N/A variant**): **conversation-only lane — no git worktree**.
+- **Status**: `active`
+
+## Closed Lanes
+
+### `side-multi-lane` (dedicated research lane) — CLOSED
+
+- **Worktree path**: `D:/Mercury/Mercury-side-mlane`
+- **Status**: `closed`
+"#;
+
+    #[test]
+    fn parses_active_lanes_section_only() {
+        let lanes = parse_lanes_md(SAMPLE_LANES_MD);
+        assert_eq!(lanes.len(), 3, "active section: main + side-bug + health");
+        assert_eq!(lanes[0].name, "main");
+        assert_eq!(lanes[1].name, "side-bug");
+        assert_eq!(lanes[2].name, "health");
+    }
+
+    #[test]
+    fn extracts_worktree_path_when_backticked() {
+        let lanes = parse_lanes_md(SAMPLE_LANES_MD);
+        assert_eq!(
+            lanes[0].worktree_path.as_deref(),
+            Some("D:/Mercury/Mercury")
+        );
+        assert_eq!(
+            lanes[1].worktree_path.as_deref(),
+            Some("D:/Mercury/Mercury-side-bug")
+        );
+    }
+
+    #[test]
+    fn health_lane_worktree_is_none() {
+        let lanes = parse_lanes_md(SAMPLE_LANES_MD);
+        assert_eq!(lanes[2].name, "health");
+        assert!(
+            lanes[2].worktree_path.is_none(),
+            "health lane has no backticked path → None"
+        );
+    }
+
+    #[test]
+    fn extracts_status() {
+        let lanes = parse_lanes_md(SAMPLE_LANES_MD);
+        assert_eq!(lanes[0].status.as_deref(), Some("active"));
+        assert_eq!(lanes[2].status.as_deref(), Some("active"));
+    }
+
+    #[test]
+    fn closed_lanes_section_excluded() {
+        let lanes = parse_lanes_md(SAMPLE_LANES_MD);
+        assert!(lanes.iter().all(|l| l.name != "side-multi-lane"));
+    }
+
+    #[test]
+    fn empty_md_yields_no_lanes() {
+        assert!(parse_lanes_md("").is_empty());
+    }
+
+    #[test]
+    fn group_matches_windows_backslash_cwd_against_forward_slash_lane() {
+        let job_windows_cwd = JobState {
+            cwd: r"D:\Mercury\Mercury".to_string(),
+            ..Default::default()
+        };
+        let lanes = vec![Lane {
+            name: "main".to_string(),
+            worktree_path: Some("D:/Mercury/Mercury".to_string()),
+            status: Some("active".to_string()),
+        }];
+        let grouped = group_jobs_by_lane(vec![job_windows_cwd], &lanes);
+        assert_eq!(grouped.get("main").map(Vec::len), Some(1));
+        assert!(
+            grouped.get("__unassigned__").map(Vec::is_empty).unwrap_or(true),
+            "no unassigned bucket when all jobs match"
+        );
+    }
+
+    #[test]
+    fn group_unassigned_when_cwd_matches_no_lane() {
+        let stray = JobState {
+            cwd: r"D:\Other\Repo".to_string(),
+            ..Default::default()
+        };
+        let lanes = vec![Lane {
+            name: "main".to_string(),
+            worktree_path: Some("D:/Mercury/Mercury".to_string()),
+            status: None,
+        }];
+        let grouped = group_jobs_by_lane(vec![stray], &lanes);
+        assert_eq!(grouped.get("__unassigned__").map(Vec::len), Some(1));
+    }
+
+    #[test]
+    fn group_handles_lane_with_no_worktree_path() {
+        let job = JobState {
+            cwd: r"D:\Mercury\Mercury".to_string(),
+            ..Default::default()
+        };
+        let lanes = vec![
+            Lane {
+                name: "health".to_string(),
+                worktree_path: None,
+                status: Some("active".to_string()),
+            },
+            Lane {
+                name: "main".to_string(),
+                worktree_path: Some("D:/Mercury/Mercury".to_string()),
+                status: Some("active".to_string()),
+            },
+        ];
+        let grouped = group_jobs_by_lane(vec![job], &lanes);
+        assert_eq!(grouped.get("main").map(Vec::len), Some(1));
+        assert_eq!(grouped.get("health").map(Vec::len), Some(0));
+    }
+}

--- a/mercury-gui/src-tauri/src/data/mod.rs
+++ b/mercury-gui/src-tauri/src/data/mod.rs
@@ -1,0 +1,74 @@
+pub mod commands;
+pub mod models;
+pub mod paths;
+pub mod watcher;
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum DataError {
+    #[error("io: {0}")]
+    Io(String),
+    #[error("parse: {0}")]
+    Parse(String),
+}
+
+impl serde::Serialize for DataError {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&self.to_string())
+    }
+}
+
+impl From<std::io::Error> for DataError {
+    fn from(e: std::io::Error) -> Self {
+        DataError::Io(redact_home(&e.to_string()))
+    }
+}
+
+impl From<serde_json::Error> for DataError {
+    fn from(e: serde_json::Error) -> Self {
+        DataError::Parse(redact_home(&e.to_string()))
+    }
+}
+
+/// Replace the resolved home directory with `~` so paths surfaced to the
+/// frontend or stderr never include `C:\Users\<name>\...` literals.
+/// Handles both backslash and forward-slash variants for cross-platform safety.
+pub fn redact_home(s: &str) -> String {
+    let Some(home) = dirs::home_dir() else {
+        return s.to_string();
+    };
+    let Some(home_str) = home.to_str() else {
+        return s.to_string();
+    };
+    if home_str.is_empty() {
+        return s.to_string();
+    }
+    let alt = home_str.replace('\\', "/");
+    let mut out = s.replace(home_str, "~");
+    if alt != home_str {
+        out = out.replace(&alt, "~");
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redact_home_replaces_home_prefix() {
+        let Some(home) = dirs::home_dir().and_then(|p| p.to_str().map(String::from)) else {
+            return;
+        };
+        let leaky = format!("read {home}/.claude/jobs/abc/state.json failed");
+        let redacted = redact_home(&leaky);
+        assert!(!redacted.contains(&home), "home path must be scrubbed");
+        assert!(redacted.contains("~/.claude/jobs/"));
+    }
+
+    #[test]
+    fn redact_home_handles_string_without_home() {
+        assert_eq!(redact_home("plain message"), "plain message");
+    }
+}

--- a/mercury-gui/src-tauri/src/data/models.rs
+++ b/mercury-gui/src-tauri/src/data/models.rs
@@ -1,0 +1,240 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Per-session state from `<claude_config_dir>/jobs/<id>/state.json`.
+///
+/// Schema-tolerant per S120 ADR — every field that may be absent on older
+/// CLI versions or non-terminal states is `Option<T>` + `#[serde(default)]`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(default)]
+pub struct JobState {
+    pub state: String,
+    pub detail: String,
+    pub tempo: String,
+    pub output: Option<serde_json::Value>,
+    pub children: Option<serde_json::Value>,
+    pub link_scan_offset: i64,
+    pub template: String,
+    pub respawn_flags: Vec<String>,
+    pub intent: String,
+    pub session_id: String,
+    pub resume_session_id: String,
+    pub daemon_short: String,
+    pub cwd: String,
+    pub created_at: Option<DateTime<Utc>>,
+    pub updated_at: Option<DateTime<Utc>>,
+    pub first_terminal_at: Option<DateTime<Utc>>,
+    pub backend: String,
+
+    pub in_flight: Option<InFlight>,
+    pub link_scan_path: Option<String>,
+    pub cli_version: Option<String>,
+    pub name: Option<String>,
+    pub name_source: Option<String>,
+
+    pub worktree_path: Option<String>,
+    pub worktree_branch: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(default)]
+pub struct InFlight {
+    pub tasks: i64,
+    pub queued: i64,
+    pub kinds: Vec<String>,
+}
+
+/// Supervisor heartbeat + active-worker registry from `<claude_config_dir>/daemon/roster.json`.
+///
+/// `updated_at` is unix milliseconds in source JSON; dispatched via `chrono::serde::ts_milliseconds`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(default)]
+pub struct RosterSnapshot {
+    pub proto: i64,
+    pub supervisor_pid: i64,
+    #[serde(with = "chrono::serde::ts_milliseconds_option")]
+    pub updated_at: Option<DateTime<Utc>>,
+    pub workers: HashMap<String, serde_json::Value>,
+}
+
+/// Mercury lane entry parsed from LANES.md.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct Lane {
+    pub name: String,
+    pub worktree_path: Option<String>,
+    pub status: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Sample from S120 ADR — sessionId `40726463`, cliVersion 2.1.142 (newer, has optional fields).
+    const SAMPLE_NEWER: &str = r#"{
+        "state": "done",
+        "detail": "answered 2+2=4 in one sentence",
+        "tempo": "idle",
+        "output": {"result": "2+2 = 4"},
+        "children": null,
+        "linkScanOffset": 17321,
+        "template": "research",
+        "respawnFlags": ["--agent", "research"],
+        "intent": "What is 2+2? Answer in one sentence then stop.",
+        "sessionId": "40726463-aaaa-bbbb-cccc-dddddddddddd",
+        "resumeSessionId": "40726463-aaaa-bbbb-cccc-dddddddddddd",
+        "daemonShort": "40726463",
+        "cwd": "D:\\Mercury\\Mercury",
+        "createdAt": "2026-05-14T16:42:55.110Z",
+        "updatedAt": "2026-05-14T16:42:55.110Z",
+        "firstTerminalAt": "2026-05-14T16:42:55.110Z",
+        "backend": "daemon",
+        "inFlight": {"tasks": 0, "queued": 0, "kinds": []},
+        "linkScanPath": "C:\\Users\\fake\\.claude\\projects\\D--Mercury-Mercury\\40726463.jsonl",
+        "cliVersion": "2.1.142",
+        "name": "math calculation response",
+        "nameSource": "auto"
+    }"#;
+
+    /// Sample from S120 ADR — sessionId `1baace78`, older session: missing inFlight / linkScanPath /
+    /// cliVersion / name / nameSource entirely.
+    const SAMPLE_OLDER: &str = r#"{
+        "state": "done",
+        "detail": "(idle — send a prompt to start)",
+        "tempo": "idle",
+        "output": null,
+        "children": null,
+        "linkScanOffset": 0,
+        "template": "bg",
+        "respawnFlags": ["--help"],
+        "intent": "",
+        "sessionId": "1baace78-6b3a-478b-829b-0def2187745c",
+        "resumeSessionId": "1baace78-6b3a-478b-829b-0def2187745c",
+        "daemonShort": "1baace78",
+        "cwd": "D:\\Mercury\\Mercury",
+        "createdAt": "2026-05-14T16:42:55.110Z",
+        "updatedAt": "2026-05-14T16:42:55.110Z",
+        "firstTerminalAt": "2026-05-14T16:42:55.110Z",
+        "backend": "daemon"
+    }"#;
+
+    #[test]
+    fn parses_newer_session_all_fields() {
+        let job: JobState = serde_json::from_str(SAMPLE_NEWER).expect("newer parse");
+        assert_eq!(job.state, "done");
+        assert_eq!(job.template, "research");
+        assert_eq!(job.cli_version.as_deref(), Some("2.1.142"));
+        assert_eq!(job.name.as_deref(), Some("math calculation response"));
+        assert!(job.in_flight.is_some());
+        assert_eq!(job.in_flight.unwrap().tasks, 0);
+        assert!(job.created_at.is_some());
+    }
+
+    #[test]
+    fn parses_older_session_missing_optional_fields() {
+        let job: JobState = serde_json::from_str(SAMPLE_OLDER).expect("older parse");
+        assert_eq!(job.daemon_short, "1baace78");
+        assert!(job.cli_version.is_none(), "cliVersion absent on older session");
+        assert!(job.name.is_none(), "name absent on older session");
+        assert!(job.name_source.is_none());
+        assert!(job.in_flight.is_none());
+        assert!(job.link_scan_path.is_none());
+    }
+
+    #[test]
+    fn unknown_fields_ignored_silently() {
+        let with_unknown = r#"{
+            "state": "done",
+            "detail": "",
+            "tempo": "idle",
+            "output": null,
+            "children": null,
+            "linkScanOffset": 0,
+            "template": "bg",
+            "respawnFlags": [],
+            "intent": "",
+            "sessionId": "x",
+            "resumeSessionId": "x",
+            "daemonShort": "x",
+            "cwd": "/tmp",
+            "createdAt": "2026-05-14T16:42:55.110Z",
+            "updatedAt": "2026-05-14T16:42:55.110Z",
+            "firstTerminalAt": "2026-05-14T16:42:55.110Z",
+            "backend": "daemon",
+            "futureField": "ignored"
+        }"#;
+        let job: JobState = serde_json::from_str(with_unknown).expect("unknown ok");
+        assert_eq!(job.daemon_short, "x");
+    }
+
+    #[test]
+    fn empty_object_yields_defaults() {
+        // Schema-tolerant: missing required-by-ADR fields parse via #[serde(default)]
+        // rather than panicking. GUI receives an empty-but-valid struct.
+        let job: JobState = serde_json::from_str("{}").expect("empty parse");
+        assert_eq!(job.state, "");
+        assert_eq!(job.link_scan_offset, 0);
+        assert!(job.created_at.is_none());
+    }
+
+    #[test]
+    fn roster_unix_ms_dispatch() {
+        let roster_json = r#"{
+            "proto": 1,
+            "supervisorPid": 2240,
+            "updatedAt": 1778822198033,
+            "workers": {}
+        }"#;
+        let roster: RosterSnapshot = serde_json::from_str(roster_json).expect("roster parse");
+        assert_eq!(roster.proto, 1);
+        assert_eq!(roster.supervisor_pid, 2240);
+        assert!(roster.updated_at.is_some());
+        // 1778822198033 ms → year 2026 (sanity check)
+        assert!(roster.updated_at.unwrap().timestamp() > 1_700_000_000);
+        assert!(roster.workers.is_empty());
+    }
+
+    #[test]
+    fn roster_empty_workers_default() {
+        let roster: RosterSnapshot = serde_json::from_str("{}").expect("empty roster");
+        assert_eq!(roster.proto, 0);
+        assert!(roster.workers.is_empty());
+    }
+
+    #[test]
+    fn worktree_fields_absent_on_terminal() {
+        let job: JobState = serde_json::from_str(SAMPLE_NEWER).expect("parse");
+        assert!(job.worktree_path.is_none());
+        assert!(job.worktree_branch.is_none());
+    }
+
+    #[test]
+    fn worktree_fields_present_on_midflight() {
+        let mid_flight = r#"{
+            "state": "working",
+            "detail": "editing file",
+            "tempo": "active",
+            "output": null,
+            "children": null,
+            "linkScanOffset": 100,
+            "template": "bg",
+            "respawnFlags": [],
+            "intent": "edit foo.txt",
+            "sessionId": "abc",
+            "resumeSessionId": "abc",
+            "daemonShort": "abc",
+            "cwd": "D:\\Mercury\\Mercury",
+            "createdAt": "2026-05-14T16:42:55.110Z",
+            "updatedAt": "2026-05-14T16:42:55.110Z",
+            "firstTerminalAt": "2026-05-14T16:42:55.110Z",
+            "backend": "daemon",
+            "worktreePath": "D:\\Mercury\\Mercury\\.claude\\worktrees\\phase6-probe-1",
+            "worktreeBranch": "phase6-probe-1"
+        }"#;
+        let job: JobState = serde_json::from_str(mid_flight).expect("mid-flight parse");
+        assert_eq!(job.worktree_branch.as_deref(), Some("phase6-probe-1"));
+    }
+}

--- a/mercury-gui/src-tauri/src/data/models.rs
+++ b/mercury-gui/src-tauri/src/data/models.rs
@@ -1,3 +1,4 @@
+use super::redact_home;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -36,6 +37,22 @@ pub struct JobState {
 
     pub worktree_path: Option<String>,
     pub worktree_branch: Option<String>,
+}
+
+impl JobState {
+    /// Strip the home directory prefix from path-bearing fields before
+    /// surfacing to the frontend. Mirrors the same scrubbing that `DataError`
+    /// applies to error messages so the GUI never sees `C:\Users\<name>\...`
+    /// literals. Idempotent.
+    pub fn sanitize_paths(&mut self) {
+        self.cwd = redact_home(&self.cwd);
+        if let Some(s) = self.link_scan_path.as_deref() {
+            self.link_scan_path = Some(redact_home(s));
+        }
+        if let Some(s) = self.worktree_path.as_deref() {
+            self.worktree_path = Some(redact_home(s));
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/mercury-gui/src-tauri/src/data/paths.rs
+++ b/mercury-gui/src-tauri/src/data/paths.rs
@@ -39,15 +39,15 @@ pub fn lanes_path() -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
 
-    // NB: cargo's default test-threads = num_cpus and env-var mutations are
-    // process-global. Each test below SET-then-READ-then-REMOVE so race windows
-    // between tests are benign (any race results in a temporarily different value,
-    // not a wrong assertion since each test reads after its own set). If new
-    // tests are added that expect env-vars UNSET, switch to `serial_test` crate.
+    // Env-var mutation is process-global; cargo's default test-threads = num_cpus.
+    // Serialize all env-touching tests under a single mutex to prevent interleaving.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn claude_config_dir_respects_env() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         std::env::set_var("CLAUDE_CONFIG_DIR", "/tmp/fake-claude");
         assert_eq!(claude_config_dir(), PathBuf::from("/tmp/fake-claude"));
         std::env::remove_var("CLAUDE_CONFIG_DIR");
@@ -55,6 +55,7 @@ mod tests {
 
     #[test]
     fn jobs_dir_under_config_dir() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         std::env::set_var("CLAUDE_CONFIG_DIR", "/tmp/cc-jobs");
         assert_eq!(jobs_dir(), PathBuf::from("/tmp/cc-jobs/jobs"));
         std::env::remove_var("CLAUDE_CONFIG_DIR");
@@ -62,6 +63,7 @@ mod tests {
 
     #[test]
     fn roster_path_under_daemon() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         std::env::set_var("CLAUDE_CONFIG_DIR", "/tmp/cc-roster");
         assert_eq!(
             roster_path(),
@@ -72,6 +74,7 @@ mod tests {
 
     #[test]
     fn lanes_path_respects_mercury_env() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         std::env::set_var("MERCURY_MEMORY_DIR", "/tmp/mem");
         assert_eq!(lanes_path(), PathBuf::from("/tmp/mem/LANES.md"));
         std::env::remove_var("MERCURY_MEMORY_DIR");

--- a/mercury-gui/src-tauri/src/data/paths.rs
+++ b/mercury-gui/src-tauri/src/data/paths.rs
@@ -1,0 +1,79 @@
+use std::path::PathBuf;
+
+/// Resolve Claude's config dir.
+///
+/// Precedence: `$CLAUDE_CONFIG_DIR` env var → `dirs::home_dir().join(".claude")`.
+/// Mercury convention; do NOT hardcode any user path.
+pub fn claude_config_dir() -> PathBuf {
+    if let Ok(s) = std::env::var("CLAUDE_CONFIG_DIR") {
+        return PathBuf::from(s);
+    }
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".claude")
+}
+
+pub fn jobs_dir() -> PathBuf {
+    claude_config_dir().join("jobs")
+}
+
+pub fn roster_path() -> PathBuf {
+    claude_config_dir().join("daemon").join("roster.json")
+}
+
+/// Mercury LANES.md canonical path per `scripts/lane-assertion.sh:128-131`.
+///
+/// Precedence: `$MERCURY_MEMORY_DIR` env override → `<claude_config_dir>/projects/D--Mercury-Mercury/memory/`.
+/// User-memory file, NOT a repo file.
+pub fn lanes_path() -> PathBuf {
+    if let Ok(s) = std::env::var("MERCURY_MEMORY_DIR") {
+        return PathBuf::from(s).join("LANES.md");
+    }
+    claude_config_dir()
+        .join("projects")
+        .join("D--Mercury-Mercury")
+        .join("memory")
+        .join("LANES.md")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // NB: cargo's default test-threads = num_cpus and env-var mutations are
+    // process-global. Each test below SET-then-READ-then-REMOVE so race windows
+    // between tests are benign (any race results in a temporarily different value,
+    // not a wrong assertion since each test reads after its own set). If new
+    // tests are added that expect env-vars UNSET, switch to `serial_test` crate.
+
+    #[test]
+    fn claude_config_dir_respects_env() {
+        std::env::set_var("CLAUDE_CONFIG_DIR", "/tmp/fake-claude");
+        assert_eq!(claude_config_dir(), PathBuf::from("/tmp/fake-claude"));
+        std::env::remove_var("CLAUDE_CONFIG_DIR");
+    }
+
+    #[test]
+    fn jobs_dir_under_config_dir() {
+        std::env::set_var("CLAUDE_CONFIG_DIR", "/tmp/cc-jobs");
+        assert_eq!(jobs_dir(), PathBuf::from("/tmp/cc-jobs/jobs"));
+        std::env::remove_var("CLAUDE_CONFIG_DIR");
+    }
+
+    #[test]
+    fn roster_path_under_daemon() {
+        std::env::set_var("CLAUDE_CONFIG_DIR", "/tmp/cc-roster");
+        assert_eq!(
+            roster_path(),
+            PathBuf::from("/tmp/cc-roster/daemon/roster.json")
+        );
+        std::env::remove_var("CLAUDE_CONFIG_DIR");
+    }
+
+    #[test]
+    fn lanes_path_respects_mercury_env() {
+        std::env::set_var("MERCURY_MEMORY_DIR", "/tmp/mem");
+        assert_eq!(lanes_path(), PathBuf::from("/tmp/mem/LANES.md"));
+        std::env::remove_var("MERCURY_MEMORY_DIR");
+    }
+}

--- a/mercury-gui/src-tauri/src/data/watcher.rs
+++ b/mercury-gui/src-tauri/src/data/watcher.rs
@@ -1,0 +1,113 @@
+use super::{paths, redact_home};
+use notify::{recommended_watcher, EventKind, RecursiveMode, Watcher};
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
+use tauri::{AppHandle, Emitter};
+
+const DEBOUNCE_MS: u64 = 300;
+
+/// Tauri event name emitted on debounced FS change. JS side listens via
+/// `import { listen } from '@tauri-apps/api/event'; listen(DATA_CHANGED_EVENT, ...)`.
+pub const DATA_CHANGED_EVENT: &str = "mercury:data-changed";
+
+/// Spawn a background OS thread that watches the read-side data sources and
+/// emits a debounced [`DATA_CHANGED_EVENT`] whenever any of them change.
+///
+/// The thread owns the `notify::Watcher`; dropping the thread (process exit)
+/// stops watching. No explicit shutdown channel for the MVP — follow-up tracked
+/// for clean shutdown on `RunEvent::ExitRequested`.
+pub fn start(app_handle: AppHandle) -> Result<(), notify::Error> {
+    let jobs = paths::jobs_dir();
+    let roster_parent = paths::roster_path().parent().map(|p| p.to_path_buf());
+    let lanes_parent = paths::lanes_path().parent().map(|p| p.to_path_buf());
+
+    thread::spawn(move || {
+        let (tx, rx) = mpsc::channel();
+        let mut watcher = match recommended_watcher(tx) {
+            Ok(w) => w,
+            Err(e) => {
+                eprintln!(
+                    "[mercury-gui] watcher init failed: {}",
+                    redact_home(&e.to_string())
+                );
+                return;
+            }
+        };
+
+        // Watch the jobs dir recursively (sessions are subdirs each with their own state.json).
+        // Missing paths are non-fatal: log + skip; GUI still works against whichever paths exist.
+        let _ = try_watch(&mut watcher, &jobs, RecursiveMode::Recursive, "jobs");
+        if let Some(p) = roster_parent {
+            let _ = try_watch(&mut watcher, &p, RecursiveMode::NonRecursive, "roster-parent");
+        }
+        if let Some(p) = lanes_parent {
+            let _ = try_watch(&mut watcher, &p, RecursiveMode::NonRecursive, "lanes-parent");
+        }
+
+        // Coalescing receive loop: drain raw events until DEBOUNCE_MS quiet window,
+        // then emit a single notification to the frontend.
+        let mut pending = false;
+        let mut last_event = Instant::now();
+        loop {
+            let timeout = if pending {
+                Duration::from_millis(DEBOUNCE_MS / 3)
+            } else {
+                Duration::from_secs(60)
+            };
+            match rx.recv_timeout(timeout) {
+                Ok(Ok(event)) => {
+                    if is_meaningful(&event.kind) {
+                        pending = true;
+                        last_event = Instant::now();
+                    }
+                }
+                Ok(Err(e)) => eprintln!(
+                    "[mercury-gui] watcher event error: {}",
+                    redact_home(&e.to_string())
+                ),
+                Err(mpsc::RecvTimeoutError::Timeout) => {
+                    if pending && last_event.elapsed() >= Duration::from_millis(DEBOUNCE_MS) {
+                        if let Err(e) = app_handle.emit(DATA_CHANGED_EVENT, ()) {
+                            eprintln!(
+                                "[mercury-gui] emit failed: {}",
+                                redact_home(&e.to_string())
+                            );
+                        }
+                        pending = false;
+                    }
+                }
+                Err(mpsc::RecvTimeoutError::Disconnected) => break,
+            }
+        }
+    });
+    Ok(())
+}
+
+fn try_watch(
+    watcher: &mut notify::RecommendedWatcher,
+    path: &std::path::Path,
+    mode: RecursiveMode,
+    label: &str,
+) -> Result<(), notify::Error> {
+    let display = redact_home(&path.display().to_string());
+    if !path.exists() {
+        eprintln!("[mercury-gui] skip watch ({label}): path absent {display}");
+        return Ok(());
+    }
+    if let Err(e) = watcher.watch(path, mode) {
+        eprintln!(
+            "[mercury-gui] watch failed ({label}) {display}: {}",
+            redact_home(&e.to_string())
+        );
+        return Err(e);
+    }
+    Ok(())
+}
+
+fn is_meaningful(kind: &EventKind) -> bool {
+    matches!(
+        kind,
+        EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_)
+    )
+}

--- a/mercury-gui/src-tauri/src/data/watcher.rs
+++ b/mercury-gui/src-tauri/src/data/watcher.rs
@@ -91,6 +91,8 @@ fn try_watch(
     label: &str,
 ) -> Result<(), notify::Error> {
     let display = redact_home(&path.display().to_string());
+    // MVP limitation: late-created paths don't auto-rewatch; restart GUI to
+    // pick them up. Tracked at https://github.com/392fyc/Mercury/issues/423.
     if !path.exists() {
         eprintln!("[mercury-gui] skip watch ({label}): path absent {display}");
         return Ok(());

--- a/mercury-gui/src-tauri/src/data/watcher.rs
+++ b/mercury-gui/src-tauri/src/data/watcher.rs
@@ -17,7 +17,11 @@ pub const DATA_CHANGED_EVENT: &str = "mercury:data-changed";
 /// The thread owns the `notify::Watcher`; dropping the thread (process exit)
 /// stops watching. No explicit shutdown channel for the MVP — follow-up tracked
 /// for clean shutdown on `RunEvent::ExitRequested`.
-pub fn start(app_handle: AppHandle) -> Result<(), notify::Error> {
+///
+/// Returns `()` because all fallible initialization happens inside the spawned
+/// thread (watcher creation + `watch()` calls). Failures are logged via stderr
+/// (`redact_home`-scrubbed). The GUI continues to work without live events.
+pub fn start(app_handle: AppHandle) {
     let jobs = paths::jobs_dir();
     let roster_parent = paths::roster_path().parent().map(|p| p.to_path_buf());
     let lanes_parent = paths::lanes_path().parent().map(|p| p.to_path_buf());
@@ -81,7 +85,6 @@ pub fn start(app_handle: AppHandle) -> Result<(), notify::Error> {
             }
         }
     });
-    Ok(())
 }
 
 fn try_watch(

--- a/mercury-gui/src-tauri/src/lib.rs
+++ b/mercury-gui/src-tauri/src/lib.rs
@@ -4,6 +4,8 @@ use tauri::{
     tray::TrayIconBuilder,
 };
 
+mod data;
+
 #[tauri::command]
 fn greet(name: &str) -> String {
     format!("Hello, {}! You've been greeted from Rust!", name)
@@ -28,7 +30,13 @@ pub fn run() {
 
     builder
         .plugin(tauri_plugin_opener::init())
-        .invoke_handler(tauri::generate_handler![greet])
+        .invoke_handler(tauri::generate_handler![
+            greet,
+            data::commands::read_jobs,
+            data::commands::read_roster,
+            data::commands::read_lanes,
+            data::commands::read_jobs_by_lane,
+        ])
         .setup(|app| {
             // System tray: "Quit Mercury" menu item.
             // Uses the app's default window icon (bundled in src-tauri/icons/).
@@ -51,6 +59,15 @@ pub fn run() {
                     }
                 })
                 .build(app)?;
+
+            // Spawn the read-side file-watcher (#414). Non-fatal if it fails —
+            // commands still work, just no live "data-changed" events.
+            if let Err(e) = data::watcher::start(app.handle().clone()) {
+                eprintln!(
+                    "[mercury-gui] data watcher start failed: {}",
+                    data::redact_home(&e.to_string())
+                );
+            }
             Ok(())
         })
         .run(tauri::generate_context!())

--- a/mercury-gui/src-tauri/src/lib.rs
+++ b/mercury-gui/src-tauri/src/lib.rs
@@ -60,14 +60,10 @@ pub fn run() {
                 })
                 .build(app)?;
 
-            // Spawn the read-side file-watcher (#414). Non-fatal if it fails —
-            // commands still work, just no live "data-changed" events.
-            if let Err(e) = data::watcher::start(app.handle().clone()) {
-                eprintln!(
-                    "[mercury-gui] data watcher start failed: {}",
-                    data::redact_home(&e.to_string())
-                );
-            }
+            // Spawn the read-side file-watcher (#414). Watcher init can fail
+            // inside the spawned thread; those failures are logged with
+            // home-redacted paths and the GUI keeps working without live events.
+            data::watcher::start(app.handle().clone());
             Ok(())
         })
         .run(tauri::generate_context!())


### PR DESCRIPTION
## Summary

Phase 6 GUI MVP **slice B** per S120 backend schema ADR + S122 Mode A 5 axes locked stack. Provides the Tauri IPC surface that the read-only agent-view UI (#415 / #416) will consume. Unblocks #415 and #416.

## Files added

- `mercury-gui/src-tauri/src/data/mod.rs` — `DataError` (string-serialized, home-path redacted via `redact_home`)
- `mercury-gui/src-tauri/src/data/paths.rs` — resolves `$CLAUDE_CONFIG_DIR` / `$MERCURY_MEMORY_DIR` with `dirs::home_dir()` fallback
- `mercury-gui/src-tauri/src/data/models.rs` — `JobState` (22 fields, schema-tolerant), `RosterSnapshot` (unix-ms time dispatch), `Lane`
- `mercury-gui/src-tauri/src/data/commands.rs` — 4 `#[tauri::command]` handlers + LANES.md parser + case-insensitive normalized-path lane matcher
- `mercury-gui/src-tauri/src/data/watcher.rs` — `std::thread` owning `notify::RecommendedWatcher`; coalesces FS events into a 300ms-debounced `mercury:data-changed` Tauri event

Plus minimal wiring in `lib.rs` (mod registration, 4 commands in `invoke_handler!`, watcher started in `setup()`) and 4 new Cargo deps.

## Cargo deps added

- `notify ^8` — file watching (Rust-side; chokidar rejected per research summary, JS-side has IPC overhead for our 5-50 file set)
- `chrono 0.4` with `serde` feature — ISO 8601 default + `ts_milliseconds_option` for roster.json
- `dirs ^5` — cross-platform home-dir (Windows uses `SHGetKnownFolderPath`, not `$HOME`)
- `thiserror ^2` — `DataError` derives

## Acceptance criteria (Issue #414)

- [x] All 4 IPC commands implemented with Rust unit tests
- [x] Schema-tolerant on S120 sample state.json files + edge cases (older/newer/mid-flight/empty/unknown-field variants)
- [x] File-watcher integrated (`notify`, Rust-side, decided + documented in code-comments)
- [x] No PII hardcoded — env-var driven (`$CLAUDE_CONFIG_DIR`, `$MERCURY_MEMORY_DIR`) + runtime `redact_home` scrubs home prefix from all surfaced strings
- [ ] Smoke test (`claude --bg ... && invoke read_jobs()`) — gated on #415 UI landing (no UI to invoke yet)
- [ ] PR through /pr-flow + Argus + dual-verify — in-flight on this PR
- [x] Closes via PR Closes-tag

## Verification

- `cargo check`: exit 0
- `cargo test --lib`: **23/23 pass** (model parse, LANES.md parser, path resolution, home-redaction, group-by-lane, schema-tolerance)
- `pnpm tauri build`: exit 0 in **53.18s** — MSI 3MB + NSIS regenerated

## Pre-commit dual-verify (S111 strict)

- **Claude code-reviewer** (sonnet): APPROVE WITH MINOR ADVISORY — 0 BLOCKER / 0 HIGH / 6 MEDIUM / 8 LOW. Addressed before commit:
  - **M1**: `read_roster` lenient parse — returns default on partial-write parse failure
  - **M2**: `read_lanes` returns empty Vec on missing file (consistent with `read_jobs` / `read_roster`)
  - **M4**: event name `mercury://data-changed` → `mercury:data-changed` (Tauri-2-conventional; constant `DATA_CHANGED_EVENT`)
  - **L1**: manual `Default` impls → `#[derive(Default)]` (-30 LOC)
  - **L8**: env-var test serialization comment corrected to honest gap statement
- **Codex sync-audit** via `scripts/codex-sync-audit.sh /tmp/codex-audit-prompt-414.txt --timeout 900` (job `task-mpdie9jg-1iuvaf`, 3m duration, no_write read-only): **2 BLOCKER** addressed:
  - **B1** PII at runtime: `redact_home()` helper added; applied to `DataError::Io` / `DataError::Parse` `From` impls + all 4 watcher `eprintln!` + `lib.rs` watcher-start failure log. `read_lanes` no longer surfaces the path (returns empty Vec on missing).
  - **B2** `read_jobs_by_lane` silent degradation: now propagates `read_lanes` errors via `?`. GUI sees explicit failure instead of `__unassigned__`-for-everything.

Deferred per code-reviewer advisory (M3/M5/M6, Codex R1/R2/R3): clean shutdown channel, schema-drift handling, path canonicalization — tracked for #415+ follow-up.

## Mandatory research protocol (per CLAUDE.md MUST)

Pre-code Web verification (S124 session log):
- Tauri 2 `State` / `Manager::manage` / `#[tauri::command]` / `Emitter::emit` semantics — https://v2.tauri.app/develop/state-management/, https://v2.tauri.app/develop/calling-rust/, https://v2.tauri.app/develop/calling-frontend/
- `notify` 8.2.0 + Windows `ReadDirectoryChangesW` support — https://docs.rs/notify/latest/notify/, https://crates.io/crates/notify
- `chokidar` 5.x ESM-only / Node 20+ trade-off — https://github.com/paulmillr/chokidar
- `chrono::serde::ts_milliseconds_option` for unix-ms dispatch — https://docs.rs/chrono/latest/chrono/struct.DateTime.html
- `dirs::home_dir` cross-platform — https://docs.rs/dirs/latest/dirs/fn.home_dir.html
- `serde` schema-tolerance default vs `deny_unknown_fields` — https://serde.rs/field-attrs.html, https://serde.rs/container-attrs.html

## Test plan

- [x] Cargo unit tests (23/23)
- [x] `pnpm tauri build` produces signed MSI + NSIS
- [ ] Manual smoke (S125+ once #415 lands a list view): `claude --bg "echo smoke"` → wait → `invoke('read_jobs')` returns ≥1 entry; `invoke('read_jobs_by_lane')` groups under `main`
- [ ] Manual smoke for watcher: edit `~/.claude/jobs/<id>/state.json` → observe `mercury:data-changed` event within 300-600ms

## Related

- Closes #414
- Depends on #413 (Tauri scaffold, MERGED `bdf1785`)
- Unblocks #415 (UI scenario 1) and #416 (UI scenario 5)
- S120 ADR: `.mercury/docs/research/phase6-gui-mvp-agentview-backend-schema-2026-05.md`
- S122 Mode A decision log: https://github.com/392fyc/Mercury/issues/413#issuecomment-4493506591

🤖 Generated with [Claude Code](https://claude.com/claude-code)