### PR TITLE
feat(mercury-gui): #439 CSP Tier-2 — split csp+devCsp + defense-in-depth directives

### DIFF
--- a/mercury-gui/src-tauri/tauri.conf.json
+++ b/mercury-gui/src-tauri/tauri.conf.json
@@ -19,7 +19,8 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; img-src 'self' asset: data:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' http://localhost:1420 ws://localhost:1421"
+      "csp": "default-src 'self'; img-src 'self' asset: data:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'none'",
+      "devCsp": "default-src 'self'; img-src 'self' asset: data:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' http://localhost:1420 ws://localhost:1421; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'none'"
     }
   },
   "bundle": {


### PR DESCRIPTION
## Summary

Closes #439. #427 v2 backlog sub-item 7 (CSP Tier-2 hardening, 6 of 8).

- Split production `csp` from `devCsp` so Vite HMR endpoints (`http://localhost:1420 ws://localhost:1421`) no longer leak into production `connect-src`.
- Add 4 defense-in-depth directives to both policies: `object-src 'none'`, `frame-ancestors 'none'`, `base-uri 'self'`, `form-action 'none'`.
- Retain `style-src 'self' 'unsafe-inline'` deliberately — Radix UI Dialog depends on `react-remove-scroll` runtime style injection; removal blocked by Radix architecture (would require Base UI migration, out of scope).

## Verification

| Check | Result |
|---|---|
| `cargo test --lib` | 55/55 pass (Tauri build script accepts `devCsp` field) |
| `pnpm build` | 294.31 kB JS unchanged, 31.66 kB CSS, 22.23s |
| JSON validity | python `json.load` OK on both `csp` + `devCsp` |
| Inline `style={}` grep | 0 hits in `mercury-gui/src` (Radix runtime is sole consumer) |
| Pre-commit Claude code-reviewer | PASS 0 Critical / 0 Major / 0 Minor / 3 Nit (all confirmations) |
| Pre-commit Codex sync-audit | PASS 0 Critical / 0 Major / 1 Minor / 0 Nit (Linux `frame-ancestors` HTML-injection variance, informational) |

## MANDATORY RESEARCH PROTOCOL — sources verified

- Tauri 2 `devCsp` + `csp` schema: [schema.tauri.app/config/2](https://schema.tauri.app/config/2), [v2.tauri.app/security/csp](https://v2.tauri.app/security/csp/), [tauri-apps/tauri@cf54dcf](https://github.com/tauri-apps/tauri/commit/cf54dcf9c81730e42c9171daa9c8aa474c95b522) introduced `devCsp`
- Radix runtime style injection constraint: [radix-ui/primitives#2057](https://github.com/radix-ui/primitives/issues/2057), [discussion #3130](https://github.com/radix-ui/primitives/discussions/3130)
- Vite HMR style-src requirement: [vitejs/vite#11862](https://github.com/vitejs/vite/issues/11862)

## Out of scope (Tier-3 / deferred)

- Removing `'unsafe-inline'` from `style-src` (blocked by Radix architecture; would require Base UI migration)
- Compile-time nonce/hash injection for Radix runtime DOM mutations (Tauri's nonce injection covers bundled assets, not runtime mutations)

## Diff

Single file `mercury-gui/src-tauri/tauri.conf.json` (+2 / -1).

## Test plan

- [x] cargo test --lib 55/55 pass
- [x] pnpm build clean (bundle size unchanged)
- [x] JSON validity
- [x] Pre-commit dual-verify (Claude + Codex both PASS)
- [ ] Argus review convergence
