### PR TITLE
feat(#453): Slice 1 — deterministic external-intel collector + state + labels

### DIFF
--- a/scripts/intel-watch.sh
+++ b/scripts/intel-watch.sh
@@ -40,12 +40,20 @@ CHANGELOG_URL="${INTEL_CHANGELOG_URL:-https://raw.githubusercontent.com/anthropi
 
 # ── Fixed source whitelist. Keys are stable identifiers; nothing here is ever
 #    built from external/LLM input (injection + label-pollution guard, ADR §5.1). ──
-#    Format per entry: "<key>|<kind>|<arg>|<label>"
+#    Format per entry: "<key>|<kind>|<arg>|<label>". The arg is a stable literal
+#    (package name / logical id) and never an env-derived URL — keeping a possibly
+#    `|`-containing URL out of this delimited record preserves the field parse and
+#    the whitelist guard. The changelog URL lives only in $CHANGELOG_URL and is
+#    consumed directly by collect_source.
 SOURCES=(
   "npm:@anthropic-ai/claude-code|npm|@anthropic-ai/claude-code|intel/sdk"
   "npm:@anthropic-ai/claude-agent-sdk|npm|@anthropic-ai/claude-agent-sdk|intel/sdk"
-  "changelog:claude-code|changelog|${CHANGELOG_URL}|intel/sdk"
+  "changelog:claude-code|changelog|claude-code|intel/sdk"
 )
+
+# Allowed source labels — parsed labels are validated against this set so a
+# malformed SOURCES entry can never inject an off-whitelist label downstream.
+ALLOWED_LABELS=" intel/sdk intel/api-docs intel/oss "
 
 STATE_FILE=""
 STATE_ISSUE=""
@@ -58,12 +66,13 @@ usage() {
 
 die() { printf 'intel-watch: %s\n' "$1" >&2; exit 2; }
 
+need_val() { [[ $# -ge 2 && -n "${2:-}" ]] || die "$1 requires a non-empty value"; }
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --state-file)  STATE_FILE="${2:-}"; shift 2 ;;
-    --state-issue) STATE_ISSUE="${2:-}"; shift 2 ;;
+    --state-file)  need_val "$@"; STATE_FILE="$2"; shift 2 ;;
+    --state-issue) need_val "$@"; STATE_ISSUE="$2"; shift 2 ;;
     --commit)      COMMIT=1; shift ;;
-    --json-out)    JSON_OUT="${2:-}"; shift 2 ;;
+    --json-out)    need_val "$@"; JSON_OUT="$2"; shift 2 ;;
     -h|--help)     usage; exit 0 ;;
     *)             die "unknown argument: $1" ;;
   esac
@@ -72,6 +81,14 @@ done
 for cmd in jq curl; do
   command -v "$cmd" >/dev/null 2>&1 || die "$cmd is required"
 done
+# Default-deny non-https source URLs (SSRF / local-file-read guard). The env
+# overrides are operator-controlled, but enforce https:// unless a test opts in
+# explicitly so a tainted environment can't redirect fetches to file:// or an
+# internal host. Tests with file:// fixtures set INTEL_ALLOW_INSECURE_SOURCE_URLS=1.
+if [[ "${INTEL_ALLOW_INSECURE_SOURCE_URLS:-0}" != "1" ]]; then
+  [[ "$NPM_REGISTRY"  == https://* ]] || die "INTEL_NPM_REGISTRY must be https:// (set INTEL_ALLOW_INSECURE_SOURCE_URLS=1 for file:// test fixtures)"
+  [[ "$CHANGELOG_URL" == https://* ]] || die "INTEL_CHANGELOG_URL must be https:// (set INTEL_ALLOW_INSECURE_SOURCE_URLS=1 for file:// test fixtures)"
+fi
 if ! command -v sha256sum >/dev/null 2>&1 \
    && ! command -v shasum   >/dev/null 2>&1 \
    && ! command -v openssl  >/dev/null 2>&1; then
@@ -130,10 +147,13 @@ fetch_changelog() {
 }
 
 collect_source() {
-  # $1=kind $2=arg → fingerprint on stdout, non-zero on failure
+  # $1=kind $2=arg → fingerprint on stdout, non-zero on failure.
+  # The changelog kind ignores the (literal) arg and reads the URL from the
+  # global $CHANGELOG_URL, so no env-derived URL ever passes through the
+  # |-delimited SOURCES record.
   case "$1" in
     npm)       fetch_npm "$2" ;;
-    changelog) fetch_changelog "$2" ;;
+    changelog) fetch_changelog "$CHANGELOG_URL" ;;
     *)         return 1 ;;
   esac
 }
@@ -196,7 +216,9 @@ state_write() {
     mv -f "$tmp" "$STATE_FILE" \
       || { rm -f "$tmp"; printf 'intel-watch: failed to move state into place\n' >&2; return 1; }
   elif [[ -n "$STATE_ISSUE" ]]; then
-    local tmp; tmp="$(mktemp)"
+    # Explicit template: BSD/macOS mktemp requires one (bare `mktemp` errors).
+    local tmp; tmp="$(mktemp "${TMPDIR:-/tmp}/intel-watch-issue.XXXXXX")" \
+      || { printf 'intel-watch: cannot create temp for Issue body\n' >&2; return 1; }
     {
       printf '# 🛰️ Intel-Watch State (auto-managed — do not edit manually)\n\n'
       printf 'Authoritative state store for the external-intel agent (#157 / #453).\n'
@@ -225,6 +247,8 @@ main() {
   local entry key kind arg label cur old
   for entry in "${SOURCES[@]}"; do
     IFS='|' read -r key kind arg label <<<"$entry"
+    [[ "$ALLOWED_LABELS" == *" $label "* ]] \
+      || die "internal: source '$key' has non-whitelisted label '$label'"
     old="$(printf '%s' "$state" | jq -r --arg k "$key" '.sources[$k] // empty')"
 
     if ! cur="$(collect_source "$kind" "$arg")"; then
@@ -257,7 +281,15 @@ main() {
     '{checked_at:$checked_at, deltas:$deltas, seeded:$seeded, unchanged:$unchanged, errors:$errors}')"
 
   if [[ -n "$JSON_OUT" ]]; then
-    printf '%s\n' "$report" > "$JSON_OUT"
+    # Atomic write + explicit failure surfacing: a full disk / missing dir /
+    # permission error must not be swallowed (caller would misjudge success).
+    local out_tmp
+    out_tmp="$(mktemp "${JSON_OUT}.tmp.XXXXXX")" \
+      || { printf 'intel-watch: cannot create temp for --json-out\n' >&2; exit 3; }
+    printf '%s\n' "$report" > "$out_tmp" \
+      || { rm -f "$out_tmp"; printf 'intel-watch: failed to write --json-out temp\n' >&2; exit 3; }
+    mv -f "$out_tmp" "$JSON_OUT" \
+      || { rm -f "$out_tmp"; printf 'intel-watch: failed to move --json-out into place\n' >&2; exit 3; }
   fi
 
   local n_delta n_seed n_err

--- a/scripts/intel-watch.sh
+++ b/scripts/intel-watch.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+# intel-watch.sh — External-intel deterministic collector (Issue #157 / #453 Slice 1)
+#
+# Watches a fixed whitelist of external sources, computes a per-source
+# fingerprint, compares against persisted state, and reports deltas. This is
+# the NO-LLM, NO-issue-create slice: it only collects + detects + (optionally)
+# persists state. The LLM significance judgment (Slice 2) and the GHA workflow
+# wiring (Slice 3) build on the delta JSON this script emits.
+#
+# Design authority: .mercury/docs/research/issue-157-external-info-agent-2026-05.md
+#   §4.2 (B-class source detection), §5.2 (dedup / state persistence mechanism c),
+#   §9 (Phase-2 entrance gate, web-verified 2026-05-25).
+#
+# Sources monitored (3 targets, 2 source types — ADR §7 step 2):
+#   npm:@anthropic-ai/claude-code        dist-tags.latest  (abbreviated packument)
+#   npm:@anthropic-ai/claude-agent-sdk   dist-tags.latest
+#   changelog:claude-code                sha256 of CHANGELOG.md raw
+#
+# State backend (pick one; default is dry-run, no persistence):
+#   --state-file <path>     local JSON file        (testable, no network/auth)
+#   --state-issue <number>  pinned Issue body      (production, via gh api; ADR §5.2 mechanism c)
+#
+# Mercury-internal tooling under scripts/ — exempt from the 200-LOC adapter cap
+# (CLAUDE.md carve-out: this implements an in-repo monitoring protocol, it does
+# not mount an external project).
+#
+# Run locally (dry-run, prints deltas, never writes):
+#   bash scripts/intel-watch.sh --state-file /tmp/intel-state.json
+# Persist state after detection:
+#   bash scripts/intel-watch.sh --state-file /tmp/intel-state.json --commit
+# Emit machine-readable delta report for the next slice:
+#   bash scripts/intel-watch.sh --state-file /tmp/intel-state.json --json-out /tmp/deltas.json
+
+set -uo pipefail
+
+# ── Source endpoints (overridable for tests via env; defaults are the
+#    web-verified official endpoints — ADR §9) ──
+NPM_REGISTRY="${INTEL_NPM_REGISTRY:-https://registry.npmjs.org}"
+CHANGELOG_URL="${INTEL_CHANGELOG_URL:-https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md}"
+
+# ── Fixed source whitelist. Keys are stable identifiers; nothing here is ever
+#    built from external/LLM input (injection + label-pollution guard, ADR §5.1). ──
+#    Format per entry: "<key>|<kind>|<arg>|<label>"
+SOURCES=(
+  "npm:@anthropic-ai/claude-code|npm|@anthropic-ai/claude-code|intel/sdk"
+  "npm:@anthropic-ai/claude-agent-sdk|npm|@anthropic-ai/claude-agent-sdk|intel/sdk"
+  "changelog:claude-code|changelog|${CHANGELOG_URL}|intel/sdk"
+)
+
+STATE_FILE=""
+STATE_ISSUE=""
+COMMIT=0
+JSON_OUT=""
+
+usage() {
+  sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+die() { printf 'intel-watch: %s\n' "$1" >&2; exit 2; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --state-file)  STATE_FILE="${2:-}"; shift 2 ;;
+    --state-issue) STATE_ISSUE="${2:-}"; shift 2 ;;
+    --commit)      COMMIT=1; shift ;;
+    --json-out)    JSON_OUT="${2:-}"; shift 2 ;;
+    -h|--help)     usage; exit 0 ;;
+    *)             die "unknown argument: $1" ;;
+  esac
+done
+
+for cmd in jq curl; do
+  command -v "$cmd" >/dev/null 2>&1 || die "$cmd is required"
+done
+if [[ -n "$STATE_FILE" && -n "$STATE_ISSUE" ]]; then
+  die "choose at most one state backend (--state-file XOR --state-issue)"
+fi
+if [[ -n "$STATE_ISSUE" ]]; then
+  command -v gh >/dev/null 2>&1 || die "gh is required for --state-issue"
+fi
+
+# Markers delimiting the JSON state block inside the pinned Issue body.
+STATE_BEGIN="<!-- INTEL_STATE_BEGIN -->"
+STATE_END="<!-- INTEL_STATE_END -->"
+
+now_utc() { TZ=UTC date +%Y-%m-%dT%H:%M:%SZ; }
+
+# ── Source collection ── each emits a fingerprint string on stdout, or exits
+#    non-zero on a fetch/parse failure (caller treats failure as "error", never
+#    as "unchanged" — a failed fetch must not silently suppress a real delta).
+fetch_npm() {
+  local pkg="$1" body
+  body="$(curl -sS --retry 3 --retry-delay 2 --max-time 30 \
+            -H "Accept: application/vnd.npm.install-v1+json" \
+            "${NPM_REGISTRY}/${pkg}" 2>/dev/null)" || return 1
+  local latest
+  latest="$(printf '%s' "$body" | jq -r '."dist-tags".latest // empty' 2>/dev/null)" || return 1
+  [[ -n "$latest" ]] || return 1
+  printf '%s' "$latest"
+}
+
+fetch_changelog() {
+  local url="$1" body
+  body="$(curl -sS --retry 3 --retry-delay 2 --max-time 30 "$url" 2>/dev/null)" || return 1
+  [[ -n "$body" ]] || return 1
+  local h
+  h="$(printf '%s' "$body" | sha256sum | cut -d' ' -f1)" || return 1
+  printf 'sha256:%s' "$h"
+}
+
+collect_source() {
+  # $1=kind $2=arg → fingerprint on stdout, non-zero on failure
+  case "$1" in
+    npm)       fetch_npm "$2" ;;
+    changelog) fetch_changelog "$2" ;;
+    *)         return 1 ;;
+  esac
+}
+
+# ── State backend I/O ── state is always one JSON object:
+#    { "schema_version": 1, "updated_at": "...", "sources": { "<key>": "<fp>" } }
+empty_state() { jq -n '{schema_version:1, updated_at:null, sources:{}}'; }
+
+state_read() {
+  if [[ -n "$STATE_FILE" ]]; then
+    if [[ -f "$STATE_FILE" ]]; then
+      jq -e . "$STATE_FILE" 2>/dev/null || { printf 'intel-watch: state file is not valid JSON: %s\n' "$STATE_FILE" >&2; return 1; }
+    else
+      empty_state
+    fi
+  elif [[ -n "$STATE_ISSUE" ]]; then
+    local body nbegin nend extracted
+    body="$(gh issue view "$STATE_ISSUE" --json body -q .body 2>/dev/null)" \
+      || { printf 'intel-watch: cannot read state Issue #%s\n' "$STATE_ISSUE" >&2; return 1; }
+    # Marker integrity gate: a fresh state Issue has neither marker → seed from
+    # empty; a complete pair (exactly one each) → trust the extraction; any other
+    # count means a truncated/corrupted body → fail loud (do NOT trust a partial
+    # BEGIN..EOF extraction, which could re-seed stale state and re-spam).
+    nbegin="$(printf '%s' "$body" | grep -cF "$STATE_BEGIN")"
+    nend="$(printf '%s' "$body" | grep -cF "$STATE_END")"
+    if [[ "$nbegin" -eq 0 && "$nend" -eq 0 ]]; then
+      empty_state; return 0
+    fi
+    if [[ "$nbegin" -ne 1 || "$nend" -ne 1 ]]; then
+      printf 'intel-watch: state Issue #%s has malformed markers (begin=%s end=%s)\n' \
+        "$STATE_ISSUE" "$nbegin" "$nend" >&2
+      return 1
+    fi
+    # Extract the JSON between the markers, stripping the ```json fences.
+    extracted="$(printf '%s' "$body" \
+      | awk -v b="$STATE_BEGIN" -v e="$STATE_END" '
+          index($0,b){f=1; next} index($0,e){f=0} f' \
+      | sed '/^```/d')"
+    if [[ -n "$(printf '%s' "$extracted" | tr -d '[:space:]')" ]]; then
+      printf '%s' "$extracted" | jq -e . 2>/dev/null \
+        || { printf 'intel-watch: state Issue #%s body has malformed JSON block\n' "$STATE_ISSUE" >&2; return 1; }
+    else
+      empty_state
+    fi
+  else
+    empty_state  # dry-run with no backend: always seeds from empty
+  fi
+}
+
+state_write() {
+  # $1 = new state JSON (string)
+  local new_state="$1"
+  if [[ -n "$STATE_FILE" ]]; then
+    # Atomic whole-body replacement: stage to a temp in the same directory, then
+    # rename (atomic on the same filesystem on both Linux and MSYS/NTFS). A crash
+    # mid-write thus leaves the prior state intact rather than a truncated file.
+    local tmp; tmp="$(mktemp "${STATE_FILE}.tmp.XXXXXX")" \
+      || { printf 'intel-watch: cannot create temp for state write\n' >&2; return 1; }
+    printf '%s\n' "$new_state" > "$tmp"
+    mv -f "$tmp" "$STATE_FILE" \
+      || { rm -f "$tmp"; printf 'intel-watch: failed to move state into place\n' >&2; return 1; }
+  elif [[ -n "$STATE_ISSUE" ]]; then
+    local tmp; tmp="$(mktemp)"
+    {
+      printf '# 🛰️ Intel-Watch State (auto-managed — do not edit manually)\n\n'
+      printf 'Authoritative state store for the external-intel agent (#157 / #453).\n'
+      printf 'The JSON block below is read and rewritten atomically each run;\n'
+      printf 'manual edits are overwritten. See `scripts/intel-watch.sh`.\n\n'
+      printf '%s\n' "$STATE_BEGIN"
+      printf '```json\n%s\n```\n' "$new_state"
+      printf '%s\n' "$STATE_END"
+    } > "$tmp"
+    gh issue edit "$STATE_ISSUE" --body-file "$tmp" >/dev/null \
+      || { rm -f "$tmp"; printf 'intel-watch: failed to write state Issue #%s\n' "$STATE_ISSUE" >&2; return 1; }
+    rm -f "$tmp"
+  fi
+  # No backend (pure dry-run): nothing to persist.
+}
+
+# ── Main collect+diff loop ──
+main() {
+  local checked_at state
+  checked_at="$(now_utc)"
+  state="$(state_read)" || exit 3
+
+  local deltas='[]' seeded='[]' unchanged='[]' errors='[]'
+  local new_sources; new_sources="$(printf '%s' "$state" | jq -c '.sources')"
+
+  local entry key kind arg label cur old
+  for entry in "${SOURCES[@]}"; do
+    IFS='|' read -r key kind arg label <<<"$entry"
+    old="$(printf '%s' "$state" | jq -r --arg k "$key" '.sources[$k] // empty')"
+
+    if ! cur="$(collect_source "$kind" "$arg")"; then
+      errors="$(jq -c --arg k "$key" '. + [$k]' <<<"$errors")"
+      printf 'ERROR    %s (fetch failed — state preserved, not treated as unchanged)\n' "$key" >&2
+      continue
+    fi
+
+    if [[ -z "$old" ]]; then
+      seeded="$(jq -c --arg k "$key" '. + [$k]' <<<"$seeded")"
+      printf 'SEEDED   %s = %s\n' "$key" "$cur"
+    elif [[ "$old" != "$cur" ]]; then
+      deltas="$(jq -c --arg k "$key" --arg kind "$kind" --arg label "$label" --arg old "$old" --arg new "$cur" \
+        '. + [{source:$k, kind:$kind, label:$label, old:$old, new:$new}]' <<<"$deltas")"
+      printf 'DELTA    %s: %s -> %s\n' "$key" "$old" "$cur"
+    else
+      unchanged="$(jq -c --arg k "$key" '. + [$k]' <<<"$unchanged")"
+      printf 'unchanged %s = %s\n' "$key" "$cur"
+    fi
+    new_sources="$(jq -c --arg k "$key" --arg v "$cur" '.[$k]=$v' <<<"$new_sources")"
+  done
+
+  local report
+  report="$(jq -n \
+    --arg checked_at "$checked_at" \
+    --argjson deltas "$deltas" \
+    --argjson seeded "$seeded" \
+    --argjson unchanged "$unchanged" \
+    --argjson errors "$errors" \
+    '{checked_at:$checked_at, deltas:$deltas, seeded:$seeded, unchanged:$unchanged, errors:$errors}')"
+
+  if [[ -n "$JSON_OUT" ]]; then
+    printf '%s\n' "$report" > "$JSON_OUT"
+  fi
+
+  local n_delta n_seed n_err
+  n_delta="$(jq '.deltas|length' <<<"$report")"
+  n_seed="$(jq '.seeded|length' <<<"$report")"
+  n_err="$(jq '.errors|length' <<<"$report")"
+  printf -- '--- summary: %s delta, %s seeded, %s error, %s unchanged @ %s ---\n' \
+    "$n_delta" "$n_seed" "$n_err" "$(jq '.unchanged|length' <<<"$report")" "$checked_at"
+
+  if [[ "$COMMIT" -eq 1 ]]; then
+    if [[ -z "$STATE_FILE" && -z "$STATE_ISSUE" ]]; then
+      printf 'intel-watch: --commit requires a state backend (--state-file or --state-issue)\n' >&2
+      exit 2
+    fi
+    local new_state
+    new_state="$(jq -n --argjson src "$new_sources" --arg ts "$checked_at" \
+      '{schema_version:1, updated_at:$ts, sources:$src}')"
+    state_write "$new_state" || exit 3
+    if [[ "$n_err" -gt 0 ]]; then
+      printf 'state committed (%s sources; %s errored — errored sources retain prior fingerprint)\n' \
+        "$(jq '.sources|length' <<<"$new_state")" "$n_err"
+    else
+      printf 'state committed (%s sources)\n' "$(jq '.sources|length' <<<"$new_state")"
+    fi
+  else
+    printf '(dry-run: state not persisted; pass --commit to persist)\n'
+  fi
+
+  # Exit non-zero if any source failed to fetch, so the caller (GHA) can react.
+  [[ "$n_err" -eq 0 ]] || exit 1
+}
+
+main

--- a/scripts/intel-watch.sh
+++ b/scripts/intel-watch.sh
@@ -72,6 +72,11 @@ done
 for cmd in jq curl; do
   command -v "$cmd" >/dev/null 2>&1 || die "$cmd is required"
 done
+if ! command -v sha256sum >/dev/null 2>&1 \
+   && ! command -v shasum   >/dev/null 2>&1 \
+   && ! command -v openssl  >/dev/null 2>&1; then
+  die "need one of: sha256sum / shasum / openssl (for CHANGELOG fingerprint)"
+fi
 if [[ -n "$STATE_FILE" && -n "$STATE_ISSUE" ]]; then
   die "choose at most one state backend (--state-file XOR --state-issue)"
 fi
@@ -99,12 +104,28 @@ fetch_npm() {
   printf '%s' "$latest"
 }
 
+# Portable sha256 of stdin → bare hex digest. Prefers sha256sum (Linux/GHA),
+# falls back to shasum -a 256 (macOS default) then openssl dgst -sha256 (broad
+# fallback). openssl prints "SHA2-256(stdin)= <hash>", so take the last field.
+sha256_hex() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum | cut -d' ' -f1
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 | cut -d' ' -f1
+  elif command -v openssl >/dev/null 2>&1; then
+    openssl dgst -sha256 | awk '{print $NF}'
+  else
+    return 1
+  fi
+}
+
 fetch_changelog() {
   local url="$1" body
   body="$(curl -sS --retry 3 --retry-delay 2 --max-time 30 "$url" 2>/dev/null)" || return 1
   [[ -n "$body" ]] || return 1
   local h
-  h="$(printf '%s' "$body" | sha256sum | cut -d' ' -f1)" || return 1
+  h="$(printf '%s' "$body" | sha256_hex)" || return 1
+  [[ -n "$h" ]] || return 1
   printf 'sha256:%s' "$h"
 }
 

--- a/scripts/intel-watch.sh
+++ b/scripts/intel-watch.sh
@@ -212,7 +212,8 @@ state_write() {
     # mid-write thus leaves the prior state intact rather than a truncated file.
     local tmp; tmp="$(mktemp "${STATE_FILE}.tmp.XXXXXX")" \
       || { printf 'intel-watch: cannot create temp for state write\n' >&2; return 1; }
-    printf '%s\n' "$new_state" > "$tmp"
+    printf '%s\n' "$new_state" > "$tmp" \
+      || { rm -f "$tmp"; printf 'intel-watch: failed to write state temp\n' >&2; return 1; }
     mv -f "$tmp" "$STATE_FILE" \
       || { rm -f "$tmp"; printf 'intel-watch: failed to move state into place\n' >&2; return 1; }
   elif [[ -n "$STATE_ISSUE" ]]; then
@@ -227,7 +228,8 @@ state_write() {
       printf '%s\n' "$STATE_BEGIN"
       printf '```json\n%s\n```\n' "$new_state"
       printf '%s\n' "$STATE_END"
-    } > "$tmp"
+    } > "$tmp" \
+      || { rm -f "$tmp"; printf 'intel-watch: failed to write Issue body temp\n' >&2; return 1; }
     gh issue edit "$STATE_ISSUE" --body-file "$tmp" >/dev/null \
       || { rm -f "$tmp"; printf 'intel-watch: failed to write state Issue #%s\n' "$STATE_ISSUE" >&2; return 1; }
     rm -f "$tmp"

--- a/scripts/test-intel-watch.sh
+++ b/scripts/test-intel-watch.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+# Tests for scripts/intel-watch.sh — mock the external sources with local
+# file:// fixtures (no network, no GitHub auth) and drive the collector through
+# every state transition: seed / unchanged / delta / fetch-error, plus the
+# state-backend round trip and the pinned-Issue-body marker extraction contract.
+#
+# Run: bash scripts/test-intel-watch.sh
+
+set -u  # not -e: each scenario inspects rc explicitly
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WATCH="$SCRIPT_DIR/intel-watch.sh"
+[[ -x "$WATCH" ]] || { printf 'intel-watch.sh not executable: %s\n' "$WATCH" >&2; exit 1; }
+
+for cmd in jq curl sha256sum; do
+  command -v "$cmd" >/dev/null 2>&1 || { printf 'SKIP-ALL: %s unavailable\n' "$cmd"; exit 0; }
+done
+
+PASS=0; FAIL=0
+declare -a FAILURES=()
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    PASS=$((PASS + 1)); printf '  ok %s\n' "$label"
+  else
+    FAIL=$((FAIL + 1)); FAILURES+=("$label: expected [$expected], got [$actual]")
+    printf '  FAIL %s -- expected [%s], got [%s]\n' "$label" "$expected" "$actual"
+  fi
+}
+assert_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    PASS=$((PASS + 1)); printf '  ok %s\n' "$label"
+  else
+    FAIL=$((FAIL + 1)); FAILURES+=("$label: missing [$needle]")
+    printf '  FAIL %s -- missing [%s]\n' "$label" "$needle"
+  fi
+}
+
+WORK_DIR="$(mktemp -d -t intel-watch-test.XXXXXX)" || { printf 'mktemp failed\n' >&2; exit 1; }
+trap '[[ -n "${WORK_DIR:-}" && -d "$WORK_DIR" ]] && rm -rf "$WORK_DIR"' EXIT
+
+# ── Build file:// mock registry + changelog. curl reads file:// and ignores
+#    the Accept header, so the abbreviated-packument JSON shape is what matters. ──
+REG="$WORK_DIR/registry"
+mkdir -p "$REG/@anthropic-ai"
+write_pkg() { # $1=pkg-basename $2=latest-version
+  jq -n --arg v "$2" '{"dist-tags":{latest:$v, next:$v}, versions:{}}' \
+    > "$REG/@anthropic-ai/$1"
+}
+write_pkg "claude-code" "2.1.150"
+write_pkg "claude-agent-sdk" "0.3.150"
+
+CHANGELOG="$WORK_DIR/CHANGELOG.md"
+printf '# Changelog\n\n## 2.1.150\n\n- initial\n' > "$CHANGELOG"
+
+# file:// URLs. The mingw64 curl build cannot see MSYS virtual paths (/tmp/...),
+# so on Windows convert to a mixed Windows path (C:/...) via cygpath; on a POSIX
+# runner (GHA ubuntu) there is no cygpath and file://<abs-posix-path> works as-is.
+to_file_url() {
+  local p="$1"
+  if command -v cygpath >/dev/null 2>&1; then
+    p="$(cygpath -m "$p")"
+  fi
+  printf 'file://%s' "$p"
+}
+export INTEL_NPM_REGISTRY; INTEL_NPM_REGISTRY="$(to_file_url "$REG")"
+export INTEL_CHANGELOG_URL; INTEL_CHANGELOG_URL="$(to_file_url "$CHANGELOG")"
+
+run_watch() { bash "$WATCH" "$@"; }
+
+# Pre-flight: confirm curl can actually read the mock changelog via file://.
+# If not (platform-specific file:// quirk), skip the network-dependent suite
+# rather than emit confusing failures.
+if ! curl -sS --max-time 5 "$INTEL_CHANGELOG_URL" >/dev/null 2>&1; then
+  printf 'SKIP-ALL: curl cannot read file:// fixtures on this platform\n'
+  exit 0
+fi
+
+# ── Scenario 1: first run on empty state file → all SEEDED, no delta, exit 0 ──
+printf '\n[1] first run seeds all sources\n'
+S1="$WORK_DIR/state1.json"
+J1="$WORK_DIR/report1.json"
+out="$(run_watch --state-file "$S1" --json-out "$J1" --commit 2>&1)"; rc=$?
+assert_eq "exit 0" "0" "$rc"
+assert_eq "3 seeded" "3" "$(jq '.seeded|length' "$J1")"
+assert_eq "0 delta" "0" "$(jq '.deltas|length' "$J1")"
+assert_eq "0 error" "0" "$(jq '.errors|length' "$J1")"
+assert_eq "state persisted 3 sources" "3" "$(jq '.sources|length' "$S1")"
+assert_eq "claude-code seeded version" "2.1.150" "$(jq -r '.sources["npm:@anthropic-ai/claude-code"]' "$S1")"
+assert_contains "changelog fp is sha256" "sha256:" "$(jq -r '.sources["changelog:claude-code"]' "$S1")"
+
+# ── Scenario 2: re-run against committed state with no upstream change → unchanged ──
+printf '\n[2] re-run with no change → unchanged\n'
+J2="$WORK_DIR/report2.json"
+out="$(run_watch --state-file "$S1" --json-out "$J2" 2>&1)"; rc=$?
+assert_eq "exit 0" "0" "$rc"
+assert_eq "0 delta" "0" "$(jq '.deltas|length' "$J2")"
+assert_eq "0 seeded" "0" "$(jq '.seeded|length' "$J2")"
+assert_eq "3 unchanged" "3" "$(jq '.unchanged|length' "$J2")"
+assert_contains "dry-run notice" "state not persisted" "$out"
+
+# ── Scenario 3: upstream version bump → DELTA with old/new ──
+printf '\n[3] npm version bump → delta\n'
+write_pkg "claude-code" "2.1.151"
+J3="$WORK_DIR/report3.json"
+out="$(run_watch --state-file "$S1" --json-out "$J3" 2>&1)"; rc=$?
+assert_eq "exit 0" "0" "$rc"
+assert_eq "1 delta" "1" "$(jq '.deltas|length' "$J3")"
+assert_eq "delta source" "npm:@anthropic-ai/claude-code" "$(jq -r '.deltas[0].source' "$J3")"
+assert_eq "delta old" "2.1.150" "$(jq -r '.deltas[0].old' "$J3")"
+assert_eq "delta new" "2.1.151" "$(jq -r '.deltas[0].new' "$J3")"
+assert_eq "delta label whitelisted" "intel/sdk" "$(jq -r '.deltas[0].label' "$J3")"
+# dry-run did NOT persist → state file still has old version
+assert_eq "state unchanged after dry-run" "2.1.150" "$(jq -r '.sources["npm:@anthropic-ai/claude-code"]' "$S1")"
+
+# ── Scenario 4: changelog content change → delta on the hash source ──
+printf '\n[4] changelog edit → hash delta\n'
+printf '# Changelog\n\n## 2.1.151\n\n- new entry\n' > "$CHANGELOG"
+J4="$WORK_DIR/report4.json"
+run_watch --state-file "$S1" --json-out "$J4" >/dev/null 2>&1
+# claude-code (2.1.151) + changelog both differ from committed state now → 2 deltas
+assert_eq "2 deltas (npm + changelog)" "2" "$(jq '.deltas|length' "$J4")"
+assert_contains "changelog in deltas" "changelog:claude-code" "$(jq -r '.deltas[].source' "$J4")"
+
+# ── Scenario 5: --commit persists the new fingerprints ──
+printf '\n[5] commit persists new state\n'
+run_watch --state-file "$S1" --commit >/dev/null 2>&1; rc=$?
+assert_eq "commit exit 0" "0" "$rc"
+assert_eq "state now 2.1.151" "2.1.151" "$(jq -r '.sources["npm:@anthropic-ai/claude-code"]' "$S1")"
+# subsequent run is clean
+run_watch --state-file "$S1" --json-out "$WORK_DIR/r5b.json" >/dev/null 2>&1
+assert_eq "clean after commit" "0" "$(jq '.deltas|length' "$WORK_DIR/r5b.json")"
+
+# ── Scenario 6: fetch error → reported as error, exit 1, state NOT corrupted ──
+printf '\n[6] unreachable source → error, exit 1, state preserved\n'
+J6="$WORK_DIR/report6.json"
+before="$(jq -r '.sources["npm:@anthropic-ai/claude-code"]' "$S1")"
+out="$(INTEL_NPM_REGISTRY="file://$WORK_DIR/nonexistent-registry" \
+       run_watch --state-file "$S1" --json-out "$J6" --commit 2>&1)"; rc=$?
+assert_eq "exit 1 on fetch error" "1" "$rc"
+assert_eq "2 npm errors" "2" "$(jq '.errors|length' "$J6")"
+assert_contains "error names a source" "npm:@anthropic-ai/claude-code" "$(jq -r '.errors[]' "$J6")"
+# changelog still reachable → it stays in state; errored npm sources keep old fp
+assert_eq "errored source kept old fp" "$before" "$(jq -r '.sources["npm:@anthropic-ai/claude-code"]' "$S1")"
+
+# ── Scenario 7: corrupt state file → exit 3, no silent reset ──
+printf '\n[7] corrupt state file → exit 3\n'
+echo "{ not json" > "$WORK_DIR/bad.json"
+out="$(run_watch --state-file "$WORK_DIR/bad.json" 2>&1)"; rc=$?
+assert_eq "exit 3 on bad state" "3" "$rc"
+assert_contains "names the problem" "not valid JSON" "$out"
+
+# ── Scenario 8: --commit with no backend → usage error (exit 2) ──
+printf '\n[8] --commit without backend → exit 2\n'
+out="$(run_watch --commit 2>&1)"; rc=$?
+assert_eq "exit 2" "2" "$rc"
+assert_contains "explains requirement" "requires a state backend" "$out"
+
+# ── Scenario 9: two state backends → mutual exclusion (exit 2) ──
+printf '\n[9] both backends → exit 2\n'
+out="$(run_watch --state-file "$S1" --state-issue 99 2>&1)"; rc=$?
+assert_eq "exit 2" "2" "$rc"
+assert_contains "explains XOR" "at most one state backend" "$out"
+
+# ── Scenario 10: pinned-Issue-body marker extraction contract ──
+# state_read uses this awk+sed pipeline to pull JSON from the Issue body. Verify
+# the exact extraction contract here without needing gh/network.
+printf '\n[10] Issue-body marker extraction contract\n'
+BODY="$WORK_DIR/issue-body.md"
+cat > "$BODY" <<'EOF'
+# 🛰️ Intel-Watch State (auto-managed)
+
+prose that must be ignored
+
+<!-- INTEL_STATE_BEGIN -->
+```json
+{"schema_version":1,"sources":{"k":"v"}}
+```
+<!-- INTEL_STATE_END -->
+
+trailing prose ignored
+EOF
+extracted="$(awk -v b="<!-- INTEL_STATE_BEGIN -->" -v e="<!-- INTEL_STATE_END -->" \
+  'index($0,b){f=1;next} index($0,e){f=0} f' "$BODY" | sed '/^```/d')"
+assert_eq "extracted is valid JSON" "v" "$(printf '%s' "$extracted" | jq -r '.sources.k')"
+assert_contains "no fence leaked" "schema_version" "$extracted"
+# a body with no markers (fresh empty Issue) extracts to whitespace → empty-state path
+empty_extract="$(printf '# just a heading\n' | awk -v b="<!-- INTEL_STATE_BEGIN -->" -v e="<!-- INTEL_STATE_END -->" \
+  'index($0,b){f=1;next} index($0,e){f=0} f' | sed '/^```/d' | tr -d '[:space:]')"
+assert_eq "no-marker body extracts empty" "" "$empty_extract"
+
+# ── Scenarios 11-13: end-to-end --state-issue path via a fake `gh` on PATH.
+# This exercises the real state_read Issue branch (incl. the marker-integrity
+# gate) without a live GitHub round trip. The live edit/write round trip is
+# Slice 3. Probe first; skip cleanly if the stub is not picked up on PATH. ──
+GHBIN="$WORK_DIR/ghbin"; mkdir -p "$GHBIN"
+cat > "$GHBIN/gh" <<'STUB'
+#!/usr/bin/env bash
+if [[ "$1" == "issue" && "$2" == "view" ]]; then cat "$FAKE_BODY"; exit 0; fi
+if [[ "$1" == "issue" && "$2" == "edit" ]]; then exit 0; fi
+echo "ghstub: unsupported: $*" >&2; exit 1
+STUB
+chmod +x "$GHBIN/gh"
+PROBE="$WORK_DIR/probe.md"; printf 'no markers\n' > "$PROBE"
+GH_STUB_OK=0
+if [[ "$(FAKE_BODY="$PROBE" PATH="$GHBIN:$PATH" gh issue view 1 --json body -q .body 2>/dev/null)" == "no markers" ]]; then
+  GH_STUB_OK=1
+fi
+
+if [[ "$GH_STUB_OK" -eq 1 ]]; then
+  # reset mock to a known head so deltas are deterministic
+  write_pkg "claude-code" "2.1.151"
+  write_pkg "claude-agent-sdk" "0.3.150"
+
+  printf '\n[11] state-issue: complete marker pair → state is read (produces delta)\n'
+  BODY11="$WORK_DIR/body11.md"
+  cat > "$BODY11" <<'EOF'
+# Intel-Watch State
+
+<!-- INTEL_STATE_BEGIN -->
+```json
+{"schema_version":1,"updated_at":"old","sources":{"npm:@anthropic-ai/claude-code":"0.0.1","npm:@anthropic-ai/claude-agent-sdk":"0.3.150","changelog:claude-code":"sha256:stale"}}
+```
+<!-- INTEL_STATE_END -->
+EOF
+  J11="$WORK_DIR/r11.json"
+  FAKE_BODY="$BODY11" PATH="$GHBIN:$PATH" bash "$WATCH" --state-issue 1 --json-out "$J11" >/dev/null 2>&1; rc=$?
+  assert_eq "exit 0" "0" "$rc"
+  assert_eq "stale claude-code → delta old 0.0.1" "0.0.1" "$(jq -r '.deltas[] | select(.source=="npm:@anthropic-ai/claude-code") | .old' "$J11")"
+  assert_eq "delta new 2.1.151" "2.1.151" "$(jq -r '.deltas[] | select(.source=="npm:@anthropic-ai/claude-code") | .new' "$J11")"
+  assert_eq "agent-sdk unchanged (read worked)" "0" "$(jq '[.deltas[]|select(.source=="npm:@anthropic-ai/claude-agent-sdk")]|length' "$J11")"
+
+  printf '\n[12] state-issue: no markers (fresh Issue) → seed from empty\n'
+  BODY12="$WORK_DIR/body12.md"; printf '# fresh state issue, no markers yet\n' > "$BODY12"
+  J12="$WORK_DIR/r12.json"
+  FAKE_BODY="$BODY12" PATH="$GHBIN:$PATH" bash "$WATCH" --state-issue 1 --json-out "$J12" >/dev/null 2>&1; rc=$?
+  assert_eq "exit 0" "0" "$rc"
+  assert_eq "3 seeded from empty" "3" "$(jq '.seeded|length' "$J12")"
+  assert_eq "0 delta on fresh issue" "0" "$(jq '.deltas|length' "$J12")"
+
+  printf '\n[13] state-issue: half marker pair (END lost) → fail loud (exit 3)\n'
+  BODY13="$WORK_DIR/body13.md"
+  cat > "$BODY13" <<'EOF'
+# corrupted: BEGIN present, END truncated
+
+<!-- INTEL_STATE_BEGIN -->
+```json
+{"schema_version":1,"sources":{"npm:@anthropic-ai/claude-code":"2.1.151"}}
+```
+EOF
+  out="$(FAKE_BODY="$BODY13" PATH="$GHBIN:$PATH" bash "$WATCH" --state-issue 1 2>&1)"; rc=$?
+  assert_eq "exit 3 on malformed markers" "3" "$rc"
+  assert_contains "names malformed markers" "malformed markers" "$out"
+else
+  printf '\n[11-13] SKIP: gh stub not picked up on PATH (platform shim) — Issue-path covered by contract test [10]\n'
+fi
+
+# ── Summary ──
+printf '\n=== intel-watch tests: %s passed, %s failed ===\n' "$PASS" "$FAIL"
+if [[ "$FAIL" -gt 0 ]]; then
+  printf 'Failures:\n'; for f in "${FAILURES[@]}"; do printf '  - %s\n' "$f"; done
+  exit 1
+fi
+exit 0

--- a/scripts/test-intel-watch.sh
+++ b/scripts/test-intel-watch.sh
@@ -12,9 +12,16 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 WATCH="$SCRIPT_DIR/intel-watch.sh"
 [[ -x "$WATCH" ]] || { printf 'intel-watch.sh not executable: %s\n' "$WATCH" >&2; exit 1; }
 
-for cmd in jq curl sha256sum; do
+for cmd in jq curl; do
   command -v "$cmd" >/dev/null 2>&1 || { printf 'SKIP-ALL: %s unavailable\n' "$cmd"; exit 0; }
 done
+# sha256 backend family (matches intel-watch.sh's sha256_hex fallback chain) —
+# stay portable on macOS/BSD where GNU sha256sum may be absent.
+if ! command -v sha256sum >/dev/null 2>&1 \
+   && ! command -v shasum   >/dev/null 2>&1 \
+   && ! command -v openssl  >/dev/null 2>&1; then
+  printf 'SKIP-ALL: no sha256 backend (sha256sum/shasum/openssl)\n'; exit 0
+fi
 
 PASS=0; FAIL=0
 declare -a FAILURES=()
@@ -67,6 +74,9 @@ to_file_url() {
 }
 export INTEL_NPM_REGISTRY; INTEL_NPM_REGISTRY="$(to_file_url "$REG")"
 export INTEL_CHANGELOG_URL; INTEL_CHANGELOG_URL="$(to_file_url "$CHANGELOG")"
+# The collector default-denies non-https source URLs; opt in for the file://
+# fixtures. Scenario 16 exercises the guard itself with this flag unset.
+export INTEL_ALLOW_INSECURE_SOURCE_URLS=1
 
 run_watch() { bash "$WATCH" "$@"; }
 
@@ -273,6 +283,19 @@ if command -v openssl >/dev/null 2>&1; then
   if [[ -n "$ref" ]]; then assert_eq "openssl == ref" "$ref" "$alt"; fi
 fi
 if [[ -z "$ref" ]]; then printf '  (no sha256 backend present to cross-check)\n'; fi
+
+# ── Scenario 15: value-bearing flag missing its value → exit 2 (no shift overrun) ──
+printf '\n[15] flag missing value → exit 2\n'
+out="$(run_watch --state-file 2>&1)"; rc=$?
+assert_eq "exit 2 on missing value" "2" "$rc"
+assert_contains "explains requirement" "requires a non-empty value" "$out"
+
+# ── Scenario 16: non-https source URL without opt-in → default-denied (exit 2) ──
+printf '\n[16] non-https source URL default-denied\n'
+out="$(INTEL_ALLOW_INSECURE_SOURCE_URLS=0 INTEL_NPM_REGISTRY="http://evil.example/r" \
+       bash "$WATCH" --state-file "$WORK_DIR/s16.json" 2>&1)"; rc=$?
+assert_eq "exit 2 on non-https" "2" "$rc"
+assert_contains "names the guard" "must be https" "$out"
 
 # ── Summary ──
 printf '\n=== intel-watch tests: %s passed, %s failed ===\n' "$PASS" "$FAIL"

--- a/scripts/test-intel-watch.sh
+++ b/scripts/test-intel-watch.sh
@@ -257,6 +257,23 @@ else
   printf '\n[11-13] SKIP: gh stub not picked up on PATH (platform shim) — Issue-path covered by contract test [10]\n'
 fi
 
+# ── Scenario 14: portable sha256 backends agree (covers sha256_hex fallbacks) ──
+# Mirrors the three extraction expressions in sha256_hex: sha256sum/shasum use
+# `cut -d' ' -f1`, openssl ("SHA2-256(stdin)= <hash>") uses `awk '{print $NF}'`.
+printf '\n[14] portable sha256 backends agree\n'
+sample="intel-watch portability probe"
+ref=""
+if command -v sha256sum >/dev/null 2>&1; then ref="$(printf '%s' "$sample" | sha256sum | cut -d' ' -f1)"; fi
+if command -v shasum >/dev/null 2>&1; then
+  alt="$(printf '%s' "$sample" | shasum -a 256 | cut -d' ' -f1)"
+  if [[ -n "$ref" ]]; then assert_eq "shasum == sha256sum" "$ref" "$alt"; else ref="$alt"; fi
+fi
+if command -v openssl >/dev/null 2>&1; then
+  alt="$(printf '%s' "$sample" | openssl dgst -sha256 | awk '{print $NF}')"
+  if [[ -n "$ref" ]]; then assert_eq "openssl == ref" "$ref" "$alt"; fi
+fi
+if [[ -z "$ref" ]]; then printf '  (no sha256 backend present to cross-check)\n'; fi
+
 # ── Summary ──
 printf '\n=== intel-watch tests: %s passed, %s failed ===\n' "$PASS" "$FAIL"
 if [[ "$FAIL" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

Phase 2 PoC **Slice 1** for #157 (External Information Update Agent), tracked by #453. This is the deterministic-collector slice **only** — no LLM, no issue-create (those are Slice 2), no GHA workflow wiring (Slice 3).

Design authority: `.mercury/docs/research/issue-157-external-info-agent-2026-05.md` (§4.2 source detection, §5.1 label whitelist / injection guard, §5.2 dedup + state mechanism c, §7 Phase 2 plan, §9 web-verified entrance gate).

## What's in this slice

- **`scripts/intel-watch.sh`** — deterministic collector:
  - Fetches 3 web-verified sources: `@anthropic-ai/claude-code` + `@anthropic-ai/claude-agent-sdk` npm `dist-tags.latest` (abbreviated packument, `Accept: application/vnd.npm.install-v1+json`) + Claude Code `CHANGELOG.md` raw (sha256). Endpoints verified 2026-05-25 against official docs (ADR §9).
  - Computes per-source fingerprints, reads/writes state via `--state-file` (local JSON, testable) **XOR** `--state-issue` (pinned Issue body, ADR §5.2 mechanism c, via `gh`), detects deltas.
  - **Dry-run by default** (no persistence); `--commit` persists. `--json-out` emits a machine-readable delta report for Slice 2 to consume.
- **`scripts/test-intel-watch.sh`** — **46 tests, all green**. `file://` mock sources + a PATH-injected `gh` stub drive every transition (seed / unchanged / delta / fetch-error), atomic state write, backend XOR mutual exclusion, corrupt-state fail-loud, and the pinned-Issue-body marker-integrity gate end-to-end.
- **Repo labels created** (via `gh label`, not in these files): `intel/{sdk,api-docs,oss,needs-triage}` + `impact/{blocking,capability,maintenance,fyi}`.

## Safety invariants (ADR-mandated, verified by review + tests)

- Source list is a **fixed in-script whitelist** — no external/LLM/release-note text is ever concatenated into a `curl`/`gh`/shell argument (injection + label-pollution guard, §5.1). Fetched bodies flow only into `jq` stdin / `sha256sum` stdin.
- A **failed fetch is reported as `error` (exit 1)** and never silently treated as "unchanged" (would suppress a real delta); the errored source keeps its prior fingerprint.
- State writes are **atomic whole-body replacement** (temp + `mv` for the file backend; `--body-file` for the Issue backend).
- Corrupt state file / malformed Issue markers **fail loud** (exit 3) rather than silently re-seed (which would re-spam).

## Slice 1 acceptance (subset of #453)

- [x] `intel/*` + `impact/*` labels exist
- [x] Collection script fetches the 3 sources via the verified endpoints and detects delta against state
- [x] State read/write round-trips across runs (dedup first gate functional) — `--state-file` live + `--state-issue` end-to-end via gh stub
- [x] No LLM/release-note text reaches a shell/`gh` arg unescaped (whitelist + `jq --arg`)
- [x] Module fully detachable (zero source-code references; delete script+labels = no-op)

Deferred to later slices (intentionally not in this PR): LLM significance judgment + guarded `gh issue create` (**Slice 2**); `.github/workflows/external-intel.yml` weekly cron + `ANTHROPIC_API_KEY` secret + live pinned state Issue (**Slice 3**).

## Verification

- `bash scripts/test-intel-watch.sh` → **46 passed, 0 failed**
- `bash -n` clean on both scripts; real-endpoint smoke (seed → unchanged across runs) confirmed.
- **Pre-commit dual-verify** (per Mercury MUST): **Codex UNAVAILABLE this session** (`codex-sync-audit.sh` exit 3, CLI not installed) — Claude lanes only:
  - `critic` (spec compliance): **PASS 7/7**, no blockers.
  - `code-reviewer` (deep review): **0 Critical / 0 High**, 2 Medium + minor. **MEDIUM-1** (atomic state-file write) + **MEDIUM-2** (Issue marker-integrity gate) + LOW-2/LOW-3 fixed before commit; the post-fix tests (46) cover both.

## Notes

- Mercury-internal tooling under `scripts/` — **exempt from the 200-LOC adapter cap** (CLAUDE.md carve-out: implements an in-repo monitoring protocol, mounts no external project).
- No cherry-pick: all code is Mercury-authored; no upstream file lifted → no `upstream-manifest.json` entry required.

Refs #157
Refs #453 (Slice 1 of 3 — does not close)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
