### PR TITLE
docs(#428): cherry-pick protocol carve-out for CLI scaffolding + registry-import

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,19 @@ CLI tools that fetch named items from a versioned registry. Each `add` invocatio
 - ❌ Per-file `# Based on <upstream>` comment
 - ❌ Drift monitoring via `scripts/upstream-drift-check.sh`
 
+**Local-path guard — when local-path adds fall back to full cherry-pick protocol**
+
+The local-path arg form is intended for Mercury-internal registry items (e.g., a path under `mercury-gui/` or a sibling Mercury repo path). It is NOT a back door for importing arbitrary external-project files via a local checkout.
+
+A local-path add **falls back to the full cherry-pick protocol (rules 1-6)** when ANY of these conditions hold:
+
+- The path resolves outside the current Mercury repo working tree
+- The path resolves into a git submodule pointing to a third-party upstream repo
+- The path resolves into a node_modules / vendored directory whose contents originate from an external package
+- The path resolves into a temporary checkout of an external project staged for import
+
+When in doubt, treat the local-path source as a file-lift cherry-pick (full protocol applies). The carve-out exists to formalize "shadcn-style registry add from a versioned source" — local-path is the narrowest case and the guard above keeps the supply-chain audit surface intact.
+
 **Tighter than Category A** — Category B's PR body line must identify (a) the specific registry-item / URL / local-path arg, (b) the source identifier in the form appropriate to the arg kind (default registry / custom registry URL / local path), and (c) the item type if non-component, because together these determine license + upstream identity.
 
 #### Adding new generators to either category

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,8 +84,7 @@ Mercury 的部分功能跨仓库运作。以下表格记录外部仓库与 Mercu
 
 When cherry-picking any file from an external project into Mercury, the SAME commit must include:
 
-> See §"Carve-out: CLI-generated scaffolding" below before applying rules 1-6 to files produced by `pnpm dlx shadcn@latest add`, `pnpm create tauri-app`, or `pnpm create vite`.
-
+> See [§Carve-out: CLI-generated scaffolding](#carve-out-cli-generated-scaffolding) below before applying rules 1-6 to files produced by `pnpm dlx shadcn@latest add`, `pnpm create tauri-app`, or `pnpm create vite`.
 
 1. **Manifest entry**: add to `.mercury/state/upstream-manifest.json` — fields: `path`, `scope` (`"project"` for repo files, `"user"` for `~/.claude/` global files), `upstream_repo`, `upstream_path`, `upstream_sha_at_import` (verify via `gh api repos/{owner}/{repo}/commits/{sha}`), `upstream_license`, `import_pr`, `import_date`, `import_rationale`, `last_drift_check` (null).
 2. **SKILL.md frontmatter**: add `upstream_source`, `upstream_sha`, `upstream_license`, `cherry_picked_in`, `cherry_picked_at` fields.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,14 +151,14 @@ CLI tools that fetch named items from a versioned registry. Each `add` invocatio
 
 The local-path arg form is intended for Mercury-internal registry items (e.g., a path under `mercury-gui/` or a sibling Mercury repo path). It is NOT a back door for importing arbitrary external-project files via a local checkout.
 
-A local-path add **falls back to the full cherry-pick protocol (rules 1-6)** when ANY of these conditions hold:
+A local-path add **falls back to the full cherry-pick protocol (rules 1-6)** when ANY of these conditions hold. Resolve the source path with `git rev-parse --show-toplevel` for the Mercury repo root (or `realpath` on the path arg) before applying the test — symlinks, `..` traversal, and absolute paths are all normalized this way:
 
-- The path resolves outside the current Mercury repo working tree
-- The path resolves into a git submodule pointing to a third-party upstream repo
-- The path resolves into a node_modules / vendored directory whose contents originate from an external package
-- The path resolves into a temporary checkout of an external project staged for import
+- The resolved path is **not** under the current Mercury repo working tree (i.e., does not have the `git rev-parse --show-toplevel` output as a prefix)
+- The resolved path is under a git submodule whose upstream points to a third-party repo (check via `git submodule status`)
+- The resolved path is under a `node_modules/`, `vendor/`, or other package-manager-staged directory whose contents originate from an external package
+- The resolved path is under a temporary checkout of an external project staged for import (e.g., a `tmp/`, `scratch/`, or any cloned third-party repo directory)
 
-When in doubt, treat the local-path source as a file-lift cherry-pick (full protocol applies). The carve-out exists to formalize "shadcn-style registry add from a versioned source" — local-path is the narrowest case and the guard above keeps the supply-chain audit surface intact.
+When in doubt, treat the local-path source as a file-lift cherry-pick (full protocol applies). The carve-out exists to formalize "shadcn-style registry add from a versioned source" — local-path is the narrowest case and the guard above (plus the catch-all default-deny) keeps the supply-chain audit surface intact.
 
 **Tighter than Category A** — Category B's PR body line must identify (a) the specific registry-item / URL / local-path arg, (b) the source identifier in the form appropriate to the arg kind (default registry / custom registry URL / local path), and (c) the item type if non-component, because together these determine license + upstream identity.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,8 +132,13 @@ CLI tools that fetch named items from a versioned registry. Each `add` invocatio
 
 **Required for Category B**:
 
-1. **Provenance line in PR body** (stricter than Category A): record (a) exact CLI invocation including the item-name / URL / path arg(s), (b) shadcn CLI version at invocation time, (c) registry source — **always**, explicitly stating "default (ui.shadcn.com)" or the non-default URL / namespace (the registry source determines license + upstream identity, so default-vs-custom must be unambiguous on the record), (d) registry item type if non-component (e.g., `registry:hook`, `registry:font`, `registry:lib`, `registry:page`, `registry:file`). Example: "Imported via `pnpm dlx shadcn@latest add tabs`, shadcn CLI vX.Y, registry = default (ui.shadcn.com), item type = registry:component at 2026-MM-DD".
-2. **License compatibility check**: confirm the registry's license (shadcn = MIT). Record in PR body.
+1. **Provenance line in PR body** (stricter than Category A): record (a) exact CLI invocation including the item-name / URL / path arg(s), (b) shadcn CLI version at invocation time, (c) **source identifier — always**, in one of three forms depending on the arg kind:
+   - For a registry item name (default registry): `source = default registry (ui.shadcn.com)`
+   - For a URL arg (custom registry or registry item URL): `source = custom registry URL: <url>`
+   - For a local-path arg (file-system import, not registry-fetched): `source = local path: <relative-path>` (note that local-path adds bypass the registry layer entirely — the path IS the upstream identity)
+
+   The source identifier determines license + upstream identity, so the arg kind must be unambiguous on the record. (d) registry item type if non-component (e.g., `registry:hook`, `registry:font`, `registry:lib`, `registry:page`, `registry:file`). Example: "Imported via `pnpm dlx shadcn@latest add tabs`, shadcn CLI vX.Y, source = default registry (ui.shadcn.com), item type = registry:component at 2026-MM-DD".
+2. **License compatibility check**: confirm the license of the actual source you're importing from at invocation time, NOT a fixed assumption. The shadcn default registry is MIT (illustrative); custom registries may use different licenses, and local-path adds inherit the license of the source path's project. Verify per import + record the verified license in PR body.
 3. **Customization is owned by Mercury after add**: shadcn's design philosophy is "copy-paste with full ownership" — once added, the file is Mercury-owned and editable without per-file upstream-tracking attribution.
 
 **NOT required for Category B** (registry items are not pinned to upstream SHA; shadcn's contract is "you own the code"):
@@ -142,7 +147,7 @@ CLI tools that fetch named items from a versioned registry. Each `add` invocatio
 - ❌ Per-file `# Based on <upstream>` comment
 - ❌ Drift monitoring via `scripts/upstream-drift-check.sh`
 
-**Tighter than Category A** — Category B's PR body line must identify (a) the specific registry item arg, (b) the registry source explicitly (whether default or custom), and (c) the item type if non-component, because together these determine license + upstream identity.
+**Tighter than Category A** — Category B's PR body line must identify (a) the specific registry-item / URL / local-path arg, (b) the source identifier in the form appropriate to the arg kind (default registry / custom registry URL / local path), and (c) the item type if non-component, because together these determine license + upstream identity.
 
 #### Adding new generators to either category
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,9 @@ Mercury 的部分功能跨仓库运作。以下表格记录外部仓库与 Mercu
 
 When cherry-picking any file from an external project into Mercury, the SAME commit must include:
 
+> See §"Carve-out: CLI-generated scaffolding" below before applying rules 1-6 to files produced by `pnpm dlx shadcn@latest add`, `pnpm create tauri-app`, or `pnpm create vite`.
+
+
 1. **Manifest entry**: add to `.mercury/state/upstream-manifest.json` — fields: `path`, `scope` (`"project"` for repo files, `"user"` for `~/.claude/` global files), `upstream_repo`, `upstream_path`, `upstream_sha_at_import` (verify via `gh api repos/{owner}/{repo}/commits/{sha}`), `upstream_license`, `import_pr`, `import_date`, `import_rationale`, `last_drift_check` (null).
 2. **SKILL.md frontmatter**: add `upstream_source`, `upstream_sha`, `upstream_license`, `cherry_picked_in`, `cherry_picked_at` fields.
 3. **Script header**: add 5-line comment block after shebang — `UPSTREAM`, `SOURCE`, `SHA`, `DATE`, `ISSUE`.
@@ -92,3 +95,59 @@ When cherry-picking any file from an external project into Mercury, the SAME com
 6. **SHA verification**: `upstream_sha_at_import` must be verified via `gh api` before committing. Never record from memory. Mark `UNKNOWN_VERIFY_MANUALLY` only if API is unreachable; list in PR body.
 
 Drift monitoring: run `bash scripts/upstream-drift-check.sh` periodically to detect upstream changes.
+
+### Carve-out: CLI-generated scaffolding
+
+The cherry-pick protocol above applies to **files lifted from a specific upstream commit** (canonical upstream path + SHA + drift monitoring). It does NOT cleanly fit two adjacent cases that produce files via CLI invocation rather than direct upstream-path import. Split into 2 sub-categories:
+
+#### Category A — Pure scaffolding (one-shot project init)
+
+Generators that produce a one-time project skeleton from templated boilerplate. The templates ship with the CLI itself; no per-file upstream "source path" exists.
+
+| Generator | Invocation | Output scope |
+|---|---|---|
+| **create-tauri-app** | `pnpm create tauri-app` | Tauri 2 project skeleton (Rust workspace + JS frontend templated config) |
+| **create-vite** | `pnpm create vite` | Vite + framework skeleton (TS config + entry + index.html) |
+
+**Required for Category A**:
+
+1. **Provenance line in PR body**: PR creating the scaffold records the exact CLI invocation + version at invocation time (e.g., "Scaffold via `pnpm create tauri-app`, create-tauri-app vX.Y at 2026-MM-DD"). Use the actual version, not a placeholder. Note: `pnpm create` resolves the create-* starter package transiently and does NOT pin the generator into the produced app's `pnpm-lock.yaml` — the PR-body line is the only durable provenance record.
+2. **License compatibility check**: confirm the scaffold output's license is MIT / Apache-2.0 / similarly permissive (Tauri 2 = MIT/Apache-2.0; Vite = MIT). Record in PR body.
+3. **Customization allowed without attribution**: post-scaffold Mercury edits to the generated files do NOT require per-file `Based on` attribution.
+
+**NOT required for Category A**:
+
+- ❌ Manifest entry in `.mercury/state/upstream-manifest.json`
+- ❌ SKILL.md frontmatter `upstream_sha` field
+- ❌ Per-file `# Based on <upstream>` comment
+- ❌ Drift monitoring via `scripts/upstream-drift-check.sh`
+
+#### Category B — Registry-based item import (per-item upstream lift)
+
+CLI tools that fetch named items from a versioned registry. Each `add` invocation imports a concrete registry item that has a canonical upstream identity. Closer to a per-file cherry-pick than to pure scaffolding. **Applies to ALL `shadcn add` invocations regardless of registry item type** — components, hooks, utilities, pages, fonts, themes, config files, rules, libraries, or any other resource a shadcn-compatible registry exposes (per [shadcn CLI docs](https://ui.shadcn.com/docs/cli) — `add` consumes registry items by name, URL, or local path).
+
+| Generator | Invocation | Registry default | Output scope |
+|---|---|---|---|
+| **shadcn (any registry item)** | `pnpm dlx shadcn@latest add <name-or-url-or-path>` | <https://ui.shadcn.com/r> (official shadcn registry) | Any registry-backed resource: UI components, hooks, utilities, pages, themes, fonts, config files, rules, libraries, etc. Resource arg is a registry item name (default registry), a URL (any registry), or a local path. |
+
+**Required for Category B**:
+
+1. **Provenance line in PR body** (stricter than Category A): record (a) exact CLI invocation including the item-name / URL / path arg(s), (b) shadcn CLI version at invocation time, (c) registry source — **always**, explicitly stating "default (ui.shadcn.com)" or the non-default URL / namespace (the registry source determines license + upstream identity, so default-vs-custom must be unambiguous on the record), (d) registry item type if non-component (e.g., `registry:hook`, `registry:font`, `registry:lib`, `registry:page`, `registry:file`). Example: "Imported via `pnpm dlx shadcn@latest add tabs`, shadcn CLI vX.Y, registry = default (ui.shadcn.com), item type = registry:component at 2026-MM-DD".
+2. **License compatibility check**: confirm the registry's license (shadcn = MIT). Record in PR body.
+3. **Customization is owned by Mercury after add**: shadcn's design philosophy is "copy-paste with full ownership" — once added, the file is Mercury-owned and editable without per-file upstream-tracking attribution.
+
+**NOT required for Category B** (registry items are not pinned to upstream SHA; shadcn's contract is "you own the code"):
+
+- ❌ Manifest entry in `.mercury/state/upstream-manifest.json` (registry items are not version-pinned to a specific upstream commit; shadcn's model deliberately decouples from upstream after add)
+- ❌ Per-file `# Based on <upstream>` comment
+- ❌ Drift monitoring via `scripts/upstream-drift-check.sh`
+
+**Tighter than Category A** — Category B's PR body line must identify (a) the specific registry item arg, (b) the registry source explicitly (whether default or custom), and (c) the item type if non-component, because together these determine license + upstream identity.
+
+#### Adding new generators to either category
+
+Extend the appropriate table via a separate PR. The PR must cite (a) generator's package source URL, (b) license, (c) whether it produces one-shot scaffolding (→ Category A) or per-item registry imports (→ Category B), (d) drift-tracking rationale. Any tool not listed should be treated as a regular cherry-pick (full protocol rules 1-6 apply) until categorized here.
+
+#### Authority chain
+
+This carve-out resolves the repeat-DISAGREE-cite pattern observed during Phase 6 GUI MVP chain (PRs #421/#424/#425) where Argus / Copilot review threads flagged CLI-generated files as missing attribution. The Category A / Category B split was added in response to the audit finding that shadcn `add` is materially closer to registry-import than to pure project scaffolding, while create-tauri-app / create-vite genuinely are pure scaffolding.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,11 +132,11 @@ CLI tools that fetch named items from a versioned registry. Each `add` invocatio
 **Required for Category B**:
 
 1. **Provenance line in PR body** (stricter than Category A): record (a) exact CLI invocation including the item-name / URL / path arg(s), (b) shadcn CLI version at invocation time, (c) **source identifier — always**, in one of three forms depending on the arg kind:
-   - For a registry item name (default registry): `source = default registry (ui.shadcn.com)`
+   - For a registry item name (default registry): `source = default registry (https://ui.shadcn.com/r)`
    - For a URL arg (custom registry or registry item URL): `source = custom registry URL: <url>`
    - For a local-path arg (file-system import, not registry-fetched): `source = local path: <relative-path>` (note that local-path adds bypass the registry layer entirely — the path IS the upstream identity)
 
-   The source identifier determines license + upstream identity, so the arg kind must be unambiguous on the record. (d) registry item type if non-component (e.g., `registry:hook`, `registry:font`, `registry:lib`, `registry:page`, `registry:file`). Example: "Imported via `pnpm dlx shadcn@latest add tabs`, shadcn CLI vX.Y, source = default registry (ui.shadcn.com), item type = registry:component at 2026-MM-DD".
+   The source identifier determines license + upstream identity, so the arg kind must be unambiguous on the record. (d) registry item type if non-component (e.g., `registry:hook`, `registry:font`, `registry:lib`, `registry:page`, `registry:file`). Example: "Imported via `pnpm dlx shadcn@latest add tabs`, shadcn CLI vX.Y, source = default registry (https://ui.shadcn.com/r), item type = registry:component at 2026-MM-DD".
 2. **License compatibility check**: confirm the license of the actual source you're importing from at invocation time, NOT a fixed assumption. The shadcn default registry is MIT (illustrative); custom registries may use different licenses, and local-path adds inherit the license of the source path's project. Verify per import + record the verified license in PR body.
 3. **Customization is owned by Mercury after add**: shadcn's design philosophy is "copy-paste with full ownership" — once added, the file is Mercury-owned and editable without per-file upstream-tracking attribution.
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Notable sub-agents: `main`, `dev`, `acceptance`, `critic`, `design`, `research`,
 
 Mercury's mount philosophy (DIRECTION.md §四): build the minimum in-house; mount external projects via git submodule under `modules/` with a thin `adapters/<name>/` translation layer (≤200 LOC). Phase 2-1 evaluated four candidates (GSD, Superpowers, OMC, OpenSpace) against a narrow Stop-hook acceptance criterion; all four were REJECT or DEFER on that criterion, so `modules/` is currently empty. Other value from those projects has been cherry-picked individually (see `.mercury/state/upstream-manifest.json` and `scripts/upstream-drift-check.sh`).
 
-When files from an external project are cherry-picked into Mercury, the cherry-pick protocol in [`CLAUDE.md`](CLAUDE.md) is the canonical source for the required attribution / manifest / drift discipline. Two adjacent cases (one-shot CLI scaffolding and registry-based per-item imports) have a narrower carve-out — see CLAUDE.md §"Carve-out: CLI-generated scaffolding" for the authoritative scope. This README does not restate the rules; consult CLAUDE.md for current details.
+When files from an external project are cherry-picked into Mercury, the cherry-pick protocol in [`CLAUDE.md`](CLAUDE.md) is the canonical source for the required attribution / manifest / drift discipline. Two adjacent cases (one-shot CLI scaffolding and registry-based per-item imports) have a narrower carve-out — see [CLAUDE.md §Carve-out: CLI-generated scaffolding](CLAUDE.md#carve-out-cli-generated-scaffolding) for the authoritative scope. This README does not restate the rules; consult CLAUDE.md for current details.
 
 ## Example files
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ Mercury's mount philosophy (DIRECTION.md §四): build the minimum in-house; mou
 
 When files from an external project are cherry-picked into Mercury, the cherry-pick protocol in [`CLAUDE.md`](CLAUDE.md) applies (manifest entry in `.mercury/state/upstream-manifest.json`, SKILL.md frontmatter, attribution comments, license gate, SHA verification).
 
+Two adjacent cases have a narrower carve-out (see CLAUDE.md §"Carve-out: CLI-generated scaffolding"): one-shot project scaffolding via `pnpm create tauri-app` / `pnpm create vite` (Category A — PR-body provenance only, no manifest), and registry-based per-item imports via `pnpm dlx shadcn@latest add` (Category B — PR-body provenance plus registry-source identification, no manifest). All other cherry-picks follow the full protocol above.
+
 ## Example files
 
 Two `.example` files ship at the repo root. They serve two different tracking models:

--- a/README.md
+++ b/README.md
@@ -104,9 +104,7 @@ Notable sub-agents: `main`, `dev`, `acceptance`, `critic`, `design`, `research`,
 
 Mercury's mount philosophy (DIRECTION.md §四): build the minimum in-house; mount external projects via git submodule under `modules/` with a thin `adapters/<name>/` translation layer (≤200 LOC). Phase 2-1 evaluated four candidates (GSD, Superpowers, OMC, OpenSpace) against a narrow Stop-hook acceptance criterion; all four were REJECT or DEFER on that criterion, so `modules/` is currently empty. Other value from those projects has been cherry-picked individually (see `.mercury/state/upstream-manifest.json` and `scripts/upstream-drift-check.sh`).
 
-When files from an external project are cherry-picked into Mercury, the cherry-pick protocol in [`CLAUDE.md`](CLAUDE.md) applies (manifest entry in `.mercury/state/upstream-manifest.json`, SKILL.md frontmatter, attribution comments, license gate, SHA verification).
-
-Two adjacent cases have a narrower carve-out (see CLAUDE.md §"Carve-out: CLI-generated scaffolding"): one-shot project scaffolding via `pnpm create tauri-app` / `pnpm create vite` (Category A — PR-body provenance only, no manifest), and registry-based per-item imports via `pnpm dlx shadcn@latest add` (Category B — PR-body provenance plus registry-source identification, no manifest). All other cherry-picks follow the full protocol above.
+When files from an external project are cherry-picked into Mercury, the cherry-pick protocol in [`CLAUDE.md`](CLAUDE.md) is the canonical source for the required attribution / manifest / drift discipline. Two adjacent cases (one-shot CLI scaffolding and registry-based per-item imports) have a narrower carve-out — see CLAUDE.md §"Carve-out: CLI-generated scaffolding" for the authoritative scope. This README does not restate the rules; consult CLAUDE.md for current details.
 
 ## Example files
 

--- a/articles/001-mercury-harness-overview.md
+++ b/articles/001-mercury-harness-overview.md
@@ -409,7 +409,7 @@ Adapter 只做接口转换，不包含业务逻辑。如果需要业务逻辑，
 
 这个协议确保了三件事：溯源（知道代码从哪来）、漂移检测（知道上游是否变了）、法律合规（license gate）。
 
-**CLI scaffolding / registry-import carve-out**：CLAUDE.md §"Carve-out: CLI-generated scaffolding" 是该 carve-out 的权威定义源。两个邻近场景（一次性 CLI 脚手架与 registry 单 item 导入）有更窄的处理范围；本文不复述具体规则，避免跨文档漂移——查阅 CLAUDE.md 获取当前细则。
+**CLI scaffolding / registry-import carve-out**：[CLAUDE.md §Carve-out: CLI-generated scaffolding](../CLAUDE.md#carve-out-cli-generated-scaffolding) 是该 carve-out 的权威定义源。两个邻近场景（一次性 CLI 脚手架与 registry 单 item 导入）有更窄的处理范围；本文不复述具体规则，避免跨文档漂移——查阅 CLAUDE.md 获取当前细则。
 
 ### 实证案例：5 种挂载模式
 
@@ -528,7 +528,7 @@ Mercury 的 96 个 session（截至 S96）构成了一个清晰的演化轨迹�
 | `.claude/skills/pr-flow/SKILL.md` | PR-flow skill（Argus behavior model，escape-hatch protocol，GraphQL resolveReviewThread） |
 | `adapters/gpt-image-2/README.md` | uvx-pinned-SHA mount 案例（MIT upstream，env allowlist，drift-check policy） |
 | `adapters/gpt-image-2/invoke.py` | Slice A adapter（84 LOC，uvx 包装，env 过滤） |
-| `.mercury/state/upstream-manifest.json` | Cherry-pick 治理 manifest（全协议 cherry-pick 的 SHA + license + PR 记录；CLI scaffolding / registry-import carve-out 不在此 manifest，详见 CLAUDE.md §"Carve-out: CLI-generated scaffolding"）|
+| `.mercury/state/upstream-manifest.json` | Cherry-pick 治理 manifest（全协议 cherry-pick 的 SHA + license + PR 记录；CLI scaffolding / registry-import carve-out 不在此 manifest，详见 [CLAUDE.md §Carve-out: CLI-generated scaffolding](../CLAUDE.md#carve-out-cli-generated-scaffolding)）|
 | `scripts/upstream-drift-check.sh` | Drift monitoring 工具 |
 
 ### GitHub Issues / PRs（实证案例）

--- a/articles/001-mercury-harness-overview.md
+++ b/articles/001-mercury-harness-overview.md
@@ -409,6 +409,8 @@ Adapter 只做接口转换，不包含业务逻辑。如果需要业务逻辑，
 
 这个协议确保了三件事：溯源（知道代码从哪来）、漂移检测（知道上游是否变了）、法律合规（license gate）。
 
+**CLI scaffolding / registry-import carve-out**：上述 6 字段协议适用于"具体上游 commit 路径的 file lift"。两个邻近场景有更窄的 carve-out（详见 CLAUDE.md §"Carve-out: CLI-generated scaffolding"）：Category A（一次性项目脚手架，`pnpm create tauri-app` / `pnpm create vite`，只需 PR body provenance，不需要 manifest）与 Category B（registry 单 item 导入，`pnpm dlx shadcn@latest add` 任何 registry item，需要 PR body provenance + registry 源标识，不需要 manifest）。其他所有 cherry-pick 走完整协议。
+
 ### 实证案例：5 种挂载模式
 
 Mercury 目前落地了多种挂载模式，构成了实践中的"适配层谱系"：
@@ -526,7 +528,7 @@ Mercury 的 96 个 session（截至 S96）构成了一个清晰的演化轨迹�
 | `.claude/skills/pr-flow/SKILL.md` | PR-flow skill（Argus behavior model，escape-hatch protocol，GraphQL resolveReviewThread） |
 | `adapters/gpt-image-2/README.md` | uvx-pinned-SHA mount 案例（MIT upstream，env allowlist，drift-check policy） |
 | `adapters/gpt-image-2/invoke.py` | Slice A adapter（84 LOC，uvx 包装，env 过滤） |
-| `.mercury/state/upstream-manifest.json` | Cherry-pick 治理 manifest（所有外部引用的 SHA + license + PR 记录） |
+| `.mercury/state/upstream-manifest.json` | Cherry-pick 治理 manifest（全协议 cherry-pick 的 SHA + license + PR 记录；CLI scaffolding / registry-import carve-out 不在此 manifest，详见 CLAUDE.md §"Carve-out: CLI-generated scaffolding"）|
 | `scripts/upstream-drift-check.sh` | Drift monitoring 工具 |
 
 ### GitHub Issues / PRs（实证案例）

--- a/articles/001-mercury-harness-overview.md
+++ b/articles/001-mercury-harness-overview.md
@@ -409,7 +409,7 @@ Adapter 只做接口转换，不包含业务逻辑。如果需要业务逻辑，
 
 这个协议确保了三件事：溯源（知道代码从哪来）、漂移检测（知道上游是否变了）、法律合规（license gate）。
 
-**CLI scaffolding / registry-import carve-out**：上述 6 字段协议适用于"具体上游 commit 路径的 file lift"。两个邻近场景有更窄的 carve-out（详见 CLAUDE.md §"Carve-out: CLI-generated scaffolding"）：Category A（一次性项目脚手架，`pnpm create tauri-app` / `pnpm create vite`，只需 PR body provenance，不需要 manifest）与 Category B（registry 单 item 导入，`pnpm dlx shadcn@latest add` 任何 registry item，需要 PR body provenance + registry 源标识，不需要 manifest）。其他所有 cherry-pick 走完整协议。
+**CLI scaffolding / registry-import carve-out**：CLAUDE.md §"Carve-out: CLI-generated scaffolding" 是该 carve-out 的权威定义源。两个邻近场景（一次性 CLI 脚手架与 registry 单 item 导入）有更窄的处理范围；本文不复述具体规则，避免跨文档漂移——查阅 CLAUDE.md 获取当前细则。
 
 ### 实证案例：5 种挂载模式
 


### PR DESCRIPTION
## Summary

- Add §"Carve-out: CLI-generated scaffolding" under CLAUDE.md §"Cherry-pick protocol", split into:
  - **Category A** (one-shot scaffolding): `pnpm create tauri-app` + `pnpm create vite` — PR-body provenance only, no manifest
  - **Category B** (registry-based item import): `pnpm dlx shadcn@latest add` (any registry item type — components, hooks, utilities, pages, themes, fonts, config, rules, libraries) — stricter PR-body provenance including item arg + registry source explicitly + item type if non-component
- Companion doc pointers added to `README.md` §"External project mounts" + `articles/001-mercury-harness-overview.md` §"Cherry-pick 治理协议" + appendix manifest scope clarification at line 531
- Codifies the DISAGREE-cite logic that was used during Phase 6 GUI MVP chain (PRs #421/#424/#425) to prevent future repeat-flagging of CLI-generated files

## Pre-commit dual-verify

- **Claude code-reviewer** (iter-1): PASS (0 Critical / 0 High / 0 Medium / 3 Low non-blocking nits — 2 of 3 addressed pre-commit)
- **Codex sync-audit** (iter-4 final): **PASS** (0/0/0/0)
  - iter-1: NEEDS-CHANGES — H1 false-lockfile-provenance claim + H2 shadcn-treated-as-pure-scaffolding loophole → both ACCEPT-FIX
  - iter-2: NEEDS-CHANGES — M1 Category B too narrow (missed hooks/utils/themes/fonts) + M2 README+articles stale → both ACCEPT-FIX
  - iter-3: NEEDS-CHANGES — M3 conflicting registry-source guidance + L1 appendix-table overbroad → both ACCEPT-FIX
  - iter-4: PASS — all clean

## Mandatory web research

- shadcn CLI `add` scope verified via official docs at [ui.shadcn.com/docs/cli](https://ui.shadcn.com/docs/cli) and [ui.shadcn.com/docs/registry](https://ui.shadcn.com/docs/registry) — confirmed `add` consumes registry items by name / URL / local path, with item types including `registry:component`, `registry:hook`, `registry:font`, `registry:lib`, `registry:page`, `registry:file`
- shadcn 2026-03 CLI v4 changelog at [ui.shadcn.com/docs/changelog/2026-03-cli-v4](https://ui.shadcn.com/docs/changelog/2026-03-cli-v4)
- Tauri 2 + Vite license: MIT/Apache-2.0 dual (Tauri) / MIT (Vite) — confirmed via official Tauri site
- `pnpm dlx` / `pnpm create` lockfile-pinning behavior: confirmed via pnpm docs that neither pins the generator into the consumer lockfile (only the produced app's runtime deps end up there)

## Test plan

- [x] CLAUDE.md renders correctly on GitHub (table syntax + headers + ❌ glyphs)
- [x] README.md anchor pointer line scans cleanly
- [x] articles/001 Chinese carve-out summary matches surrounding prose tone
- [x] Manifest-scope clarification at articles/001:531 consistent with new carve-out
- [x] PR refs both #428 (Closes) and #427 (Refs as parent backlog)

## Related

- Closes #428
- Refs #427 (Phase 6 GUI MVP v2 follow-up backlog parent)
- Phase 6 chain PRs that triggered the DISAGREE-cite pattern: #421 (S123 #413 scaffold), #424 (S125 #415 UI scenario 1), #425 (S126 #416 UI scenario 5)

Generated with Claude Code