### PR TITLE
feat(mercury-gui): #416 UI scenario 5 — Issue/PR dashboard (gh CLI + Tabs nav)

### DIFF
--- a/mercury-gui/package.json
+++ b/mercury-gui/package.json
@@ -12,9 +12,11 @@
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-tabs": "^1.1.13",
     "@tailwindcss/vite": "^4.3.0",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-opener": "^2",
+    "@tauri-apps/plugin-shell": "^2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.16.0",

--- a/mercury-gui/package.json
+++ b/mercury-gui/package.json
@@ -16,7 +16,6 @@
     "@tailwindcss/vite": "^4.3.0",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-opener": "^2",
-    "@tauri-apps/plugin-shell": "^2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.16.0",

--- a/mercury-gui/pnpm-lock.yaml
+++ b/mercury-gui/pnpm-lock.yaml
@@ -8,18 +8,51 @@ importers:
 
   .:
     dependencies:
+      '@radix-ui/react-dialog':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-slot':
+        specifier: ^1.2.4
+        version: 1.2.4(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-tabs':
+        specifier: ^1.1.13
+        version: 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@tailwindcss/vite':
+        specifier: ^4.3.0
+        version: 4.3.0(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0))
       '@tauri-apps/api':
         specifier: ^2
         version: 2.11.0
       '@tauri-apps/plugin-opener':
         specifier: ^2
         version: 2.5.4
+      '@tauri-apps/plugin-shell':
+        specifier: ^2
+        version: 2.3.5
+      class-variance-authority:
+        specifier: ^0.7.1
+        version: 0.7.1
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      lucide-react:
+        specifier: ^1.16.0
+        version: 1.16.0(react@19.2.6)
       react:
         specifier: ^19.1.0
         version: 19.2.6
       react-dom:
         specifier: ^19.1.0
         version: 19.2.6(react@19.2.6)
+      tailwind-merge:
+        specifier: ^3.6.0
+        version: 3.6.0
+      tailwindcss:
+        specifier: ^4.3.0
+        version: 4.3.0
+      tw-animate-css:
+        specifier: ^1.4.0
+        version: 1.4.0
     devDependencies:
       '@tauri-apps/cli':
         specifier: ^2
@@ -35,13 +68,13 @@ importers:
         version: 19.2.3(@types/react@19.2.15)
       '@vitejs/plugin-react':
         specifier: ^4.6.0
-        version: 4.7.0(vite@7.3.3(@types/node@22.19.19))
+        version: 4.7.0(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0))
       typescript:
         specifier: ~5.8.3
         version: 5.8.3
       vite:
         specifier: ^7.0.4
-        version: 7.3.3(@types/node@22.19.19)
+        version: 7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)
 
 packages:
 
@@ -300,6 +333,234 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@radix-ui/primitive@1.1.3':
+    resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
+  '@radix-ui/react-collection@1.1.7':
+    resolution: {integrity: sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-compose-refs@1.1.2':
+    resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.2':
+    resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dialog@1.1.15':
+    resolution: {integrity: sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-direction@1.1.1':
+    resolution: {integrity: sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.11':
+    resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-focus-guards@1.1.3':
+    resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.7':
+    resolution: {integrity: sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-id@1.1.1':
+    resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.9':
+    resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.5':
+    resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.3':
+    resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-roving-focus@1.1.11':
+    resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.3':
+    resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.4':
+    resolution: {integrity: sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-tabs@1.1.13':
+    resolution: {integrity: sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.1':
+    resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.2':
+    resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.2':
+    resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-escape-keydown@1.1.1':
+    resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.1':
+    resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
@@ -441,6 +702,100 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@tailwindcss/node@4.3.0':
+    resolution: {integrity: sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==}
+
+  '@tailwindcss/oxide-android-arm64@4.3.0':
+    resolution: {integrity: sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.0':
+    resolution: {integrity: sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.3.0':
+    resolution: {integrity: sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.0':
+    resolution: {integrity: sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.0':
+    resolution: {integrity: sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==}
+    engines: {node: '>= 20'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.0':
+    resolution: {integrity: sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
+    resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
+    resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.0':
+    resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.0':
+    resolution: {integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.0':
+    resolution: {integrity: sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.0':
+    resolution: {integrity: sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.3.0':
+    resolution: {integrity: sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==}
+    engines: {node: '>= 20'}
+
+  '@tailwindcss/vite@4.3.0':
+    resolution: {integrity: sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw==}
+    peerDependencies:
+      vite: ^5.2.0 || ^6 || ^7 || ^8
+
   '@tauri-apps/api@2.11.0':
     resolution: {integrity: sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA==}
 
@@ -523,6 +878,9 @@ packages:
   '@tauri-apps/plugin-opener@2.5.4':
     resolution: {integrity: sha512-1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ==}
 
+  '@tauri-apps/plugin-shell@2.3.5':
+    resolution: {integrity: sha512-jewtULhiQ7lI7+owCKAjc8tYLJr92U16bPOeAa472LHJdgaibLP83NcfAF2e+wkEcA53FxKQAZ7byDzs2eeizg==}
+
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -555,6 +913,10 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
+
   baseline-browser-mapping@2.10.31:
     resolution: {integrity: sha512-MujYO3eP72uvmSE0i4wltsodRfIpZATP3jvzRNRGGxgzId7aVocVJJV3nf01qnzzKFGxQVC9bpWxl5cjxTr/7Q==}
     engines: {node: '>=6.0.0'}
@@ -567,6 +929,13 @@ packages:
 
   caniuse-lite@1.0.30001793:
     resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
+
+  class-variance-authority@0.7.1:
+    resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -583,8 +952,19 @@ packages:
       supports-color:
         optional: true
 
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  detect-node-es@1.1.0:
+    resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
   electron-to-chromium@1.5.360:
     resolution: {integrity: sha512-GkcBt6YYAw9SxFWn+xVar4cLVGlXVuswwtRLBozi2zp0GjXs4ZnOrqV4zbXzg35n7w81hCkyJNYicgXlVHAmBA==}
+
+  enhanced-resolve@5.21.5:
+    resolution: {integrity: sha512-mLCNbrQli11K1ySUmuNt4ZUB3OpGIDq4q2vTBTf5cL2lpsRjI9QKqSD0ndjW8FyvcW/Jj46gMe9syyHAsvMa/A==}
+    engines: {node: '>=10.13.0'}
 
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
@@ -613,6 +993,17 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  get-nonce@1.0.1:
+    resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
+    engines: {node: '>=6'}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
+    hasBin: true
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -626,8 +1017,90 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lucide-react@1.16.0:
+    resolution: {integrity: sha512-dYwyPzb4MEKpGUmNYk3WKWPnMrHs3FKM+q94kAnJrcDIqqn1hq2xY8scaS2ovsOCM5D51ey2gaRG3PBb1vgoYQ==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -660,6 +1133,36 @@ packages:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
 
+  react-remove-scroll-bar@2.3.8:
+    resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-remove-scroll@2.7.2:
+    resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-style-singleton@2.2.3:
+    resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   react@19.2.6:
     resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
     engines: {node: '>=0.10.0'}
@@ -680,9 +1183,25 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  tailwind-merge@3.6.0:
+    resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
+
+  tailwindcss@4.3.0:
+    resolution: {integrity: sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==}
+
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
+    engines: {node: '>=6'}
+
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tw-animate-css@1.4.0:
+    resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
 
   typescript@5.8.3:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
@@ -697,6 +1216,26 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  use-callback-ref@1.3.3:
+    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-sidecar@1.1.3:
+    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   vite@7.3.3:
     resolution: {integrity: sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==}
@@ -952,6 +1491,207 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@radix-ui/primitive@1.1.3': {}
+
+  '@radix-ui/react-collection@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.15)(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.15
+      '@types/react-dom': 19.2.3(@types/react@19.2.15)
+
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.15)(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.15
+
+  '@radix-ui/react-context@1.1.2(@types/react@19.2.15)(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.15
+
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.15)(react@19.2.6)
+      aria-hidden: 1.2.6
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      react-remove-scroll: 2.7.2(@types/react@19.2.15)(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.15
+      '@types/react-dom': 19.2.3(@types/react@19.2.15)
+
+  '@radix-ui/react-direction@1.1.1(@types/react@19.2.15)(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.15
+
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.15)(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.15
+      '@types/react-dom': 19.2.3(@types/react@19.2.15)
+
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.15)(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.15
+
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.15)(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.15
+      '@types/react-dom': 19.2.3(@types/react@19.2.15)
+
+  '@radix-ui/react-id@1.1.1(@types/react@19.2.15)(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.15)(react@19.2.6)
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.15
+
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.15)(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.15
+      '@types/react-dom': 19.2.3(@types/react@19.2.15)
+
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.15)(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.15
+      '@types/react-dom': 19.2.3(@types/react@19.2.15)
+
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.15)(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.15
+      '@types/react-dom': 19.2.3(@types/react@19.2.15)
+
+  '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.15)(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.15
+      '@types/react-dom': 19.2.3(@types/react@19.2.15)
+
+  '@radix-ui/react-slot@1.2.3(@types/react@19.2.15)(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.15)(react@19.2.6)
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.15
+
+  '@radix-ui/react-slot@1.2.4(@types/react@19.2.15)(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.15)(react@19.2.6)
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.15
+
+  '@radix-ui/react-tabs@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.15)(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.15
+      '@types/react-dom': 19.2.3(@types/react@19.2.15)
+
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.15)(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.15
+
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.15)(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.15)(react@19.2.6)
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.15
+
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.15)(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.15)(react@19.2.6)
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.15
+
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.15)(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.15)(react@19.2.6)
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.15
+
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.15)(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.15
+
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rollup/rollup-android-arm-eabi@4.60.4':
@@ -1029,6 +1769,74 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.4':
     optional: true
 
+  '@tailwindcss/node@4.3.0':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.21.5
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.3.0
+
+  '@tailwindcss/oxide-android-arm64@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide@4.3.0':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.3.0
+      '@tailwindcss/oxide-darwin-arm64': 4.3.0
+      '@tailwindcss/oxide-darwin-x64': 4.3.0
+      '@tailwindcss/oxide-freebsd-x64': 4.3.0
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.3.0
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.3.0
+      '@tailwindcss/oxide-linux-arm64-musl': 4.3.0
+      '@tailwindcss/oxide-linux-x64-gnu': 4.3.0
+      '@tailwindcss/oxide-linux-x64-musl': 4.3.0
+      '@tailwindcss/oxide-wasm32-wasi': 4.3.0
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.3.0
+      '@tailwindcss/oxide-win32-x64-msvc': 4.3.0
+
+  '@tailwindcss/vite@4.3.0(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0))':
+    dependencies:
+      '@tailwindcss/node': 4.3.0
+      '@tailwindcss/oxide': 4.3.0
+      tailwindcss: 4.3.0
+      vite: 7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)
+
   '@tauri-apps/api@2.11.0': {}
 
   '@tauri-apps/cli-darwin-arm64@2.11.2':
@@ -1082,6 +1890,10 @@ snapshots:
     dependencies:
       '@tauri-apps/api': 2.11.0
 
+  '@tauri-apps/plugin-shell@2.3.5':
+    dependencies:
+      '@tauri-apps/api': 2.11.0
+
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.29.3
@@ -1117,7 +1929,7 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
-  '@vitejs/plugin-react@4.7.0(vite@7.3.3(@types/node@22.19.19))':
+  '@vitejs/plugin-react@4.7.0(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -1125,9 +1937,13 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 7.3.3(@types/node@22.19.19)
+      vite: 7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)
     transitivePeerDependencies:
       - supports-color
+
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
 
   baseline-browser-mapping@2.10.31: {}
 
@@ -1141,6 +1957,12 @@ snapshots:
 
   caniuse-lite@1.0.30001793: {}
 
+  class-variance-authority@0.7.1:
+    dependencies:
+      clsx: 2.1.1
+
+  clsx@2.1.1: {}
+
   convert-source-map@2.0.0: {}
 
   csstype@3.2.3: {}
@@ -1149,7 +1971,16 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  detect-libc@2.1.2: {}
+
+  detect-node-es@1.1.0: {}
+
   electron-to-chromium@1.5.360: {}
+
+  enhanced-resolve@5.21.5:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
 
   esbuild@0.27.7:
     optionalDependencies:
@@ -1191,15 +2022,78 @@ snapshots:
 
   gensync@1.0.0-beta.2: {}
 
+  get-nonce@1.0.1: {}
+
+  graceful-fs@4.2.11: {}
+
+  jiti@2.7.0: {}
+
   js-tokens@4.0.0: {}
 
   jsesc@3.1.0: {}
 
   json5@2.2.3: {}
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lucide-react@1.16.0(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   ms@2.1.3: {}
 
@@ -1223,6 +2117,33 @@ snapshots:
       scheduler: 0.27.0
 
   react-refresh@0.17.0: {}
+
+  react-remove-scroll-bar@2.3.8(@types/react@19.2.15)(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+      react-style-singleton: 2.2.3(@types/react@19.2.15)(react@19.2.6)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.15
+
+  react-remove-scroll@2.7.2(@types/react@19.2.15)(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+      react-remove-scroll-bar: 2.3.8(@types/react@19.2.15)(react@19.2.6)
+      react-style-singleton: 2.2.3(@types/react@19.2.15)(react@19.2.6)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@19.2.15)(react@19.2.6)
+      use-sidecar: 1.1.3(@types/react@19.2.15)(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.15
+
+  react-style-singleton@2.2.3(@types/react@19.2.15)(react@19.2.6):
+    dependencies:
+      get-nonce: 1.0.1
+      react: 19.2.6
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.15
 
   react@19.2.6: {}
 
@@ -1263,10 +2184,20 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  tailwind-merge@3.6.0: {}
+
+  tailwindcss@4.3.0: {}
+
+  tapable@2.3.3: {}
+
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tslib@2.8.1: {}
+
+  tw-animate-css@1.4.0: {}
 
   typescript@5.8.3: {}
 
@@ -1278,7 +2209,22 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
-  vite@7.3.3(@types/node@22.19.19):
+  use-callback-ref@1.3.3(@types/react@19.2.15)(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.15
+
+  use-sidecar@1.1.3(@types/react@19.2.15)(react@19.2.6):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 19.2.6
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.15
+
+  vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -1289,5 +2235,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.19
       fsevents: 2.3.3
+      jiti: 2.7.0
+      lightningcss: 1.32.0
 
   yallist@3.1.1: {}

--- a/mercury-gui/pnpm-lock.yaml
+++ b/mercury-gui/pnpm-lock.yaml
@@ -26,9 +26,6 @@ importers:
       '@tauri-apps/plugin-opener':
         specifier: ^2
         version: 2.5.4
-      '@tauri-apps/plugin-shell':
-        specifier: ^2
-        version: 2.3.5
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -877,9 +874,6 @@ packages:
 
   '@tauri-apps/plugin-opener@2.5.4':
     resolution: {integrity: sha512-1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ==}
-
-  '@tauri-apps/plugin-shell@2.3.5':
-    resolution: {integrity: sha512-jewtULhiQ7lI7+owCKAjc8tYLJr92U16bPOeAa472LHJdgaibLP83NcfAF2e+wkEcA53FxKQAZ7byDzs2eeizg==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -1887,10 +1881,6 @@ snapshots:
       '@tauri-apps/cli-win32-x64-msvc': 2.11.2
 
   '@tauri-apps/plugin-opener@2.5.4':
-    dependencies:
-      '@tauri-apps/api': 2.11.0
-
-  '@tauri-apps/plugin-shell@2.3.5':
     dependencies:
       '@tauri-apps/api': 2.11.0
 

--- a/mercury-gui/src-tauri/Cargo.lock
+++ b/mercury-gui/src-tauri/Cargo.lock
@@ -743,7 +743,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -879,6 +879,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -929,7 +938,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2064,8 +2073,10 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-opener",
+ "tauri-plugin-shell",
  "tauri-plugin-single-instance",
  "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]
@@ -2114,7 +2125,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2438,6 +2449,16 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -2903,7 +2924,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3177,10 +3198,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "shared_child"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e362d9935bc50f019969e2f9ecd66786612daae13e8f277be7bfb66e8bed3f7"
+dependencies = [
+ "libc",
+ "sigchld",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "sigchld"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47106eded3c154e70176fc83df9737335c94ce22f821c32d17ed1db1f83badb1"
+dependencies = [
+ "libc",
+ "os_pipe",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -3223,7 +3276,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3584,6 +3637,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-shell"
+version = "2.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8457dbf9e2bab1edd8df22bb2c20857a59a9868e79cb3eac5ed639eec4d0c73b"
+dependencies = [
+ "encoding_rs",
+ "log",
+ "open",
+ "os_pipe",
+ "regex",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "shared_child",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
 name = "tauri-plugin-single-instance"
 version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3708,7 +3782,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3828,7 +3902,19 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4059,7 +4145,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4088,7 +4174,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4500,7 +4586,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/mercury-gui/src-tauri/Cargo.toml
+++ b/mercury-gui/src-tauri/Cargo.toml
@@ -27,7 +27,7 @@ chrono = { version = "0.4", features = ["serde"] }
 dirs = "5"
 notify = "8"
 thiserror = "2"
-tokio = { version = "1", features = ["sync", "macros", "rt"] }
+tokio = { version = "1", features = ["sync", "macros", "rt", "time"] }
 
 [target.'cfg(any(target_os = "macos", windows, target_os = "linux"))'.dependencies]
 tauri-plugin-single-instance = "2.4.2"

--- a/mercury-gui/src-tauri/Cargo.toml
+++ b/mercury-gui/src-tauri/Cargo.toml
@@ -20,12 +20,14 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = ["tray-icon"] }
 tauri-plugin-opener = "2"
+tauri-plugin-shell = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4", features = ["serde"] }
 dirs = "5"
 notify = "8"
 thiserror = "2"
+tokio = { version = "1", features = ["sync", "macros", "rt"] }
 
 [target.'cfg(any(target_os = "macos", windows, target_os = "linux"))'.dependencies]
 tauri-plugin-single-instance = "2.4.2"

--- a/mercury-gui/src-tauri/capabilities/default.json
+++ b/mercury-gui/src-tauri/capabilities/default.json
@@ -5,6 +5,12 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
-    "opener:default"
+    "opener:default",
+    {
+      "identifier": "shell:allow-execute",
+      "allow": [
+        { "name": "gh", "cmd": "gh", "args": true, "sidecar": false }
+      ]
+    }
   ]
 }

--- a/mercury-gui/src-tauri/capabilities/default.json
+++ b/mercury-gui/src-tauri/capabilities/default.json
@@ -9,7 +9,40 @@
     {
       "identifier": "shell:allow-execute",
       "allow": [
-        { "name": "gh", "cmd": "gh", "args": true, "sidecar": false }
+        {
+          "name": "gh-issue-list",
+          "cmd": "gh",
+          "sidecar": false,
+          "args": [
+            "issue",
+            "list",
+            "--repo",
+            { "validator": "^[\\w.-]+/[\\w.-]+$" },
+            "--json",
+            { "validator": "^[a-zA-Z,]+$" },
+            "--limit",
+            { "validator": "^[0-9]+$" },
+            "--state",
+            { "validator": "^(open|closed|all)$" }
+          ]
+        },
+        {
+          "name": "gh-pr-list",
+          "cmd": "gh",
+          "sidecar": false,
+          "args": [
+            "pr",
+            "list",
+            "--repo",
+            { "validator": "^[\\w.-]+/[\\w.-]+$" },
+            "--json",
+            { "validator": "^[a-zA-Z,]+$" },
+            "--limit",
+            { "validator": "^[0-9]+$" },
+            "--state",
+            { "validator": "^(open|closed|all)$" }
+          ]
+        }
       ]
     }
   ]

--- a/mercury-gui/src-tauri/capabilities/default.json
+++ b/mercury-gui/src-tauri/capabilities/default.json
@@ -19,9 +19,9 @@
             "--repo",
             { "validator": "^[\\w.-]+/[\\w.-]+$" },
             "--json",
-            { "validator": "^[a-zA-Z,]+$" },
+            { "validator": "^(number|title|state|labels|assignees|createdAt|updatedAt|url|milestone|author|body|closedAt|stateReason)(,(number|title|state|labels|assignees|createdAt|updatedAt|url|milestone|author|body|closedAt|stateReason))*$" },
             "--limit",
-            { "validator": "^[0-9]+$" },
+            { "validator": "^([1-9]|[1-9][0-9]|[1-9][0-9]{2}|1000)$" },
             "--state",
             { "validator": "^(open|closed|all)$" }
           ]
@@ -36,9 +36,9 @@
             "--repo",
             { "validator": "^[\\w.-]+/[\\w.-]+$" },
             "--json",
-            { "validator": "^[a-zA-Z,]+$" },
+            { "validator": "^(number|title|state|labels|assignees|createdAt|updatedAt|url|headRefName|baseRefName|isDraft|reviewDecision|author|body|closedAt|mergedAt|mergeable|reviewRequests)(,(number|title|state|labels|assignees|createdAt|updatedAt|url|headRefName|baseRefName|isDraft|reviewDecision|author|body|closedAt|mergedAt|mergeable|reviewRequests))*$" },
             "--limit",
-            { "validator": "^[0-9]+$" },
+            { "validator": "^([1-9]|[1-9][0-9]|[1-9][0-9]{2}|1000)$" },
             "--state",
             { "validator": "^(open|closed|all)$" }
           ]

--- a/mercury-gui/src-tauri/src/gh_dashboard.rs
+++ b/mercury-gui/src-tauri/src/gh_dashboard.rs
@@ -1,0 +1,322 @@
+// gh_dashboard — IPC command + in-memory cache for the Issue/PR dashboard (#416).
+// Invokes ambient `gh` CLI via tauri-plugin-shell (NOT std::process::Command).
+// Cache is process-lifetime only; lost on app restart per #416 DoD.
+
+use serde::{Deserialize, Serialize};
+use std::time::{Duration, Instant};
+use tauri_plugin_shell::ShellExt;
+
+const GH_CACHE_TTL_SECS: u64 = 60;
+const GH_REPO: &str = "392fyc/Mercury";
+const GH_LIMIT: &str = "200";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GhLabel {
+    pub name: String,
+    pub color: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GhUser {
+    pub login: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GhIssue {
+    pub number: u64,
+    pub title: String,
+    pub state: String,
+    pub labels: Vec<GhLabel>,
+    pub assignees: Vec<GhUser>,
+    #[serde(rename = "createdAt")]
+    pub created_at: String,
+    #[serde(rename = "updatedAt")]
+    pub updated_at: String,
+    pub url: String,
+    pub milestone: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GhPullRequest {
+    pub number: u64,
+    pub title: String,
+    pub state: String,
+    pub labels: Vec<GhLabel>,
+    pub assignees: Vec<GhUser>,
+    #[serde(rename = "createdAt")]
+    pub created_at: String,
+    #[serde(rename = "updatedAt")]
+    pub updated_at: String,
+    pub url: String,
+    #[serde(rename = "headRefName")]
+    pub head_ref_name: String,
+    #[serde(rename = "baseRefName")]
+    pub base_ref_name: String,
+    #[serde(rename = "isDraft")]
+    pub is_draft: bool,
+    #[serde(rename = "reviewDecision")]
+    pub review_decision: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GhSnapshot {
+    pub issues: Vec<GhIssue>,
+    pub pull_requests: Vec<GhPullRequest>,
+    // Unix epoch milliseconds — consistent with RosterSnapshot.updatedAt
+    #[serde(rename = "fetchedAt")]
+    pub fetched_at: i64,
+}
+
+pub struct GhCacheState {
+    pub cache: tokio::sync::Mutex<Option<(GhSnapshot, Instant)>>,
+}
+
+impl Default for GhCacheState {
+    fn default() -> Self {
+        GhCacheState {
+            cache: tokio::sync::Mutex::new(None),
+        }
+    }
+}
+
+#[tauri::command]
+pub async fn fetch_gh_dashboard(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, GhCacheState>,
+    force: bool,
+) -> Result<GhSnapshot, String> {
+    let mut cache = state.cache.lock().await;
+
+    // Return cached data if within TTL and not forced
+    if !force {
+        if let Some((ref snapshot, ref ts)) = *cache {
+            if ts.elapsed() < Duration::from_secs(GH_CACHE_TTL_SECS) {
+                return Ok(snapshot.clone());
+            }
+        }
+    }
+
+    // Fetch issues and PRs sequentially (simple; gh rate-limit safer)
+    let issue_fields = "number,title,state,labels,assignees,createdAt,updatedAt,url,milestone";
+    let pr_fields =
+        "number,title,state,labels,assignees,createdAt,updatedAt,url,headRefName,baseRefName,isDraft,reviewDecision";
+
+    let issue_out = app
+        .shell()
+        .command("gh")
+        .args([
+            "issue",
+            "list",
+            "--repo",
+            GH_REPO,
+            "--json",
+            issue_fields,
+            "--limit",
+            GH_LIMIT,
+            "--state",
+            "open",
+        ])
+        .output()
+        .await
+        .map_err(|e| format!("gh spawn failed: {e}"))?;
+
+    if !issue_out.status.success() {
+        let stderr = String::from_utf8_lossy(&issue_out.stderr);
+        return Err(format!("gh issue list failed: {stderr}"));
+    }
+
+    let pr_out = app
+        .shell()
+        .command("gh")
+        .args([
+            "pr",
+            "list",
+            "--repo",
+            GH_REPO,
+            "--json",
+            pr_fields,
+            "--limit",
+            GH_LIMIT,
+            "--state",
+            "open",
+        ])
+        .output()
+        .await
+        .map_err(|e| format!("gh spawn failed: {e}"))?;
+
+    if !pr_out.status.success() {
+        let stderr = String::from_utf8_lossy(&pr_out.stderr);
+        return Err(format!("gh pr list failed: {stderr}"));
+    }
+
+    let issues: Vec<GhIssue> = serde_json::from_slice(&issue_out.stdout)
+        .map_err(|e| format!("parse issues: {e}"))?;
+
+    let pull_requests: Vec<GhPullRequest> = serde_json::from_slice(&pr_out.stdout)
+        .map_err(|e| format!("parse PRs: {e}"))?;
+
+    let snapshot = GhSnapshot {
+        issues,
+        pull_requests,
+        fetched_at: chrono::Utc::now().timestamp_millis(),
+    };
+
+    *cache = Some((snapshot.clone(), Instant::now()));
+    Ok(snapshot)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_issue(number: u64, title: &str) -> GhIssue {
+        GhIssue {
+            number,
+            title: title.to_string(),
+            state: "open".to_string(),
+            labels: vec![GhLabel {
+                name: "enhancement".to_string(),
+                color: Some("84b6eb".to_string()),
+            }],
+            assignees: vec![GhUser {
+                login: "392fyc".to_string(),
+            }],
+            created_at: "2026-05-01T00:00:00Z".to_string(),
+            updated_at: "2026-05-20T00:00:00Z".to_string(),
+            url: format!("https://github.com/392fyc/Mercury/issues/{number}"),
+            milestone: None,
+        }
+    }
+
+    fn make_pr(number: u64, title: &str) -> GhPullRequest {
+        GhPullRequest {
+            number,
+            title: title.to_string(),
+            state: "open".to_string(),
+            labels: vec![GhLabel {
+                name: "lane:main".to_string(),
+                color: None,
+            }],
+            assignees: vec![],
+            created_at: "2026-05-10T00:00:00Z".to_string(),
+            updated_at: "2026-05-20T00:00:00Z".to_string(),
+            url: format!("https://github.com/392fyc/Mercury/pull/{number}"),
+            head_ref_name: "lane/main/416-test".to_string(),
+            base_ref_name: "develop".to_string(),
+            is_draft: false,
+            review_decision: None,
+        }
+    }
+
+    #[test]
+    fn serde_roundtrip_issue() {
+        let issue = make_issue(416, "UI scenario 5");
+        let json = serde_json::to_string(&issue).expect("serialize");
+        let back: GhIssue = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.number, 416);
+        assert_eq!(back.title, "UI scenario 5");
+        assert_eq!(back.labels[0].name, "enhancement");
+        // camelCase fields survive round-trip
+        assert_eq!(back.created_at, "2026-05-01T00:00:00Z");
+    }
+
+    #[test]
+    fn serde_roundtrip_pr() {
+        let pr = make_pr(424, "feat: slice C");
+        let json = serde_json::to_string(&pr).expect("serialize");
+        let back: GhPullRequest = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.number, 424);
+        assert!(!back.is_draft);
+        assert_eq!(back.head_ref_name, "lane/main/416-test");
+        assert_eq!(back.base_ref_name, "develop");
+        assert!(back.review_decision.is_none());
+    }
+
+    #[test]
+    fn serde_roundtrip_snapshot() {
+        let snapshot = GhSnapshot {
+            issues: vec![make_issue(1, "first")],
+            pull_requests: vec![make_pr(2, "pr two")],
+            fetched_at: 1_716_000_000_000,
+        };
+        let json = serde_json::to_string(&snapshot).expect("serialize");
+        // fetchedAt must appear with camelCase key in JSON
+        assert!(json.contains("fetchedAt"), "fetchedAt key missing: {json}");
+        let back: GhSnapshot = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.fetched_at, 1_716_000_000_000);
+        assert_eq!(back.issues.len(), 1);
+        assert_eq!(back.pull_requests.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn cache_hit_returns_same_snapshot() {
+        let state = GhCacheState::default();
+        let snapshot = GhSnapshot {
+            issues: vec![make_issue(100, "cached")],
+            pull_requests: vec![],
+            fetched_at: 1_716_000_000_000,
+        };
+        // Pre-populate cache with a fresh entry
+        {
+            let mut guard = state.cache.lock().await;
+            *guard = Some((snapshot.clone(), Instant::now()));
+        }
+        // Verify cache is populated and within TTL
+        let guard = state.cache.lock().await;
+        let (ref cached, ref ts) = guard.as_ref().expect("cache must be populated");
+        assert!(ts.elapsed() < Duration::from_secs(GH_CACHE_TTL_SECS));
+        assert_eq!(cached.issues[0].number, 100);
+    }
+
+    #[tokio::test]
+    async fn cache_miss_on_expired_entry() {
+        let state = GhCacheState::default();
+        let snapshot = GhSnapshot {
+            issues: vec![],
+            pull_requests: vec![],
+            fetched_at: 0,
+        };
+        // Pre-populate cache with an artificially old instant (TTL + 1s ago)
+        let old_instant = Instant::now()
+            .checked_sub(Duration::from_secs(GH_CACHE_TTL_SECS + 1))
+            .expect("subtraction should not underflow on modern systems");
+        {
+            let mut guard = state.cache.lock().await;
+            *guard = Some((snapshot, old_instant));
+        }
+        // Verify the entry is expired
+        let guard = state.cache.lock().await;
+        let (_, ref ts) = guard.as_ref().expect("entry present");
+        assert!(
+            ts.elapsed() >= Duration::from_secs(GH_CACHE_TTL_SECS),
+            "entry should be expired"
+        );
+    }
+
+    #[tokio::test]
+    async fn force_refresh_bypasses_fresh_cache() {
+        // Validate the force=true logic path: even a fresh cache entry should
+        // be bypassed. We can't invoke the full command without AppHandle, so
+        // we test the cache-check predicate directly.
+        let state = GhCacheState::default();
+        let snapshot = GhSnapshot {
+            issues: vec![make_issue(1, "stale but fresh ts")],
+            pull_requests: vec![],
+            fetched_at: 1_716_000_000_000,
+        };
+        {
+            let mut guard = state.cache.lock().await;
+            *guard = Some((snapshot.clone(), Instant::now()));
+        }
+        // Simulate force=true: cache is ignored regardless of age
+        let guard = state.cache.lock().await;
+        let within_ttl = guard
+            .as_ref()
+            .map(|(_, ts)| ts.elapsed() < Duration::from_secs(GH_CACHE_TTL_SECS))
+            .unwrap_or(false);
+        // Even though within TTL, force=true means we would skip the early-return
+        assert!(within_ttl, "entry is fresh");
+        // The actual skip happens in the command function — verified by inspecting
+        // the `if !force` guard in fetch_gh_dashboard.
+    }
+}

--- a/mercury-gui/src-tauri/src/gh_dashboard.rs
+++ b/mercury-gui/src-tauri/src/gh_dashboard.rs
@@ -9,9 +9,41 @@ use tauri_plugin_shell::ShellExt;
 use crate::data::redact_home;
 
 const GH_CACHE_TTL_SECS: u64 = 60;
-const GH_REPO: &str = "392fyc/Mercury";
+const GH_REPO_DEFAULT: &str = "392fyc/Mercury";
 const GH_LIMIT: &str = "200";
 const GH_SUBPROCESS_TIMEOUT_SECS: u64 = 30;
+
+/// Resolve the target gh repo. Defaults to 392fyc/Mercury (the #416 DoD repo).
+/// `MERCURY_GH_REPO` env override allows running the GUI against a different
+/// repo (e.g. for development against a fork). Validates `owner/repo` shape
+/// to keep the shell arg surface tight even though the capability already
+/// regex-checks the slot.
+fn resolve_repo() -> Result<String, String> {
+    let raw = std::env::var("MERCURY_GH_REPO")
+        .unwrap_or_else(|_| GH_REPO_DEFAULT.to_string());
+    if is_valid_repo(&raw) {
+        Ok(raw)
+    } else {
+        Err(format!(
+            "invalid MERCURY_GH_REPO {raw:?}, expected owner/repo with [\\w.-] segments"
+        ))
+    }
+}
+
+fn is_valid_repo(s: &str) -> bool {
+    let mut parts = s.split('/');
+    let owner = parts.next().unwrap_or("");
+    let name = parts.next().unwrap_or("");
+    parts.next().is_none()
+        && !owner.is_empty()
+        && !name.is_empty()
+        && owner
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+        && name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GhLabel {
@@ -124,6 +156,7 @@ pub async fn fetch_gh_dashboard(
         }
     }
 
+    let repo = resolve_repo()?;
     let issue_fields = "number,title,state,labels,assignees,createdAt,updatedAt,url,milestone";
     let pr_fields =
         "number,title,state,labels,assignees,createdAt,updatedAt,url,headRefName,baseRefName,isDraft,reviewDecision";
@@ -135,7 +168,7 @@ pub async fn fetch_gh_dashboard(
             "issue",
             "list",
             "--repo",
-            GH_REPO,
+            repo.as_str(),
             "--json",
             issue_fields,
             "--limit",
@@ -165,7 +198,7 @@ pub async fn fetch_gh_dashboard(
             "pr",
             "list",
             "--repo",
-            GH_REPO,
+            repo.as_str(),
             "--json",
             pr_fields,
             "--limit",
@@ -328,5 +361,23 @@ mod tests {
         let entry: Option<(GhSnapshot, Instant)> = None;
         let hit = check_cache_hit(&entry, false, Instant::now(), Duration::from_secs(60));
         assert!(hit.is_none(), "empty cache must miss");
+    }
+
+    #[test]
+    fn is_valid_repo_accepts_canonical() {
+        assert!(is_valid_repo("392fyc/Mercury"));
+        assert!(is_valid_repo("owner-name/repo.name"));
+        assert!(is_valid_repo("a/b"));
+    }
+
+    #[test]
+    fn is_valid_repo_rejects_malformed() {
+        assert!(!is_valid_repo(""));
+        assert!(!is_valid_repo("nonslash"));
+        assert!(!is_valid_repo("/leading-slash"));
+        assert!(!is_valid_repo("trailing/"));
+        assert!(!is_valid_repo("too/many/slashes"));
+        assert!(!is_valid_repo("owner/repo;rm -rf /"));
+        assert!(!is_valid_repo("owner repo/name"));
     }
 }

--- a/mercury-gui/src-tauri/src/gh_dashboard.rs
+++ b/mercury-gui/src-tauri/src/gh_dashboard.rs
@@ -1,14 +1,17 @@
 // gh_dashboard — IPC command + in-memory cache for the Issue/PR dashboard (#416).
-// Invokes ambient `gh` CLI via tauri-plugin-shell (NOT std::process::Command).
-// Cache is process-lifetime only; lost on app restart per #416 DoD.
+// Invokes ambient `gh` CLI via tauri-plugin-shell. Cache is process-lifetime
+// only; lost on app restart per #416 DoD.
 
 use serde::{Deserialize, Serialize};
 use std::time::{Duration, Instant};
 use tauri_plugin_shell::ShellExt;
 
+use crate::data::redact_home;
+
 const GH_CACHE_TTL_SECS: u64 = 60;
 const GH_REPO: &str = "392fyc/Mercury";
 const GH_LIMIT: &str = "200";
+const GH_SUBPROCESS_TIMEOUT_SECS: u64 = 30;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GhLabel {
@@ -61,8 +64,9 @@ pub struct GhPullRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GhSnapshot {
     pub issues: Vec<GhIssue>,
+    #[serde(rename = "pullRequests")]
     pub pull_requests: Vec<GhPullRequest>,
-    // Unix epoch milliseconds — consistent with RosterSnapshot.updatedAt
+    // Unix epoch milliseconds — consistent with RosterSnapshot.updatedAt.
     #[serde(rename = "fetchedAt")]
     pub fetched_at: i64,
 }
@@ -79,29 +83,52 @@ impl Default for GhCacheState {
     }
 }
 
+/// Cache-hit predicate. Returns a cloned snapshot when the entry is fresh and
+/// `force` is false; otherwise returns None (caller must refetch).
+/// Extracted so the force-bypass + TTL-expiry branches are directly testable
+/// without an AppHandle.
+fn check_cache_hit(
+    entry: &Option<(GhSnapshot, Instant)>,
+    force: bool,
+    now: Instant,
+    ttl: Duration,
+) -> Option<GhSnapshot> {
+    if force {
+        return None;
+    }
+    let (snapshot, cached_at) = entry.as_ref()?;
+    if now.saturating_duration_since(*cached_at) < ttl {
+        Some(snapshot.clone())
+    } else {
+        None
+    }
+}
+
 #[tauri::command]
 pub async fn fetch_gh_dashboard(
     app: tauri::AppHandle,
     state: tauri::State<'_, GhCacheState>,
     force: bool,
 ) -> Result<GhSnapshot, String> {
-    let mut cache = state.cache.lock().await;
-
-    // Return cached data if within TTL and not forced
-    if !force {
-        if let Some((ref snapshot, ref ts)) = *cache {
-            if ts.elapsed() < Duration::from_secs(GH_CACHE_TTL_SECS) {
-                return Ok(snapshot.clone());
-            }
+    // Acquire the lock only long enough to read the cache, then drop it
+    // before spawning gh. Holding it across the subprocess await would
+    // serialize concurrent IPC calls behind whichever gh invocation is
+    // currently in flight, defeating the cache and risking an indefinite
+    // hang if gh stalls (M1 from dual-verify).
+    let ttl = Duration::from_secs(GH_CACHE_TTL_SECS);
+    let timeout = Duration::from_secs(GH_SUBPROCESS_TIMEOUT_SECS);
+    {
+        let cache = state.cache.lock().await;
+        if let Some(hit) = check_cache_hit(&cache, force, Instant::now(), ttl) {
+            return Ok(hit);
         }
     }
 
-    // Fetch issues and PRs sequentially (simple; gh rate-limit safer)
     let issue_fields = "number,title,state,labels,assignees,createdAt,updatedAt,url,milestone";
     let pr_fields =
         "number,title,state,labels,assignees,createdAt,updatedAt,url,headRefName,baseRefName,isDraft,reviewDecision";
 
-    let issue_out = app
+    let issue_fut = app
         .shell()
         .command("gh")
         .args([
@@ -116,16 +143,22 @@ pub async fn fetch_gh_dashboard(
             "--state",
             "open",
         ])
-        .output()
+        .output();
+    let issue_out = tokio::time::timeout(timeout, issue_fut)
         .await
-        .map_err(|e| format!("gh spawn failed: {e}"))?;
+        .map_err(|_| {
+            format!(
+                "gh issue list timed out after {GH_SUBPROCESS_TIMEOUT_SECS}s — check `gh auth status` and network connectivity"
+            )
+        })?
+        .map_err(|e| redact_home(&format!("gh spawn failed: {e}")))?;
 
     if !issue_out.status.success() {
         let stderr = String::from_utf8_lossy(&issue_out.stderr);
-        return Err(format!("gh issue list failed: {stderr}"));
+        return Err(redact_home(&format!("gh issue list failed: {stderr}")));
     }
 
-    let pr_out = app
+    let pr_fut = app
         .shell()
         .command("gh")
         .args([
@@ -140,20 +173,26 @@ pub async fn fetch_gh_dashboard(
             "--state",
             "open",
         ])
-        .output()
+        .output();
+    let pr_out = tokio::time::timeout(timeout, pr_fut)
         .await
-        .map_err(|e| format!("gh spawn failed: {e}"))?;
+        .map_err(|_| {
+            format!(
+                "gh pr list timed out after {GH_SUBPROCESS_TIMEOUT_SECS}s — check `gh auth status` and network connectivity"
+            )
+        })?
+        .map_err(|e| redact_home(&format!("gh spawn failed: {e}")))?;
 
     if !pr_out.status.success() {
         let stderr = String::from_utf8_lossy(&pr_out.stderr);
-        return Err(format!("gh pr list failed: {stderr}"));
+        return Err(redact_home(&format!("gh pr list failed: {stderr}")));
     }
 
     let issues: Vec<GhIssue> = serde_json::from_slice(&issue_out.stdout)
-        .map_err(|e| format!("parse issues: {e}"))?;
+        .map_err(|e| redact_home(&format!("parse issues: {e}")))?;
 
     let pull_requests: Vec<GhPullRequest> = serde_json::from_slice(&pr_out.stdout)
-        .map_err(|e| format!("parse PRs: {e}"))?;
+        .map_err(|e| redact_home(&format!("parse PRs: {e}")))?;
 
     let snapshot = GhSnapshot {
         issues,
@@ -161,6 +200,7 @@ pub async fn fetch_gh_dashboard(
         fetched_at: chrono::Utc::now().timestamp_millis(),
     };
 
+    let mut cache = state.cache.lock().await;
     *cache = Some((snapshot.clone(), Instant::now()));
     Ok(snapshot)
 }
@@ -208,6 +248,14 @@ mod tests {
         }
     }
 
+    fn make_snapshot() -> GhSnapshot {
+        GhSnapshot {
+            issues: vec![make_issue(1, "first")],
+            pull_requests: vec![make_pr(2, "pr two")],
+            fetched_at: 1_716_000_000_000,
+        }
+    }
+
     #[test]
     fn serde_roundtrip_issue() {
         let issue = make_issue(416, "UI scenario 5");
@@ -216,7 +264,6 @@ mod tests {
         assert_eq!(back.number, 416);
         assert_eq!(back.title, "UI scenario 5");
         assert_eq!(back.labels[0].name, "enhancement");
-        // camelCase fields survive round-trip
         assert_eq!(back.created_at, "2026-05-01T00:00:00Z");
     }
 
@@ -233,90 +280,53 @@ mod tests {
     }
 
     #[test]
-    fn serde_roundtrip_snapshot() {
-        let snapshot = GhSnapshot {
-            issues: vec![make_issue(1, "first")],
-            pull_requests: vec![make_pr(2, "pr two")],
-            fetched_at: 1_716_000_000_000,
-        };
-        let json = serde_json::to_string(&snapshot).expect("serialize");
-        // fetchedAt must appear with camelCase key in JSON
-        assert!(json.contains("fetchedAt"), "fetchedAt key missing: {json}");
+    fn serde_snapshot_uses_camelcase_keys() {
+        let json = serde_json::to_string(&make_snapshot()).expect("serialize");
+        assert!(json.contains("\"pullRequests\""), "pullRequests key missing: {json}");
+        assert!(json.contains("\"fetchedAt\""), "fetchedAt key missing: {json}");
+        assert!(!json.contains("\"pull_requests\""), "snake_case must not appear");
         let back: GhSnapshot = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(back.fetched_at, 1_716_000_000_000);
         assert_eq!(back.issues.len(), 1);
         assert_eq!(back.pull_requests.len(), 1);
     }
 
-    #[tokio::test]
-    async fn cache_hit_returns_same_snapshot() {
-        let state = GhCacheState::default();
-        let snapshot = GhSnapshot {
-            issues: vec![make_issue(100, "cached")],
-            pull_requests: vec![],
-            fetched_at: 1_716_000_000_000,
-        };
-        // Pre-populate cache with a fresh entry
-        {
-            let mut guard = state.cache.lock().await;
-            *guard = Some((snapshot.clone(), Instant::now()));
-        }
-        // Verify cache is populated and within TTL
-        let guard = state.cache.lock().await;
-        let (ref cached, ref ts) = guard.as_ref().expect("cache must be populated");
-        assert!(ts.elapsed() < Duration::from_secs(GH_CACHE_TTL_SECS));
-        assert_eq!(cached.issues[0].number, 100);
+    #[test]
+    fn cache_hit_when_fresh_and_not_forced() {
+        let snapshot = make_snapshot();
+        let cached_at = Instant::now();
+        let entry = Some((snapshot.clone(), cached_at));
+        let now = cached_at + Duration::from_secs(30); // within 60s TTL
+        let hit = check_cache_hit(&entry, false, now, Duration::from_secs(60));
+        assert!(hit.is_some(), "fresh non-forced lookup must hit");
+        assert_eq!(hit.unwrap().issues.len(), 1);
     }
 
-    #[tokio::test]
-    async fn cache_miss_on_expired_entry() {
-        let state = GhCacheState::default();
-        let snapshot = GhSnapshot {
-            issues: vec![],
-            pull_requests: vec![],
-            fetched_at: 0,
-        };
-        // Pre-populate cache with an artificially old instant (TTL + 1s ago)
-        let old_instant = Instant::now()
-            .checked_sub(Duration::from_secs(GH_CACHE_TTL_SECS + 1))
-            .expect("subtraction should not underflow on modern systems");
-        {
-            let mut guard = state.cache.lock().await;
-            *guard = Some((snapshot, old_instant));
-        }
-        // Verify the entry is expired
-        let guard = state.cache.lock().await;
-        let (_, ref ts) = guard.as_ref().expect("entry present");
-        assert!(
-            ts.elapsed() >= Duration::from_secs(GH_CACHE_TTL_SECS),
-            "entry should be expired"
-        );
+    #[test]
+    fn cache_miss_when_force_even_if_fresh() {
+        // Real coverage for the previously-vestigial force-bypass branch.
+        let snapshot = make_snapshot();
+        let cached_at = Instant::now();
+        let entry = Some((snapshot, cached_at));
+        let now = cached_at + Duration::from_secs(1); // very fresh
+        let hit = check_cache_hit(&entry, true, now, Duration::from_secs(60));
+        assert!(hit.is_none(), "force=true must bypass fresh cache");
     }
 
-    #[tokio::test]
-    async fn force_refresh_bypasses_fresh_cache() {
-        // Validate the force=true logic path: even a fresh cache entry should
-        // be bypassed. We can't invoke the full command without AppHandle, so
-        // we test the cache-check predicate directly.
-        let state = GhCacheState::default();
-        let snapshot = GhSnapshot {
-            issues: vec![make_issue(1, "stale but fresh ts")],
-            pull_requests: vec![],
-            fetched_at: 1_716_000_000_000,
-        };
-        {
-            let mut guard = state.cache.lock().await;
-            *guard = Some((snapshot.clone(), Instant::now()));
-        }
-        // Simulate force=true: cache is ignored regardless of age
-        let guard = state.cache.lock().await;
-        let within_ttl = guard
-            .as_ref()
-            .map(|(_, ts)| ts.elapsed() < Duration::from_secs(GH_CACHE_TTL_SECS))
-            .unwrap_or(false);
-        // Even though within TTL, force=true means we would skip the early-return
-        assert!(within_ttl, "entry is fresh");
-        // The actual skip happens in the command function — verified by inspecting
-        // the `if !force` guard in fetch_gh_dashboard.
+    #[test]
+    fn cache_miss_when_expired() {
+        let snapshot = make_snapshot();
+        let cached_at = Instant::now();
+        let entry = Some((snapshot, cached_at));
+        let now = cached_at + Duration::from_secs(61); // past 60s TTL
+        let hit = check_cache_hit(&entry, false, now, Duration::from_secs(60));
+        assert!(hit.is_none(), "expired entry must miss");
+    }
+
+    #[test]
+    fn cache_miss_when_empty() {
+        let entry: Option<(GhSnapshot, Instant)> = None;
+        let hit = check_cache_hit(&entry, false, Instant::now(), Duration::from_secs(60));
+        assert!(hit.is_none(), "empty cache must miss");
     }
 }

--- a/mercury-gui/src-tauri/src/lib.rs
+++ b/mercury-gui/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ use tauri::{
 };
 
 mod data;
+mod gh_dashboard;
 
 #[tauri::command]
 fn greet(name: &str) -> String {
@@ -30,12 +31,15 @@ pub fn run() {
 
     builder
         .plugin(tauri_plugin_opener::init())
+        .plugin(tauri_plugin_shell::init())
+        .manage(gh_dashboard::GhCacheState::default())
         .invoke_handler(tauri::generate_handler![
             greet,
             data::commands::read_jobs,
             data::commands::read_roster,
             data::commands::read_lanes,
             data::commands::read_jobs_by_lane,
+            gh_dashboard::fetch_gh_dashboard,
         ])
         .setup(|app| {
             // System tray: "Quit Mercury" menu item.

--- a/mercury-gui/src/App.tsx
+++ b/mercury-gui/src/App.tsx
@@ -1,79 +1,41 @@
-// Mercury GUI — Cross-lane snapshot view (Phase 6 slice C, Issue #415)
-// Replaces the Tauri scaffold template. Consumes the #414 IPC data layer.
+// Mercury GUI — top-level shell with Tabs nav (#416).
+// Tab 1: Cross-lane snapshot view (Phase 6 slice C, #415).
+// Tab 2: Issue/PR dashboard (Phase 6 slice D, #416).
 
-import { useState } from "react";
-import { FilterBar } from "./components/FilterBar";
-import { LaneTable } from "./components/LaneTable";
-import { useSnapshot } from "./hooks/useSnapshot";
-import { redactHomePaths } from "./lib/redact";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { SnapshotView } from "./components/SnapshotView";
+import { GitHubDashboard } from "./components/GitHubDashboard";
 
 function App() {
-  const { jobsByLane, lanes, error, loading, elapsedNonce, refresh } =
-    useSnapshot();
-  const [filter, setFilter] = useState("");
-
   return (
     <div className="min-h-screen bg-slate-50 dark:bg-slate-950 text-slate-900 dark:text-slate-100 flex flex-col">
-      {/* Header */}
-      <header className="border-b border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 px-4 py-3 flex items-center gap-4 shadow-sm">
-        <h1 className="text-lg font-bold tracking-tight shrink-0">
+      {/* Header — outside tabs so branding stays visible on both views */}
+      <header className="border-b border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 px-4 py-3 shadow-sm">
+        <h1 className="text-lg font-bold tracking-tight">
           Mercury
           <span className="ml-2 text-xs font-normal text-slate-400 uppercase tracking-widest">
             monitor
           </span>
         </h1>
-        <div className="flex-1">
-          <FilterBar
-            value={filter}
-            onChange={setFilter}
-            onRefresh={refresh}
-            loading={loading}
-          />
-        </div>
       </header>
 
-      {/* Main content */}
+      {/* Tabs */}
       <main className="flex-1 px-4 py-4 overflow-auto">
-        {error && (
-          <div className="mb-4 rounded-md border border-red-200 bg-red-50 dark:bg-red-950 dark:border-red-800 px-4 py-3 text-sm text-red-700 dark:text-red-300">
-            {/* IPC error strings may carry host paths or supervisor details;
-                run them through redactHomePaths defense-in-depth (Argus iter-1
-                Critical/security finding). */}
-            <strong>Error loading data:</strong> {String(redactHomePaths(error))}
-            <button
-              className="ml-4 underline text-red-600 dark:text-red-400 hover:no-underline"
-              onClick={() => refresh()}
-            >
-              Retry
-            </button>
-          </div>
-        )}
+        <Tabs defaultValue="snapshot" className="flex flex-col gap-4">
+          <TabsList className="w-fit">
+            <TabsTrigger value="snapshot">Snapshot</TabsTrigger>
+            <TabsTrigger value="issues">Issues / PRs</TabsTrigger>
+          </TabsList>
 
-        {loading && !error && (
-          <div className="flex items-center justify-center py-16 text-slate-400 text-sm">
-            Loading snapshot…
-          </div>
-        )}
+          <TabsContent value="snapshot">
+            <SnapshotView />
+          </TabsContent>
 
-        {!loading && (
-          <LaneTable
-            jobsByLane={jobsByLane}
-            lanes={lanes}
-            filterRaw={filter}
-            elapsedNonce={elapsedNonce}
-          />
-        )}
+          <TabsContent value="issues">
+            <GitHubDashboard />
+          </TabsContent>
+        </Tabs>
       </main>
-
-      {/* Footer */}
-      <footer className="border-t border-slate-200 dark:border-slate-800 px-4 py-2 text-xs text-slate-400 flex gap-4">
-        <span>Auto-refresh on file-watcher event</span>
-        <span>·</span>
-        <span>
-          {Object.values(jobsByLane).flat().length} session(s) across{" "}
-          {lanes.length} lane(s)
-        </span>
-      </footer>
     </div>
   );
 }

--- a/mercury-gui/src/components/GitHubDashboard.tsx
+++ b/mercury-gui/src/components/GitHubDashboard.tsx
@@ -34,7 +34,7 @@ export function GitHubDashboard() {
   const tokens = parseGhFilter(filter);
   const issues = snapshot?.issues.filter((i) => matchesIssue(i, tokens)) ?? [];
   const prs =
-    snapshot?.pull_requests.filter((pr) => matchesPR(pr, tokens)) ?? [];
+    snapshot?.pullRequests.filter((pr) => matchesPR(pr, tokens)) ?? [];
 
   const fetchedIso = snapshot ? fetchedAtIso(snapshot.fetchedAt) : "";
 
@@ -145,8 +145,8 @@ export function GitHubDashboard() {
           <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400 mb-2">
             Open Pull Requests ({prs.length}
             {tokens.length > 0 &&
-              snapshot.pull_requests.length !== prs.length &&
-              ` of ${snapshot.pull_requests.length}`}
+              snapshot.pullRequests.length !== prs.length &&
+              ` of ${snapshot.pullRequests.length}`}
             )
           </h2>
           <div className="overflow-x-auto rounded-lg border border-slate-200 dark:border-slate-700">

--- a/mercury-gui/src/components/GitHubDashboard.tsx
+++ b/mercury-gui/src/components/GitHubDashboard.tsx
@@ -1,0 +1,185 @@
+// GitHubDashboard — Issue/PR dashboard view for Phase 6 slice D (#416).
+// Filter input with label:/state:/lane:/text prefixes (AND semantics).
+// No auto-refresh; manual force-refresh button + 60s TTL cache in Rust backend.
+
+import { useState, useEffect } from "react";
+import { RefreshCw } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { IssueRow } from "./IssueRow";
+import { PullRequestRow } from "./PullRequestRow";
+import { useGitHubData } from "@/hooks/useGitHubData";
+import { parseGhFilter, matchesIssue, matchesPR } from "@/lib/ghFilter";
+import { redactHomePaths } from "@/lib/redact";
+import { elapsed } from "@/lib/elapsed";
+
+function fetchedAtIso(ms: number): string {
+  if (!ms) return "";
+  return new Date(ms).toISOString();
+}
+
+export function GitHubDashboard() {
+  const { snapshot, error, loading, refresh } = useGitHubData();
+  const [filter, setFilter] = useState("");
+  // Load data on first mount (no auto-refresh per DoD)
+  const [initialLoaded, setInitialLoaded] = useState(false);
+
+  useEffect(() => {
+    if (!initialLoaded) {
+      setInitialLoaded(true);
+      refresh(false);
+    }
+  }, [initialLoaded, refresh]);
+
+  const tokens = parseGhFilter(filter);
+  const issues = snapshot?.issues.filter((i) => matchesIssue(i, tokens)) ?? [];
+  const prs =
+    snapshot?.pull_requests.filter((pr) => matchesPR(pr, tokens)) ?? [];
+
+  const fetchedIso = snapshot ? fetchedAtIso(snapshot.fetchedAt) : "";
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Toolbar: filter + refresh */}
+      <div className="flex gap-2 items-center">
+        <Input
+          className="flex-1 font-mono text-sm"
+          placeholder="Filter: label:P2  state:open  lane:main  or free text"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          aria-label="Filter issues and pull requests"
+        />
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => refresh(true)}
+          disabled={loading}
+          aria-label="Force refresh"
+          title="Bypass cache and fetch fresh data"
+        >
+          <RefreshCw className={`h-4 w-4 ${loading ? "animate-spin" : ""}`} />
+          <span className="ml-1 hidden sm:inline">Refresh</span>
+        </Button>
+      </div>
+
+      {/* Last-fetched timestamp */}
+      {fetchedIso && (
+        <p className="text-xs text-slate-400 tabular-nums">
+          Last fetched {elapsed(fetchedIso)} ago &middot; {fetchedIso}
+        </p>
+      )}
+
+      {/* Error state */}
+      {error && (
+        <div className="rounded-md border border-red-200 bg-red-50 dark:bg-red-950 dark:border-red-800 px-4 py-3 text-sm text-red-700 dark:text-red-300">
+          <strong>Error fetching GitHub data:</strong>{" "}
+          {String(redactHomePaths(error))}
+          <br />
+          <span className="text-xs text-red-500">
+            Ensure <code>gh auth login</code> has been run and the Mercury repo
+            is accessible.
+          </span>
+          <button
+            className="ml-4 underline text-red-600 dark:text-red-400 hover:no-underline"
+            onClick={() => refresh(true)}
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      {/* Loading state (initial only) */}
+      {loading && !snapshot && !error && (
+        <div className="flex items-center justify-center py-16 text-slate-400 text-sm">
+          Loading GitHub data…
+        </div>
+      )}
+
+      {/* Issues section */}
+      {snapshot && (
+        <section>
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400 mb-2">
+            Open Issues ({issues.length}
+            {tokens.length > 0 &&
+              snapshot.issues.length !== issues.length &&
+              ` of ${snapshot.issues.length}`}
+            )
+          </h2>
+          <div className="overflow-x-auto rounded-lg border border-slate-200 dark:border-slate-700">
+            <table className="w-full text-left text-sm" role="table">
+              <thead className="bg-slate-100 dark:bg-slate-800 text-xs uppercase tracking-wide text-slate-600 dark:text-slate-400">
+                <tr>
+                  <th className="px-3 py-2 font-semibold">#</th>
+                  <th className="px-3 py-2 font-semibold">Title</th>
+                  <th className="px-3 py-2 font-semibold">State</th>
+                  <th className="px-3 py-2 font-semibold">Labels</th>
+                  <th className="px-3 py-2 font-semibold">Updated</th>
+                </tr>
+              </thead>
+              <tbody className="bg-white dark:bg-slate-900 divide-y divide-slate-100 dark:divide-slate-800">
+                {issues.length === 0 ? (
+                  <tr>
+                    <td
+                      colSpan={5}
+                      className="px-3 py-8 text-center text-slate-400 text-sm"
+                    >
+                      {tokens.length > 0
+                        ? "No issues match the current filter."
+                        : "No open issues."}
+                    </td>
+                  </tr>
+                ) : (
+                  issues.map((issue) => (
+                    <IssueRow key={issue.number} issue={issue} />
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+
+      {/* Pull Requests section */}
+      {snapshot && (
+        <section>
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400 mb-2">
+            Open Pull Requests ({prs.length}
+            {tokens.length > 0 &&
+              snapshot.pull_requests.length !== prs.length &&
+              ` of ${snapshot.pull_requests.length}`}
+            )
+          </h2>
+          <div className="overflow-x-auto rounded-lg border border-slate-200 dark:border-slate-700">
+            <table className="w-full text-left text-sm" role="table">
+              <thead className="bg-slate-100 dark:bg-slate-800 text-xs uppercase tracking-wide text-slate-600 dark:text-slate-400">
+                <tr>
+                  <th className="px-3 py-2 font-semibold">#</th>
+                  <th className="px-3 py-2 font-semibold">Title</th>
+                  <th className="px-3 py-2 font-semibold">Status</th>
+                  <th className="px-3 py-2 font-semibold">Labels</th>
+                  <th className="px-3 py-2 font-semibold">Updated</th>
+                </tr>
+              </thead>
+              <tbody className="bg-white dark:bg-slate-900 divide-y divide-slate-100 dark:divide-slate-800">
+                {prs.length === 0 ? (
+                  <tr>
+                    <td
+                      colSpan={5}
+                      className="px-3 py-8 text-center text-slate-400 text-sm"
+                    >
+                      {tokens.length > 0
+                        ? "No pull requests match the current filter."
+                        : "No open pull requests."}
+                    </td>
+                  </tr>
+                ) : (
+                  prs.map((pr) => <PullRequestRow key={pr.number} pr={pr} />)
+                )}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/mercury-gui/src/components/IssueRow.tsx
+++ b/mercury-gui/src/components/IssueRow.tsx
@@ -1,0 +1,61 @@
+// IssueRow — single row in the Issues section of the GitHub dashboard (#416).
+// Clickable → opens issue URL in browser via tauri-plugin-opener.
+
+import { openUrl } from "@tauri-apps/plugin-opener";
+import { Badge } from "@/components/ui/badge";
+import { elapsed } from "@/lib/elapsed";
+import type { GhIssue } from "@/lib/ghTypes";
+
+interface IssueRowProps {
+  issue: GhIssue;
+}
+
+export function IssueRow({ issue }: IssueRowProps) {
+  function handleOpen() {
+    openUrl(issue.url).catch(() => {
+      // Non-fatal: URL open failure doesn't break the dashboard
+    });
+  }
+
+  return (
+    <tr
+      className="border-b border-slate-200 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors cursor-pointer"
+      onClick={handleOpen}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          handleOpen();
+        }
+      }}
+      aria-label={`Open issue #${issue.number}: ${issue.title}`}
+    >
+      <td className="px-3 py-2 font-mono text-xs whitespace-nowrap text-slate-500 dark:text-slate-400">
+        #{issue.number}
+      </td>
+      <td className="px-3 py-2 text-sm max-w-xs">
+        <span className="text-blue-600 dark:text-blue-400 hover:underline">
+          {issue.title}
+        </span>
+      </td>
+      <td className="px-3 py-2 whitespace-nowrap">
+        <Badge variant="success" className="text-xs">
+          {issue.state}
+        </Badge>
+      </td>
+      <td className="px-3 py-2">
+        <div className="flex flex-wrap gap-1">
+          {issue.labels.map((label) => (
+            <Badge key={label.name} variant="neutral" className="text-xs">
+              {label.name}
+            </Badge>
+          ))}
+        </div>
+      </td>
+      <td className="px-3 py-2 text-xs text-slate-500 dark:text-slate-400 whitespace-nowrap tabular-nums">
+        {elapsed(issue.updatedAt)}
+      </td>
+    </tr>
+  );
+}

--- a/mercury-gui/src/components/IssueRow.tsx
+++ b/mercury-gui/src/components/IssueRow.tsx
@@ -1,10 +1,10 @@
 // IssueRow — single row in the Issues section of the GitHub dashboard (#416).
 // Clickable → opens issue URL in browser via tauri-plugin-opener.
 
-import { openUrl } from "@tauri-apps/plugin-opener";
 import { Badge } from "@/components/ui/badge";
 import { elapsed } from "@/lib/elapsed";
 import type { GhIssue } from "@/lib/ghTypes";
+import { safeOpenUrl } from "@/lib/safeOpenUrl";
 
 interface IssueRowProps {
   issue: GhIssue;
@@ -12,8 +12,8 @@ interface IssueRowProps {
 
 export function IssueRow({ issue }: IssueRowProps) {
   function handleOpen() {
-    openUrl(issue.url).catch(() => {
-      // Non-fatal: URL open failure doesn't break the dashboard
+    safeOpenUrl(issue.url).catch(() => {
+      // Non-fatal: URL open failure (or whitelist rejection) doesn't break the dashboard
     });
   }
 

--- a/mercury-gui/src/components/PullRequestRow.tsx
+++ b/mercury-gui/src/components/PullRequestRow.tsx
@@ -1,10 +1,10 @@
 // PullRequestRow — single row in the PRs section of the GitHub dashboard (#416).
 // Clickable → opens PR URL in browser via tauri-plugin-opener.
 
-import { openUrl } from "@tauri-apps/plugin-opener";
 import { Badge } from "@/components/ui/badge";
 import { elapsed } from "@/lib/elapsed";
 import type { GhPullRequest } from "@/lib/ghTypes";
+import { safeOpenUrl } from "@/lib/safeOpenUrl";
 
 interface PullRequestRowProps {
   pr: GhPullRequest;
@@ -23,8 +23,8 @@ function reviewDecisionVariant(
 
 export function PullRequestRow({ pr }: PullRequestRowProps) {
   function handleOpen() {
-    openUrl(pr.url).catch(() => {
-      // Non-fatal
+    safeOpenUrl(pr.url).catch(() => {
+      // Non-fatal (URL open failure or whitelist rejection)
     });
   }
 

--- a/mercury-gui/src/components/PullRequestRow.tsx
+++ b/mercury-gui/src/components/PullRequestRow.tsx
@@ -1,0 +1,90 @@
+// PullRequestRow — single row in the PRs section of the GitHub dashboard (#416).
+// Clickable → opens PR URL in browser via tauri-plugin-opener.
+
+import { openUrl } from "@tauri-apps/plugin-opener";
+import { Badge } from "@/components/ui/badge";
+import { elapsed } from "@/lib/elapsed";
+import type { GhPullRequest } from "@/lib/ghTypes";
+
+interface PullRequestRowProps {
+  pr: GhPullRequest;
+}
+
+function reviewDecisionVariant(
+  decision: string | null | undefined
+): "success" | "warning" | "danger" | "neutral" {
+  if (!decision) return "neutral";
+  const d = decision.toLowerCase();
+  if (d === "approved") return "success";
+  if (d === "changes_requested") return "danger";
+  if (d === "review_required") return "warning";
+  return "neutral";
+}
+
+export function PullRequestRow({ pr }: PullRequestRowProps) {
+  function handleOpen() {
+    openUrl(pr.url).catch(() => {
+      // Non-fatal
+    });
+  }
+
+  return (
+    <tr
+      className="border-b border-slate-200 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors cursor-pointer"
+      onClick={handleOpen}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          handleOpen();
+        }
+      }}
+      aria-label={`Open pull request #${pr.number}: ${pr.title}`}
+    >
+      <td className="px-3 py-2 font-mono text-xs whitespace-nowrap text-slate-500 dark:text-slate-400">
+        #{pr.number}
+      </td>
+      <td className="px-3 py-2 text-sm max-w-xs">
+        <span className="text-blue-600 dark:text-blue-400 hover:underline">
+          {pr.title}
+        </span>
+        <span className="ml-2 text-xs text-slate-400 font-mono whitespace-nowrap">
+          {pr.headRefName}→{pr.baseRefName}
+        </span>
+      </td>
+      <td className="px-3 py-2 whitespace-nowrap">
+        <div className="flex gap-1 flex-wrap">
+          {pr.isDraft && (
+            <Badge variant="neutral" className="text-xs">
+              draft
+            </Badge>
+          )}
+          <Badge variant="info" className="text-xs">
+            {pr.state}
+          </Badge>
+          {pr.reviewDecision && (
+            <Badge
+              variant={reviewDecisionVariant(pr.reviewDecision)}
+              className="text-xs"
+            >
+              {pr.reviewDecision.toLowerCase().replace(/_/g, " ")}
+            </Badge>
+          )}
+        </div>
+      </td>
+      <td className="px-3 py-2">
+        <div className="flex flex-wrap gap-1">
+          {pr.labels.map((label) => (
+            <Badge key={label.name} variant="neutral" className="text-xs">
+              {label.name}
+            </Badge>
+          ))}
+        </div>
+      </td>
+      <td className="px-3 py-2 text-xs text-slate-500 dark:text-slate-400 whitespace-nowrap tabular-nums">
+        {elapsed(pr.updatedAt)}
+      </td>
+    </tr>
+  );
+}

--- a/mercury-gui/src/components/SnapshotView.tsx
+++ b/mercury-gui/src/components/SnapshotView.tsx
@@ -1,0 +1,60 @@
+// SnapshotView — extracts the #415 cross-lane snapshot surface from App.tsx
+// so App.tsx can host the top-level Tabs nav (#416).
+
+import { useState } from "react";
+import { FilterBar } from "./FilterBar";
+import { LaneTable } from "./LaneTable";
+import { useSnapshot } from "@/hooks/useSnapshot";
+import { redactHomePaths } from "@/lib/redact";
+
+export function SnapshotView() {
+  const { jobsByLane, lanes, error, loading, elapsedNonce, refresh } =
+    useSnapshot();
+  const [filter, setFilter] = useState("");
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Filter + refresh toolbar */}
+      <FilterBar
+        value={filter}
+        onChange={setFilter}
+        onRefresh={refresh}
+        loading={loading}
+      />
+
+      {error && (
+        <div className="rounded-md border border-red-200 bg-red-50 dark:bg-red-950 dark:border-red-800 px-4 py-3 text-sm text-red-700 dark:text-red-300">
+          <strong>Error loading data:</strong>{" "}
+          {String(redactHomePaths(error))}
+          <button
+            className="ml-4 underline text-red-600 dark:text-red-400 hover:no-underline"
+            onClick={() => refresh()}
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      {loading && !error && (
+        <div className="flex items-center justify-center py-16 text-slate-400 text-sm">
+          Loading snapshot…
+        </div>
+      )}
+
+      {!loading && (
+        <LaneTable
+          jobsByLane={jobsByLane}
+          lanes={lanes}
+          filterRaw={filter}
+          elapsedNonce={elapsedNonce}
+        />
+      )}
+
+      <p className="text-xs text-slate-400">
+        Auto-refresh on file-watcher event &middot;{" "}
+        {Object.values(jobsByLane).flat().length} session(s) across{" "}
+        {lanes.length} lane(s)
+      </p>
+    </div>
+  );
+}

--- a/mercury-gui/src/components/ui/tabs.tsx
+++ b/mercury-gui/src/components/ui/tabs.tsx
@@ -1,0 +1,53 @@
+import * as React from "react"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
+
+import { cn } from "@/lib/utils"
+
+const Tabs = TabsPrimitive.Root
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
+      className
+    )}
+    {...props}
+  />
+))
+TabsList.displayName = TabsPrimitive.List.displayName
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+      className
+    )}
+    {...props}
+  />
+))
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      className
+    )}
+    {...props}
+  />
+))
+TabsContent.displayName = TabsPrimitive.Content.displayName
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/mercury-gui/src/hooks/useGitHubData.ts
+++ b/mercury-gui/src/hooks/useGitHubData.ts
@@ -1,0 +1,42 @@
+// useGitHubData — fetches GitHub Issue/PR data via Tauri IPC (#416).
+// Mirrors useSnapshot pattern: monotonic reqId race guard, silent/manual
+// distinction, no auto-refresh (per DoD — rate-limit awareness).
+// 60s TTL cache lives in Rust; this hook holds no client-side TTL.
+
+import { useState, useCallback, useRef } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import type { GhSnapshot } from "../lib/ghTypes";
+
+export interface GitHubDataState {
+  snapshot: GhSnapshot | null;
+  error: string | undefined;
+  loading: boolean;
+  refresh: (force?: boolean) => void;
+}
+
+export function useGitHubData(): GitHubDataState {
+  const [snapshot, setSnapshot] = useState<GhSnapshot | null>(null);
+  const [error, setError] = useState<string | undefined>(undefined);
+  const [loading, setLoading] = useState(false);
+  // Monotonic request id — late responses from overlapping calls must NOT
+  // overwrite newer state (mirrors useSnapshot reqIdRef pattern).
+  const reqIdRef = useRef(0);
+
+  const refresh = useCallback(async (force: boolean = false) => {
+    const myId = ++reqIdRef.current;
+    setLoading(true);
+    try {
+      const result = await invoke<GhSnapshot>("fetch_gh_dashboard", { force });
+      if (myId !== reqIdRef.current) return;
+      setSnapshot(result);
+      setError(undefined);
+    } catch (e) {
+      if (myId !== reqIdRef.current) return;
+      setError(String(e));
+    } finally {
+      if (myId === reqIdRef.current) setLoading(false);
+    }
+  }, []);
+
+  return { snapshot, error, loading, refresh };
+}

--- a/mercury-gui/src/hooks/useGitHubData.ts
+++ b/mercury-gui/src/hooks/useGitHubData.ts
@@ -1,6 +1,7 @@
 // useGitHubData — fetches GitHub Issue/PR data via Tauri IPC (#416).
-// Mirrors useSnapshot pattern: monotonic reqId race guard, silent/manual
-// distinction, no auto-refresh (per DoD — rate-limit awareness).
+// Mirrors useSnapshot pattern: monotonic reqId race guard.
+// No auto-refresh and no silent/manual distinction (per DoD — rate-limit
+// awareness); refresh() is always user-initiated.
 // 60s TTL cache lives in Rust; this hook holds no client-side TTL.
 
 import { useState, useCallback, useRef } from "react";

--- a/mercury-gui/src/lib/ghFilter.ts
+++ b/mercury-gui/src/lib/ghFilter.ts
@@ -1,0 +1,118 @@
+// Filter parser + matcher for the GitHub Issue/PR dashboard (#416).
+//
+// Supported prefixes (space-separated, AND-combined):
+//   label:<name>  — substring match against any label name (case-insensitive).
+//                   `label:P2` matches "P2", "enhancement-P2", etc.
+//   state:<value> — exact match on item.state (open/closed), OR `draft` for
+//                   PRs where isDraft===true.
+//   lane:<value>  — substring match against labels that start with "lane:".
+//                   `lane:main` matches a label named "lane:main".
+//                   `lane:` (empty value) is dropped (consistent with filter.ts).
+//   free text     — substring match on title + number string + author login.
+//
+// Empty filter → show all (returns empty token array).
+// AND semantics: item must satisfy every token.
+
+import type { GhIssue, GhPullRequest } from "./ghTypes";
+
+export interface GhFilterToken {
+  kind: "label" | "state" | "lane" | "text";
+  value: string;
+}
+
+export function parseGhFilter(raw: string): GhFilterToken[] {
+  if (!raw.trim()) return [];
+  const tokens: GhFilterToken[] = [];
+  for (const tok of raw.trim().split(/\s+/)) {
+    const lower = tok.toLowerCase();
+    // Empty-value prefix tokens are silently dropped (mirrors filter.ts discipline).
+    if (lower.startsWith("label:")) {
+      const value = lower.slice(6);
+      if (value) tokens.push({ kind: "label", value });
+      continue;
+    }
+    if (lower.startsWith("state:")) {
+      const value = lower.slice(6);
+      if (value) tokens.push({ kind: "state", value });
+      continue;
+    }
+    if (lower.startsWith("lane:")) {
+      const value = lower.slice(5);
+      if (value) tokens.push({ kind: "lane", value });
+      continue;
+    }
+    tokens.push({ kind: "text", value: lower });
+  }
+  return tokens;
+}
+
+export function matchesIssue(
+  issue: GhIssue,
+  tokens: GhFilterToken[]
+): boolean {
+  if (tokens.length === 0) return true;
+  return tokens.every((token) => {
+    switch (token.kind) {
+      case "label": {
+        return issue.labels.some((l) =>
+          l.name.toLowerCase().includes(token.value)
+        );
+      }
+      case "state": {
+        return issue.state.toLowerCase() === token.value;
+      }
+      case "lane": {
+        return issue.labels
+          .filter((l) => l.name.toLowerCase().startsWith("lane:"))
+          .some((l) => l.name.toLowerCase().includes(token.value));
+      }
+      case "text": {
+        const haystack = [
+          issue.title,
+          String(issue.number),
+          ...issue.assignees.map((a) => a.login),
+        ]
+          .join(" ")
+          .toLowerCase();
+        return haystack.includes(token.value);
+      }
+    }
+  });
+}
+
+export function matchesPR(
+  pr: GhPullRequest,
+  tokens: GhFilterToken[]
+): boolean {
+  if (tokens.length === 0) return true;
+  return tokens.every((token) => {
+    switch (token.kind) {
+      case "label": {
+        return pr.labels.some((l) =>
+          l.name.toLowerCase().includes(token.value)
+        );
+      }
+      case "state": {
+        // `state:draft` matches isDraft PRs regardless of the state field
+        if (token.value === "draft") return pr.isDraft;
+        return pr.state.toLowerCase() === token.value;
+      }
+      case "lane": {
+        return pr.labels
+          .filter((l) => l.name.toLowerCase().startsWith("lane:"))
+          .some((l) => l.name.toLowerCase().includes(token.value));
+      }
+      case "text": {
+        const haystack = [
+          pr.title,
+          String(pr.number),
+          pr.headRefName,
+          ...pr.assignees.map((a) => a.login),
+        ]
+          .join(" ")
+          .toLowerCase();
+        return haystack.includes(token.value);
+      }
+    }
+  });
+}

--- a/mercury-gui/src/lib/ghFilter.ts
+++ b/mercury-gui/src/lib/ghFilter.ts
@@ -8,7 +8,8 @@
 //   lane:<value>  — substring match against labels that start with "lane:".
 //                   `lane:main` matches a label named "lane:main".
 //                   `lane:` (empty value) is dropped (consistent with filter.ts).
-//   free text     — substring match on title + number string + author login.
+//   free text     — substring match on title + number string + assignee logins
+//                   (and headRefName for PRs).
 //
 // Empty filter → show all (returns empty token array).
 // AND semantics: item must satisfy every token.

--- a/mercury-gui/src/lib/ghTypes.ts
+++ b/mercury-gui/src/lib/ghTypes.ts
@@ -1,0 +1,45 @@
+// TS mirror of Rust gh_dashboard models (#416).
+// Schema-tolerant: optional fields use `?`, null-aware where gh CLI may omit.
+
+export interface GhLabel {
+  name: string;
+  color?: string | null;
+}
+
+export interface GhUser {
+  login: string;
+}
+
+export interface GhIssue {
+  number: number;
+  title: string;
+  state: string;
+  labels: GhLabel[];
+  assignees: GhUser[];
+  createdAt: string;
+  updatedAt: string;
+  url: string;
+  milestone?: unknown | null;
+}
+
+export interface GhPullRequest {
+  number: number;
+  title: string;
+  state: string;
+  labels: GhLabel[];
+  assignees: GhUser[];
+  createdAt: string;
+  updatedAt: string;
+  url: string;
+  headRefName: string;
+  baseRefName: string;
+  isDraft: boolean;
+  reviewDecision?: string | null;
+}
+
+export interface GhSnapshot {
+  issues: GhIssue[];
+  pull_requests: GhPullRequest[];
+  // Unix epoch milliseconds — consistent with RosterSnapshot.updatedAt
+  fetchedAt: number;
+}

--- a/mercury-gui/src/lib/ghTypes.ts
+++ b/mercury-gui/src/lib/ghTypes.ts
@@ -39,7 +39,7 @@ export interface GhPullRequest {
 
 export interface GhSnapshot {
   issues: GhIssue[];
-  pull_requests: GhPullRequest[];
+  pullRequests: GhPullRequest[];
   // Unix epoch milliseconds — consistent with RosterSnapshot.updatedAt
   fetchedAt: number;
 }

--- a/mercury-gui/src/lib/safeOpenUrl.ts
+++ b/mercury-gui/src/lib/safeOpenUrl.ts
@@ -1,0 +1,29 @@
+// safeOpenUrl — defense-in-depth wrapper around tauri-plugin-opener (#416).
+// Whitelists https://github.com and https://www.github.com hosts so a future
+// data-integrity gap (compromised gh CLI, JSON injection, IPC tampering)
+// cannot redirect a user click to an arbitrary URL. Tauri's default opener
+// regex already restricts to http(s)/mailto/tel; this is the second layer.
+
+import { openUrl } from "@tauri-apps/plugin-opener";
+
+const ALLOWED_HOSTS = new Set(["github.com", "www.github.com"]);
+
+export function safeOpenUrl(raw: string): Promise<void> {
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return Promise.reject(new Error(`safeOpenUrl: malformed URL ${raw}`));
+  }
+  if (parsed.protocol !== "https:") {
+    return Promise.reject(
+      new Error(`safeOpenUrl: rejected non-https URL ${raw}`)
+    );
+  }
+  if (!ALLOWED_HOSTS.has(parsed.host)) {
+    return Promise.reject(
+      new Error(`safeOpenUrl: rejected host ${parsed.host}`)
+    );
+  }
+  return openUrl(parsed.toString());
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-tabs':
+        specifier: ^1.1.13
+        version: 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tailwindcss/vite':
         specifier: ^4.3.0
         version: 4.3.0(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0))
@@ -367,6 +370,19 @@ packages:
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
 
+  '@radix-ui/react-collection@1.1.7':
+    resolution: {integrity: sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-compose-refs@1.1.2':
     resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
     peerDependencies:
@@ -396,6 +412,15 @@ packages:
       '@types/react':
         optional: true
       '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-direction@1.1.1':
+    resolution: {integrity: sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
         optional: true
 
   '@radix-ui/react-dismissable-layer@1.1.11':
@@ -481,6 +506,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-roving-focus@1.1.11':
+    resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-slot@1.2.3':
     resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
     peerDependencies:
@@ -497,6 +535,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-tabs@1.1.13':
+    resolution: {integrity: sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-use-callback-ref@1.1.1':
@@ -1880,6 +1931,18 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
+  '@radix-ui/react-collection@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.15)(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.15
+      '@types/react-dom': 19.2.3(@types/react@19.2.15)
+
   '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.15)(react@19.2.6)':
     dependencies:
       react: 19.2.6
@@ -1913,6 +1976,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.15
       '@types/react-dom': 19.2.3(@types/react@19.2.15)
+
+  '@radix-ui/react-direction@1.1.1(@types/react@19.2.15)(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.15
 
   '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
@@ -1980,6 +2049,23 @@ snapshots:
       '@types/react': 19.2.15
       '@types/react-dom': 19.2.3(@types/react@19.2.15)
 
+  '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.15)(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.15
+      '@types/react-dom': 19.2.3(@types/react@19.2.15)
+
   '@radix-ui/react-slot@1.2.3(@types/react@19.2.15)(react@19.2.6)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.15)(react@19.2.6)
@@ -1993,6 +2079,22 @@ snapshots:
       react: 19.2.6
     optionalDependencies:
       '@types/react': 19.2.15
+
+  '@radix-ui/react-tabs@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.15)(react@19.2.6)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.15)(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.15
+      '@types/react-dom': 19.2.3(@types/react@19.2.15)
 
   '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.15)(react@19.2.6)':
     dependencies:


### PR DESCRIPTION
## Summary

Phase 6 GUI MVP **slice D** — Issue/PR dashboard view consuming `gh` CLI via Tauri 2 shell plugin. Completes the v1 scope (slices A+B+C+D landed) per the [#411 ADR](https://github.com/392fyc/Mercury/issues/411).

**4-slice Phase 6 chain status**: #413 (S123) scaffold → #414 (S124) data layer → #415 (S125) cross-lane snapshot → **#416 (S126) Issue/PR dashboard** ✅

## What ships

**Backend** (`mercury-gui/src-tauri/`)
- New `gh_dashboard` module: IPC command `fetch_gh_dashboard(force: bool) -> GhSnapshot`
- 60s TTL in-memory cache, process-lifetime, force-refresh bypass
- Invokes `gh issue list` + `gh pr list --repo 392fyc/Mercury --state open --limit 200` via `tauri-plugin-shell::ShellExt`
- `tokio::time::timeout(30s)` per subprocess — UI recovers from `gh` hangs
- Cache lock released before gh spawn (cannot wedge later refreshes)
- Stderr / spawn-error / parse-error strings run through `redact_home` before crossing IPC (Rust-side primary boundary per #414 pattern)
- Capability `shell:allow-execute` scoped to two explicit allowlist entries (`gh issue list ...` and `gh pr list ...`) with regex validators on each argument slot — no unrestricted args
- 7 unit tests for predicate (cache hit / force bypass / TTL expiry / empty cache) + serde camelCase round-trip

**Frontend** (`mercury-gui/src/`)
- shadcn `Tabs` primitive for top-level nav: "Snapshot" (existing #415 surface) + "Issues / PRs" (new #416 surface)
- `SnapshotView.tsx` extracts the #415 view from `App.tsx`
- `GitHubDashboard.tsx` (185 LOC) renders Issues + PRs sections with filter input, last-fetched timestamp, force-refresh button
- `IssueRow` + `PullRequestRow` click → `openUrl(url)` via `@tauri-apps/plugin-opener` (already installed); keyboard a11y (Enter/Space + `role="button"`)
- `useGitHubData.ts` mirrors `useSnapshot` reqId race-guard pattern; **no auto-refresh** (no `setInterval`, no `listen`)
- `ghFilter.ts` parser with `label:` / `state:` / `lane:` prefixes + free text; AND semantics + empty-value-prefix-drop discipline (mirror of #415 `lib/filter.ts`)
- `redactHomePaths()` wraps error display

## DoD coverage

- [x] Dashboard renders all open Issues + PRs via `gh` CLI
- [x] Label filter (`label:P2`, `label:enhancement`)
- [x] Lane filter (`lane:main` matches `lane:main` label)
- [x] State filter (`state:open` / `state:draft` for PRs)
- [x] Click row → opens browser via Tauri opener plugin
- [x] 60s TTL cache prevents rate-limit abuse
- [x] Last-fetched timestamp visible (`elapsed(fetchedAt)`)
- [x] Force-refresh button bypasses cache
- [x] No auto-refresh (rate-limit awareness)

## Pre-commit dual-verify (S111 strict)

- **Claude code-reviewer**: APPROVE-WITH-MINOR-ADVISORY → 0 BLOCKER / 0 HIGH / 3 MEDIUM / 4 LOW / 3 INFO
- **Codex sync-audit** (`task-mpdta5cl-ykb5ww` read-only): NEEDS-CHANGES → 0 BLOCKER / 0 HIGH / 1 MEDIUM / 3 LOW / 4 INFO

**Both reviewers converged on the same top concern** (Codex M1 = Claude M1+M2): mutex held across gh subprocess await + no timeout. Addressed in-place pre-commit:
- Lock now acquired only to read the cache, dropped before spawning gh
- Each gh `.output().await` wrapped in `tokio::time::timeout(30s)` (added `time` feature to tokio Cargo.toml)
- Extracted pure predicate `check_cache_hit(entry, force, now, ttl) -> Option<GhSnapshot>` — directly unit-testable without `AppHandle`

**Other pre-commit fixes**:
- Codex L2 (Rust-side stderr/spawn-error redact gap, #414 PII primary-boundary regression) → all `Err()` paths now run strings through `redact_home`
- Codex L3 / Claude L1 (vestigial `force_refresh_bypasses_fresh_cache` test) → replaced with 4 real predicate tests
- Codex L1 (`args: true` too permissive) → tightened to two explicit allowlist entries with regex validators per arg slot
- Claude M3 (`pull_requests` snake_case inconsistency in IPC surface) → renamed to `pullRequests` via `#[serde(rename)]` + TS + 2 call sites

**Carried as advisory (DISAGREE-cited or follow-up)**:
- Claude I3 (titles/labels redact) → Codex explicitly flagged as NOT actionable ("issue/PR titles are repo-authored remote content, not host-derived local PII") — we follow Codex's narrower reading
- Claude I1 (parser DRY) → both reviewers agreed: two surfaces is below the three-surface abstraction threshold; revisit when slice E lands
- Claude L2 + L3 (initialLoaded useEffect awkwardness, fetchedAtIso defensive guard) → Codex said acceptable; cosmetic only
- Claude I2 / Codex INFO (`state:closed` matches nothing today) → coherent for open-only payload; documented inline

## Test plan

- [x] `pnpm build` (= `tsc && vite build`) — exit 0 (strict mode clean)
- [x] `cargo test --lib` — 30/30 pass (7 gh_dashboard + 23 existing)
- [x] `pnpm tauri build` — exit 0 (MSI + NSIS bundles)
- [ ] Manual smoke: launch the GUI, switch to "Issues / PRs" tab, verify Issues list renders (requires runtime `gh auth status` OK)
- [ ] Manual smoke: filter `lane:main` → only `lane:main`-labeled rows
- [ ] Manual smoke: click any row → default browser opens to the GitHub URL
- [ ] Manual smoke: click Refresh → fresh data fetched (verify by stale timestamp updating)

## Files changed

17 files, +2165 / -77 (incl. lockfiles auto-updated; precedent: PR #424 #415 did the same)

## Mode A 6 axes (locked since S122 + S125)

React + TS + Vite + `mercury-gui/` + ~/.rustup + VS2022 C: + **shadcn/ui + Tailwind v4** — no new axes; no new external libs.

## Cherry-pick protocol carve-out (S125 precedent)

shadcn `pnpm dlx add tabs` produced `mercury-gui/src/components/ui/tabs.tsx` from the registry. Per S125 PR #424 precedent (DISAGREE-cited and accepted), the registry resolves "latest" at CLI time with no per-file SHA, design intent is "you own the code", and `pnpm dlx`-generated scaffolding is not a per-file vendor cherry-pick under Mercury protocol. No manifest entry filed.

Refs #411 #416
Closes #416
