### PR TITLE
fix(mercury-gui): #432 align LaneTable displayed job with active filter

### DIFF
--- a/mercury-gui/src/components/LaneRow.tsx
+++ b/mercury-gui/src/components/LaneRow.tsx
@@ -1,5 +1,7 @@
 // LaneRow — one row in the cross-lane snapshot table.
-// Shows the most-recent job per lane plus "+N more" indicator.
+// Shows the most-recent of the jobs passed in, plus "+N more" for siblings.
+// Caller (LaneTable) is responsible for pre-filtering `jobs` so this row's
+// display never contradicts the active filter (#432 — filter-display alignment).
 
 import { StateBadge } from "./StateBadge";
 import { elapsed } from "@/lib/elapsed";

--- a/mercury-gui/src/components/LaneTable.tsx
+++ b/mercury-gui/src/components/LaneTable.tsx
@@ -1,11 +1,13 @@
 // LaneTable — full cross-lane snapshot table.
 // Renders known lanes first, then the __unassigned__ bucket if non-empty.
-// Applies filter tokens to hide non-matching rows.
+// Applies filter tokens to hide non-matching rows AND to align the row's
+// displayed job with the filter (#432 — most-recent MATCHING job, not most-
+// recent overall job, so the surfaced row never contradicts the active filter).
 
 import { useState } from "react";
 import { LaneRow } from "./LaneRow";
 import { JobDetailDialog } from "./JobDetailDialog";
-import { laneMatchesFilter, parseFilter } from "@/lib/filter";
+import { laneMatchesFilter, matchesJob, parseFilter } from "@/lib/filter";
 import type { JobState, Lane } from "@/lib/types";
 
 // Canonical lane order for v1
@@ -51,6 +53,9 @@ export function LaneTable({
   const [dialogOpen, setDialogOpen] = useState(false);
 
   const tokens = parseFilter(filterRaw);
+  // Job-relevant tokens drive the row's displayed job; `l:` tokens select
+  // lanes only and are filtered out so they don't accidentally exclude jobs.
+  const jobTokens = tokens.filter((t) => t.kind !== "lane");
   const laneList = buildLaneList(lanes);
   const unassigned = jobsByLane["__unassigned__"] ?? [];
 
@@ -58,6 +63,13 @@ export function LaneTable({
     setSelectedLane(laneName);
     setSelectedJob(job);
     setDialogOpen(true);
+  }
+
+  // Display-job picker: matching jobs only, so the row never contradicts the
+  // active filter. Empty `jobTokens` → all jobs match → same list as before.
+  function matchingJobs(laneName: string, jobs: JobState[]): JobState[] {
+    if (jobTokens.length === 0) return jobs;
+    return jobs.filter((job) => matchesJob(job, laneName, jobTokens));
   }
 
   const visibleLanes = laneList.filter((lane) => {
@@ -89,7 +101,7 @@ export function LaneTable({
               <LaneRow
                 key={lane.name}
                 lane={lane}
-                jobs={jobsByLane[lane.name] ?? []}
+                jobs={matchingJobs(lane.name, jobsByLane[lane.name] ?? [])}
                 onSelect={(job) => handleSelect(lane.name, job)}
                 elapsedNonce={elapsedNonce}
               />
@@ -98,7 +110,7 @@ export function LaneTable({
               <LaneRow
                 key="__unassigned__"
                 lane={{ name: "__unassigned__" }}
-                jobs={unassigned}
+                jobs={matchingJobs("__unassigned__", unassigned)}
                 onSelect={(job) => handleSelect("__unassigned__", job)}
                 elapsedNonce={elapsedNonce}
               />


### PR DESCRIPTION
## Summary

Aligns `LaneTable`'s displayed job with the user's active filter, resolving the S125 Argus iter-2/3/4 advisory carried into `#427` sub-item 4 (now standalone Issue `#432`).

Before this PR, the cross-lane snapshot table used two divergent matching rules:

- **Lane survival** (`laneMatchesFilter`): lane is shown if **ANY** of its jobs matches the filter (e.g. `s:working`).
- **Row display** (`mostRecent` in `LaneRow`): always the most-recent overall job by `createdAt`, regardless of match.

Result: a row could surface for filter `s:working` while displaying a `done` job — directly contradicting the token the user typed.

## Fix

`LaneTable` now splits the parsed filter into `laneTokens` (`l:`-prefixed) vs `jobTokens` (everything else), then pre-filters each lane's jobs against `jobTokens` before passing them to `LaneRow`:

```ts
const jobTokens = tokens.filter((t) => t.kind !== "lane");

function matchingJobs(laneName: string, jobs: JobState[]): JobState[] {
  if (jobTokens.length === 0) return jobs;
  return jobs.filter((job) => matchesJob(job, laneName, jobTokens));
}
```

`LaneRow`'s existing `mostRecent` picker then operates over only the matching jobs. `+N more` reflects additional matching jobs minus the displayed one.

### Implementation note (vs Issue #432 "Proposed fix" section)

Issue #432 sketched a `displayJob` + `extraCount` prop shape on `LaneRow`. This PR takes the lighter path of pre-filtering the existing `jobs` prop and leaving `LaneRow`'s contract intact — semantically equivalent (`mostRecent` operates over the same matching set either way), smaller diff, and the JSDoc on both files is updated to encode the new caller/callee contract. Flagged by critic agent as worth surfacing here.

### Behavior under each filter mode

| Filter | jobTokens | Behavior |
|---|---|---|
| (empty) | `[]` (short-circuit) | Returns input as-is → identical to pre-fix |
| `l:main` only | `[]` (lane tokens stripped) | Returns input as-is → same as empty filter |
| `s:working` only | `[{state, "working"}]` | Row shows newest working job; `+N more` counts other working jobs |
| `l:main s:working` | `[{state, "working"}]` | Lane survives if any working job in main; row shows newest working |

## Out of scope

- `laneMatchesFilter` lane-survival semantics unchanged (intentional `ANY-match` rule).
- `JobDetailDialog` shows the single passed job; no behavior change there.
- No new filter tokens or UI affordances.
- No unit tests added — `mercury-gui/` has no frontend test framework installed (pre-existing condition); verification is `pnpm build` strict + manual UI exercise. Adding Vitest is a separate decision (could be a #427 follow-up if desired).

## Pre-commit dual-verify (S111)

- **Codex sync-audit**: `=== VERDICT: PASS ===` — verified picker correctness against `matchesJob`/`laneMatchesFilter` in `filter.ts:49-112`, lane-survival unchanged, `+N more` semantics consistent, no `useMemo` needed at this scale, `JobDetailDialog` flow correct.
- **Claude critic (oh-my-claudecode:critic)**: **VERDICT: PASS** — independent verification of all four filter modes; no Critical / Major / Minor findings; one Nit (closure recreated each render — irrelevant at ~4-8 lanes); confirmed AC items 1-4 satisfied.

## Build / test

- `pnpm build` exit 0 (TS strict + Vite production, 1841 modules, 12.4s).
- `cargo test --lib` 45/45 pass unchanged.

## Test plan

- [x] `pnpm build` clean
- [x] `cargo test --lib` 45/45 pass
- [ ] Manual UI exercise: type `s:working` with a lane that has both `done` (newer) + `working` (older) jobs → row should display the working job
- [ ] Manual UI exercise: type `l:main` only → row shows most-recent overall (unchanged)
- [ ] Manual UI exercise: empty filter → row shows most-recent overall (unchanged)

Refs `#427` (sub-item 4 of 8). 
Closes `#432`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
