### PR TITLE
feat(#453): Slice 3 — external-intel GHA workflow wiring + cross-run dedup

### DIFF
--- a/.github/workflows/external-intel.yml
+++ b/.github/workflows/external-intel.yml
@@ -1,0 +1,197 @@
+name: external-intel
+
+# Weekly external-intelligence watch (Issue #157 / #453 — Phase 2 PoC, Slice 3).
+#
+# Orchestrates the two Mercury-internal scripts into a scheduled GitHub Actions job:
+#   1. scripts/intel-watch.sh  — deterministic collector: fetches the watched
+#      sources (2 npm dist-tags + Claude Code CHANGELOG hash), diffs against the
+#      pinned state Issue, emits a delta report (Slice 1).
+#   2. scripts/intel-judge.sh  — one Anthropic API call judges significance, then
+#      behind guardrails files exactly one `intel/needs-triage` Issue or degrades
+#      to a digest; --dedup skips re-filing a batch already covered by an open
+#      Issue (Slice 2 + the Slice 3 cross-run dedup).
+#
+# Design authority: .mercury/docs/research/issue-157-external-info-agent-2026-05.md
+#   §5.2 (state mechanism c + dedup), §7 Phase 2 step 1-6.
+#
+# Fully detachable (DIRECTION.md modular design): delete this file + the two scripts
+# and the feature is gone. The auto-created state Issue and the intel/* + impact/*
+# labels are then harmless orphans (close / delete by hand if desired).
+#
+# One-time operator setup (environment config, intentionally NOT in the repo):
+#   * Repo secret ANTHROPIC_API_KEY (a real key). If unset, the judge step degrades
+#     every delta into the digest (no Issue filed) — safe, just no triage Issues.
+#   * Nothing else. The pinned state Issue is auto-created on first run (found by the
+#     intel/state label thereafter); the intel/* + impact/* labels are ensured
+#     idempotently at the top of every run.
+
+on:
+  schedule:
+    # Weekly, Monday 09:23 UTC. cron is always UTC. The off-the-hour minute (:23,
+    # not :00) follows GitHub's guidance that jobs scheduled on the hour are the
+    # most delayed/dropped under high load.
+    - cron: '23 9 * * 1'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Detect + judge but do NOT create an Issue or persist state'
+        required: false
+        type: boolean
+        default: false
+
+# Minimal GITHUB_TOKEN scopes: create/edit/list Issues (issues:write) + checkout
+# the scripts (contents:read). No PAT required.
+permissions:
+  contents: read
+  issues: write
+
+# Serialize scheduled vs manual runs so two runs never read-modify-write the shared
+# state Issue at once. cancel-in-progress:false → a new trigger queues behind an
+# in-flight run rather than cancelling it mid-state-write.
+concurrency:
+  group: external-intel
+  cancel-in-progress: false
+
+jobs:
+  watch:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      # gh CLI (preinstalled on ubuntu-latest) authenticates from GH_TOKEN.
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+    steps:
+      - name: Checkout (intel scripts must be on disk)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Ensure intel/* + impact/* labels exist (idempotent)
+        run: |
+          set -euo pipefail
+          # gh label create --force is an idempotent upsert (creates, or updates
+          # color/description if the label already exists). Keeps the module
+          # self-bootstrapping on a fresh clone without an out-of-band setup step.
+          ensure() { gh label create "$1" --repo "$REPO" --color "$2" --description "$3" --force >/dev/null; }
+          ensure "intel/sdk"          "1d76db" "External intel: SDK/CLI change (Claude Code, Agent SDK)"
+          ensure "intel/api-docs"     "1d76db" "External intel: Anthropic API / docs change"
+          ensure "intel/oss"          "1d76db" "External intel: referenced OSS project change"
+          ensure "intel/needs-triage" "fbca04" "Auto-created intel Issue awaiting human triage (kept out of normal backlog)"
+          ensure "intel/state"        "ededed" "Auto-managed intel-watch state tracking Issue (do not triage)"
+          ensure "impact/blocking"    "b60205" "Intel impact: conflicts with / breaks existing Mercury functionality"
+          ensure "impact/capability"  "0e8a16" "Intel impact: new capability worth adopting"
+          ensure "impact/maintenance" "c5def5" "Intel impact: routine bump / maintenance"
+          ensure "impact/fyi"         "ededed" "Intel impact: informational only"
+
+      - name: Find or create the pinned state Issue
+        id: state
+        run: |
+          set -euo pipefail
+          # KNOWN RESIDUAL: find-or-create is not atomic. The workflow-level
+          # `concurrency` group (no ref → all scheduled + dispatch runs serialize,
+          # cancel-in-progress:false → queue) is the guard: two runs never reach this
+          # step at once, so they can't both create a state Issue. If a stray second
+          # intel/state Issue ever appears, runs deterministically pick `.[0]` (oldest
+          # open) — close the extra by hand. Do NOT close the state Issue during
+          # triage: a fresh one would re-seed (all SEEDED, zero deltas) → one blind run.
+          num="$(gh issue list --repo "$REPO" --label intel/state --state open --limit 1 \
+                   --json number --jq '.[0].number // empty')"
+          if [ -z "$num" ]; then
+            url="$(gh issue create --repo "$REPO" --label intel/state \
+                     --title '🛰️ Intel-Watch State (auto-managed — do not edit)' \
+                     --body 'Auto-managed state store for the external-intel agent (#157 / #453). The body below is rewritten atomically each run by scripts/intel-watch.sh — manual edits are overwritten.')"
+            num="${url##*/}"
+            echo "Created state Issue #$num"
+          else
+            echo "Reusing state Issue #$num"
+          fi
+          echo "issue=$num" >> "$GITHUB_OUTPUT"
+
+      - name: Detect deltas
+        id: detect
+        run: |
+          # GHA's default shell is `bash -eo pipefail` (set -e IS active). We capture
+          # intel-watch's exit code with `|| rc=$?` so its non-zero exits drive the
+          # orchestration below instead of aborting the step. The later bare `jq` is
+          # intentionally left under -e: a malformed deltas.json should fail the run.
+          rc=0
+          bash scripts/intel-watch.sh --state-issue "${{ steps.state.outputs.issue }}" \
+            --json-out deltas.json || rc=$?
+          echo "watch_rc=$rc" >> "$GITHUB_OUTPUT"
+          # rc 0 = clean; rc 1 = a source fetch errored (errored sources keep their
+          # prior fingerprint — safe, just judge whatever else changed); rc 2 = usage,
+          # rc 3 = state-read / json-out write failure → abort (don't judge a bogus batch).
+          if [ "$rc" -ge 2 ]; then
+            echo "::error::intel-watch failed (rc=$rc)"; exit "$rc"
+          fi
+          n="$(jq '.deltas | length' deltas.json)"
+          echo "n_delta=$n" >> "$GITHUB_OUTPUT"
+          echo "Detected $n delta(s) (watch rc=$rc)"
+
+      - name: Judge significance + guarded issue-create
+        id: judge
+        # Explicit success gate: detect aborts the job on rc>=2 anyway (no
+        # continue-on-error), but the outcome check documents the dependency and is
+        # robust if a future edit makes detect tolerant.
+        if: steps.detect.outcome == 'success' && steps.detect.outputs.n_delta != '0'
+        timeout-minutes: 10
+        env:
+          # Injected as an env var (never an argv); auto-masked in logs. Empty when
+          # the secret is unset → intel-judge degrades the batch to the digest.
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          rc=0
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            # Dry run: judge + preview only, no Issue, no dedup query, no state change.
+            bash scripts/intel-judge.sh --deltas-file deltas.json \
+              --repo "$REPO" --digest-file intel-digest.md || rc=$?
+          else
+            bash scripts/intel-judge.sh --deltas-file deltas.json \
+              --create-issue --dedup --repo "$REPO" --digest-file intel-digest.md || rc=$?
+          fi
+          echo "judge_rc=$rc" >> "$GITHUB_OUTPUT"
+          # 0 = batch landed (Issue created / deduped / digested / non-significant) →
+          #     state may be persisted; 2 = usage error → abort; 3 = batch did NOT
+          #     land (e.g. digest write failed) → do NOT persist, retry whole batch.
+          if [ "$rc" = "2" ]; then echo "::error::intel-judge usage error"; exit 2; fi
+          echo "judge rc=$rc"
+
+      - name: Persist intel-watch state (unless a delta failed to land)
+        # Commit when not a dry run AND detect was clean (watch_rc == 0) AND either
+        # there were no deltas (persist the seed / steady state so the dedup gate stays
+        # warm) or the judge landed the batch (rc 0). Skip when a delta did NOT land
+        # (judge rc 3) so it is retried whole next run.
+        #
+        # The watch_rc == 0 requirement is load-bearing: if detect had a fetch error
+        # (rc 1), the errored source was NOT judged, yet `--commit` here RE-FETCHES and
+        # could now succeed for it and write its new fingerprint into state — silently
+        # absorbing an unjudged delta. So when any source errored on detect, defer the
+        # whole persist to a future run with a clean fetch (the already-judged deltas
+        # are re-detected then, and --dedup stops them re-filing). NOTE: even on a clean
+        # detect, --commit re-fetches; a version that moves again in the seconds between
+        # detect and commit is absorbed un-judged — negligible at weekly cadence.
+        if: >-
+          inputs.dry_run != true &&
+          steps.detect.outputs.watch_rc == '0' &&
+          (steps.detect.outputs.n_delta == '0' || steps.judge.outputs.judge_rc == '0')
+        run: |
+          rc=0
+          bash scripts/intel-watch.sh --state-issue "${{ steps.state.outputs.issue }}" \
+            --commit || rc=$?
+          # rc 1 = a source errored on the commit re-fetch (errored sources retain
+          # their prior fingerprint and state was still written) → tolerate. rc >= 2
+          # = the state write genuinely failed → fail so next run retries.
+          if [ "$rc" -ge 2 ]; then echo "::error::state commit failed (rc=$rc)"; exit "$rc"; fi
+          echo "state committed (rc=$rc)"
+
+      - name: Surface digest in the run summary (if any deltas degraded)
+        if: always()
+        run: |
+          if [ -s intel-digest.md ]; then
+            {
+              echo "## external-intel digest (degraded / non-significant deltas)"
+              echo
+              cat intel-digest.md
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "digest surfaced to run summary"
+          else
+            echo "no digest this run"
+          fi

--- a/.github/workflows/external-intel.yml
+++ b/.github/workflows/external-intel.yml
@@ -5,7 +5,7 @@ name: external-intel
 # Orchestrates the two Mercury-internal scripts into a scheduled GitHub Actions job:
 #   1. scripts/intel-watch.sh  — deterministic collector: fetches the watched
 #      sources (2 npm dist-tags + Claude Code CHANGELOG hash), diffs against the
-#      pinned state Issue, emits a delta report (Slice 1).
+#      tracking state Issue, emits a delta report (Slice 1).
 #   2. scripts/intel-judge.sh  — one Anthropic API call judges significance, then
 #      behind guardrails files exactly one `intel/needs-triage` Issue or degrades
 #      to a digest; --dedup skips re-filing a batch already covered by an open
@@ -21,7 +21,7 @@ name: external-intel
 # One-time operator setup (environment config, intentionally NOT in the repo):
 #   * Repo secret ANTHROPIC_API_KEY (a real key). If unset, the judge step degrades
 #     every delta into the digest (no Issue filed) — safe, just no triage Issues.
-#   * Nothing else. The pinned state Issue is auto-created on first run (found by the
+#   * Nothing else. The tracking state Issue is auto-created on first run (found by the
 #     intel/state label thereafter); the intel/* + impact/* labels are ensured
 #     idempotently at the top of every run.
 
@@ -81,11 +81,11 @@ jobs:
           ensure "impact/maintenance" "c5def5" "Intel impact: routine bump / maintenance"
           ensure "impact/fyi"         "ededed" "Intel impact: informational only"
 
-      - name: Find or create the pinned state Issue
+      - name: Find or create the tracking state Issue
         id: state
         run: |
           set -euo pipefail
-          # find-or-create the pinned state Issue. The workflow `concurrency` group
+          # find-or-create the tracking state Issue. The workflow `concurrency` group
           # (no ref → all scheduled + dispatch runs serialize; cancel-in-progress:false
           # → queue) means two runs never reach this step at once, so they can't both
           # create one. As defense-in-depth against a stray duplicate (e.g. a manually
@@ -154,10 +154,15 @@ jobs:
               --create-issue --dedup --repo "$REPO" --digest-file intel-digest.md || rc=$?
           fi
           echo "judge_rc=$rc" >> "$GITHUB_OUTPUT"
-          # 0 = batch landed (Issue created / deduped / digested / non-significant) →
-          #     state may be persisted; 2 = usage error → abort; 3 = batch did NOT
-          #     land (e.g. digest write failed) → do NOT persist, retry whole batch.
-          if [ "$rc" = "2" ]; then echo "::error::intel-judge usage error"; exit 2; fi
+          # Contract: 0 = batch landed (Issue created / deduped / digested /
+          #   non-significant) → state may be persisted; 3 = batch did NOT land (digest
+          #   write failed, or dedup deferred) → do NOT persist, retry whole batch next
+          #   run. ANY other code (2 = usage; or an unexpected 1 / 127 / … from a bug,
+          #   missing script, or interpreter fault) is fatal → fail the run so the
+          #   anomaly surfaces rather than silently skipping persist.
+          if [ "$rc" != "0" ] && [ "$rc" != "3" ]; then
+            echo "::error::intel-judge exited with unexpected/contract-fatal code $rc"; exit "$rc"
+          fi
           echo "judge rc=$rc"
 
       - name: Persist intel-watch state (unless a delta failed to land)

--- a/.github/workflows/external-intel.yml
+++ b/.github/workflows/external-intel.yml
@@ -85,15 +85,21 @@ jobs:
         id: state
         run: |
           set -euo pipefail
-          # KNOWN RESIDUAL: find-or-create is not atomic. The workflow-level
-          # `concurrency` group (no ref → all scheduled + dispatch runs serialize,
-          # cancel-in-progress:false → queue) is the guard: two runs never reach this
-          # step at once, so they can't both create a state Issue. If a stray second
-          # intel/state Issue ever appears, runs deterministically pick `.[0]` (oldest
-          # open) — close the extra by hand. Do NOT close the state Issue during
-          # triage: a fresh one would re-seed (all SEEDED, zero deltas) → one blind run.
-          num="$(gh issue list --repo "$REPO" --label intel/state --state open --limit 1 \
-                   --json number --jq '.[0].number // empty')"
+          # find-or-create the pinned state Issue. The workflow `concurrency` group
+          # (no ref → all scheduled + dispatch runs serialize; cancel-in-progress:false
+          # → queue) means two runs never reach this step at once, so they can't both
+          # create one. As defense-in-depth against a stray duplicate (e.g. a manually
+          # created intel/state Issue), select DETERMINISTICALLY by lowest issue number
+          # and warn if more than one open intel/state Issue exists — do not rely on
+          # gh's default ordering. Do NOT close the state Issue during triage: a fresh
+          # one would re-seed (all SEEDED, zero deltas) → one blind run.
+          state_json="$(gh issue list --repo "$REPO" --label intel/state --state open \
+                          --limit 100 --json number)"
+          count="$(printf '%s' "$state_json" | jq 'length')"
+          if [ "$count" -gt 1 ]; then
+            echo "::warning::multiple open intel/state Issues ($(printf '%s' "$state_json" | jq -c '[.[].number]')); using the lowest-numbered. Close the extras to keep state single-sourced."
+          fi
+          num="$(printf '%s' "$state_json" | jq -r 'sort_by(.number) | .[0].number // empty')"
           if [ -z "$num" ]; then
             url="$(gh issue create --repo "$REPO" --label intel/state \
                      --title '🛰️ Intel-Watch State (auto-managed — do not edit)' \
@@ -101,7 +107,7 @@ jobs:
             num="${url##*/}"
             echo "Created state Issue #$num"
           else
-            echo "Reusing state Issue #$num"
+            echo "Reusing state Issue #$num (lowest of $count open)"
           fi
           echo "issue=$num" >> "$GITHUB_OUTPUT"
 

--- a/scripts/intel-judge.sh
+++ b/scripts/intel-judge.sh
@@ -352,8 +352,9 @@ in_set() {
 }
 
 # ── stable delta signature for cross-run dedup (ADR §5.2 layer 2) ──
-# sha256 over the sorted "source<TAB>old<TAB>new" triples, truncated to 16 hex. The
-# key identifies the specific TRANSITION (old→new), not just the resulting version:
+# sha256 over the sorted, compact-JSON-encoded [source, old, new] triples (one
+# JSON array per delta), truncated to 16 hex. The key identifies the specific
+# TRANSITION (old→new), not just the resulting version:
 #   * Re-detection of an un-persisted batch (Issue created but state-commit then
 #     failed → intel-watch re-emits the SAME old→new next run) reproduces the same
 #     key and matches the marker in the open Issue → skipped. Cross-run dedup intact.

--- a/scripts/intel-judge.sh
+++ b/scripts/intel-judge.sh
@@ -45,14 +45,17 @@
 #   bash scripts/intel-judge.sh --deltas-file deltas.json
 #   # really create the Issue (Slice 3 / GHA wires this on the significant path)
 #   bash scripts/intel-judge.sh --deltas-file deltas.json --create-issue --repo owner/name
+#   # with cross-run open-Issue dedup (Slice 3 / GHA passes this; needs --repo)
+#   bash scripts/intel-judge.sh --deltas-file deltas.json --create-issue --dedup --repo owner/name
 #   # degrade target for non-significant / error batches
 #   bash scripts/intel-judge.sh --deltas-file deltas.json --digest-file digest.md
 #   # TEST HOOK: inject a mock API response (no key, no network)
 #   bash scripts/intel-judge.sh --deltas-file deltas.json --llm-response-file mock.json
 #
 # Exit codes (contract for the Slice 3 orchestrator):
-#   0  deltas landed (Issue created / dry-run previewed / written to digest /
-#      judged non-significant) → caller MAY now persist intel-watch state.
+#   0  deltas landed (Issue created / deduped against an existing open Issue /
+#      dry-run previewed / written to digest / judged non-significant) → caller MAY
+#      now persist intel-watch state.
 #   2  usage error (bad/missing args) → nothing happened.
 #   3  delta did NOT land (e.g. digest write failed) → caller MUST NOT persist
 #      state, so the batch is retried whole next run (never silently dropped).
@@ -65,6 +68,7 @@ CONTEXT_FILE=""                 # optional extra context (e.g. changelog excerpt
                                 #   orchestrator-fed; only ever enters the API body
 DIGEST_FILE=""                  # where non-significant / degraded batches are recorded
 CREATE_ISSUE=0                  # default dry-run; --create-issue actually calls gh
+DEDUP=0                         # --dedup: cross-run open-Issue dedup (ADR §5.2 layer 2)
 REPO=""                         # owner/name for `gh issue create --repo`
 MAX_ISSUES=1                    # PoC hard cap: only 0 (force-digest) vs ≥1 (one
                                 #   Issue for the whole batch) are meaningful this
@@ -101,6 +105,7 @@ while [[ $# -gt 0 ]]; do
     --max-issues)        need_val "$@"; MAX_ISSUES="$2"; shift 2 ;;
     --llm-response-file) need_val "$@"; LLM_RESPONSE_FILE="$2"; shift 2 ;;
     --create-issue)      CREATE_ISSUE=1; shift ;;
+    --dedup)             DEDUP=1; shift ;;
     -h|--help)           sed -n '2,55p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
     *)                   die "unknown argument: $1" ;;
   esac
@@ -109,6 +114,9 @@ done
 [[ -n "$DELTAS_FILE" ]] || die "--deltas-file is required"
 [[ -f "$DELTAS_FILE" ]] || die "deltas file not found: $DELTAS_FILE"
 [[ "$MAX_ISSUES" =~ ^[0-9]+$ ]] || die "--max-issues must be a non-negative integer"
+# --dedup needs an explicit repo (the open-Issue query target must be unambiguous,
+# never inferred from cwd) so the cross-run dedup query is deterministic + testable.
+[[ "$DEDUP" -eq 0 || -n "$REPO" ]] || die "--dedup requires --repo"
 # Active dependency probes (not just `command -v`): on MSYS a tool can be present
 # on PATH yet fail to execute (e.g. a winget shim without exec permission). Probe
 # that each tool actually RUNS, so a broken interpreter fails fast here as a
@@ -125,6 +133,13 @@ done
 [[ "$API_TIMEOUT" -ge 1 ]] || die "INTEL_JUDGE_API_TIMEOUT must be >= 1 (got: $API_TIMEOUT)"
 
 jq -n null >/dev/null 2>&1 || die "jq is required and must be runnable"
+# --dedup derives a delta signature via a sha256 helper (mirrors intel-watch.sh);
+# require one up front (startup config error) so the marker can always be embedded
+# and matched. GHA ubuntu always ships sha256sum.
+if [[ "$DEDUP" -eq 1 ]]; then
+  command -v sha256sum >/dev/null 2>&1 || command -v shasum >/dev/null 2>&1 || command -v openssl >/dev/null 2>&1 \
+    || die "--dedup needs one of: sha256sum / shasum / openssl (for the delta signature)"
+fi
 if [[ -z "$LLM_RESPONSE_FILE" ]]; then
   # SSRF / credential-exfil guard: in live mode the API key is sent to
   # $ANTHROPIC_API_URL, so refuse any non-official override. Tests bypass the
@@ -151,7 +166,20 @@ if [[ -n "$CONTEXT_FILE" ]]; then
   [[ -r "$CONTEXT_FILE" ]] || die "context file not readable: $CONTEXT_FILE"
   [[ ! -L "$CONTEXT_FILE" ]] || die "context file must not be a symlink (data-exfil guard): $CONTEXT_FILE"
   _ctx_real="$(realpath "$CONTEXT_FILE" 2>/dev/null)" || die "cannot resolve context file path: $CONTEXT_FILE"
-  [[ "$_ctx_real" == "$(pwd -P)/"* ]] \
+  # Boundary = the git worktree root, so a legitimate context file is accepted no
+  # matter which subdirectory the caller invokes us from (prior code used `pwd -P`,
+  # which fail-closed-rejected valid files when called from a subdir — PR #456 Argus
+  # advisory). Normalize the root through `cd ... && pwd -P` so it matches the form
+  # realpath emits for the file: on MSYS `git rev-parse --show-toplevel` prints a
+  # Windows-style `D:/x` path that would NEVER prefix-match realpath's `/d/x` form;
+  # `cd`+`pwd -P` collapses both to one physical form on Linux and MSYS alike. Fall
+  # back to physical cwd outside a git tree.
+  _tree_root="$(git rev-parse --show-toplevel 2>/dev/null)"
+  if [[ -n "$_tree_root" ]]; then
+    _tree_root="$(cd "$_tree_root" 2>/dev/null && pwd -P)" || _tree_root=""
+  fi
+  [[ -n "$_tree_root" ]] || _tree_root="$(pwd -P)"
+  [[ "$_ctx_real" == "$_tree_root/"* ]] \
     || die "context file must resolve inside the working tree (data-exfil guard): $CONTEXT_FILE"
 fi
 
@@ -321,10 +349,36 @@ in_set() {
   return 1
 }
 
+# ── stable delta signature for cross-run dedup (ADR §5.2 layer 2) ──
+# sha256 over the sorted "source<TAB>old<TAB>new" triples, truncated to 16 hex. The
+# key identifies the specific TRANSITION (old→new), not just the resulting version:
+#   * Re-detection of an un-persisted batch (Issue created but state-commit then
+#     failed → intel-watch re-emits the SAME old→new next run) reproduces the same
+#     key and matches the marker in the open Issue → skipped. Cross-run dedup intact.
+#   * Including `old` avoids a collision Codex flagged: a source that later RETURNS to
+#     a previously-seen `new` value (e.g. B→C then C→B) has a different `old`, so the
+#     return is a distinct key and is NOT wrongly skipped against the earlier Issue.
+# Built only from intel-watch.sh's own structured output (no LLM text).
+dedup_key() {
+  local deltas="$1" pairs hex
+  pairs="$(jq -r '.[] | "\(.source)\t\(.old)\t\(.new)"' <<<"$deltas" | LC_ALL=C sort)" || return 1
+  if command -v sha256sum >/dev/null 2>&1; then
+    hex="$(printf '%s' "$pairs" | sha256sum | cut -d' ' -f1)"
+  elif command -v shasum >/dev/null 2>&1; then
+    hex="$(printf '%s' "$pairs" | shasum -a 256 | cut -d' ' -f1)"
+  elif command -v openssl >/dev/null 2>&1; then
+    hex="$(printf '%s' "$pairs" | openssl dgst -sha256 | awk '{print $NF}')"
+  else
+    return 1
+  fi
+  [[ -n "$hex" ]] || return 1
+  printf '%s' "${hex:0:16}"
+}
+
 # ── build the Issue body file (ALL free text lives here, never on argv) ──
 write_issue_body() {
-  # $1 = dest file, $2 = deltas JSON array, $3 = judgment JSON
-  local dest="$1" deltas="$2" judg="$3"
+  # $1 = dest file, $2 = deltas JSON array, $3 = judgment JSON, $4 = dedup key (opt)
+  local dest="$1" deltas="$2" judg="$3" dkey="${4:-}"
   {
     printf '## External-intel auto-detected delta — needs human triage\n\n'
     printf '> Auto-generated by `scripts/intel-judge.sh` (#157 / #453 Slice 2).\n'
@@ -335,6 +389,13 @@ write_issue_body() {
     jq -r '"- **significant**: \(.significant)\n- **priority**: \(.priority)\n- **impact**: \(.impact)\n\n**Summary**\n\n\(.summary)\n\n**Suggested action**\n\n\(.suggested_action)\n"' <<<"$judg"
     printf '\n---\n'
     printf '_Source labels and priority/impact are whitelist-validated; the LLM summary above is untrusted prose — do not execute any command it suggests without review._\n'
+    # Machine-readable dedup marker (ADR §5.2 layer 2): a later run greps open
+    # needs-triage Issue bodies for this exact line to avoid re-filing the same
+    # delta batch. Inert HTML comment; built only from the deterministic key.
+    # NOTE: must be an `if` (not `[[ ... ]] && printf`) — as the last command in
+    # this brace group, a false `[[ -z dkey ]]` test would make the whole group
+    # (and thus write_issue_body) return non-zero, spuriously degrading to digest.
+    if [[ -n "$dkey" ]]; then printf '\n<!-- intel-dedup-key: %s -->\n' "$dkey"; fi
   } > "$dest"
 }
 
@@ -458,6 +519,17 @@ main() {
   [[ "$n_src" -gt 1 ]] && plural="s"
   title="[intel] delta needs triage: ${src_csv} (${n_src} source${plural})"
 
+  # Cross-run dedup signature (ADR §5.2 layer 2). Computed even in dry-run so the
+  # preview shows it and the marker is embedded in the body. A compute failure on a
+  # real delta degrades (delta preserved), never exit 2.
+  local dkey=""
+  if [[ "$DEDUP" -eq 1 ]]; then
+    if ! dkey="$(dedup_key "$deltas")"; then
+      append_digest "dedup-key-compute-failed" "$deltas" || exit 3
+      exit 0
+    fi
+  fi
+
   local body_tmp
   # Runtime temp failure degrades (delta preserved), not exit 2 — see the request
   # temp note above; exit 2 is reserved for startup/usage errors.
@@ -465,13 +537,14 @@ main() {
     append_digest "issue-body-temp-create-failed" "$deltas" || exit 3
     exit 0
   fi
-  write_issue_body "$body_tmp" "$deltas" "$judg" \
+  write_issue_body "$body_tmp" "$deltas" "$judg" "$dkey" \
     || { rm -f "$body_tmp"; append_digest "issue-body-write-failed" "$deltas" || exit 3; exit 0; }
 
   if [[ "$CREATE_ISSUE" -ne 1 ]]; then
     printf '(dry-run: would create 1 Issue; pass --create-issue to actually create)\n'
     printf '  title : %s\n' "$title"
     printf '  labels:'; printf ' %s' "${label_args[@]}"; printf '\n'
+    [[ -n "$dkey" ]] && printf '  dedup : intel-dedup-key %s\n' "$dkey"
     printf '  body  : %s (%s bytes)\n' "$body_tmp" "$(wc -c <"$body_tmp" | tr -d ' ')"
     printf '  ---- body preview ----\n'
     sed 's/^/  | /' "$body_tmp"
@@ -484,10 +557,47 @@ main() {
   # KNOWN RESIDUAL (PoC-acceptable): gh-create is treated as all-or-nothing. If gh
   # ever exits non-zero AFTER the server already created the Issue, the delta is
   # ALSO appended to the digest → double-landed. The ≤1-Issue/run cap bounds it to
-  # at most one duplicate, and Slice 3's cross-run open-Issue dedup (ADR §5.2
-  # layer 2) closes it for good. Not fixable inside one un-idempotent gh call here.
+  # at most one duplicate within a run. The CROSS-run double-land (Issue created,
+  # state-commit then failed) is now closed by the --dedup open-Issue check above
+  # (ADR §5.2 layer 2). The within-run gh-then-digest edge remains un-fixable inside
+  # one un-idempotent gh call here.
   local -a repo_args=()
   [[ -n "$REPO" ]] && repo_args=(--repo "$REPO")
+
+  # Cross-run open-Issue dedup (ADR §5.2 layer 2): if an OPEN needs-triage Issue
+  # already embeds this delta-key, the batch is already represented → skip create
+  # and treat as landed (so state is persisted and the same delta stops re-firing).
+  # Closes the un-idempotent gh-create window (an Issue created last run, but the
+  # state-commit then failed). We list label-filtered open Issues (server-side) and
+  # match the marker locally — more reliable than gh's fuzzy `--search`. --limit 100
+  # is ample since the cap is ≤1 new Issue/run and triaged Issues get closed.
+  if [[ "$DEDUP" -eq 1 ]]; then
+    local existing_bodies list_rc=0
+    existing_bodies="$(gh issue list "${repo_args[@]}" --label "$TRIAGE_LABEL" --state open \
+                         --limit 100 --json body --jq '.[].body' 2>/dev/null)" || list_rc=$?
+    if [[ "$list_rc" -ne 0 ]]; then
+      # The dedup query itself failed (network / auth / rate-limit). We cannot tell
+      # whether an open Issue already covers this batch, so creating now could file a
+      # duplicate. DEFER: do not create, do not persist state (exit 3) → the whole
+      # batch is retried next run when the query hopefully succeeds. No delta is lost
+      # (state unchanged) and no duplicate is filed — a one-run delay is preferable to
+      # either spam or loss. (Distinguishing query-failure from a genuine no-match is
+      # what keeps the cross-run double-land truly closed, not just usually.)
+      printf 'intel-judge: dedup query failed (gh issue list rc=%s) — deferring create to next run (state NOT persisted)\n' \
+        "$list_rc" >&2
+      rm -f "$body_tmp"
+      exit 3
+    fi
+    # Match the full marker incl. the trailing ` -->` (defensive: keys are fixed-width
+    # 16-hex so none is a prefix of another, but the closing token removes all doubt).
+    if [[ "$existing_bodies" == *"intel-dedup-key: $dkey -->"* ]]; then
+      printf 'dedup: an open %s Issue already covers delta-key %s — skipping create (treated as landed)\n' \
+        "$TRIAGE_LABEL" "$dkey"
+      rm -f "$body_tmp"
+      exit 0
+    fi
+  fi
+
   if gh issue create "${repo_args[@]}" --title "$title" --body-file "$body_tmp" "${label_args[@]}" >/dev/null 2>&1; then
     printf 'created 1 Issue: %s\n' "$title"
     rm -f "$body_tmp"

--- a/scripts/intel-judge.sh
+++ b/scripts/intel-judge.sh
@@ -578,8 +578,12 @@ main() {
   # is ample since the cap is ≤1 new Issue/run and triaged Issues get closed.
   if [[ "$DEDUP" -eq 1 ]]; then
     local existing_json list_rc=0 n_open
+    # Fetch DEDUP_LIST_LIMIT+1 so we can DISTINGUISH "exactly limit Issues, complete
+    # listing" (safe) from "more than limit, possibly truncated" (unsafe) — fetching
+    # exactly the limit makes count==limit ambiguous and would false-defer at steady
+    # state (Argus minor). gh paginates internally up to --limit.
     existing_json="$(gh issue list "${repo_args[@]}" --label "$TRIAGE_LABEL" --state open \
-                       --limit "$DEDUP_LIST_LIMIT" --json body 2>/dev/null)" || list_rc=$?
+                       --limit "$(( DEDUP_LIST_LIMIT + 1 ))" --json body 2>/dev/null)" || list_rc=$?
     if [[ "$list_rc" -ne 0 ]]; then
       # The dedup query itself failed (network / auth / rate-limit). We cannot tell
       # whether an open Issue already covers this batch, so creating now could file a
@@ -593,17 +597,7 @@ main() {
       rm -f "$body_tmp"
       exit 3
     fi
-    n_open="$(jq 'length' <<<"$existing_json" 2>/dev/null)" || n_open=0
-    if [[ "$n_open" -ge "$DEDUP_LIST_LIMIT" ]]; then
-      # The listing hit the page cap, so a matching marker beyond the cap could be
-      # silently missed → we cannot confirm dedup. DEFER (exit 3) rather than risk a
-      # duplicate, same as a query failure (Argus finding). ≥limit open needs-triage
-      # Issues is itself a triage-backlog signal that needs human attention.
-      printf 'intel-judge: open %s Issues hit the --limit %s cap — cannot confirm dedup, deferring (state NOT persisted)\n' \
-        "$TRIAGE_LABEL" "$DEDUP_LIST_LIMIT" >&2
-      rm -f "$body_tmp"
-      exit 3
-    fi
+    # A FOUND marker is conclusive even if the listing is truncated → check it first.
     # Match the full marker incl. the trailing ` -->` (defensive: keys are fixed-width
     # 16-hex so none is a prefix of another, but the closing token removes all doubt).
     if [[ "$(jq -r '.[].body' <<<"$existing_json")" == *"intel-dedup-key: $dkey -->"* ]]; then
@@ -611,6 +605,19 @@ main() {
         "$TRIAGE_LABEL" "$dkey"
       rm -f "$body_tmp"
       exit 0
+    fi
+    # Marker absent. Only NOW does truncation matter: if we got back MORE than the
+    # scan limit, the listing was truncated and a matching marker could lie beyond it
+    # → we cannot confirm dedup. DEFER (exit 3) rather than risk a duplicate, same as
+    # a query failure. `> limit` (not `>= limit`) — fetching limit+1 means exactly
+    # `limit` open Issues is a COMPLETE listing and must NOT defer. >limit open
+    # needs-triage Issues is itself a triage-backlog signal needing human attention.
+    n_open="$(jq 'length' <<<"$existing_json" 2>/dev/null)" || n_open=0
+    if [[ "$n_open" -gt "$DEDUP_LIST_LIMIT" ]]; then
+      printf 'intel-judge: open %s Issues exceed the --limit %s scan cap — cannot confirm dedup, deferring (state NOT persisted)\n' \
+        "$TRIAGE_LABEL" "$DEDUP_LIST_LIMIT" >&2
+      rm -f "$body_tmp"
+      exit 3
     fi
   fi
 

--- a/scripts/intel-judge.sh
+++ b/scripts/intel-judge.sh
@@ -82,6 +82,7 @@ ANTHROPIC_API_URL="${INTEL_ANTHROPIC_API_URL:-$DEFAULT_ANTHROPIC_API_URL}"
 MAX_RETRIES="${INTEL_JUDGE_MAX_RETRIES:-3}"
 RETRY_BASE_DELAY="${INTEL_JUDGE_RETRY_BASE_DELAY:-2}"  # seconds; tests set 0 for speed
 API_TIMEOUT="${INTEL_JUDGE_API_TIMEOUT:-60}"          # per-attempt curl --max-time
+DEDUP_LIST_LIMIT="${INTEL_JUDGE_DEDUP_LIST_LIMIT:-100}"  # max open Issues scanned for dedup
 
 # ── Fixed whitelists (label-injection guard) — the ONLY label values that can
 #    ever reach `gh`. Parsed/LLM-derived values are validated against these. ──
@@ -125,12 +126,13 @@ done
 # Numeric env config must be valid integers — they feed arithmetic / sleep /
 # curl --max-time, so a non-integer would crash mid-run and bypass the degrade /
 # exit-code contract. Validate up front as a startup error (exit 2).
-for _vn in MAX_RETRIES RETRY_BASE_DELAY API_TIMEOUT; do
+for _vn in MAX_RETRIES RETRY_BASE_DELAY API_TIMEOUT DEDUP_LIST_LIMIT; do
   _vv="${!_vn}"
   [[ "$_vv" =~ ^[0-9]+$ ]] || die "$_vn must be a non-negative integer (got: '$_vv')"
 done
 [[ "$MAX_RETRIES" -ge 1 ]] || die "INTEL_JUDGE_MAX_RETRIES must be >= 1 (got: $MAX_RETRIES)"
 [[ "$API_TIMEOUT" -ge 1 ]] || die "INTEL_JUDGE_API_TIMEOUT must be >= 1 (got: $API_TIMEOUT)"
+[[ "$DEDUP_LIST_LIMIT" -ge 1 ]] || die "INTEL_JUDGE_DEDUP_LIST_LIMIT must be >= 1 (got: $DEDUP_LIST_LIMIT)"
 
 jq -n null >/dev/null 2>&1 || die "jq is required and must be runnable"
 # --dedup derives a delta signature via a sha256 helper (mirrors intel-watch.sh);
@@ -358,10 +360,13 @@ in_set() {
 #   * Including `old` avoids a collision Codex flagged: a source that later RETURNS to
 #     a previously-seen `new` value (e.g. B→C then C→B) has a different `old`, so the
 #     return is a distinct key and is NOT wrongly skipped against the earlier Issue.
-# Built only from intel-watch.sh's own structured output (no LLM text).
+# Each triple is emitted as a compact JSON array (jq -c) rather than tab-joined: JSON
+# string-escapes any embedded tab/newline, so a delimiter inside a field value can no
+# longer create sequence ambiguity or a forged-collision (Argus finding). Built only
+# from intel-watch.sh's own structured output (no LLM text).
 dedup_key() {
   local deltas="$1" pairs hex
-  pairs="$(jq -r '.[] | "\(.source)\t\(.old)\t\(.new)"' <<<"$deltas" | LC_ALL=C sort)" || return 1
+  pairs="$(jq -c '.[] | [.source, .old, .new]' <<<"$deltas" | LC_ALL=C sort)" || return 1
   if command -v sha256sum >/dev/null 2>&1; then
     hex="$(printf '%s' "$pairs" | sha256sum | cut -d' ' -f1)"
   elif command -v shasum >/dev/null 2>&1; then
@@ -572,9 +577,9 @@ main() {
   # match the marker locally — more reliable than gh's fuzzy `--search`. --limit 100
   # is ample since the cap is ≤1 new Issue/run and triaged Issues get closed.
   if [[ "$DEDUP" -eq 1 ]]; then
-    local existing_bodies list_rc=0
-    existing_bodies="$(gh issue list "${repo_args[@]}" --label "$TRIAGE_LABEL" --state open \
-                         --limit 100 --json body --jq '.[].body' 2>/dev/null)" || list_rc=$?
+    local existing_json list_rc=0 n_open
+    existing_json="$(gh issue list "${repo_args[@]}" --label "$TRIAGE_LABEL" --state open \
+                       --limit "$DEDUP_LIST_LIMIT" --json body 2>/dev/null)" || list_rc=$?
     if [[ "$list_rc" -ne 0 ]]; then
       # The dedup query itself failed (network / auth / rate-limit). We cannot tell
       # whether an open Issue already covers this batch, so creating now could file a
@@ -588,9 +593,20 @@ main() {
       rm -f "$body_tmp"
       exit 3
     fi
+    n_open="$(jq 'length' <<<"$existing_json" 2>/dev/null)" || n_open=0
+    if [[ "$n_open" -ge "$DEDUP_LIST_LIMIT" ]]; then
+      # The listing hit the page cap, so a matching marker beyond the cap could be
+      # silently missed → we cannot confirm dedup. DEFER (exit 3) rather than risk a
+      # duplicate, same as a query failure (Argus finding). ≥limit open needs-triage
+      # Issues is itself a triage-backlog signal that needs human attention.
+      printf 'intel-judge: open %s Issues hit the --limit %s cap — cannot confirm dedup, deferring (state NOT persisted)\n' \
+        "$TRIAGE_LABEL" "$DEDUP_LIST_LIMIT" >&2
+      rm -f "$body_tmp"
+      exit 3
+    fi
     # Match the full marker incl. the trailing ` -->` (defensive: keys are fixed-width
     # 16-hex so none is a prefix of another, but the closing token removes all doubt).
-    if [[ "$existing_bodies" == *"intel-dedup-key: $dkey -->"* ]]; then
+    if [[ "$(jq -r '.[].body' <<<"$existing_json")" == *"intel-dedup-key: $dkey -->"* ]]; then
       printf 'dedup: an open %s Issue already covers delta-key %s — skipping create (treated as landed)\n' \
         "$TRIAGE_LABEL" "$dkey"
       rm -f "$body_tmp"

--- a/scripts/test-intel-judge.sh
+++ b/scripts/test-intel-judge.sh
@@ -376,6 +376,97 @@ assert_eq "exit 2 on out-of-tree context" "2" "$rc"
 assert_contains "names the working-tree guard" "working tree" "$out"
 rm -f "$OUTCTX"
 
+# ── Scenarios 26-28: cross-run open-Issue dedup (--dedup, ADR §5.2 layer 2).
+#    Fresh gh stub answers `issue list --json body --jq '.[].body'` from
+#    $GH_DEDUP_EXISTING and records whether `issue create` was invoked. ──
+R26="$WORK_DIR/r26.json"; mk_resp "$(mk_judgment true P2 capability "dedup" "act")" > "$R26"
+
+printf '\n[26] --dedup without --repo → exit 2 (config error, before any API call)\n'
+out="$(bash "$JUDGE" --deltas-file "$DELTAS" --llm-response-file "$R26" --create-issue --dedup 2>&1)"; rc=$?
+assert_eq "exit 2" "2" "$rc"
+assert_contains "names --dedup/--repo requirement" "--dedup requires --repo" "$out"
+
+DDBIN="$WORK_DIR/ddbin"; mkdir -p "$DDBIN"
+cat > "$DDBIN/gh" <<'STUB'
+#!/usr/bin/env bash
+if [[ "$1" == "--version" ]]; then echo "gh 2.0.0 (stub)"; exit 0; fi
+if [[ "$1" == "issue" && "$2" == "list" ]]; then
+  if [[ "${GH_LIST_FAIL:-0}" == "1" ]]; then echo "simulated gh list failure" >&2; exit 1; fi
+  # Emulate `gh issue list --json body --jq '.[].body'`: print configured bodies.
+  printf '%s\n' "${GH_DEDUP_EXISTING:-}"; exit 0
+fi
+if [[ "$1" == "issue" && "$2" == "create" ]]; then
+  : > "$GH_CREATE_CALLED"   # record that create was invoked
+  while [[ $# -gt 0 ]]; do [[ "$1" == "--body-file" ]] && cp "$2" "$GH_BODY_COPY"; shift; done
+  echo "https://github.com/owner/repo/issues/77"; exit 0
+fi
+echo "ddstub: unsupported: $*" >&2; exit 1
+STUB
+chmod +x "$DDBIN/gh"
+
+if [[ "$GH_STUB_OK" -eq 1 ]]; then
+  printf '\n[27] --dedup: no matching open Issue → creates + body carries dedup marker\n'
+  CR27="$WORK_DIR/created27"; rm -f "$CR27"; BODY27="$WORK_DIR/body27.md"
+  out="$(GH_DEDUP_EXISTING="unrelated open issue without any key" GH_CREATE_CALLED="$CR27" GH_BODY_COPY="$BODY27" \
+        PATH="$DDBIN:$PATH" bash "$JUDGE" --deltas-file "$DELTAS" --llm-response-file "$R26" \
+        --create-issue --dedup --repo owner/repo 2>&1)"; rc=$?
+  assert_eq "exit 0" "0" "$rc"
+  assert_eq "create WAS called" "yes" "$([[ -f "$CR27" ]] && echo yes || echo no)"
+  assert_contains "body carries dedup marker" "intel-dedup-key:" "$(cat "$BODY27")"
+  DKEY="$(grep -oE 'intel-dedup-key: [0-9a-f]+' "$BODY27" | head -n1 | awk '{print $2}')"
+
+  printf '\n[28] --dedup: open Issue already embeds same key → skip create (treated as landed)\n'
+  CR28="$WORK_DIR/created28"; rm -f "$CR28"
+  EXISTING_BODY="prior open triage issue
+<!-- intel-dedup-key: $DKEY -->"
+  out="$(GH_DEDUP_EXISTING="$EXISTING_BODY" GH_CREATE_CALLED="$CR28" GH_BODY_COPY="$WORK_DIR/body28.md" \
+        PATH="$DDBIN:$PATH" bash "$JUDGE" --deltas-file "$DELTAS" --llm-response-file "$R26" \
+        --create-issue --dedup --repo owner/repo 2>&1)"; rc=$?
+  assert_eq "exit 0 (skipped, landed)" "0" "$rc"
+  assert_contains "reports dedup skip" "skipping create" "$out"
+  assert_eq "create NOT called" "no" "$([[ -f "$CR28" ]] && echo yes || echo no)"
+
+  printf '\n[29] --dedup: gh issue list failure → defer (exit 3, create NOT called)\n'
+  CR29="$WORK_DIR/created29"; rm -f "$CR29"
+  out="$(GH_LIST_FAIL=1 GH_DEDUP_EXISTING="ignored" GH_CREATE_CALLED="$CR29" GH_BODY_COPY="$WORK_DIR/body29.md" \
+        PATH="$DDBIN:$PATH" bash "$JUDGE" --deltas-file "$DELTAS" --llm-response-file "$R26" \
+        --create-issue --dedup --repo owner/repo 2>&1)"; rc=$?
+  assert_eq "exit 3 (deferred, not landed)" "3" "$rc"
+  assert_contains "reports dedup query failure" "dedup query failed" "$out"
+  assert_eq "create NOT called on query failure" "no" "$([[ -f "$CR29" ]] && echo yes || echo no)"
+
+  printf '\n[31] --dedup: same new but different old → distinct key, NOT deduped (Codex collision fix)\n'
+  DALT="$WORK_DIR/deltas_altold.json"
+  jq -n '{checked_at:"2026-05-26T00:00:00Z",
+    deltas:[{source:"npm:@anthropic-ai/claude-code", kind:"npm", label:"intel/sdk", old:"2.1.0", new:"2.2.0"}],
+    seeded:[], unchanged:[], errors:[]}' > "$DALT" || fixture_fail "deltas_altold"
+  CR31="$WORK_DIR/created31"; rm -f "$CR31"
+  # Existing open Issue carries DKEY (from [27], old=2.1.150→2.2.0). This batch is
+  # old=2.1.0→2.2.0 (same new, different old) → different key → must NOT be skipped.
+  out="$(GH_DEDUP_EXISTING="prior issue
+<!-- intel-dedup-key: $DKEY -->" GH_CREATE_CALLED="$CR31" GH_BODY_COPY="$WORK_DIR/body31.md" \
+        PATH="$DDBIN:$PATH" bash "$JUDGE" --deltas-file "$DALT" --llm-response-file "$R26" \
+        --create-issue --dedup --repo owner/repo 2>&1)"; rc=$?
+  assert_eq "exit 0" "0" "$rc"
+  assert_eq "create WAS called (distinct transition, not deduped)" "yes" "$([[ -f "$CR31" ]] && echo yes || echo no)"
+else
+  printf '\n[27-29,31] SKIP: gh stub not picked up on PATH (platform shim)\n'
+fi
+
+# ── Scenario 30: the --context-file boundary is the git worktree root, so a context
+#    file in the repo ROOT is accepted even when invoked from a SUBDIR (the PR #456
+#    Argus advisory; old code used `pwd -P` and would fail-closed-reject it). No gh
+#    needed. The startup path-validation accepts it; --llm-response-file then bypasses
+#    the (unused) body build, so a clean dry-run preview exit 0 means "accepted". ──
+printf '\n[30] context-file in repo root accepted when invoked from a subdir (boundary widening)\n'
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+POSCTX="$REPO_ROOT/.intel-ctx-positive-$$.tmp"; printf 'ctx-positive\n' > "$POSCTX"
+out="$(cd "$SCRIPT_DIR" && bash "$JUDGE" --deltas-file "$DELTAS" --llm-response-file "$R26" \
+      --context-file "$POSCTX" 2>&1)"; rc=$?
+rm -f "$POSCTX"
+assert_eq "exit 0 (context in repo root accepted from subdir)" "0" "$rc"
+assert_not_contains "no working-tree rejection" "working tree" "$out"
+
 # ── Summary ──
 printf '\n=== intel-judge tests: %s passed, %s failed ===\n' "$PASS" "$FAIL"
 if [[ "$FAIL" -gt 0 ]]; then

--- a/scripts/test-intel-judge.sh
+++ b/scripts/test-intel-judge.sh
@@ -376,8 +376,9 @@ assert_eq "exit 2 on out-of-tree context" "2" "$rc"
 assert_contains "names the working-tree guard" "working tree" "$out"
 rm -f "$OUTCTX"
 
-# ── Scenarios 26-32: cross-run open-Issue dedup (--dedup, ADR §5.2 layer 2).
-#    Fresh gh stub answers `issue list --json body` with the JSON array in
+# ── Scenarios 26-29 + 31-33: cross-run open-Issue dedup (--dedup, ADR §5.2 layer 2).
+#    (Scenario 30, defined after this block, covers the unrelated --context-file
+#    boundary.) Fresh gh stub answers `issue list --json body` with the JSON array in
 #    $GH_DEDUP_EXISTING and records whether `issue create` was invoked. ──
 R26="$WORK_DIR/r26.json"; mk_resp "$(mk_judgment true P2 capability "dedup" "act")" > "$R26"
 

--- a/scripts/test-intel-judge.sh
+++ b/scripts/test-intel-judge.sh
@@ -376,8 +376,8 @@ assert_eq "exit 2 on out-of-tree context" "2" "$rc"
 assert_contains "names the working-tree guard" "working tree" "$out"
 rm -f "$OUTCTX"
 
-# ── Scenarios 26-28: cross-run open-Issue dedup (--dedup, ADR §5.2 layer 2).
-#    Fresh gh stub answers `issue list --json body --jq '.[].body'` from
+# ── Scenarios 26-32: cross-run open-Issue dedup (--dedup, ADR §5.2 layer 2).
+#    Fresh gh stub answers `issue list --json body` with the JSON array in
 #    $GH_DEDUP_EXISTING and records whether `issue create` was invoked. ──
 R26="$WORK_DIR/r26.json"; mk_resp "$(mk_judgment true P2 capability "dedup" "act")" > "$R26"
 
@@ -392,8 +392,8 @@ cat > "$DDBIN/gh" <<'STUB'
 if [[ "$1" == "--version" ]]; then echo "gh 2.0.0 (stub)"; exit 0; fi
 if [[ "$1" == "issue" && "$2" == "list" ]]; then
   if [[ "${GH_LIST_FAIL:-0}" == "1" ]]; then echo "simulated gh list failure" >&2; exit 1; fi
-  # Emulate `gh issue list --json body --jq '.[].body'`: print configured bodies.
-  printf '%s\n' "${GH_DEDUP_EXISTING:-}"; exit 0
+  # Emulate `gh issue list --json body`: print the configured JSON array (default []).
+  printf '%s\n' "${GH_DEDUP_EXISTING:-[]}"; exit 0
 fi
 if [[ "$1" == "issue" && "$2" == "create" ]]; then
   : > "$GH_CREATE_CALLED"   # record that create was invoked
@@ -407,7 +407,7 @@ chmod +x "$DDBIN/gh"
 if [[ "$GH_STUB_OK" -eq 1 ]]; then
   printf '\n[27] --dedup: no matching open Issue → creates + body carries dedup marker\n'
   CR27="$WORK_DIR/created27"; rm -f "$CR27"; BODY27="$WORK_DIR/body27.md"
-  out="$(GH_DEDUP_EXISTING="unrelated open issue without any key" GH_CREATE_CALLED="$CR27" GH_BODY_COPY="$BODY27" \
+  out="$(GH_DEDUP_EXISTING='[{"body":"unrelated open issue without any key"}]' GH_CREATE_CALLED="$CR27" GH_BODY_COPY="$BODY27" \
         PATH="$DDBIN:$PATH" bash "$JUDGE" --deltas-file "$DELTAS" --llm-response-file "$R26" \
         --create-issue --dedup --repo owner/repo 2>&1)"; rc=$?
   assert_eq "exit 0" "0" "$rc"
@@ -419,7 +419,8 @@ if [[ "$GH_STUB_OK" -eq 1 ]]; then
   CR28="$WORK_DIR/created28"; rm -f "$CR28"
   EXISTING_BODY="prior open triage issue
 <!-- intel-dedup-key: $DKEY -->"
-  out="$(GH_DEDUP_EXISTING="$EXISTING_BODY" GH_CREATE_CALLED="$CR28" GH_BODY_COPY="$WORK_DIR/body28.md" \
+  EXISTING_JSON="$(jq -nc --arg b "$EXISTING_BODY" '[{body:$b}]')" || fixture_fail "existing_json 28"
+  out="$(GH_DEDUP_EXISTING="$EXISTING_JSON" GH_CREATE_CALLED="$CR28" GH_BODY_COPY="$WORK_DIR/body28.md" \
         PATH="$DDBIN:$PATH" bash "$JUDGE" --deltas-file "$DELTAS" --llm-response-file "$R26" \
         --create-issue --dedup --repo owner/repo 2>&1)"; rc=$?
   assert_eq "exit 0 (skipped, landed)" "0" "$rc"
@@ -443,14 +444,28 @@ if [[ "$GH_STUB_OK" -eq 1 ]]; then
   CR31="$WORK_DIR/created31"; rm -f "$CR31"
   # Existing open Issue carries DKEY (from [27], old=2.1.150→2.2.0). This batch is
   # old=2.1.0→2.2.0 (same new, different old) → different key → must NOT be skipped.
-  out="$(GH_DEDUP_EXISTING="prior issue
-<!-- intel-dedup-key: $DKEY -->" GH_CREATE_CALLED="$CR31" GH_BODY_COPY="$WORK_DIR/body31.md" \
+  EXISTING_BODY31="prior issue
+<!-- intel-dedup-key: $DKEY -->"
+  EXISTING_JSON31="$(jq -nc --arg b "$EXISTING_BODY31" '[{body:$b}]')" || fixture_fail "existing_json 31"
+  out="$(GH_DEDUP_EXISTING="$EXISTING_JSON31" GH_CREATE_CALLED="$CR31" GH_BODY_COPY="$WORK_DIR/body31.md" \
         PATH="$DDBIN:$PATH" bash "$JUDGE" --deltas-file "$DALT" --llm-response-file "$R26" \
         --create-issue --dedup --repo owner/repo 2>&1)"; rc=$?
   assert_eq "exit 0" "0" "$rc"
   assert_eq "create WAS called (distinct transition, not deduped)" "yes" "$([[ -f "$CR31" ]] && echo yes || echo no)"
+
+  printf '\n[32] --dedup: open Issues hit the list cap → defer (exit 3, create NOT called)\n'
+  CR32="$WORK_DIR/created32"; rm -f "$CR32"
+  # INTEL_JUDGE_DEDUP_LIST_LIMIT=1 + a 1-element list → n_open >= limit → cannot
+  # confirm dedup (listing may be truncated) → defer rather than risk a duplicate.
+  out="$(INTEL_JUDGE_DEDUP_LIST_LIMIT=1 GH_DEDUP_EXISTING='[{"body":"some open triage issue"}]' \
+        GH_CREATE_CALLED="$CR32" GH_BODY_COPY="$WORK_DIR/body32.md" \
+        PATH="$DDBIN:$PATH" bash "$JUDGE" --deltas-file "$DELTAS" --llm-response-file "$R26" \
+        --create-issue --dedup --repo owner/repo 2>&1)"; rc=$?
+  assert_eq "exit 3 (cap hit, deferred)" "3" "$rc"
+  assert_contains "reports cap defer" "hit the --limit" "$out"
+  assert_eq "create NOT called at cap" "no" "$([[ -f "$CR32" ]] && echo yes || echo no)"
 else
-  printf '\n[27-29,31] SKIP: gh stub not picked up on PATH (platform shim)\n'
+  printf '\n[27-29,31-32] SKIP: gh stub not picked up on PATH (platform shim)\n'
 fi
 
 # ── Scenario 30: the --context-file boundary is the git worktree root, so a context

--- a/scripts/test-intel-judge.sh
+++ b/scripts/test-intel-judge.sh
@@ -453,19 +453,31 @@ if [[ "$GH_STUB_OK" -eq 1 ]]; then
   assert_eq "exit 0" "0" "$rc"
   assert_eq "create WAS called (distinct transition, not deduped)" "yes" "$([[ -f "$CR31" ]] && echo yes || echo no)"
 
-  printf '\n[32] --dedup: open Issues hit the list cap → defer (exit 3, create NOT called)\n'
+  printf '\n[32] --dedup: open Issues EXCEED the scan cap → defer (exit 3, create NOT called)\n'
   CR32="$WORK_DIR/created32"; rm -f "$CR32"
-  # INTEL_JUDGE_DEDUP_LIST_LIMIT=1 + a 1-element list → n_open >= limit → cannot
-  # confirm dedup (listing may be truncated) → defer rather than risk a duplicate.
-  out="$(INTEL_JUDGE_DEDUP_LIST_LIMIT=1 GH_DEDUP_EXISTING='[{"body":"some open triage issue"}]' \
+  # LIMIT=1 + a 2-element list (no marker) → the code fetches limit+1=2 and gets 2,
+  # so n_open(2) > limit(1) → listing may be truncated → cannot confirm dedup → defer.
+  out="$(INTEL_JUDGE_DEDUP_LIST_LIMIT=1 GH_DEDUP_EXISTING='[{"body":"open issue a"},{"body":"open issue b"}]' \
         GH_CREATE_CALLED="$CR32" GH_BODY_COPY="$WORK_DIR/body32.md" \
         PATH="$DDBIN:$PATH" bash "$JUDGE" --deltas-file "$DELTAS" --llm-response-file "$R26" \
         --create-issue --dedup --repo owner/repo 2>&1)"; rc=$?
-  assert_eq "exit 3 (cap hit, deferred)" "3" "$rc"
-  assert_contains "reports cap defer" "hit the --limit" "$out"
+  assert_eq "exit 3 (exceeds cap, deferred)" "3" "$rc"
+  assert_contains "reports cap defer" "exceed the --limit" "$out"
   assert_eq "create NOT called at cap" "no" "$([[ -f "$CR32" ]] && echo yes || echo no)"
+
+  printf '\n[33] --dedup: open Issues EXACTLY at the cap → complete listing, creates (no false defer)\n'
+  CR33="$WORK_DIR/created33"; rm -f "$CR33"
+  # LIMIT=2 + a 2-element list (no marker) → fetch limit+1=3 returns 2, so n_open(2)
+  # is NOT > limit(2): the listing is complete, no marker → create (Argus minor fix:
+  # exactly `limit` open Issues must not be a false-positive defer).
+  out="$(INTEL_JUDGE_DEDUP_LIST_LIMIT=2 GH_DEDUP_EXISTING='[{"body":"open issue a"},{"body":"open issue b"}]' \
+        GH_CREATE_CALLED="$CR33" GH_BODY_COPY="$WORK_DIR/body33.md" \
+        PATH="$DDBIN:$PATH" bash "$JUDGE" --deltas-file "$DELTAS" --llm-response-file "$R26" \
+        --create-issue --dedup --repo owner/repo 2>&1)"; rc=$?
+  assert_eq "exit 0 (complete listing at cap)" "0" "$rc"
+  assert_eq "create WAS called (no false defer at exactly cap)" "yes" "$([[ -f "$CR33" ]] && echo yes || echo no)"
 else
-  printf '\n[27-29,31-32] SKIP: gh stub not picked up on PATH (platform shim)\n'
+  printf '\n[27-29,31-33] SKIP: gh stub not picked up on PATH (platform shim)\n'
 fi
 
 # ── Scenario 30: the --context-file boundary is the git worktree root, so a context


### PR DESCRIPTION
## Summary

Final slice of the #157 Phase 2 PoC (B-class external-intel agent). Wires the Slice 1 collector (`scripts/intel-watch.sh`) + Slice 2 judge (`scripts/intel-judge.sh`) into a scheduled GitHub Actions workflow, and adds the ADR §5.2 layer-2 cross-run open-Issue dedup the design called for.

**`.github/workflows/external-intel.yml` (NEW):**
- Weekly cron `'23 9 * * 1'` (off-the-hour per GitHub's high-load guidance) + `workflow_dispatch` (boolean `dry_run`) + workflow-level `concurrency` group (`cancel-in-progress: false` → serializes scheduled vs manual so two runs never read-modify-write the state Issue at once).
- `permissions: contents:read + issues:write` (GITHUB_TOKEN, **no PAT**).
- Orchestration: ensure `intel/*` + `impact/*` + `intel/state` labels (idempotent `gh label create --force`) → find-or-create the pinned state Issue by the `intel/state` label → `intel-watch.sh --json-out` (detect) → `intel-judge.sh --create-issue --dedup` (judge) → persist state with `--commit` **only when landed and detect was clean** → digest to step summary.
- Exit-code contract honored: intel-watch `rc≥2` aborts / `rc1` tolerated; intel-judge `rc2` aborts / `rc3` (not landed) skips persist so the batch retries whole.
- `ANTHROPIC_API_KEY` injected via **env (never argv)**; auto-masked. Module **fully detachable** (delete workflow + scripts = no-op; state Issue + labels are harmless orphans).
- `actions/checkout` pinned by SHA `de0fac2e4500dabe0009e67214ff5f5447ce83dd` (v6.0.2, MIT) — verified via `gh api`. (Pinning exceeds the repo's existing floating-`@v4` convention; `uses:` refs are not manifest-tracked, matching the precedent of `auto-verify.yml`/`skill-drift.yml`.)

**`scripts/intel-judge.sh`:**
- New opt-in `--dedup` (requires `--repo`): `dedup_key()` = sha256 of sorted `source<TAB>old<TAB>new` triples (16 hex); inert HTML marker embedded in the Issue body; before `gh issue create`, lists open `intel/needs-triage` Issues and **skips re-filing** if the marker is already present (treated as landed). On a list-query **failure** it **defers (exit 3)** rather than risk a duplicate. Closes the cross-run double-land window left by Slice 2's un-idempotent `gh create`.
- Hardened the `--context-file` boundary from `pwd -P` to the **git worktree root**, normalized via `cd … && pwd -P` so it matches `realpath`'s form on MSYS as well as Linux (addresses the PR #456 Argus advisory; a naive git-toplevel comparison false-rejects on Windows, where git prints `D:/x` vs realpath's `/d/x`).

**`scripts/test-intel-judge.sh`:** +7 assertions (dedup create+marker, skip-on-match, `--dedup`-requires-`--repo`, list-failure defer, same-`new`-different-`old` distinct key, positive subdir context-file acceptance).

## Dual-verify (mandatory pre-commit gate)

| Reviewer | Verdict | Findings (all fixed) |
|---|---|---|
| Claude critic | 0 Critical / 0 High / 3 Medium | dedup list-fail defer, state-Issue non-atomic residual note, test gaps |
| Claude code-reviewer | 0 Critical / 0 High / 3 Medium | inaccurate `set -e` comment, judge `if` success-gate, list-fail handling |
| **Codex code-audit** (raw `codex exec` 0.129.0) | 0 Critical / **1 High** / 1 Medium | **persist gate must require a clean detect (`watch_rc==0`)** so a source that errored on detect can't have its unjudged delta absorbed by the `--commit` re-fetch; **dedup_key collision** on version-return (now includes `old`) |

Dual-verify Codex side: PASS (via raw `codex exec`; the codex-companion wrapper returned exit 3 / UNAVAILABLE this session, raw CLI worked).

## Test plan
- [x] `intel-judge` tests: **92/92**
- [x] `intel-watch` tests: **52/52** (unchanged — regression check)
- [x] `actionlint` on the workflow: **clean** (exit 0)
- [x] `gh label create`/`gh issue list` flags + `github.repository`/`checkout` SHA verified against official docs + local `gh`
- [x] LF line endings confirmed in the git index for all 3 files (ubuntu runner gets LF)

## Notes
- `Closes #453` — this is the **final** of the 3 slices.
- `Refs #157` — the design ADR Issue stays **OPEN**.
- One-time operator setup to actually run it: set repo secret `ANTHROPIC_API_KEY` (without it, deltas degrade safely to the digest). The state Issue + labels auto-bootstrap on first run.

Closes #453
Refs #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)