### PR TITLE
feat(#453): Slice 2 — external-intel LLM significance judgment + guarded issue-create

### DIFF
--- a/scripts/intel-judge.sh
+++ b/scripts/intel-judge.sh
@@ -73,7 +73,8 @@ LLM_RESPONSE_FILE=""            # TEST HOOK: raw API response JSON, bypasses cur
 MODEL="${INTEL_JUDGE_MODEL:-claude-haiku-4-5}"
 API_KEY_ENV="${INTEL_JUDGE_API_KEY_ENV:-ANTHROPIC_API_KEY}"  # NAME of the env var
                                 #   holding the key — the key value is never an argv
-ANTHROPIC_API_URL="${INTEL_ANTHROPIC_API_URL:-https://api.anthropic.com/v1/messages}"
+DEFAULT_ANTHROPIC_API_URL="https://api.anthropic.com/v1/messages"
+ANTHROPIC_API_URL="${INTEL_ANTHROPIC_API_URL:-$DEFAULT_ANTHROPIC_API_URL}"
 MAX_RETRIES="${INTEL_JUDGE_MAX_RETRIES:-3}"
 RETRY_BASE_DELAY="${INTEL_JUDGE_RETRY_BASE_DELAY:-2}"  # seconds; tests set 0 for speed
 API_TIMEOUT="${INTEL_JUDGE_API_TIMEOUT:-60}"          # per-attempt curl --max-time
@@ -113,15 +114,45 @@ done
 # that each tool actually RUNS, so a broken interpreter fails fast here as a
 # startup error (exit 2) rather than mid-run, where a `jq` failure would otherwise
 # muddy the exit-code contract (a runtime fault must degrade, not look like usage).
+# Numeric env config must be valid integers — they feed arithmetic / sleep /
+# curl --max-time, so a non-integer would crash mid-run and bypass the degrade /
+# exit-code contract. Validate up front as a startup error (exit 2).
+for _vn in MAX_RETRIES RETRY_BASE_DELAY API_TIMEOUT; do
+  _vv="${!_vn}"
+  [[ "$_vv" =~ ^[0-9]+$ ]] || die "$_vn must be a non-negative integer (got: '$_vv')"
+done
+[[ "$MAX_RETRIES" -ge 1 ]] || die "INTEL_JUDGE_MAX_RETRIES must be >= 1 (got: $MAX_RETRIES)"
+[[ "$API_TIMEOUT" -ge 1 ]] || die "INTEL_JUDGE_API_TIMEOUT must be >= 1 (got: $API_TIMEOUT)"
+
 jq -n null >/dev/null 2>&1 || die "jq is required and must be runnable"
 if [[ -z "$LLM_RESPONSE_FILE" ]]; then
+  # SSRF / credential-exfil guard: in live mode the API key is sent to
+  # $ANTHROPIC_API_URL, so refuse any non-official override. Tests bypass the
+  # network entirely via --llm-response-file, so this only gates real calls.
+  [[ "$ANTHROPIC_API_URL" == "$DEFAULT_ANTHROPIC_API_URL" ]] \
+    || die "custom Anthropic API URL not allowed in live mode (SSRF guard): $ANTHROPIC_API_URL"
   curl --version >/dev/null 2>&1 || die "curl is required and must be runnable (unless --llm-response-file)"
+else
+  # The mock-response file is config, not LLM output: an unreadable file is a
+  # startup error (exit 2), not an LLM failure that should degrade to digest.
+  [[ -f "$LLM_RESPONSE_FILE" ]] || die "llm-response file not found: $LLM_RESPONSE_FILE"
+  [[ -r "$LLM_RESPONSE_FILE" ]] || die "llm-response file not readable: $LLM_RESPONSE_FILE"
 fi
 if [[ "$CREATE_ISSUE" -eq 1 ]]; then
   gh --version >/dev/null 2>&1 || die "gh is required and must be runnable for --create-issue"
 fi
-if [[ -n "$CONTEXT_FILE" && ! -f "$CONTEXT_FILE" ]]; then
-  die "context file not found: $CONTEXT_FILE"
+# --context-file is read verbatim into the API request body, so harden the path:
+# reject missing/unreadable, reject a symlink (data-exfil via a link to a
+# sensitive file), and require it to resolve inside the working tree. Size is
+# capped at read time in build_request_body. An unreadable context file is a
+# startup config error (exit 2), not a runtime degrade.
+if [[ -n "$CONTEXT_FILE" ]]; then
+  [[ -f "$CONTEXT_FILE" ]] || die "context file not found: $CONTEXT_FILE"
+  [[ -r "$CONTEXT_FILE" ]] || die "context file not readable: $CONTEXT_FILE"
+  [[ ! -L "$CONTEXT_FILE" ]] || die "context file must not be a symlink (data-exfil guard): $CONTEXT_FILE"
+  _ctx_real="$(realpath "$CONTEXT_FILE" 2>/dev/null)" || die "cannot resolve context file path: $CONTEXT_FILE"
+  [[ "$_ctx_real" == "$(pwd -P)/"* ]] \
+    || die "context file must resolve inside the working tree (data-exfil guard): $CONTEXT_FILE"
 fi
 
 # ── Mercury context fed to the LLM so it can judge relevance, not just novelty.
@@ -179,7 +210,9 @@ build_request_body() {
   # Deterministic, structured delta summary — never raw LLM/command text.
   delta_lines="$(jq -r '.[] | "- \(.source) (\(.kind)): \(.old) -> \(.new)"' <<<"$deltas")"
   if [[ -n "$CONTEXT_FILE" ]]; then
-    context="$(cat "$CONTEXT_FILE")"
+    # Path/symlink/readability already validated at startup; cap the size here so
+    # an oversized context can't bloat the request or exfil a huge file.
+    context="$(head -c 20000 "$CONTEXT_FILE")" || return 1
   fi
   local user_prompt
   user_prompt="$(printf 'Mercury context:\n%s\n\nDetected deltas:\n%s\n' \
@@ -205,33 +238,52 @@ call_anthropic() {
   local body_file="$1" attempt=1 delay="$RETRY_BASE_DELAY" key
   key="${!API_KEY_ENV:-}"
   [[ -n "$key" ]] || { printf 'intel-judge: env %s is empty (no API key)\n' "$API_KEY_ENV" >&2; return 1; }
+  # Put ALL request headers (incl. the API key) in a 0600 temp file read via
+  # `-H @file` (curl >= 7.55), so the key never appears in argv / process list
+  # (/proc/<pid>/cmdline, `ps`). Mirrors the repo convention in
+  # scripts/lane-auto-report.sh:84-99 — `umask 077` for the perms + EXPLICIT
+  # rc-capture cleanup, deliberately NOT `trap RETURN` (which persists across
+  # reinvocations and re-fires on later returns — prior Argus finding 3144785807).
+  local hdr_file rc=1 out=""
+  hdr_file="$(umask 077 && mktemp "${TMPDIR:-/tmp}/intel-judge-hdr.XXXXXX")" || return 1
+  if ! {
+        printf 'x-api-key: %s\n' "$key"
+        printf 'anthropic-version: 2023-06-01\n'
+        printf 'content-type: application/json\n'
+      } > "$hdr_file"; then
+    rm -f "$hdr_file"; return 1
+  fi
   while (( attempt <= MAX_RETRIES )); do
-    local resp http payload
+    local resp http payload curl_rc
     # -w appends the HTTP status on its own trailing line; --data @file keeps the
-    # (already jq-escaped) body off the command line.
+    # (already jq-escaped) body and -H @file keep the key off the command line.
     resp="$(curl -sS --max-time "$API_TIMEOUT" -X POST "$ANTHROPIC_API_URL" \
-              -H "x-api-key: $key" \
-              -H "anthropic-version: 2023-06-01" \
-              -H "content-type: application/json" \
+              -H @"$hdr_file" \
               --data @"$body_file" \
               -w $'\n%{http_code}' 2>/dev/null)"
-    local curl_rc=$?
+    curl_rc=$?
     http="${resp##*$'\n'}"
     payload="${resp%$'\n'*}"
     if [[ $curl_rc -eq 0 && "$http" == 2* ]]; then
-      printf '%s' "$payload"; return 0
+      out="$payload"; rc=0; break
     fi
     if [[ $curl_rc -eq 0 && "$http" == 4* && "$http" != "429" ]]; then
       printf 'intel-judge: Anthropic API client error HTTP %s (not retried)\n' "$http" >&2
-      return 1
+      rc=1; break
     fi
     printf 'intel-judge: API attempt %s/%s failed (curl_rc=%s http=%s); retrying\n' \
       "$attempt" "$MAX_RETRIES" "$curl_rc" "${http:-none}" >&2
     (( attempt < MAX_RETRIES )) && [[ "$delay" != "0" ]] && sleep "$delay"
     delay=$(( delay * 2 )); attempt=$(( attempt + 1 ))
   done
-  printf 'intel-judge: Anthropic API exhausted %s attempts\n' "$MAX_RETRIES" >&2
-  return 1
+  rm -f "$hdr_file"
+  # Only the genuine retry-exhaustion path logs "exhausted" (a 4xx break leaves
+  # attempt <= MAX_RETRIES, so it won't double-log).
+  if [[ $rc -ne 0 && $attempt -gt $MAX_RETRIES ]]; then
+    printf 'intel-judge: Anthropic API exhausted %s attempts\n' "$MAX_RETRIES" >&2
+  fi
+  [[ $rc -eq 0 ]] && printf '%s' "$out"
+  return $rc
 }
 
 # ── extract + validate the judgment JSON from an API response ──

--- a/scripts/intel-judge.sh
+++ b/scripts/intel-judge.sh
@@ -1,0 +1,451 @@
+#!/usr/bin/env bash
+# intel-judge.sh — External-intel LLM significance judgment + guarded issue-create
+#                  (Issue #157 / #453 Slice 2)
+#
+# Consumes the delta report emitted by intel-watch.sh (Slice 1, via --json-out),
+# runs a SINGLE Anthropic Messages API call to judge whether the batch of deltas
+# is significant enough to warrant a human-triaged GitHub Issue, then — behind
+# hard anti-spam + injection guardrails — either opens exactly one
+# `intel/needs-triage` Issue or degrades the batch into a digest. No business
+# code is touched; nothing is pushed to a protected branch.
+#
+# Design authority: .mercury/docs/research/issue-157-external-info-agent-2026-05.md
+#   §5.1 (label whitelist + injection guard), §5.2 (significance gate = dedup
+#   layer 3), §5.3 (Issue-vs-digest split), §7 step 4-5 (Phase-2 LLM call + error
+#   degradation + guarded gh issue create).
+#
+# Anthropic Messages API (web-verified 2026-05-26 against
+#   https://platform.claude.com/docs/en/api/messages):
+#   POST https://api.anthropic.com/v1/messages
+#   headers: x-api-key: $KEY | anthropic-version: 2023-06-01 | content-type: application/json
+#   body:    { "model", "max_tokens", "system"?, "messages":[{"role","content"}] }
+#   response text lives in content[].text (TextBlock, type=="text").
+#   model: claude-haiku-4-5 (cheap, sufficient for significance judgment).
+#
+# Mercury-internal tooling under scripts/ — exempt from the 200-LOC adapter cap
+# (CLAUDE.md carve-out: implements an in-repo monitoring protocol, does NOT mount
+# an external project).
+#
+# ── INJECTION GUARD (first-class constraint, ADR §5.1/§7 step 5) ──
+#   * LLM output and external release-note / changelog text NEVER reach a shell
+#     or `gh` command as a parsed token. All such text flows into (a) the API
+#     request body via `jq --arg` (jq escapes it) and (b) the Issue body via a
+#     `--body-file` temp file. It is never concatenated into a command string,
+#     never `eval`-ed, and never used to build a label.
+#   * Labels come ONLY from fixed whitelists. The LLM may *select* a priority /
+#     impact from a closed enum; a value outside the enum is rejected (the Issue
+#     is downgraded to digest), so a poisoned LLM response cannot inject a label.
+#   * The Issue title is built from the delta source-keys (intel-watch.sh's fixed
+#     SOURCES literals) + a delta count — never LLM text. deltas.json is trusted
+#     input (it is intel-watch.sh's own output); regardless, the title reaches
+#     `gh` only as a single discrete argv element and is never reparsed by a shell.
+#
+# Usage:
+#   # dry-run (default): judge + print what WOULD be created, never calls gh
+#   bash scripts/intel-judge.sh --deltas-file deltas.json
+#   # really create the Issue (Slice 3 / GHA wires this on the significant path)
+#   bash scripts/intel-judge.sh --deltas-file deltas.json --create-issue --repo owner/name
+#   # degrade target for non-significant / error batches
+#   bash scripts/intel-judge.sh --deltas-file deltas.json --digest-file digest.md
+#   # TEST HOOK: inject a mock API response (no key, no network)
+#   bash scripts/intel-judge.sh --deltas-file deltas.json --llm-response-file mock.json
+#
+# Exit codes (contract for the Slice 3 orchestrator):
+#   0  deltas landed (Issue created / dry-run previewed / written to digest /
+#      judged non-significant) → caller MAY now persist intel-watch state.
+#   2  usage error (bad/missing args) → nothing happened.
+#   3  delta did NOT land (e.g. digest write failed) → caller MUST NOT persist
+#      state, so the batch is retried whole next run (never silently dropped).
+
+set -uo pipefail
+
+# ── Configuration / args ──
+DELTAS_FILE=""
+CONTEXT_FILE=""                 # optional extra context (e.g. changelog excerpt),
+                                #   orchestrator-fed; only ever enters the API body
+DIGEST_FILE=""                  # where non-significant / degraded batches are recorded
+CREATE_ISSUE=0                  # default dry-run; --create-issue actually calls gh
+REPO=""                         # owner/name for `gh issue create --repo`
+MAX_ISSUES=1                    # PoC hard cap: only 0 (force-digest) vs ≥1 (one
+                                #   Issue for the whole batch) are meaningful this
+                                #   slice; the multi-Issue path does not exist yet
+LLM_RESPONSE_FILE=""            # TEST HOOK: raw API response JSON, bypasses curl
+MODEL="${INTEL_JUDGE_MODEL:-claude-haiku-4-5}"
+API_KEY_ENV="${INTEL_JUDGE_API_KEY_ENV:-ANTHROPIC_API_KEY}"  # NAME of the env var
+                                #   holding the key — the key value is never an argv
+ANTHROPIC_API_URL="${INTEL_ANTHROPIC_API_URL:-https://api.anthropic.com/v1/messages}"
+MAX_RETRIES="${INTEL_JUDGE_MAX_RETRIES:-3}"
+RETRY_BASE_DELAY="${INTEL_JUDGE_RETRY_BASE_DELAY:-2}"  # seconds; tests set 0 for speed
+API_TIMEOUT="${INTEL_JUDGE_API_TIMEOUT:-60}"          # per-attempt curl --max-time
+
+# ── Fixed whitelists (label-injection guard) — the ONLY label values that can
+#    ever reach `gh`. Parsed/LLM-derived values are validated against these. ──
+ALLOWED_SOURCE_LABELS=" intel/sdk intel/api-docs intel/oss "
+ALLOWED_PRIORITIES=" P1 P2 P3 "
+ALLOWED_IMPACTS=" impact/blocking impact/capability impact/maintenance impact/fyi "
+TRIAGE_LABEL="intel/needs-triage"
+# Significance gate: build an Issue only when significant AND priority ≥ P2
+# (P1 highest, P3 lowest → {P1,P2}). Everything else degrades to digest.
+GATE_PRIORITIES=" P1 P2 "
+
+die() { printf 'intel-judge: %s\n' "$1" >&2; exit 2; }
+need_val() { [[ $# -ge 2 && -n "${2:-}" ]] || die "$1 requires a non-empty value"; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --deltas-file)       need_val "$@"; DELTAS_FILE="$2"; shift 2 ;;
+    --context-file)      need_val "$@"; CONTEXT_FILE="$2"; shift 2 ;;
+    --digest-file)       need_val "$@"; DIGEST_FILE="$2"; shift 2 ;;
+    --repo)              need_val "$@"; REPO="$2"; shift 2 ;;
+    --max-issues)        need_val "$@"; MAX_ISSUES="$2"; shift 2 ;;
+    --llm-response-file) need_val "$@"; LLM_RESPONSE_FILE="$2"; shift 2 ;;
+    --create-issue)      CREATE_ISSUE=1; shift ;;
+    -h|--help)           sed -n '2,55p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *)                   die "unknown argument: $1" ;;
+  esac
+done
+
+[[ -n "$DELTAS_FILE" ]] || die "--deltas-file is required"
+[[ -f "$DELTAS_FILE" ]] || die "deltas file not found: $DELTAS_FILE"
+[[ "$MAX_ISSUES" =~ ^[0-9]+$ ]] || die "--max-issues must be a non-negative integer"
+# Active dependency probes (not just `command -v`): on MSYS a tool can be present
+# on PATH yet fail to execute (e.g. a winget shim without exec permission). Probe
+# that each tool actually RUNS, so a broken interpreter fails fast here as a
+# startup error (exit 2) rather than mid-run, where a `jq` failure would otherwise
+# muddy the exit-code contract (a runtime fault must degrade, not look like usage).
+jq -n null >/dev/null 2>&1 || die "jq is required and must be runnable"
+if [[ -z "$LLM_RESPONSE_FILE" ]]; then
+  curl --version >/dev/null 2>&1 || die "curl is required and must be runnable (unless --llm-response-file)"
+fi
+if [[ "$CREATE_ISSUE" -eq 1 ]]; then
+  gh --version >/dev/null 2>&1 || die "gh is required and must be runnable for --create-issue"
+fi
+if [[ -n "$CONTEXT_FILE" && ! -f "$CONTEXT_FILE" ]]; then
+  die "context file not found: $CONTEXT_FILE"
+fi
+
+# ── Mercury context fed to the LLM so it can judge relevance, not just novelty.
+#    Double-quoted with trailing-backslash continuation (the line breaks collapse);
+#    the text contains no $, backtick, or " so nothing expands. ──
+MERCURY_CONTEXT="Mercury is a lightweight, modular multi-agent harness built on \
+Claude Code. It depends on the Claude Code CLI (npm @anthropic-ai/claude-code), \
+the Claude Agent SDK (npm @anthropic-ai/claude-agent-sdk), and the Anthropic \
+Messages API. Significant = a change that could break the harness, deprecate \
+something Mercury relies on, or offer a capability worth adopting. A routine \
+patch bump with no substantive changelog is NOT significant."
+
+SYSTEM_PROMPT="You are an external-intelligence triage assistant for the Mercury \
+project. You are given one or more detected upstream deltas (version bumps / \
+changelog hash changes). Judge whether the batch is worth a human-reviewed \
+GitHub issue. Respond with EXACTLY one JSON object and nothing else (no prose, \
+no markdown fences), with these keys: \
+\"significant\" (boolean), \
+\"priority\" (one of \"P1\",\"P2\",\"P3\"), \
+\"impact\" (one of \"blocking\",\"capability\",\"maintenance\",\"fyi\"), \
+\"summary\" (string, <=2 sentences), \
+\"suggested_action\" (string, <=2 sentences). \
+Be conservative: only mark significant=true when a human should look."
+
+# ── digest degradation ── append a record so a delta is NEVER lost when the LLM
+#    path can't produce a clean judgment or the Issue can't be created.
+append_digest() {
+  # $1 = reason, $2 = deltas JSON array
+  local reason deltas="$2" ts
+  # Keep the reason single-line: it can interpolate LLM-derived values (priority/
+  # impact) which, if poisoned with newlines, would otherwise inject extra lines
+  # into the digest markdown. The values stay inert (printf %s, never exec) — this
+  # only keeps the digest well-formed.
+  reason="$(printf '%s' "$1" | tr -d '\n\r')"
+  ts="$(TZ=UTC date +%Y-%m-%dT%H:%M:%SZ)"
+  [[ -n "$DIGEST_FILE" ]] || { printf 'intel-judge: %s (no --digest-file; %s deltas NOT persisted)\n' \
+        "$reason" "$(jq 'length' <<<"$deltas")" >&2; return 1; }
+  {
+    printf '## intel digest entry — %s\n\n' "$ts"
+    # `--` so a format string starting with '-' is not parsed as a printf option.
+    printf -- '- reason: %s\n' "$reason"
+    # Render deltas deterministically from the structured report (no LLM text).
+    jq -r '.[] | "- delta: \(.source) (\(.kind)) \(.old) -> \(.new) [\(.label)]"' <<<"$deltas"
+    printf '\n'
+  } >> "$DIGEST_FILE" \
+    || { printf 'intel-judge: failed to append digest %s\n' "$DIGEST_FILE" >&2; return 1; }
+  printf 'degraded to digest (%s): %s delta(s) recorded in %s\n' \
+    "$reason" "$(jq 'length' <<<"$deltas")" "$DIGEST_FILE"
+}
+
+# ── build the Anthropic request body via jq (escapes ALL injected text) ──
+build_request_body() {
+  # $1 = deltas JSON array; reads $CONTEXT_FILE if set.
+  local deltas="$1" delta_lines context=""
+  # Deterministic, structured delta summary — never raw LLM/command text.
+  delta_lines="$(jq -r '.[] | "- \(.source) (\(.kind)): \(.old) -> \(.new)"' <<<"$deltas")"
+  if [[ -n "$CONTEXT_FILE" ]]; then
+    context="$(cat "$CONTEXT_FILE")"
+  fi
+  local user_prompt
+  user_prompt="$(printf 'Mercury context:\n%s\n\nDetected deltas:\n%s\n' \
+                   "$MERCURY_CONTEXT" "$delta_lines")"
+  if [[ -n "$context" ]]; then
+    user_prompt="$(printf '%s\nRelevant changelog/release excerpt:\n%s\n' \
+                     "$user_prompt" "$context")"
+  fi
+  user_prompt="$(printf '%s\nReturn only the JSON object described in the system prompt.' \
+                   "$user_prompt")"
+  jq -n \
+    --arg model "$MODEL" \
+    --arg system "$SYSTEM_PROMPT" \
+    --arg user "$user_prompt" \
+    '{model:$model, max_tokens:1024, system:$system,
+      messages:[{role:"user", content:$user}]}'
+}
+
+# ── call the API with bounded exponential backoff. Returns the raw response body
+#    on a 2xx, non-zero otherwise. 4xx (except 429) is a client error and is NOT
+#    retried (it won't fix itself); 429/5xx/transport failures are retried. ──
+call_anthropic() {
+  local body_file="$1" attempt=1 delay="$RETRY_BASE_DELAY" key
+  key="${!API_KEY_ENV:-}"
+  [[ -n "$key" ]] || { printf 'intel-judge: env %s is empty (no API key)\n' "$API_KEY_ENV" >&2; return 1; }
+  while (( attempt <= MAX_RETRIES )); do
+    local resp http payload
+    # -w appends the HTTP status on its own trailing line; --data @file keeps the
+    # (already jq-escaped) body off the command line.
+    resp="$(curl -sS --max-time "$API_TIMEOUT" -X POST "$ANTHROPIC_API_URL" \
+              -H "x-api-key: $key" \
+              -H "anthropic-version: 2023-06-01" \
+              -H "content-type: application/json" \
+              --data @"$body_file" \
+              -w $'\n%{http_code}' 2>/dev/null)"
+    local curl_rc=$?
+    http="${resp##*$'\n'}"
+    payload="${resp%$'\n'*}"
+    if [[ $curl_rc -eq 0 && "$http" == 2* ]]; then
+      printf '%s' "$payload"; return 0
+    fi
+    if [[ $curl_rc -eq 0 && "$http" == 4* && "$http" != "429" ]]; then
+      printf 'intel-judge: Anthropic API client error HTTP %s (not retried)\n' "$http" >&2
+      return 1
+    fi
+    printf 'intel-judge: API attempt %s/%s failed (curl_rc=%s http=%s); retrying\n' \
+      "$attempt" "$MAX_RETRIES" "$curl_rc" "${http:-none}" >&2
+    (( attempt < MAX_RETRIES )) && [[ "$delay" != "0" ]] && sleep "$delay"
+    delay=$(( delay * 2 )); attempt=$(( attempt + 1 ))
+  done
+  printf 'intel-judge: Anthropic API exhausted %s attempts\n' "$MAX_RETRIES" >&2
+  return 1
+}
+
+# ── extract + validate the judgment JSON from an API response ──
+parse_judgment() {
+  # $1 = raw API response body → prints validated judgment JSON on stdout, or
+  # non-zero if the response can't be turned into a well-formed judgment.
+  local resp="$1" text judg
+  text="$(jq -r '.content[]? | select(.type=="text") | .text' 2>/dev/null <<<"$resp")" || return 1
+  [[ -n "$text" ]] || return 1
+  # Tolerate a model that wraps JSON in ```json fences despite instructions.
+  text="$(sed '/^[[:space:]]*```/d' <<<"$text")"
+  # Must be EXACTLY ONE JSON object with all required keys of the right type.
+  # Slurp (-s) so a multi-object stream or multi-text-block response (which jq -e
+  # would otherwise validate object-by-object and accept) becomes a length>1 array
+  # and is rejected → degrade, never a half-parsed judgment.
+  judg="$(jq -se '
+      if (length==1)
+         and (.[0]|type=="object")
+         and (.[0].significant|type=="boolean")
+         and (.[0].priority|type=="string")
+         and (.[0].impact|type=="string")
+         and (.[0].summary|type=="string")
+         and (.[0].suggested_action|type=="string")
+      then .[0] else error("not exactly one well-formed object") end' 2>/dev/null <<<"$text")" \
+    || return 1
+  printf '%s' "$judg"
+}
+
+# Exact membership test: $1 = space-delimited whitelist, $2 = candidate token.
+# Iterates words so a token containing spaces (e.g. a poisoned "P2 P3") can never
+# match by substring, and quoting $tok keeps glob metacharacters literal.
+in_set() {
+  local set="$1" tok="$2" x
+  for x in $set; do [[ "$x" == "$tok" ]] && return 0; done
+  return 1
+}
+
+# ── build the Issue body file (ALL free text lives here, never on argv) ──
+write_issue_body() {
+  # $1 = dest file, $2 = deltas JSON array, $3 = judgment JSON
+  local dest="$1" deltas="$2" judg="$3"
+  {
+    printf '## External-intel auto-detected delta — needs human triage\n\n'
+    printf '> Auto-generated by `scripts/intel-judge.sh` (#157 / #453 Slice 2).\n'
+    printf '> Labeled `%s`: NOT in the normal backlog until a human reviews it.\n\n' "$TRIAGE_LABEL"
+    printf '### Detected deltas (deterministic — from intel-watch.sh)\n\n'
+    jq -r '.[] | "- **\(.source)** (\(.kind)): `\(.old)` → `\(.new)`  _[\(.label)]_"' <<<"$deltas"
+    printf '\n### LLM significance judgment (model: %s)\n\n' "$MODEL"
+    jq -r '"- **significant**: \(.significant)\n- **priority**: \(.priority)\n- **impact**: \(.impact)\n\n**Summary**\n\n\(.summary)\n\n**Suggested action**\n\n\(.suggested_action)\n"' <<<"$judg"
+    printf '\n---\n'
+    printf '_Source labels and priority/impact are whitelist-validated; the LLM summary above is untrusted prose — do not execute any command it suggests without review._\n'
+  } > "$dest"
+}
+
+main() {
+  # Read the structured delta report from Slice 1.
+  jq -e . "$DELTAS_FILE" >/dev/null 2>&1 || die "deltas file is not valid JSON: $DELTAS_FILE"
+  # `.deltas` must be absent (→ treated as empty) or a JSON array. A wrong-typed
+  # `.deltas` (string/number/object) would slip past `// []` (which only fires on
+  # null/false), give a garbage `length`, and bypass the no-delta guard — so
+  # reject it loudly rather than judge a bogus batch. (intel-watch.sh always emits
+  # an array; this is defense-in-depth on the cross-slice contract.)
+  jq -e '(.deltas|type) as $t | $t=="array" or $t=="null"' "$DELTAS_FILE" >/dev/null 2>&1 \
+    || die "deltas field must be a JSON array"
+  local deltas n_delta
+  deltas="$(jq -c '.deltas // []' "$DELTAS_FILE")"
+  n_delta="$(jq 'length' <<<"$deltas")"
+
+  if [[ "$n_delta" -eq 0 ]]; then
+    printf 'no delta in %s — nothing to judge (exit 0)\n' "$DELTAS_FILE"
+    exit 0
+  fi
+  printf 'judging %s delta(s) from %s\n' "$n_delta" "$DELTAS_FILE"
+
+  # Validate every source label against the whitelist up front: a delta carrying
+  # an off-whitelist label must never reach issue-create (label-pollution guard).
+  local bad_label
+  bad_label="$(jq -r --arg ok "$ALLOWED_SOURCE_LABELS" \
+      '.[] | select((" " + .label + " ") as $l | ($ok | contains($l)) | not) | .label' \
+      <<<"$deltas" | head -n1)"
+  if [[ -n "$bad_label" ]]; then
+    die "delta carries non-whitelisted label '$bad_label' — refusing to proceed"
+  fi
+
+  # ── obtain the judgment: mock file (tests) or live API with retry ──
+  local api_resp
+  if [[ -n "$LLM_RESPONSE_FILE" ]]; then
+    [[ -f "$LLM_RESPONSE_FILE" ]] || die "llm-response file not found: $LLM_RESPONSE_FILE"
+    api_resp="$(cat "$LLM_RESPONSE_FILE")"
+  else
+    # Runtime temp/build failures degrade (delta preserved) rather than die: by
+    # this point a delta exists and must land somewhere, so a transient I/O fault
+    # must NOT exit 2 (which the contract reserves for startup/usage errors).
+    local body_tmp
+    if ! body_tmp="$(mktemp "${TMPDIR:-/tmp}/intel-judge-req.XXXXXX")"; then
+      append_digest "request-temp-create-failed" "$deltas" || exit 3
+      exit 0
+    fi
+    if ! build_request_body "$deltas" > "$body_tmp"; then
+      rm -f "$body_tmp"
+      append_digest "request-body-build-failed" "$deltas" || exit 3
+      exit 0
+    fi
+    if ! api_resp="$(call_anthropic "$body_tmp")"; then
+      rm -f "$body_tmp"
+      # API failed after retries → degrade (delta preserved in digest).
+      append_digest "anthropic-api-unavailable" "$deltas" || exit 3
+      exit 0
+    fi
+    rm -f "$body_tmp"
+  fi
+
+  # ── parse + validate; any malformation degrades to digest (never crash) ──
+  local judg
+  if ! judg="$(parse_judgment "$api_resp")"; then
+    append_digest "llm-response-unparseable" "$deltas" || exit 3
+    exit 0
+  fi
+
+  local significant priority impact
+  significant="$(jq -r '.significant' <<<"$judg")"
+  priority="$(jq -r '.priority' <<<"$judg")"
+  impact="$(jq -r '.impact' <<<"$judg")"
+
+  # priority/impact must be in the closed enums — a poisoned value degrades.
+  if ! in_set "$ALLOWED_PRIORITIES" "$priority"; then
+    append_digest "llm-priority-off-whitelist:$priority" "$deltas" || exit 3
+    exit 0
+  fi
+  if ! in_set "$ALLOWED_IMPACTS" "impact/$impact"; then
+    append_digest "llm-impact-off-whitelist:$impact" "$deltas" || exit 3
+    exit 0
+  fi
+
+  # ── significance gate (dedup layer 3 / ADR §5.2.3) ──
+  if [[ "$significant" != "true" ]] || ! in_set "$GATE_PRIORITIES" "$priority"; then
+    printf 'judged not actionable (significant=%s priority=%s) → digest, no Issue\n' \
+      "$significant" "$priority"
+    append_digest "below-significance-gate(significant=$significant,priority=$priority)" "$deltas" \
+      || exit 3
+    exit 0
+  fi
+
+  # ── significant + ≥P2 → build exactly one Issue (≤MAX_ISSUES) ──
+  if [[ "$MAX_ISSUES" -lt 1 ]]; then
+    printf 'significant batch but --max-issues=%s → digest instead of Issue\n' "$MAX_ISSUES"
+    append_digest "max-issues-cap-zero" "$deltas" || exit 3
+    exit 0
+  fi
+
+  # Labels: union of whitelisted source labels + validated priority + impact +
+  # triage. Built ONLY from whitelist-validated values — no LLM/external text.
+  local source_labels
+  source_labels="$(jq -r '[.[].label] | unique | .[]' <<<"$deltas")"
+  local -a label_args=()
+  local lbl
+  while IFS= read -r lbl; do
+    [[ -n "$lbl" ]] || continue
+    in_set "$ALLOWED_SOURCE_LABELS" "$lbl" || die "internal: label '$lbl' escaped whitelist check"
+    label_args+=(--label "$lbl")
+  done <<<"$source_labels"
+  label_args+=(--label "$priority")
+  label_args+=(--label "impact/$impact")
+  label_args+=(--label "$TRIAGE_LABEL")
+
+  # Deterministic title: fixed prefix + source-key list + delta count. The source
+  # keys originate from intel-watch.sh's fixed SOURCES whitelist (repo literals),
+  # and are passed as a single argv element — never concatenated into a command.
+  local title src_csv n_src plural=""
+  src_csv="$(jq -r '[.[].source] | unique | join(", ")' <<<"$deltas")"
+  n_src="$(jq -r '[.[].source] | unique | length' <<<"$deltas")"
+  [[ "$n_src" -gt 1 ]] && plural="s"
+  title="[intel] delta needs triage: ${src_csv} (${n_src} source${plural})"
+
+  local body_tmp
+  # Runtime temp failure degrades (delta preserved), not exit 2 — see the request
+  # temp note above; exit 2 is reserved for startup/usage errors.
+  if ! body_tmp="$(mktemp "${TMPDIR:-/tmp}/intel-judge-body.XXXXXX")"; then
+    append_digest "issue-body-temp-create-failed" "$deltas" || exit 3
+    exit 0
+  fi
+  write_issue_body "$body_tmp" "$deltas" "$judg" \
+    || { rm -f "$body_tmp"; append_digest "issue-body-write-failed" "$deltas" || exit 3; exit 0; }
+
+  if [[ "$CREATE_ISSUE" -ne 1 ]]; then
+    printf '(dry-run: would create 1 Issue; pass --create-issue to actually create)\n'
+    printf '  title : %s\n' "$title"
+    printf '  labels:'; printf ' %s' "${label_args[@]}"; printf '\n'
+    printf '  body  : %s (%s bytes)\n' "$body_tmp" "$(wc -c <"$body_tmp" | tr -d ' ')"
+    printf '  ---- body preview ----\n'
+    sed 's/^/  | /' "$body_tmp"
+    rm -f "$body_tmp"
+    exit 0
+  fi
+
+  # Real creation. body via --body-file (no inline body); title/labels passed as
+  # discrete argv elements (bash does not re-parse them as a command string).
+  # KNOWN RESIDUAL (PoC-acceptable): gh-create is treated as all-or-nothing. If gh
+  # ever exits non-zero AFTER the server already created the Issue, the delta is
+  # ALSO appended to the digest → double-landed. The ≤1-Issue/run cap bounds it to
+  # at most one duplicate, and Slice 3's cross-run open-Issue dedup (ADR §5.2
+  # layer 2) closes it for good. Not fixable inside one un-idempotent gh call here.
+  local -a repo_args=()
+  [[ -n "$REPO" ]] && repo_args=(--repo "$REPO")
+  if gh issue create "${repo_args[@]}" --title "$title" --body-file "$body_tmp" "${label_args[@]}" >/dev/null 2>&1; then
+    printf 'created 1 Issue: %s\n' "$title"
+    rm -f "$body_tmp"
+    exit 0
+  else
+    rm -f "$body_tmp"
+    # gh failed → degrade so the significant delta is not lost (ADR §7 step 4).
+    append_digest "gh-issue-create-failed" "$deltas" || exit 3
+    exit 0
+  fi
+}
+
+main

--- a/scripts/test-intel-judge.sh
+++ b/scripts/test-intel-judge.sh
@@ -295,6 +295,8 @@ cat > "$CURLBIN/curl" <<'STUB'
 # The startup probe (`curl --version`) must NOT count as an API attempt.
 if [[ "$1" == "--version" ]]; then echo "curl 8.0.0 (stub)"; exit 0; fi
 printf 'x\n' >> "$CURL_CALLS"
+# Capture argv (NUL-delimited) so a test can assert the API key never appears.
+[[ -n "${CURL_ARGV_LOG:-}" ]] && printf '%s\0' "$@" >> "$CURL_ARGV_LOG"
 printf '%s\n%s' "$CURL_STUB_BODY" "$CURL_STUB_CODE"
 exit 0
 STUB
@@ -335,9 +337,44 @@ if [[ "$CURL_STUB_OK" -eq 1 ]]; then
   assert_eq "exit 0 (degraded)" "0" "$rc"
   assert_eq "429 retried exactly MAX_RETRIES=3 times" "3" "$(wc -l < "$CURL_CALLS" | tr -d ' ')"
   assert_contains "digest notes API unavailable" "anthropic-api-unavailable" "$(cat "$DIG21")"
+
+  printf '\n[22] secret guard: API key never appears in curl argv (-H @file)\n'
+  : > "$CURL_CALLS"
+  ARGV22="$WORK_DIR/curl_argv22"; : > "$ARGV22"
+  DIG22="$WORK_DIR/digest22.md"
+  # 200 with a non-significant judgment → exercises the full live curl path then
+  # degrades to digest (no Issue). The key value is a sentinel we grep argv for.
+  out="$(ANTHROPIC_API_KEY="sk-secret-sentinel-DO-NOT-LEAK" \
+        CURL_STUB_BODY="$(mk_resp "$(mk_judgment false P3 maintenance "x" "y")")" CURL_STUB_CODE=200 \
+        CURL_CALLS="$CURL_CALLS" CURL_ARGV_LOG="$ARGV22" INTEL_JUDGE_RETRY_BASE_DELAY=0 \
+        PATH="$CURLBIN:$PATH" bash "$JUDGE" --deltas-file "$DELTAS" --digest-file "$DIG22" 2>&1)"; rc=$?
+  assert_eq "exit 0 (degraded, non-significant)" "0" "$rc"
+  argv22="$(tr '\0' ' ' < "$ARGV22")"
+  assert_not_contains "key value absent from curl argv" "sk-secret-sentinel-DO-NOT-LEAK" "$argv22"
+  assert_not_contains "x-api-key header absent from curl argv" "x-api-key" "$argv22"
+  assert_contains "curl reads headers from @file" "-H @" "$argv22"
 else
-  printf '\n[17-18,21] SKIP: curl stub not picked up on PATH (platform shim)\n'
+  printf '\n[17-18,21-22] SKIP: curl stub not picked up on PATH (platform shim)\n'
 fi
+
+# ── Scenarios 23-25: startup security guards (no curl/gh stub needed) ──
+printf '\n[23] SSRF guard: non-official API URL in live mode → exit 2\n'
+out="$(INTEL_ANTHROPIC_API_URL="https://evil.example/v1/messages" \
+      bash "$JUDGE" --deltas-file "$DELTAS" 2>&1)"; rc=$?
+assert_eq "exit 2 on custom live URL" "2" "$rc"
+assert_contains "names SSRF guard" "SSRF guard" "$out"
+
+printf '\n[24] non-integer numeric env → exit 2 (startup, not mid-run)\n'
+out="$(INTEL_JUDGE_MAX_RETRIES="abc" bash "$JUDGE" --deltas-file "$DELTAS" --llm-response-file "$R2" 2>&1)"; rc=$?
+assert_eq "exit 2 on bad MAX_RETRIES" "2" "$rc"
+assert_contains "names the var" "MAX_RETRIES" "$out"
+
+printf '\n[25] context-file outside the working tree → exit 2 (data-exfil guard)\n'
+OUTCTX="$(mktemp "${TMPDIR:-/tmp}/intel-outside-tree.XXXXXX")"; printf 'ctx\n' > "$OUTCTX"
+out="$(bash "$JUDGE" --deltas-file "$DELTAS" --llm-response-file "$R2" --context-file "$OUTCTX" 2>&1)"; rc=$?
+assert_eq "exit 2 on out-of-tree context" "2" "$rc"
+assert_contains "names the working-tree guard" "working tree" "$out"
+rm -f "$OUTCTX"
 
 # ── Summary ──
 printf '\n=== intel-judge tests: %s passed, %s failed ===\n' "$PASS" "$FAIL"

--- a/scripts/test-intel-judge.sh
+++ b/scripts/test-intel-judge.sh
@@ -1,0 +1,348 @@
+#!/usr/bin/env bash
+# Tests for scripts/intel-judge.sh — drive the LLM-judgment + guarded
+# issue-create slice WITHOUT a real API key or live GitHub:
+#   * --llm-response-file injects a mock Anthropic response (bypasses curl) to
+#     cover parse / significance-gate / whitelist / issue-create / degrade paths.
+#   * A fake `curl` on PATH exercises the retry→degrade path (HTTP 5xx/4xx).
+#   * A fake `gh` on PATH captures the exact argv + body-file of issue-create so
+#     the injection + label-whitelist guarantees can be asserted.
+#
+# Run: bash scripts/test-intel-judge.sh
+
+set -u  # not -e: each scenario inspects rc explicitly
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+JUDGE="$SCRIPT_DIR/intel-judge.sh"
+[[ -x "$JUDGE" ]] || { printf 'intel-judge.sh not executable: %s\n' "$JUDGE" >&2; exit 1; }
+# Active probe (not `command -v`): a present-but-unrunnable jq (e.g. a winget shim
+# without exec permission on MSYS) would otherwise fan out into dozens of
+# misleading scenario failures. Skip cleanly instead.
+jq -n null >/dev/null 2>&1 || { printf 'SKIP-ALL: jq not runnable\n'; exit 0; }
+
+PASS=0; FAIL=0
+declare -a FAILURES=()
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    PASS=$((PASS + 1)); printf '  ok %s\n' "$label"
+  else
+    FAIL=$((FAIL + 1)); FAILURES+=("$label: expected [$expected], got [$actual]")
+    printf '  FAIL %s -- expected [%s], got [%s]\n' "$label" "$expected" "$actual"
+  fi
+}
+assert_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    PASS=$((PASS + 1)); printf '  ok %s\n' "$label"
+  else
+    FAIL=$((FAIL + 1)); FAILURES+=("$label: missing [$needle]")
+    printf '  FAIL %s -- missing [%s]\n' "$label" "$needle"
+  fi
+}
+assert_not_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    PASS=$((PASS + 1)); printf '  ok %s\n' "$label"
+  else
+    FAIL=$((FAIL + 1)); FAILURES+=("$label: unexpected [$needle]")
+    printf '  FAIL %s -- unexpectedly present [%s]\n' "$label" "$needle"
+  fi
+}
+
+WORK_DIR="$(mktemp -d -t intel-judge-test.XXXXXX)" || { printf 'mktemp failed\n' >&2; exit 1; }
+trap '[[ -n "${WORK_DIR:-}" && -d "$WORK_DIR" ]] && rm -rf "$WORK_DIR"' EXIT
+
+run_judge() { bash "$JUDGE" "$@"; }
+
+# ── helpers: build a Slice-1-shaped delta report + a mock Anthropic response ──
+# Fixture writers hard-fail the suite on a jq error (rather than silently
+# producing an empty/garbage fixture that fans out into misleading assertions).
+fixture_fail() { printf 'FIXTURE-FAIL: %s\n' "$1" >&2; exit 1; }
+write_deltas() {
+  # $1 = dest, $2 = label (default intel/sdk)
+  local dest="$1" label="${2:-intel/sdk}"
+  jq -n --arg label "$label" '{
+    checked_at:"2026-05-26T00:00:00Z",
+    deltas:[{source:"npm:@anthropic-ai/claude-code", kind:"npm", label:$label, old:"2.1.150", new:"2.2.0"}],
+    seeded:[], unchanged:[], errors:[]}' > "$dest" || fixture_fail "write_deltas $dest"
+}
+write_no_deltas() {
+  jq -n '{checked_at:"2026-05-26T00:00:00Z", deltas:[], seeded:["x"], unchanged:[], errors:[]}' > "$1" \
+    || fixture_fail "write_no_deltas $1"
+}
+mk_judgment() { # $1=significant(bool) $2=priority $3=impact $4=summary $5=action
+  jq -nc --argjson sig "$1" --arg p "$2" --arg i "$3" --arg s "$4" --arg a "$5" \
+    '{significant:$sig, priority:$p, impact:$i, summary:$s, suggested_action:$a}'
+}
+mk_resp() { # $1 = inner text (judgment JSON, or anything) → Anthropic response shape
+  jq -n --arg t "$1" '{id:"msg_x", type:"message", role:"assistant",
+    content:[{type:"text", text:$t}], stop_reason:"end_turn"}'
+}
+
+DELTAS="$WORK_DIR/deltas.json";     write_deltas "$DELTAS"
+NODELTAS="$WORK_DIR/nodeltas.json"; write_no_deltas "$NODELTAS"
+
+# ── Scenario 1: no delta → exit 0, nothing judged ──
+printf '\n[1] no delta → exit 0, nothing to judge\n'
+out="$(run_judge --deltas-file "$NODELTAS" 2>&1)"; rc=$?
+assert_eq "exit 0" "0" "$rc"
+assert_contains "says nothing to judge" "nothing to judge" "$out"
+
+# ── Scenario 2: significant P2 → dry-run, 1 Issue preview, whitelist labels ──
+printf '\n[2] significant P2 → dry-run preview with whitelist labels\n'
+R2="$WORK_DIR/r2.json"; mk_resp "$(mk_judgment true P2 capability "major bump" "review changelog")" > "$R2"
+out="$(run_judge --deltas-file "$DELTAS" --llm-response-file "$R2" 2>&1)"; rc=$?
+assert_eq "exit 0" "0" "$rc"
+assert_contains "would create 1 Issue" "would create 1 Issue" "$out"
+assert_contains "source label" "--label intel/sdk" "$out"
+assert_contains "priority label" "--label P2" "$out"
+assert_contains "impact label" "--label impact/capability" "$out"
+assert_contains "triage label" "--label intel/needs-triage" "$out"
+assert_contains "title is deterministic" "[intel] delta needs triage:" "$out"
+
+# ── Scenario 3: significant P1 → gate passes too ──
+printf '\n[3] significant P1 → gate passes\n'
+R3="$WORK_DIR/r3.json"; mk_resp "$(mk_judgment true P1 blocking "breaking change" "pin version")" > "$R3"
+out="$(run_judge --deltas-file "$DELTAS" --llm-response-file "$R3" 2>&1)"; rc=$?
+assert_eq "exit 0" "0" "$rc"
+assert_contains "would create Issue" "would create 1 Issue" "$out"
+assert_contains "P1 label" "--label P1" "$out"
+
+# ── Scenario 4: not significant → digest, no Issue ──
+printf '\n[4] not significant → digest, no Issue\n'
+DIG4="$WORK_DIR/digest4.md"
+R4="$WORK_DIR/r4.json"; mk_resp "$(mk_judgment false P3 maintenance "routine patch" "none")" > "$R4"
+out="$(run_judge --deltas-file "$DELTAS" --llm-response-file "$R4" --digest-file "$DIG4" 2>&1)"; rc=$?
+assert_eq "exit 0" "0" "$rc"
+assert_not_contains "no Issue created" "would create 1 Issue" "$out"
+assert_contains "degraded to digest" "digest" "$out"
+assert_contains "digest file has delta" "npm:@anthropic-ai/claude-code" "$(cat "$DIG4")"
+
+# ── Scenario 5: significant but P3 → below gate (≥P2) → digest, no Issue ──
+printf '\n[5] significant + P3 → below significance gate → digest\n'
+DIG5="$WORK_DIR/digest5.md"
+R5="$WORK_DIR/r5.json"; mk_resp "$(mk_judgment true P3 fyi "minor" "fyi")" > "$R5"
+out="$(run_judge --deltas-file "$DELTAS" --llm-response-file "$R5" --digest-file "$DIG5" 2>&1)"; rc=$?
+assert_eq "exit 0" "0" "$rc"
+assert_not_contains "no Issue (P3 gated)" "would create 1 Issue" "$out"
+assert_contains "names the gate" "below-significance-gate" "$(cat "$DIG5")"
+
+# ── Scenario 6: off-whitelist priority → degrade to digest (label-injection guard) ──
+printf '\n[6] off-whitelist priority → degrade\n'
+DIG6="$WORK_DIR/digest6.md"
+R6="$WORK_DIR/r6.json"; mk_resp "$(mk_judgment true P9 capability "x" "y")" > "$R6"
+out="$(run_judge --deltas-file "$DELTAS" --llm-response-file "$R6" --digest-file "$DIG6" 2>&1)"; rc=$?
+assert_eq "exit 0" "0" "$rc"
+assert_not_contains "no Issue on bad priority" "would create 1 Issue" "$out"
+assert_contains "digest notes off-whitelist priority" "priority-off-whitelist" "$(cat "$DIG6")"
+
+# ── Scenario 7: off-whitelist impact → degrade ──
+printf '\n[7] off-whitelist impact → degrade\n'
+DIG7="$WORK_DIR/digest7.md"
+R7="$WORK_DIR/r7.json"; mk_resp "$(mk_judgment true P2 doomsday "x" "y")" > "$R7"
+out="$(run_judge --deltas-file "$DELTAS" --llm-response-file "$R7" --digest-file "$DIG7" 2>&1)"; rc=$?
+assert_eq "exit 0" "0" "$rc"
+assert_contains "digest notes off-whitelist impact" "impact-off-whitelist" "$(cat "$DIG7")"
+
+# ── Scenario 8: malformed (non-JSON) LLM text → degrade, never crash ──
+printf '\n[8] malformed LLM text → degrade to digest\n'
+DIG8="$WORK_DIR/digest8.md"
+R8="$WORK_DIR/r8.json"; mk_resp "I cannot answer in JSON, sorry." > "$R8"
+out="$(run_judge --deltas-file "$DELTAS" --llm-response-file "$R8" --digest-file "$DIG8" 2>&1)"; rc=$?
+assert_eq "exit 0" "0" "$rc"
+assert_contains "digest notes unparseable" "unparseable" "$(cat "$DIG8")"
+
+# ── Scenario 9: markdown-fenced JSON → tolerated, parses OK ──
+printf '\n[9] ```json-fenced response → parses\n'
+R9="$WORK_DIR/r9.json"
+fenced="$(printf '```json\n%s\n```' "$(mk_judgment true P2 capability "fenced" "act")")"
+mk_resp "$fenced" > "$R9"
+out="$(run_judge --deltas-file "$DELTAS" --llm-response-file "$R9" 2>&1)"; rc=$?
+assert_eq "exit 0" "0" "$rc"
+assert_contains "fenced JSON still creates Issue" "would create 1 Issue" "$out"
+
+# ── Scenario 10: INJECTION GUARD — shell metachars in summary stay inert text ──
+printf '\n[10] injection guard: shell metachars in summary are inert\n'
+SENTINEL="$WORK_DIR/PWNED"
+PAYLOAD='harmless then $('"touch $SENTINEL"') `'"touch $SENTINEL"'` ; rm -rf / #'
+R10="$WORK_DIR/r10.json"; mk_resp "$(mk_judgment true P2 capability "$PAYLOAD" "also $(printf '%s' '`id`')")" > "$R10"
+out="$(run_judge --deltas-file "$DELTAS" --llm-response-file "$R10" 2>&1)"; rc=$?
+assert_eq "exit 0" "0" "$rc"
+[[ -e "$SENTINEL" ]] && { FAIL=$((FAIL+1)); FAILURES+=("[10] injection executed: sentinel created"); printf '  FAIL injection executed\n'; } \
+  || { PASS=$((PASS+1)); printf '  ok no injection (sentinel absent)\n'; }
+assert_contains "payload preserved as literal text" 'rm -rf' "$out"
+
+# ── Scenario 11: off-whitelist source label in delta → refuse (exit 2) ──
+printf '\n[11] off-whitelist source label → exit 2\n'
+BADL="$WORK_DIR/bad-label.json"; write_deltas "$BADL" "intel/evil"
+R11="$WORK_DIR/r11.json"; mk_resp "$(mk_judgment true P2 capability "x" "y")" > "$R11"
+out="$(run_judge --deltas-file "$BADL" --llm-response-file "$R11" 2>&1)"; rc=$?
+assert_eq "exit 2 on bad label" "2" "$rc"
+assert_contains "names non-whitelisted label" "non-whitelisted label" "$out"
+
+# ── Scenario 12: --max-issues 0 → cap forces digest even when significant ──
+printf '\n[12] --max-issues 0 → digest instead of Issue\n'
+DIG12="$WORK_DIR/digest12.md"
+R12="$WORK_DIR/r12.json"; mk_resp "$(mk_judgment true P1 blocking "x" "y")" > "$R12"
+out="$(run_judge --deltas-file "$DELTAS" --llm-response-file "$R12" --digest-file "$DIG12" --max-issues 0 2>&1)"; rc=$?
+assert_eq "exit 0" "0" "$rc"
+assert_not_contains "cap blocks Issue" "would create 1 Issue" "$out"
+assert_contains "digest notes cap" "max-issues-cap-zero" "$(cat "$DIG12")"
+
+# ── Scenario 13: degrade with NO --digest-file → exit 3 (delta did not land) ──
+printf '\n[13] degrade with no digest-file → exit 3\n'
+R13="$WORK_DIR/r13.json"; mk_resp "$(mk_judgment false P3 maintenance "x" "y")" > "$R13"
+out="$(run_judge --deltas-file "$DELTAS" --llm-response-file "$R13" 2>&1)"; rc=$?
+assert_eq "exit 3 when delta cannot land" "3" "$rc"
+
+# ── Scenario 14: usage errors ──
+printf '\n[14] usage errors → exit 2\n'
+out="$(run_judge 2>&1)"; rc=$?
+assert_eq "missing --deltas-file → exit 2" "2" "$rc"
+assert_contains "explains requirement" "--deltas-file is required" "$out"
+out="$(run_judge --deltas-file "$WORK_DIR/nope.json" 2>&1)"; rc=$?
+assert_eq "missing file → exit 2" "2" "$rc"
+echo "{ not json" > "$WORK_DIR/badjson.json"
+out="$(run_judge --deltas-file "$WORK_DIR/badjson.json" 2>&1)"; rc=$?
+assert_eq "bad deltas JSON → exit 2" "2" "$rc"
+out="$(run_judge --deltas-file "$DELTAS" --max-issues abc 2>&1)"; rc=$?
+assert_eq "non-integer --max-issues → exit 2" "2" "$rc"
+
+# ── Scenario 19: multi-object / multi-text-block response → reject (degrade) ──
+# parse_judgment slurps, so two objects (length>1) must NOT validate as one.
+printf '\n[19] multi-text-block response → degrade, no Issue\n'
+DIG19="$WORK_DIR/digest19.md"
+R19="$WORK_DIR/r19.json"
+jq -n --arg t1 "$(mk_judgment true P1 blocking "first" "act1")" \
+      --arg t2 "$(mk_judgment false P3 fyi "second" "act2")" \
+   '{content:[{type:"text",text:$t1},{type:"text",text:$t2}]}' > "$R19"
+out="$(run_judge --deltas-file "$DELTAS" --llm-response-file "$R19" --digest-file "$DIG19" 2>&1)"; rc=$?
+assert_eq "exit 0" "0" "$rc"
+assert_not_contains "no Issue from multi-object" "would create 1 Issue" "$out"
+assert_contains "multi-object degrades as unparseable" "unparseable" "$(cat "$DIG19")"
+
+# ── Scenario 20: wrong-typed .deltas (not an array) → exit 2 ──
+printf '\n[20] non-array .deltas field → exit 2\n'
+echo '{"checked_at":"t","deltas":"not-an-array"}' > "$WORK_DIR/badtype.json"
+out="$(run_judge --deltas-file "$WORK_DIR/badtype.json" 2>&1)"; rc=$?
+assert_eq "exit 2 on non-array deltas" "2" "$rc"
+assert_contains "names the contract" "must be a JSON array" "$out"
+
+# ── Scenarios 15-16: fake `gh` on PATH → real issue-create argv/body capture.
+#    Probe first; skip cleanly if the shim is not picked up (platform PATH quirk). ──
+GHBIN="$WORK_DIR/ghbin"; mkdir -p "$GHBIN"
+cat > "$GHBIN/gh" <<'STUB'
+#!/usr/bin/env bash
+if [[ "$1" == "--version" ]]; then echo "gh 2.0.0 (stub)"; exit 0; fi   # startup probe
+if [[ "$1" == "issue" && "$2" == "create" ]]; then
+  printf '%s\0' "$@" > "$GH_ARGV_LOG"          # NUL-delimited argv (exact capture)
+  while [[ $# -gt 0 ]]; do
+    if [[ "$1" == "--body-file" ]]; then cp "$2" "$GH_BODY_COPY"; fi
+    shift
+  done
+  echo "https://github.com/owner/repo/issues/42"
+  exit 0
+fi
+echo "ghstub: unsupported: $*" >&2; exit 1
+STUB
+chmod +x "$GHBIN/gh"
+GH_STUB_OK=0
+if [[ "$(GH_ARGV_LOG=/dev/null PATH="$GHBIN:$PATH" gh issue create --title t 2>/dev/null)" == https://github.com/* ]]; then
+  GH_STUB_OK=1
+fi
+
+if [[ "$GH_STUB_OK" -eq 1 ]]; then
+  printf '\n[15] --create-issue: gh receives whitelist labels + --body-file (no inline body)\n'
+  R15="$WORK_DIR/r15.json"; mk_resp "$(mk_judgment true P2 capability "create me" "do x")" > "$R15"
+  GH_ARGV_LOG="$WORK_DIR/argv15"; GH_BODY_COPY="$WORK_DIR/body15.md"
+  out="$(GH_ARGV_LOG="$GH_ARGV_LOG" GH_BODY_COPY="$GH_BODY_COPY" PATH="$GHBIN:$PATH" \
+        bash "$JUDGE" --deltas-file "$DELTAS" --llm-response-file "$R15" --create-issue --repo owner/repo 2>&1)"; rc=$?
+  assert_eq "exit 0" "0" "$rc"
+  assert_contains "reports creation" "created 1 Issue" "$out"
+  argv="$(tr '\0' ' ' < "$GH_ARGV_LOG")"
+  assert_contains "argv has issue create" "issue create" "$argv"
+  assert_contains "argv passes --body-file" "--body-file" "$argv"
+  assert_contains "argv has source label" "--label intel/sdk" "$argv"
+  assert_contains "argv has priority label" "--label P2" "$argv"
+  assert_contains "argv has triage label" "--label intel/needs-triage" "$argv"
+  assert_contains "argv has repo" "--repo owner/repo" "$argv"
+  assert_not_contains "no inline --body flag" "--body " "$argv"
+  assert_contains "body file carries summary" "create me" "$(cat "$GH_BODY_COPY")"
+
+  printf '\n[16] --create-issue: gh failure degrades to digest (delta preserved)\n'
+  cat > "$GHBIN/gh" <<'STUB'
+#!/usr/bin/env bash
+if [[ "$1" == "--version" ]]; then echo "gh 2.0.0 (stub)"; exit 0; fi   # startup probe
+echo "simulated gh failure" >&2; exit 1
+STUB
+  chmod +x "$GHBIN/gh"
+  DIG16="$WORK_DIR/digest16.md"
+  R16="$WORK_DIR/r16.json"; mk_resp "$(mk_judgment true P2 capability "x" "y")" > "$R16"
+  out="$(PATH="$GHBIN:$PATH" bash "$JUDGE" --deltas-file "$DELTAS" --llm-response-file "$R16" \
+        --create-issue --digest-file "$DIG16" 2>&1)"; rc=$?
+  assert_eq "exit 0 (degraded, delta saved)" "0" "$rc"
+  assert_contains "digest notes gh failure" "gh-issue-create-failed" "$(cat "$DIG16")"
+else
+  printf '\n[15-16] SKIP: gh stub not picked up on PATH (platform shim)\n'
+fi
+
+# ── Scenarios 17-18: fake `curl` on PATH → retry→degrade path (no real API).
+#    The stub mimics curl -w by printing "<body>\n<http_code>". ──
+CURLBIN="$WORK_DIR/curlbin"; mkdir -p "$CURLBIN"
+CURL_CALLS="$WORK_DIR/curl_calls"
+cat > "$CURLBIN/curl" <<'STUB'
+#!/usr/bin/env bash
+# The startup probe (`curl --version`) must NOT count as an API attempt.
+if [[ "$1" == "--version" ]]; then echo "curl 8.0.0 (stub)"; exit 0; fi
+printf 'x\n' >> "$CURL_CALLS"
+printf '%s\n%s' "$CURL_STUB_BODY" "$CURL_STUB_CODE"
+exit 0
+STUB
+chmod +x "$CURLBIN/curl"
+CURL_STUB_OK=0
+probe="$(CURL_STUB_BODY='{}' CURL_STUB_CODE=503 CURL_CALLS=/dev/null PATH="$CURLBIN:$PATH" curl -sS x 2>/dev/null)"
+[[ "$probe" == *503* ]] && CURL_STUB_OK=1
+
+if [[ "$CURL_STUB_OK" -eq 1 ]]; then
+  printf '\n[17] API 5xx exhausts retries → degrade to digest (delta preserved)\n'
+  : > "$CURL_CALLS"
+  DIG17="$WORK_DIR/digest17.md"
+  out="$(ANTHROPIC_API_KEY="fake-key" CURL_STUB_BODY='{"error":"overloaded"}' CURL_STUB_CODE=503 \
+        CURL_CALLS="$CURL_CALLS" INTEL_JUDGE_RETRY_BASE_DELAY=0 INTEL_JUDGE_MAX_RETRIES=3 \
+        INTEL_ANTHROPIC_API_URL="https://api.anthropic.com/v1/messages" \
+        PATH="$CURLBIN:$PATH" bash "$JUDGE" --deltas-file "$DELTAS" --digest-file "$DIG17" 2>&1)"; rc=$?
+  assert_eq "exit 0 (degraded)" "0" "$rc"
+  assert_eq "retried exactly MAX_RETRIES=3 times" "3" "$(wc -l < "$CURL_CALLS" | tr -d ' ')"
+  assert_contains "digest notes API unavailable" "anthropic-api-unavailable" "$(cat "$DIG17")"
+
+  printf '\n[18] API 400 (client error) → no retry, degrade once\n'
+  : > "$CURL_CALLS"
+  DIG18="$WORK_DIR/digest18.md"
+  out="$(ANTHROPIC_API_KEY="fake-key" CURL_STUB_BODY='{"error":"bad request"}' CURL_STUB_CODE=400 \
+        CURL_CALLS="$CURL_CALLS" INTEL_JUDGE_RETRY_BASE_DELAY=0 INTEL_JUDGE_MAX_RETRIES=3 \
+        INTEL_ANTHROPIC_API_URL="https://api.anthropic.com/v1/messages" \
+        PATH="$CURLBIN:$PATH" bash "$JUDGE" --deltas-file "$DELTAS" --digest-file "$DIG18" 2>&1)"; rc=$?
+  assert_eq "exit 0 (degraded)" "0" "$rc"
+  assert_eq "4xx not retried (1 call only)" "1" "$(wc -l < "$CURL_CALLS" | tr -d ' ')"
+
+  printf '\n[21] API 429 (rate limit) → IS retried (like 5xx) then degrade\n'
+  : > "$CURL_CALLS"
+  DIG21="$WORK_DIR/digest21.md"
+  out="$(ANTHROPIC_API_KEY="fake-key" CURL_STUB_BODY='{"error":"rate_limited"}' CURL_STUB_CODE=429 \
+        CURL_CALLS="$CURL_CALLS" INTEL_JUDGE_RETRY_BASE_DELAY=0 INTEL_JUDGE_MAX_RETRIES=3 \
+        INTEL_ANTHROPIC_API_URL="https://api.anthropic.com/v1/messages" \
+        PATH="$CURLBIN:$PATH" bash "$JUDGE" --deltas-file "$DELTAS" --digest-file "$DIG21" 2>&1)"; rc=$?
+  assert_eq "exit 0 (degraded)" "0" "$rc"
+  assert_eq "429 retried exactly MAX_RETRIES=3 times" "3" "$(wc -l < "$CURL_CALLS" | tr -d ' ')"
+  assert_contains "digest notes API unavailable" "anthropic-api-unavailable" "$(cat "$DIG21")"
+else
+  printf '\n[17-18,21] SKIP: curl stub not picked up on PATH (platform shim)\n'
+fi
+
+# ── Summary ──
+printf '\n=== intel-judge tests: %s passed, %s failed ===\n' "$PASS" "$FAIL"
+if [[ "$FAIL" -gt 0 ]]; then
+  printf 'Failures:\n'; for f in "${FAILURES[@]}"; do printf '  - %s\n' "$f"; done
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Phase 2 PoC for #157 (External Information Update Agent), **Slice 2** of #453. Builds on the merged Slice 1 collector (`scripts/intel-watch.sh`): consumes its `--json-out` delta report, makes **one** Anthropic Messages API call (curl direct) to judge significance, then behind hard guardrails either opens **exactly one** `intel/needs-triage` Issue or degrades the batch to a digest.

`Refs #157` — single slice; **does NOT close #453** (Slice 3 GHA wiring still pending). #157 stays OPEN as the design issue.

### What's in this slice

- **`scripts/intel-judge.sh`** (Mercury-internal tooling under `scripts/` — exempt from the 200-LOC adapter cap per CLAUDE.md carve-out):
  - Single Anthropic Messages API call, **only when a delta exists** (no delta → no call, exit 0).
  - **Significance gate**: build an Issue only when `significant==true` AND priority ≥ P2 ({P1,P2}); P3 / non-significant → digest, no Issue.
  - **Guarded `gh issue create`**: source-label looked up from a fixed whitelist (`intel/sdk`/`intel/api-docs`/`intel/oss`); priority/impact validated against closed enums; body via `--body-file` (never inline); ≤1 Issue/run cap.
  - **Injection guard (first-class)**: LLM output + external release-note text reach `gh`/shell *only* via `jq --arg` (API body) and `--body-file` (Issue body); labels strictly whitelist-validated; a poisoned LLM priority/impact is rejected (degrade), never injected as a label. Verified with an active `$(...)`/backtick/`;rm` payload — stays inert text.
  - **Error degradation**: API timeout/5xx/429 → bounded exponential-backoff retry → degrade to digest while **preserving the delta** (never drop or double-report); 4xx-non-429 not retried; `gh`-create failure also degrades. Exit-code contract: `0`=delta landed (caller may persist intel-watch state), `2`=startup/usage error, `3`=delta did NOT land (caller must NOT persist).
- **`scripts/test-intel-judge.sh`**: 67 mock-driven tests (no API key, no live `gh`/network) — parse / significance gate / whitelist rejection / issue-create argv + `--body-file` / retry (5xx, 429, 4xx) / degrade / injection guard / exit-code contract.

### Research (MANDATORY RESEARCH PROTOCOL)

Anthropic Messages API web-verified **2026-05-26** against the official docs — `POST https://api.anthropic.com/v1/messages`, headers `x-api-key` + `anthropic-version: 2023-06-01` + `content-type`, body `{model,max_tokens,system?,messages:[{role,content}]}`, response text in `content[].text`, model `claude-haiku-4-5`. Source: https://platform.claude.com/docs/en/api/messages + https://platform.claude.com/docs/en/about-claude/models/overview

### dual-verify (pre-commit gate)

Ran **all three** reviewers in parallel:
- **Claude critic**: ACCEPT-WITH-RESERVATIONS — all 6 acceptance criteria PASS; reservations (`.deltas` array-type guard) addressed.
- **Claude code-reviewer**: approve-with-suggestions, no CRITICAL/HIGH; injection guard empirically verified; MEDIUM items (`parse_judgment` single-object enforcement, `.source` title-comment accuracy) addressed.
- **Codex code-audit** (codex-cli 0.129.0 — **available this session**, contrary to the prior handoff's "UNAVAILABLE" note): no CRITICAL/HIGH, no command-injection bypass found. All 3 findings addressed: active dependency probes (not just `command -v`) so a present-but-unrunnable tool fails fast as a startup error instead of muddying the exit-code contract; runtime temp/build failures degrade instead of exit-2; added a 429 retry test. Known residual (PoC-acceptable, documented in-code): `gh issue create` is un-idempotent — Slice 3's cross-run open-Issue dedup (ADR §5.2 layer 2) closes the double-land window.

## Test plan

- [x] `bash scripts/test-intel-judge.sh` → **67 passed, 0 failed**
- [x] `bash -n` syntax check both files
- [x] Injection payload (`$(touch …)`, backticks, `;rm -rf`) in LLM summary stays inert text
- [x] git index EOL = LF (GHA ubuntu checkout safe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)