### PR TITLE
feat(#458): Slice A — playwright-mcp mount governance + security config-gate

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -21,7 +21,7 @@
         "./adapters/playwright-mcp/launch.cjs",
         "--isolated",
         "--caps=storage",
-        "--storage-state=%LOCALAPPDATA%/mercury/playwright-mcp/auth-state.json"
+        "--storage-state=$MERCURY_PLAYWRIGHT_STORAGE_STATE"
       ]
     }
   }

--- a/.mcp.json
+++ b/.mcp.json
@@ -13,6 +13,16 @@
     "mercury-telegram": {
       "command": "node",
       "args": ["./adapters/mercury-channel-client/channel.cjs"]
+    },
+    "playwright": {
+      "type": "stdio",
+      "command": "node",
+      "args": [
+        "./adapters/playwright-mcp/launch.cjs",
+        "--isolated",
+        "--caps=storage",
+        "--storage-state=%LOCALAPPDATA%/mercury/playwright-mcp/auth-state.json"
+      ]
     }
   }
 }

--- a/.mercury/docs/DIRECTION.md
+++ b/.mercury/docs/DIRECTION.md
@@ -225,6 +225,21 @@ Mercury 的核心价值不在代码里，在方法论里。
 
 ## 四、外部项目挂载策略
 
+### 挂载方式（三类并列）
+
+外部项目按以下三类受治理的挂载模式之一接入，**默认首选 git submodule**：
+
+1. **git submodule（默认）** — 每个外部项目作为 git submodule 挂载到 `modules/` 目录下（详见下方"挂载方式: Git Submodule"）。
+2. **uvx git+SHA runtime-only** — runtime-only 依赖经 `uvx --from git+<repo>@<SHA>` 引用（首例 `adapters/gpt-image-2/`），不 vendoring 源码，按 git commit SHA pin。
+3. **npm-version-pinned MCP server（runtime-only）** — runtime-only 的 MCP server 经 npm 按版本解析挂载（如 `npx @playwright/mcp@<pinned-version>` 或等价的 `npm install --prefix <repo 外 cache>`），首例 `adapters/playwright-mcp/`（playwright-mcp / Issue #154）。
+
+模式 2、3 同为 runtime-only 例外，均须满足：
+- **license gate**：仅 permissive（MIT / Apache-2.0 等）。
+- **provenance**：在 `.mercury/state/upstream-manifest.json` 登记 + 对应 `adapters/<vendor>/UPSTREAM.md` 记录版本/license/已知不兼容项。
+- **drift 监控**：`scripts/upstream-drift-check.sh` 跟踪上游版本契约文件。
+
+**版本 pin 规则（模式 3）**：`.mcp.json` / wrapper 必须 pin 确切 npm 版本号（**禁止浮动 `@latest`**）。执行契约 = pinned npm 版本；manifest 的 `upstream_sha_at_import` = 对应 git tag commit（审计元数据，非执行契约）。依据见 `research/issue-154-web-automation-2026-05.md` §5.1 + Issue #458。
+
 ### 挂载方式: Git Submodule
 
 每个外部项目作为 git submodule 挂载到 modules/ 目录下。

--- a/.mercury/state/upstream-manifest.json
+++ b/.mercury/state/upstream-manifest.json
@@ -247,7 +247,7 @@
     "upstream_path": "package.json",
     "upstream_sha_at_import": "8116437ffcfee1309cebc07dd30cee37720d2d19",
     "upstream_license": "Apache-2.0",
-    "import_pr": null,
+    "import_pr": 459,
     "import_date": "2026-05-26",
     "import_rationale": "Phase 2 Slice A (Issue #458, ADR issue-154-web-automation) — npm-version-pinned MCP server runtime mount (third mount mode, alongside git submodule and uvx git+SHA). Execution contract = pinned npm version @playwright/mcp@0.0.75; upstream_sha_at_import = the git tag v0.0.75 commit (audit metadata mapping the pinned npm version back to an upstream git tag, NOT the execution contract). upstream_path=package.json tracks the canonical version/deps/bin contract so scripts/upstream-drift-check.sh can detect upstream version bumps that may require re-pinning this adapter. No upstream source vendored; adapters/playwright-mcp/launch.cjs is a Mercury config-gate wrapper only.",
     "last_drift_check": null

--- a/.mercury/state/upstream-manifest.json
+++ b/.mercury/state/upstream-manifest.json
@@ -239,5 +239,17 @@
     "import_date": "2026-05-08",
     "import_rationale": "Phase 2 Slice A — wuyoscar/gpt_image_2_skill MIT mount via uvx-pinned-SHA per ADR pixel-animation-workflow §7.2.1 + S87 refinement (Issue #351). No upstream source vendored. upstream_path=pyproject.toml tracks the canonical version contract (deps, entry points) so scripts/upstream-drift-check.sh can detect upstream version bumps that affect this adapter's pinned SHA.",
     "last_drift_check": null
+  },
+  {
+    "path": "adapters/playwright-mcp/UPSTREAM.md",
+    "scope": "project",
+    "upstream_repo": "microsoft/playwright-mcp",
+    "upstream_path": "package.json",
+    "upstream_sha_at_import": "8116437ffcfee1309cebc07dd30cee37720d2d19",
+    "upstream_license": "Apache-2.0",
+    "import_pr": null,
+    "import_date": "2026-05-26",
+    "import_rationale": "Phase 2 Slice A (Issue #458, ADR issue-154-web-automation) — npm-version-pinned MCP server runtime mount (third mount mode, alongside git submodule and uvx git+SHA). Execution contract = pinned npm version @playwright/mcp@0.0.75; upstream_sha_at_import = the git tag v0.0.75 commit (audit metadata mapping the pinned npm version back to an upstream git tag, NOT the execution contract). upstream_path=package.json tracks the canonical version/deps/bin contract so scripts/upstream-drift-check.sh can detect upstream version bumps that may require re-pinning this adapter. No upstream source vendored; adapters/playwright-mcp/launch.cjs is a Mercury config-gate wrapper only.",
+    "last_drift_check": null
   }
 ]

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -22,9 +22,13 @@ adapters/
 | `mercury-channel-client/` | MCP channel server (one per Claude Code session); bridges session to router |
 | `mercury-notify/` | Thin HTTP client for hook scripts to notify via router (fire-and-forget) |
 | `gpt-image-2/` | OpenAI gpt-image-2 image generation; mounts wuyoscar/gpt_image_2_skill via uvx-pinned-SHA |
+| `playwright-mcp/` | Config-gate wrapper mounting microsoft/playwright-mcp (Apache-2.0) as a pinned MCP server; enforces ADR §4.2 security red lines |
 
 ## 约束
 
 - 适配层不超过 200 行。超过说明耦合过深，需重新评估挂载方式。
-- 默认通过 git submodule 挂载到 `modules/` 目录（`.mercury/docs/DIRECTION.md` §4）。
-- runtime-only 依赖可经 `uvx --from git+<repo>@<SHA>` 引用，作为 Phase 2 ADR `pixel-animation-workflow` §7.2.1 引入的有限例外（首例：`adapters/gpt-image-2/`）；引入时仍须满足 `CLAUDE.md` §"Cherry-pick protocol"（含 §6 SHA verification）。
+- 挂载方式分三类受治理的模式（详见 `.mercury/docs/DIRECTION.md` §四"挂载方式（三类并列）"）：
+  1. **git submodule（默认）** — 挂载到 `modules/` 目录。
+  2. **uvx git+SHA runtime-only** — 经 `uvx --from git+<repo>@<SHA>` 引用，Phase 2 ADR `pixel-animation-workflow` §7.2.1 引入的有限例外（首例：`adapters/gpt-image-2/`）；仍须满足 `CLAUDE.md` §"Cherry-pick protocol"（含 §6 SHA verification）。
+  3. **npm-version-pinned MCP server（runtime-only）** — runtime-only 的 MCP server 经 npm 按确切版本挂载（**禁止 `@latest`**），首例 `adapters/playwright-mcp/`（playwright-mcp / Issue #154，ADR `research/issue-154-web-automation-2026-05.md` §5.1）。
+- 模式 2、3 均须满足 license gate（仅 permissive）+ provenance（manifest + UPSTREAM.md）+ drift 监控（`scripts/upstream-drift-check.sh`）。

--- a/adapters/playwright-mcp/README.md
+++ b/adapters/playwright-mcp/README.md
@@ -35,8 +35,8 @@ The recommended `.mcp.json` args (passed *through* this wrapper) are:
   / `browser_storage_state` tools required for auth reuse (ADR §4.4). Without
   it those tools do not exist.
 - `--storage-state=<path>` — storageState file for an isolated session, kept
-  at a **repo-external per-user private path** (e.g.
-  `%LOCALAPPDATA%/mercury/playwright-mcp/auth-state.json`).
+  at a **repo-external per-user private path** supplied via
+  `$MERCURY_PLAYWRIGHT_STORAGE_STATE` (see §Setup).
 
 ## Security red lines (enforced by `launch.cjs`)
 
@@ -52,7 +52,6 @@ Only these flags are permitted (default-deny — any unknown flag is rejected):
 | `--isolated` | Enforces fresh in-memory profile (injected if omitted) |
 | `--caps` | Opt-in capabilities (e.g. `storage` for auth reuse) |
 | `--storage-state` | StorageState file path (repo-external, validated) |
-| `--user-data-dir` | Custom profile dir (repo-external, validated) |
 | `--allowed-origins` | Origin allowlist for network requests |
 | `--blocked-origins` | Origin blocklist |
 | `--headless` / `--headed` | Headless mode toggle |
@@ -85,43 +84,49 @@ Removed from allowlist (vs. Slice A first draft) and why:
    (Playwright engine names). Real-browser channel names (`chrome`, `msedge`,
    `chrome-beta`, `msedge-*`, `cdp`, …) are rejected — they attach to real
    installed browsers that hold the user's cookies.
-4. **Flag value attach-token scan.** For all non-path flags, the value is also
-   scanned for attach/connect tokens — prevents `--allowed-origins=cdp://x`
-   style value-smuggling.
-5. **Path resolution (env-var → absolute, hard-fail).** Values of
-   `--storage-state` / `--user-data-dir` are env-expanded (Windows `%VAR%`,
-   POSIX `$VAR` / `${VAR}`) and resolved to an absolute path. Unresolved tokens
-   → launch rejected (not silently passed through).
-6. **Reject repo-internal and real-profile paths.** The resolved path is
+4. **Flag value attach-token scan.** For all non-path, non-origin flags, the
+   value is scanned for attach/connect tokens — prevents `--caps=connect` style
+   value-smuggling. `--allowed-origins` / `--blocked-origins` are excluded from
+   this scan: their values are origin lists that legitimately contain substrings
+   like `remote` or `endpoint`; the real attach vector for those flags is
+   flag-name-based and already covered by rule 2.
+5. **Positional arguments rejected.** Any argument that does not start with `-`
+   is rejected (exit 2). All flag values must use `--flag=value` equals form
+   (not `--flag value` space form) except `--browser` and `--storage-state`
+   which also accept space form internally.
+6. **Path resolution (env-var → absolute, hard-fail).** Values of
+   `--storage-state` are env-expanded (`$VAR` / `${VAR}`) and resolved to an
+   absolute path. Unresolved tokens → launch rejected (not silently passed
+   through).
+7. **Reject repo-internal and real-profile paths.** The resolved path is
    canonicalized via `fs.realpathSync.native()` (resolves symlinks, Windows 8.3
    short names, junctions) before comparison. Rejected if inside the repo
    working tree (repo root resolved from `__dirname` — deterministic, no
    `git`/cwd dependency) or matching a real browser profile fragment
    (`Google/Chrome/User Data`, `Microsoft/Edge/User Data`, …; case- and
    slash-insensitive).
-7. **Repo-root fail-closed.** If the adapter cannot determine the repo root
+8. **Repo-root fail-closed.** If the adapter cannot determine the repo root
    (unusual deployment), path-type flags are rejected rather than silently
    allowed.
 
 Any violation → stderr error + exit `2` (config gate reject) or `3`
 (CLI cache absent — see §Setup). The MCP server never starts with an unsafe config.
 
-> The `.mcp.json` entry uses `%LOCALAPPDATA%/...` as the storage-state path.
-> That env var is expanded **by this wrapper at launch time** (rule 3). If the
-> runtime environment does not define it, the wrapper hard-fails rather than
-> pointing at a literal `%LOCALAPPDATA%` directory.
+> The `.mcp.json` entry uses `$MERCURY_PLAYWRIGHT_STORAGE_STATE` as the
+> storage-state path. Export this env var to point at your repo-external private
+> auth-state file before starting Slice B live sessions. If the variable is
+> unset, the wrapper hard-fails at launch (fail-closed — never silently
+> passes an unresolved path).
+>
+> **Value form requirement:** all flag values (except `--browser` and
+> `--storage-state`) must use `--flag=value` equals form. Space-separated
+> positional values are rejected by the config gate (exit 2).
 
 ## Setup (one-time provision)
 
 Before first use, provision the pinned package into the per-user cache. This
 is a **one-time step** — Slice A does not need it for gate tests, only for
 actual browser spawning (Slice B).
-
-```
-npm install --no-save --no-fund --no-audit \
-  --prefix "%LOCALAPPDATA%\..\..\.cache\mercury\playwright-mcp\0.0.75" \
-  @playwright/mcp@0.0.75
-```
 
 Cross-platform form (matches the path `launch.cjs` resolves via `os.homedir()`):
 
@@ -133,6 +138,17 @@ npm install --no-save --no-fund --no-audit \
 
 If the cache is absent at launch time, the adapter exits 3 and prints the
 exact command to run (fail-closed — it never auto-installs at runtime).
+
+Before Slice B live sessions, also export the storage-state env var pointing
+at a **repo-external** private path:
+
+```sh
+# PowerShell (Windows)
+$env:MERCURY_PLAYWRIGHT_STORAGE_STATE = "$env:LOCALAPPDATA\mercury\playwright-mcp\auth-state.json"
+
+# POSIX shell
+export MERCURY_PLAYWRIGHT_STORAGE_STATE="$HOME/.local/mercury/playwright-mcp/auth-state.json"
+```
 
 ## How it runs (spawn form)
 
@@ -167,7 +183,7 @@ The server is registered in the repo-root `.mcp.json` under `playwright`:
     "args": [
       "./adapters/playwright-mcp/launch.cjs",
       "--isolated", "--caps=storage",
-      "--storage-state=%LOCALAPPDATA%/mercury/playwright-mcp/auth-state.json"
+      "--storage-state=$MERCURY_PLAYWRIGHT_STORAGE_STATE"
     ]
   }
 }

--- a/adapters/playwright-mcp/README.md
+++ b/adapters/playwright-mcp/README.md
@@ -1,0 +1,202 @@
+# playwright-mcp
+
+Mercury adapter that mounts Microsoft's official
+[`@playwright/mcp`](https://github.com/microsoft/playwright-mcp) (Apache-2.0)
+as a Claude Code MCP server, pinned to **`@playwright/mcp@0.0.75`**. The
+adapter is a **config-gate wrapper only** — it holds no browser logic. All
+browser control lives in the upstream MCP server; Mercury only enforces
+security defaults before the server starts.
+
+Design authority:
+[`.mercury/docs/research/issue-154-web-automation-2026-05.md`](../../.mercury/docs/research/issue-154-web-automation-2026-05.md)
+(Phase 1 ADR). This adapter is Phase 2 **Slice A** (mount + governance gate +
+config封装). See Issue #458 / #154.
+
+## Why mounted
+
+The ADR (§3) selects `@playwright/mcp` over lightpanda (AGPL-3.0, fails the
+license gate), puppeteer (no official MCP → would need self-research), and
+browser-use (agent-within-agent). `@playwright/mcp` is the official,
+permissive-licensed, ready-made MCP server for stateful browser automation
+with Cookie/Session reuse — matching #154's needs without building our own.
+
+## What is configured
+
+The recommended `.mcp.json` args (passed *through* this wrapper) are:
+
+```
+--isolated --caps=storage --storage-state=<repo-external per-user path>
+```
+
+- `--isolated` — fresh in-memory profile per session, nothing persisted to
+  disk (ADR §4.3 least-privilege default). The wrapper **injects `--isolated`
+  if the caller omits it**.
+- `--caps=storage` — opt-in capability that enables the cookie / localStorage
+  / `browser_storage_state` tools required for auth reuse (ADR §4.4). Without
+  it those tools do not exist.
+- `--storage-state=<path>` — storageState file for an isolated session, kept
+  at a **repo-external per-user private path** (e.g.
+  `%LOCALAPPDATA%/mercury/playwright-mcp/auth-state.json`).
+
+## Security red lines (enforced by `launch.cjs`)
+
+All validation logic lives in `launch.cjs` (single file). The gate runs
+**before** the upstream server is spawned.
+
+### Minimum flag allowlist
+
+Only these flags are permitted (default-deny — any unknown flag is rejected):
+
+| Flag | Why kept |
+|---|---|
+| `--isolated` | Enforces fresh in-memory profile (injected if omitted) |
+| `--caps` | Opt-in capabilities (e.g. `storage` for auth reuse) |
+| `--storage-state` | StorageState file path (repo-external, validated) |
+| `--user-data-dir` | Custom profile dir (repo-external, validated) |
+| `--allowed-origins` | Origin allowlist for network requests |
+| `--blocked-origins` | Origin blocklist |
+| `--headless` / `--headed` | Headless mode toggle |
+| `--browser` | Playwright engine — value restricted to `chromium`/`firefox`/`webkit` |
+| `--device` | Emulated device preset |
+| `--viewport-size` | Viewport dimensions |
+
+Removed from allowlist (vs. Slice A first draft) and why:
+
+| Removed flag | Reason |
+|---|---|
+| `--config` | Config JSON accepts `cdpEndpoint`/`isolated:false` → backdoor past all three red lines |
+| `--port` / `--host` | Switch stdio transport to SSE/HTTP → exposes unauthenticated network endpoint |
+| `--help` / `--version` | Print plain text to stdout → contaminate JSON-RPC channel |
+| `--save-trace` / `--save-session` / `--output-dir` | Artifact paths contain auth cookies; not needed for Slice A PoC |
+| `--no-sandbox` | Weakens Chromium sandbox |
+| `--timeout-action` / `--timeout-navigation` | Not required for Slice A |
+
+### Enforcement rules
+
+1. **Default-deny flag allowlist.** Any flag not on the allowlist is rejected —
+   so a *new* attach-class flag introduced upstream automatically falls into
+   default-deny.
+2. **Whole-class rejection of attach / connect flags** (ADR §4.2(b)). Any flag
+   whose name contains `cdp` / `endpoint` / `extension` / `connect` / `remote`
+   is rejected — covers `--extension`, `--cdp-endpoint`, `--remote-endpoint`,
+   `remoteEndpoint` and future siblings. Mercury never attaches to a
+   pre-existing or externally-launched browser.
+3. **`--browser` value whitelist.** Only `chromium`, `firefox`, `webkit`
+   (Playwright engine names). Real-browser channel names (`chrome`, `msedge`,
+   `chrome-beta`, `msedge-*`, `cdp`, …) are rejected — they attach to real
+   installed browsers that hold the user's cookies.
+4. **Flag value attach-token scan.** For all non-path flags, the value is also
+   scanned for attach/connect tokens — prevents `--allowed-origins=cdp://x`
+   style value-smuggling.
+5. **Path resolution (env-var → absolute, hard-fail).** Values of
+   `--storage-state` / `--user-data-dir` are env-expanded (Windows `%VAR%`,
+   POSIX `$VAR` / `${VAR}`) and resolved to an absolute path. Unresolved tokens
+   → launch rejected (not silently passed through).
+6. **Reject repo-internal and real-profile paths.** The resolved path is
+   canonicalized via `fs.realpathSync.native()` (resolves symlinks, Windows 8.3
+   short names, junctions) before comparison. Rejected if inside the repo
+   working tree (repo root resolved from `__dirname` — deterministic, no
+   `git`/cwd dependency) or matching a real browser profile fragment
+   (`Google/Chrome/User Data`, `Microsoft/Edge/User Data`, …; case- and
+   slash-insensitive).
+7. **Repo-root fail-closed.** If the adapter cannot determine the repo root
+   (unusual deployment), path-type flags are rejected rather than silently
+   allowed.
+
+Any violation → stderr error + exit `2` (config gate reject) or `3`
+(CLI cache absent — see §Setup). The MCP server never starts with an unsafe config.
+
+> The `.mcp.json` entry uses `%LOCALAPPDATA%/...` as the storage-state path.
+> That env var is expanded **by this wrapper at launch time** (rule 3). If the
+> runtime environment does not define it, the wrapper hard-fails rather than
+> pointing at a literal `%LOCALAPPDATA%` directory.
+
+## Setup (one-time provision)
+
+Before first use, provision the pinned package into the per-user cache. This
+is a **one-time step** — Slice A does not need it for gate tests, only for
+actual browser spawning (Slice B).
+
+```
+npm install --no-save --no-fund --no-audit \
+  --prefix "%LOCALAPPDATA%\..\..\.cache\mercury\playwright-mcp\0.0.75" \
+  @playwright/mcp@0.0.75
+```
+
+Cross-platform form (matches the path `launch.cjs` resolves via `os.homedir()`):
+
+```
+npm install --no-save --no-fund --no-audit \
+  --prefix "~/.cache/mercury/playwright-mcp/0.0.75" \
+  @playwright/mcp@0.0.75
+```
+
+If the cache is absent at launch time, the adapter exits 3 and prints the
+exact command to run (fail-closed — it never auto-installs at runtime).
+
+## How it runs (spawn form)
+
+`launch.cjs` mounts the upstream server **runtime-only, with no vendored
+`node_modules` in the repo**:
+
+1. It resolves `cli.js` from the per-user cache
+   (`~/.cache/mercury/playwright-mcp/0.0.75/node_modules/@playwright/mcp/cli.js`).
+   If absent → exit 3 with the provision command above (fail-closed; no
+   network access, no npm noise on the MCP stdio channel).
+2. It spawns `node <cli.js> <safe-args>` with `stdio: 'inherit'` (transparent
+   MCP stdio JSON-RPC) and propagates the exit code.
+
+**Why not plain `npx @playwright/mcp@0.0.75`?** On the Windows dev host (Node
+24 / npx 11, Node installed under `D:\Program Files` — a path with a space),
+npx's generated bin-shim for `playwright-mcp` fails with
+`'playwright-mcp' is not recognized as an internal or external command`. This
+was reproduced under MSYS bash, `cmd.exe`, and PowerShell. By contrast
+`node <cli.js>` (shell-free, PATH-independent, via `process.execPath`) works
+reliably. Smoke-verified 2026-05-26: gate rejections exit 2; valid config
+with provisioned cache reaches upstream `--version` → `Version 0.0.75`.
+
+## Run
+
+The server is registered in the repo-root `.mcp.json` under `playwright`:
+
+```jsonc
+{
+  "playwright": {
+    "type": "stdio",
+    "command": "node",
+    "args": [
+      "./adapters/playwright-mcp/launch.cjs",
+      "--isolated", "--caps=storage",
+      "--storage-state=%LOCALAPPDATA%/mercury/playwright-mcp/auth-state.json"
+    ]
+  }
+}
+```
+
+## Test
+
+```
+node --test "adapters/playwright-mcp/test/*.cjs"
+```
+
+Uses Node.js built-in `node:test` — no external deps. Tests cover the config
+gate's pure validation functions (attach-class reject, default-deny unknown
+flags, repo-internal / real-profile path reject, unresolved-env reject, legal
+config pass + `--isolated` injection, slash/case robustness). Tests never
+spawn a real browser.
+
+## Out of scope (Slice B)
+
+The following need an MCP client session + manual login to a target site and
+are **not** part of Slice A: live navigate + screenshot (ADR V1), auth reuse
+via storageState (V2), and storageState domain-scope / sessionStorage
+identification (V6). They are deferred to Slice B (requires session restart +
+human login).
+
+## Provenance / license
+
+`launch.cjs` is original Mercury code (MIT, project license). Upstream
+`@playwright/mcp` is Apache-2.0, invoked as a runtime dependency (not
+redistributed by this repo). See [`UPSTREAM.md`](UPSTREAM.md) for the
+npm-version ↔ git-tag pin and drift policy; manifest entry in
+`.mercury/state/upstream-manifest.json`.

--- a/adapters/playwright-mcp/UPSTREAM.md
+++ b/adapters/playwright-mcp/UPSTREAM.md
@@ -1,0 +1,99 @@
+# UPSTREAM — playwright-mcp
+
+## Origin
+
+Adapter mounts Microsoft's official
+[`microsoft/playwright-mcp`](https://github.com/microsoft/playwright-mcp)
+(`@playwright/mcp` on npm, Apache-2.0) as a Claude Code MCP server. No
+upstream source is vendored — `launch.cjs` is original Mercury code that
+resolves the cached `cli.js` at runtime and spawns it; provisioning is a
+one-time manual step (see adapter README §Setup).
+
+This is the **third mount mode** in Mercury's adapter policy — an
+**npm-version-pinned MCP server (runtime-only)** — alongside (1) git submodule
+to `modules/` and (2) `uvx git+<repo>@<SHA>` runtime-only (gpt-image-2). See
+`adapters/README.md` §约束 + `.mercury/docs/DIRECTION.md` §四.
+
+## Pin
+
+| Field | Value |
+|---|---|
+| Repo | `microsoft/playwright-mcp` (Apache-2.0) |
+| **Execution contract** | npm version **`@playwright/mcp@0.0.75`** |
+| npm `dist-tags.latest` at pin | `0.0.75` (verified `registry.npmjs.org/@playwright/mcp/latest`) |
+| `upstream_sha_at_import` | `8116437ffcfee1309cebc07dd30cee37720d2d19` |
+| Pinned date | 2026-05-26 |
+| bin | `{ "playwright-mcp": "cli.js" }` |
+| License | Apache-2.0 |
+
+### npm-version ↔ git-tag mapping (important)
+
+The **execution contract is the pinned npm version `0.0.75`** — npm resolves
+the package tarball *by version* from the registry, not by git checkout. The
+`upstream_sha_at_import`
+(`8116437ffcfee1309cebc07dd30cee37720d2d19`) is the commit that git tag
+`v0.0.75` points to, verified via
+`gh api repos/microsoft/playwright-mcp/git/refs/tags/v0.0.75` on 2026-05-26.
+That SHA is **audit metadata** (maps the pinned npm version back to an
+upstream git tag for supply-chain / drift auditing) — it is **not** the
+execution contract. `scripts/upstream-drift-check.sh` tracks
+`upstream_path: package.json` to flag upstream version bumps that may require
+re-pinning this adapter.
+
+## Known incompatibilities / caveats
+
+- **storage tools are opt-in** — cookie / localStorage / `browser_storage_state`
+  tools require `--caps=storage`. Without it the auth-reuse flow does not
+  exist (ADR §4.4). The adapter's recommended `.mcp.json` args include it.
+- **CDP endpoint + storage-state is an open issue**
+  ([microsoft/playwright-mcp#983](https://github.com/microsoft/playwright-mcp/issues/983))
+  — when connecting via a CDP endpoint, storage-state config support is
+  unresolved. Mercury avoids this entirely: the adapter hard-rejects all
+  CDP / attach-class flags (ADR §4.2(b)) and only runs the MCP server's own
+  self-launched isolated browser.
+- **pre-1.0 API (0.0.x)** — CLI flags / tool names may change between minor
+  versions. The flag allowlist in `launch.cjs` may need review on version
+  bumps. Drift-check monitors `package.json`.
+- **storageState scope** — `browser_storage_state` exports the *whole current
+  context* (cookies + localStorage, **no** sessionStorage, **no** built-in
+  domain filter). Single-domain scope comes from context isolation, not from
+  the file format (ADR §4.1). Slice B work.
+
+## Spawn-form note (Windows dev host)
+
+On the dev host (Node 24 / npx 11, Node under `D:\Program Files`), npx's
+generated bin-shim for `playwright-mcp` fails (`not recognized as an internal
+or external command`) — reproduced under MSYS, cmd, and PowerShell. The
+adapter therefore spawns `node cli.js` directly (shell-free, PATH-independent),
+which returns `Version 0.0.75` reliably. No `node_modules` is vendored into
+the repo.
+
+The package is provisioned once via the one-time `npm install --no-save
+--prefix <cacheDir>` command documented in adapter README §Setup. At runtime
+the adapter only resolves the cached `cli.js` path (fail-closed if absent —
+never auto-installs). See adapter README §"How it runs" for full rationale.
+
+## Drift policy
+
+`scripts/upstream-drift-check.sh` compares the upstream `package.json` blob
+SHA at the pinned import SHA against the same file at upstream `HEAD`. The
+manifest entry sets `upstream_path: "package.json"` because that file is the
+canonical version/deps/bin contract — any change there signals the adapter's
+pinned npm version may need review. The full upstream tree is not
+file-by-file tracked (mounted as a runtime npm dependency, not by vendoring
+source).
+
+When drift-check reports `CHANGED`: review the upstream diff for license /
+CLI-flag / tool-name changes before bumping the pinned npm version (in
+`launch.cjs` `PINNED`, the `.mcp.json` args, the adapter README, and this
+file) and the manifest `upstream_sha_at_import`.
+
+## License
+
+Upstream `@playwright/mcp` is Apache-2.0 (permissive — passes Mercury's
+license gate). Mercury invokes it as a runtime dependency; no upstream source
+is redistributed by this repository. `launch.cjs` is original Mercury code
+(MIT, project license).
+
+Cherry-pick / mount-provenance is recorded in the import commit message and
+the `.mercury/state/upstream-manifest.json` entry.

--- a/adapters/playwright-mcp/UPSTREAM.md
+++ b/adapters/playwright-mcp/UPSTREAM.md
@@ -25,6 +25,7 @@ to `modules/` and (2) `uvx git+<repo>@<SHA>` runtime-only (gpt-image-2). See
 | Pinned date | 2026-05-26 |
 | bin | `{ "playwright-mcp": "cli.js" }` |
 | License | Apache-2.0 |
+| import_pr | 459 |
 
 ### npm-version ↔ git-tag mapping (important)
 

--- a/adapters/playwright-mcp/launch.cjs
+++ b/adapters/playwright-mcp/launch.cjs
@@ -101,7 +101,7 @@ function buildSafeArgs(rawArgs, opts = {}) {
   let hasIsolated = false;
   for (let i = 0; i < rawArgs.length; i++) {
     const arg = rawArgs[i];
-    if (typeof arg !== 'string' || !arg.startsWith('-')) { out.push(arg); continue; }
+    if (typeof arg !== 'string' || !arg.startsWith('-')) throw new Error('positional arguments are not allowed by config gate (use --flag=value): ' + String(arg));
     const eq = arg.indexOf('=');
     const flag = eq >= 0 ? arg.slice(0, eq) : arg;
     let value = eq >= 0 ? arg.slice(eq + 1) : undefined;
@@ -120,14 +120,14 @@ function buildSafeArgs(rawArgs, opts = {}) {
       if (eq < 0) out.push(value);
       continue;
     }
-    // Value-smuggling guard: scan non-path flag values for attach tokens.
-    if (!PATH_VALUE_FLAGS.has(flag) && value !== undefined && isAttachValue(value))
+    // Value-smuggling guard: scan non-path, non-origin flag values for attach tokens.
+    // --allowed-origins/--blocked-origins are excluded: their values are origin lists that
+    // legitimately contain substrings like "remote" or "endpoint" (ADR §4.3; the real
+    // attach vector is flag-name-based and already covered by the whole-class reject above).
+    // Note: space-form values for these flags are now rejected as positional args (see above).
+    if (!PATH_VALUE_FLAGS.has(flag) && flag !== '--allowed-origins' && flag !== '--blocked-origins'
+        && value !== undefined && isAttachValue(value))
       throw new Error(`flag value contains attach/connect token (rejected): ${flag}=${value}`);
-    if (!PATH_VALUE_FLAGS.has(flag) && value === undefined && i + 1 < rawArgs.length) {
-      const next = rawArgs[i + 1];
-      if (typeof next === 'string' && !next.startsWith('-') && isAttachValue(next))
-        throw new Error(`flag value contains attach/connect token (rejected): ${flag} ${next}`);
-    }
     if (PATH_VALUE_FLAGS.has(flag)) {
       if (value === undefined) value = rawArgs[++i];
       if (value === undefined) throw new Error(`${flag} requires a value`);

--- a/adapters/playwright-mcp/launch.cjs
+++ b/adapters/playwright-mcp/launch.cjs
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+'use strict';
+// Mercury adapter: config-gate wrapper for @playwright/mcp (Issue #458 / #154 ADR).
+// Enforces ADR §4.2 (deny attach-class), §4.3 (least-privilege), §5.2 (path rules)
+// before spawning the upstream MCP server. Fail-closed: absent CLI cache → exit 3
+// with a one-time provision command (never auto-installs at runtime).
+const { spawn } = require('node:child_process');
+const path = require('node:path');
+const fs = require('node:fs');
+const os = require('node:os');
+const PINNED_VERSION = '0.0.75';
+const PINNED = `@playwright/mcp@${PINNED_VERSION}`;
+// Minimum allowlist — only flags the stdio MCP server actually needs.
+// Removed: --config (cdpEndpoint/isolated:false backdoor), --port/--host (network),
+// --help/--version (contaminates JSON-RPC), --save-trace/--save-session/--output-dir
+// (artifact paths / auth cookies), --no-sandbox, --user-data-dir (persistent profile).
+const FLAG_ALLOWLIST = new Set([
+  '--isolated', '--caps', '--storage-state',
+  '--allowed-origins', '--blocked-origins', '--headless', '--headed',
+  '--browser', '--device', '--viewport-size',
+]);
+// Tokens that mark a flag as attach/connect-class → hard reject (整类拦截).
+const ATTACH_TOKENS = ['cdp', 'endpoint', 'extension', 'connect', 'remote', 'ws-endpoint'];
+// --browser value whitelist: Playwright engine names only. Real-browser channels
+// (chrome/msedge/chrome-beta/msedge-*) attach to installed browsers with user cookies.
+const BROWSER_ALLOWLIST = new Set(['chromium', 'firefox', 'webkit']);
+// Flags whose value is a file-system path requiring validation.
+const PATH_VALUE_FLAGS = new Set(['--storage-state']);
+// Real browser profile fragments (case-insensitive, slash-normalized) → reject.
+const PROFILE_FRAGMENTS = [
+  'google/chrome/user data', 'microsoft/edge/user data',
+  'bravesoftware/brave-browser/user data', 'chromium/user data',
+];
+function normPath(p) { return String(p).replace(/\\/g, '/').toLowerCase(); }
+function isAttachFlag(flag) {
+  const name = flag.replace(/^--?/, '').toLowerCase();
+  return ATTACH_TOKENS.some((t) => name.includes(t));
+}
+
+function isAttachValue(value) {
+  const v = String(value).toLowerCase();
+  return ATTACH_TOKENS.some((t) => v.includes(t));
+}
+// Expand %VAR% / $VAR / ${VAR}; hard-fail if any token remains unresolved.
+function expandEnv(value, env) {
+  let out = String(value)
+    .replace(/%([^%]+)%/g, (m, n) => (env[n] !== undefined ? env[n] : m))
+    .replace(/\$\{([^}]+)\}/g, (m, n) => (env[n] !== undefined ? env[n] : m))
+    .replace(/\$([A-Za-z_][A-Za-z0-9_]*)/g, (m, n) => (env[n] !== undefined ? env[n] : m));
+  if (/%[^%]+%/.test(out) || /\$\{[^}]+\}/.test(out) || /\$[A-Za-z_]/.test(out))
+    throw new Error(`unresolved environment variable in path: "${value}" → "${out}"`);
+  return out;
+}
+// Canonicalize: resolve symlinks / 8.3 short names / junctions via realpathSync.native.
+// If the full path does not exist, walk up to the nearest existing ancestor and
+// re-append the non-existing tail. TOCTOU window is narrow — acceptable for PoC.
+function canonicalize(absPath) {
+  try { return fs.realpathSync.native(absPath); } catch (_) { /* path tail may not exist */ }
+  let cur = absPath;
+  const tail = [];
+  for (;;) {
+    const parent = path.dirname(cur);
+    if (parent === cur) break;
+    tail.unshift(path.basename(cur));
+    cur = parent;
+    try { return path.join(fs.realpathSync.native(cur), ...tail); } catch (_) { /* keep walking */ }
+  }
+  return absPath;
+}
+
+// Resolve repo root from adapter __dirname (deterministic; no cwd/git dependency).
+function resolveRepoRoot(fromDir) {
+  let cur = fromDir || __dirname;
+  for (let i = 0; i < 8; i++) {
+    if (fs.existsSync(path.join(cur, '.git'))) return cur;
+    const parent = path.dirname(cur);
+    if (parent === cur) break;
+    cur = parent;
+  }
+  return null;
+}
+
+// Validate one resolved absolute path against repo-inside + browser-profile rules.
+function assertPathAllowed(absPath, root) {
+  const n = normPath(canonicalize(absPath));
+  if (root) {
+    const nr = normPath(canonicalize(root)).replace(/\/+$/, '');
+    if (n === nr || n.startsWith(nr + '/'))
+      throw new Error(`path inside repo working tree is rejected: ${absPath}`);
+  }
+  for (const frag of PROFILE_FRAGMENTS)
+    if (n.includes(frag)) throw new Error(`path points at a real browser profile (rejected): ${absPath}`);
+}
+
+// Core pure gate: validate + normalize args. Throws on any violation.
+// Returns the final args array (with --isolated injected if missing).
+function buildSafeArgs(rawArgs, opts = {}) {
+  const env = opts.env || process.env;
+  const root = opts.repoRoot !== undefined ? opts.repoRoot : resolveRepoRoot();
+  const out = [];
+  let hasIsolated = false;
+  for (let i = 0; i < rawArgs.length; i++) {
+    const arg = rawArgs[i];
+    if (typeof arg !== 'string' || !arg.startsWith('-')) { out.push(arg); continue; }
+    const eq = arg.indexOf('=');
+    const flag = eq >= 0 ? arg.slice(0, eq) : arg;
+    let value = eq >= 0 ? arg.slice(eq + 1) : undefined;
+    if (isAttachFlag(flag)) throw new Error(`attach/connect-class flag is rejected (ADR §4.2): ${flag}`);
+    if (!FLAG_ALLOWLIST.has(flag)) throw new Error(`flag not in safe allowlist (default-deny): ${flag}`);
+    if (flag === '--isolated') hasIsolated = true;
+    if (flag === '--browser') {
+      if (value === undefined) value = rawArgs[++i];
+      if (!value || !BROWSER_ALLOWLIST.has(value.toLowerCase()))
+        throw new Error(
+          `--browser value "${value}" is not an allowed Playwright engine ` +
+          `(allowed: ${[...BROWSER_ALLOWLIST].join(', ')}); ` +
+          `real-browser channels (chrome, msedge, cdp, …) are rejected`,
+        );
+      out.push(eq >= 0 ? `${flag}=${value}` : flag);
+      if (eq < 0) out.push(value);
+      continue;
+    }
+    // Value-smuggling guard: scan non-path flag values for attach tokens.
+    if (!PATH_VALUE_FLAGS.has(flag) && value !== undefined && isAttachValue(value))
+      throw new Error(`flag value contains attach/connect token (rejected): ${flag}=${value}`);
+    if (!PATH_VALUE_FLAGS.has(flag) && value === undefined && i + 1 < rawArgs.length) {
+      const next = rawArgs[i + 1];
+      if (typeof next === 'string' && !next.startsWith('-') && isAttachValue(next))
+        throw new Error(`flag value contains attach/connect token (rejected): ${flag} ${next}`);
+    }
+    if (PATH_VALUE_FLAGS.has(flag)) {
+      if (value === undefined) value = rawArgs[++i];
+      if (value === undefined) throw new Error(`${flag} requires a value`);
+      const abs = path.resolve(expandEnv(value, env));
+      if (root === null)
+        throw new Error(
+          `repo root could not be determined; rejecting path flag ${flag} (fail-closed). ` +
+          `Ensure the adapter runs from within the Mercury repo working tree.`,
+        );
+      assertPathAllowed(abs, root);
+      out.push(eq >= 0 ? `${flag}=${abs}` : flag);
+      if (eq < 0) out.push(abs);
+      continue;
+    }
+    out.push(arg);
+  }
+  if (!hasIsolated) out.unshift('--isolated');
+  return out;
+}
+
+// Resolve the pinned cli.js from the per-user cache. Fail-closed: if absent,
+// throw with a one-time provision command. NEVER runs npm install at runtime —
+// avoids network access and npm noise on the MCP stdio JSON-RPC channel.
+function resolveCli(opts = {}) {
+  const cacheDir = opts.cacheDir
+    || path.join(os.homedir(), '.cache', 'mercury', 'playwright-mcp', PINNED_VERSION);
+  const cli = path.join(cacheDir, 'node_modules', '@playwright', 'mcp', 'cli.js');
+  if (fs.existsSync(cli)) return cli;
+  throw new Error(
+    `${PINNED} not provisioned. Run once:\n` +
+    `  npm install --no-save --no-fund --no-audit --prefix "${cacheDir}" ${PINNED}\n` +
+    `(see adapters/playwright-mcp/README.md §Setup)`,
+  );
+}
+
+function main() {
+  let safeArgs;
+  try {
+    safeArgs = buildSafeArgs(process.argv.slice(2));
+  } catch (e) {
+    process.stderr.write(`[playwright-mcp adapter] config gate rejected launch: ${e.message}\n`);
+    process.exit(2);
+  }
+  let cli;
+  try {
+    cli = resolveCli();
+  } catch (e) {
+    process.stderr.write(`[playwright-mcp adapter] ${e.message}\n`);
+    process.exit(3);
+  }
+  // stdio:'inherit' only here — this IS the JSON-RPC channel and must be transparent.
+  const child = spawn(process.execPath, [cli, ...safeArgs], { stdio: 'inherit', shell: false });
+  child.on('exit', (code, sig) => {
+    if (sig) { try { process.kill(process.pid, sig); } catch (_) { process.exit(1); } }
+    process.exit(code === null ? 1 : code);
+  });
+  child.on('error', (e) => {
+    process.stderr.write(`[playwright-mcp adapter] spawn failed: ${e.message}\n`);
+    process.exit(1);
+  });
+}
+
+if (require.main === module) main();
+
+module.exports = {
+  buildSafeArgs, expandEnv, isAttachFlag, isAttachValue, assertPathAllowed,
+  normPath, canonicalize, resolveRepoRoot, resolveCli,
+  FLAG_ALLOWLIST, ATTACH_TOKENS, BROWSER_ALLOWLIST, PATH_VALUE_FLAGS, PINNED,
+};

--- a/adapters/playwright-mcp/package.json
+++ b/adapters/playwright-mcp/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "playwright-mcp-adapter",
+  "version": "1.0.0",
+  "description": "Mercury config-gate wrapper for @playwright/mcp (pinned, security defaults)",
+  "private": true,
+  "type": "commonjs",
+  "main": "launch.cjs",
+  "scripts": {
+    "test": "node --test \"test/*.cjs\""
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "license": "MIT"
+}

--- a/adapters/playwright-mcp/test/launch.test.cjs
+++ b/adapters/playwright-mcp/test/launch.test.cjs
@@ -1,0 +1,414 @@
+'use strict';
+// launch.test.cjs — config-gate reject-rule tests for the playwright-mcp adapter.
+// Tests the pure validation functions; never spawns a real browser.
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const fs = require('node:fs');
+const os = require('node:os');
+
+const {
+  buildSafeArgs, expandEnv, isAttachFlag, isAttachValue, assertPathAllowed,
+  normPath, FLAG_ALLOWLIST, BROWSER_ALLOWLIST, canonicalize, resolveCli,
+} = require('../launch.cjs');
+
+// A repo root + safe outside-repo private path to reuse across tests.
+const REPO = process.platform === 'win32' ? 'D:/Mercury/Mercury' : '/repo/mercury';
+const SAFE_ABS = process.platform === 'win32'
+  ? 'D:/Users/agent/AppData/Local/mercury/playwright-mcp/auth-state.json'
+  : '/home/agent/.local/mercury/playwright-mcp/auth-state.json';
+
+function gate(args, env = {}) {
+  return buildSafeArgs(args, { env, repoRoot: REPO, cwd: REPO });
+}
+
+// ── attach-class flags are rejected (整类拦截) ──────────────────────────────
+test('rejects --extension (attach-class)', () => {
+  assert.throws(() => gate(['--extension']), /attach\/connect-class/);
+});
+test('rejects --cdp-endpoint (attach-class)', () => {
+  assert.throws(() => gate(['--cdp-endpoint=http://localhost:9222']), /attach\/connect-class/);
+});
+test('rejects --endpoint (attach-class)', () => {
+  assert.throws(() => gate(['--endpoint', 'ws://x']), /attach\/connect-class/);
+});
+test('rejects --remote-endpoint / remoteEndpoint token (attach-class)', () => {
+  assert.throws(() => gate(['--remote-endpoint=ws://x']), /attach\/connect-class/);
+  assert.ok(isAttachFlag('--remoteEndpoint'));
+});
+test('rejects a hypothetical new connect-class flag by token (default-deny generalizes)', () => {
+  assert.throws(() => gate(['--connect-over-cdp=foo']), /attach\/connect-class/);
+});
+
+// ── unknown flags rejected by default-deny allowlist ────────────────────────
+test('rejects unknown flag not in allowlist', () => {
+  assert.throws(() => gate(['--totally-unknown-flag']), /default-deny/);
+});
+
+// ── CRITICAL: removed flags are now default-deny ────────────────────────────
+test('[CRITICAL] rejects --config (backdoor: cdpEndpoint/isolated:false in config file)', () => {
+  assert.throws(() => gate(['--config', 'x.json']), /default-deny/);
+});
+test('[CRITICAL] rejects --config=x.json (= form)', () => {
+  assert.throws(() => gate(['--config=x.json']), /default-deny/);
+});
+
+// ── HIGH: --port/--host switch to SSE/HTTP transport ────────────────────────
+test('[HIGH] rejects --port (switches stdio server to SSE/HTTP network listener)', () => {
+  assert.throws(() => gate(['--port', '3000']), /default-deny/);
+});
+test('[HIGH] rejects --host (exposes unauthenticated network endpoint)', () => {
+  assert.throws(() => gate(['--host', '0.0.0.0']), /default-deny/);
+});
+
+// ── HIGH: --help/--version contaminate JSON-RPC stdout ──────────────────────
+test('[HIGH] rejects --help (stdout text contaminates JSON-RPC channel)', () => {
+  assert.throws(() => gate(['--help']), /default-deny/);
+});
+test('[HIGH] rejects --version (stdout text contaminates JSON-RPC channel)', () => {
+  assert.throws(() => gate(['--version']), /default-deny/);
+});
+
+// ── HIGH: --browser value whitelist ─────────────────────────────────────────
+test('[HIGH] rejects --browser chrome (real-browser channel, reuses installed Chrome)', () => {
+  assert.throws(() => gate(['--browser', 'chrome']), /not an allowed Playwright engine/);
+});
+test('[HIGH] rejects --browser=msedge (real-browser channel)', () => {
+  assert.throws(() => gate(['--browser=msedge']), /not an allowed Playwright engine/);
+});
+test('[HIGH] rejects --browser=cdp (attach-class value)', () => {
+  assert.throws(() => gate(['--browser=cdp']), /not an allowed Playwright engine/);
+});
+test('[HIGH] rejects --browser chrome-beta (channel variant)', () => {
+  assert.throws(() => gate(['--browser', 'chrome-beta']), /not an allowed Playwright engine/);
+});
+test('[HIGH] rejects --browser msedge-dev (channel variant)', () => {
+  assert.throws(() => gate(['--browser', 'msedge-dev']), /not an allowed Playwright engine/);
+});
+test('[HIGH] allows --browser=chromium (Playwright engine)', () => {
+  const out = gate(['--browser=chromium']);
+  assert.ok(out.includes('--browser=chromium') || out.some((a) => a === '--browser=chromium'));
+});
+test('[HIGH] allows --browser firefox (Playwright engine, space form)', () => {
+  const out = gate(['--browser', 'firefox']);
+  assert.ok(out.includes('firefox'));
+});
+test('[HIGH] allows --browser webkit (Playwright engine)', () => {
+  const out = gate(['--browser', 'webkit']);
+  assert.ok(out.includes('webkit'));
+});
+
+// ── HIGH: value-smuggling via non-path flag values ───────────────────────────
+test('[HIGH] rejects --allowed-origins=cdp://x (attach token in value)', () => {
+  assert.throws(() => gate(['--allowed-origins=cdp://x']), /attach\/connect token/);
+});
+test('[HIGH] rejects --allowed-origins with ws-endpoint value (attach token)', () => {
+  assert.throws(() => gate(['--allowed-origins=ws-endpoint://x']), /attach\/connect token/);
+});
+test('[HIGH] rejects --caps value containing connect token', () => {
+  assert.throws(() => gate(['--caps=connect']), /attach\/connect token/);
+});
+test('[HIGH] allows --allowed-origins=https://example.com (no attach token)', () => {
+  assert.doesNotThrow(() => gate(['--allowed-origins=https://example.com']));
+});
+
+// ── HIGH: removed artifact path flags ───────────────────────────────────────
+test('[HIGH] rejects --save-trace (removed from allowlist)', () => {
+  assert.throws(() => gate(['--save-trace', '/tmp/trace']), /default-deny/);
+});
+test('[HIGH] rejects --save-session (removed from allowlist)', () => {
+  assert.throws(() => gate(['--save-session', '/tmp/session']), /default-deny/);
+});
+test('[HIGH] rejects --output-dir (removed from allowlist)', () => {
+  assert.throws(() => gate(['--output-dir', '/tmp/out']), /default-deny/);
+});
+test('[HIGH] rejects --no-sandbox (weakens sandbox)', () => {
+  assert.throws(() => gate(['--no-sandbox']), /default-deny/);
+});
+
+// ── repo-inside path rejected ───────────────────────────────────────────────
+test('rejects --storage-state pointing inside repo working tree', () => {
+  assert.throws(
+    () => gate([`--storage-state=${REPO}/secrets/auth.json`]),
+    /inside repo working tree/,
+  );
+});
+
+// ── real browser profile path rejected ──────────────────────────────────────
+test('rejects --storage-state pointing at a real Chrome profile', () => {
+  const chrome = 'C:/Users/me/AppData/Local/Google/Chrome/User Data/Default/state.json';
+  assert.throws(() => gate([`--storage-state=${chrome}`]), /real browser profile/);
+});
+test('rejects --storage-state pointing at a real Edge profile (backslash + case insensitive)', () => {
+  const edge = 'C:\\Users\\Me\\AppData\\Local\\Microsoft\\Edge\\USER DATA\\state.json';
+  assert.throws(() => gate([`--storage-state=${edge}`]), /real browser profile/);
+});
+
+// ── HIGH-2: --user-data-dir removed from allowlist (persistent-profile conflicts with --isolated) ──
+test('[HIGH] rejects --user-data-dir= form (default-deny: persistent-profile mode removed)', () => {
+  assert.throws(() => gate(['--user-data-dir=/tmp/profile']), /default-deny/);
+});
+test('[HIGH] rejects --user-data-dir space form (default-deny)', () => {
+  assert.throws(() => gate(['--user-data-dir', '/tmp/profile']), /default-deny/);
+});
+
+// ── HIGH: 8.3 short-name path bypass (Codex finding: was passing, must be red) ──
+// Windows 8.3 short names like GOOGLE~1 can refer to "Google" etc.
+// canonicalize() uses fs.realpathSync.native() which resolves these on Windows.
+// On non-Windows we simulate with a symlink/known-path test instead.
+test('[HIGH] rejects 8.3 short-name path pointing at Chrome User Data (Windows)', () => {
+  if (process.platform !== 'win32') {
+    // On non-Windows: verify normPath + profile fragment matching catches case variations
+    const tricky = 'C:/Users/me/GOOGLE~1/Chrome/User Data/Default/state.json';
+    // Without canonicalization, GOOGLE~1 doesn't match fragment "google/chrome/user data"
+    // With our implementation, 8.3 short names are resolved by fs.realpathSync.native() on Windows.
+    // On Linux/Mac the path doesn't exist so canonicalize returns the path as-is,
+    // but the fragment check still catches "user data" in the fragment list if the
+    // canonical path (after resolution) contains the profile fragment.
+    // Since the path doesn't exist on non-Windows, we test the logic directly:
+    const n = normPath('C:/Users/me/GOOGLE~1/Chrome/User Data/Default/state.json');
+    // "user data" is in the path — it will be caught if 8.3 resolves to the real name.
+    // On non-Windows we can't resolve 8.3; document that this test is Windows-specific.
+    // Instead verify assertPathAllowed catches the fragment match for the resolved form.
+    assert.throws(
+      () => assertPathAllowed('C:/Users/me/AppData/Local/Google/Chrome/User Data/Default/state.json', REPO),
+      /real browser profile/,
+    );
+    return;
+  }
+  // On Windows: construct a path using 8.3 form pointing at Chrome User Data.
+  // We can't guarantee the actual short name exists on any given machine, so we test
+  // canonicalize behavior directly: if realpathSync.native resolves a path, the resolved
+  // form must match the profile fragment check.
+  // Smoke: verify that a known real Chrome profile path (if it exists) is rejected.
+  const knownChromePath = path.join(
+    os.homedir(), 'AppData', 'Local', 'Google', 'Chrome', 'User Data',
+  );
+  if (fs.existsSync(knownChromePath)) {
+    assert.throws(
+      () => assertPathAllowed(knownChromePath, REPO),
+      /real browser profile/,
+    );
+  }
+  // Verify that a constructed 8.3-style path that after normPath contains the fragment
+  // is caught — simulated since real 8.3 names vary per filesystem.
+  // The key invariant: after canonicalize, profile fragments are matched case-insensitively.
+  assert.throws(
+    () => assertPathAllowed('C:\\Users\\me\\AppData\\Local\\Google\\Chrome\\User Data\\Default', REPO),
+    /real browser profile/,
+  );
+});
+
+// ── HIGH: symlink bypass ─────────────────────────────────────────────────────
+test('[HIGH] rejects symlink pointing at real Chrome profile (if symlink creation allowed)', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-test-'));
+  const linkPath = path.join(tmpDir, 'fake-state.json');
+  // Try to create a symlink to a Chrome profile path.
+  const chromeDataDir = process.platform === 'win32'
+    ? path.join(os.homedir(), 'AppData', 'Local', 'Google', 'Chrome', 'User Data')
+    : '/home/user/.config/google-chrome';
+  let symlinkCreated = false;
+  try {
+    fs.symlinkSync(chromeDataDir, linkPath);
+    symlinkCreated = true;
+  } catch (_) {
+    // symlink creation requires privileges on Windows; skip if not available
+  }
+  try {
+    if (symlinkCreated && fs.existsSync(chromeDataDir)) {
+      // canonicalize will resolve the symlink to the real Chrome profile path → rejected
+      assert.throws(
+        () => assertPathAllowed(linkPath, REPO),
+        /real browser profile/,
+      );
+    } else {
+      // Can't create symlink or target doesn't exist — verify the canonicalize
+      // function at least handles a symlink to a path inside the repo (which we can create).
+      let repoSymLink = path.join(tmpDir, 'repo-link');
+      try {
+        fs.symlinkSync(REPO, repoSymLink);
+        const targetPath = path.join(repoSymLink, 'secrets', 'auth.json');
+        assert.throws(
+          () => assertPathAllowed(targetPath, REPO),
+          /inside repo working tree/,
+        );
+      } catch (symlinkErr) {
+        // Skip: symlink creation not available in this environment.
+        // Document: this test requires symlink privileges (Windows: SeCreateSymbolicLinkPrivilege).
+        assert.ok(true, 'symlink test skipped: insufficient privileges');
+      }
+    }
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+// ── MEDIUM: repoRoot fail-closed ─────────────────────────────────────────────
+test('[MEDIUM] fail-closed when repoRoot is null and path-type flag is used', () => {
+  // When repoRoot cannot be determined (null), path flags must be rejected.
+  assert.throws(
+    () => buildSafeArgs([`--storage-state=${SAFE_ABS}`], { repoRoot: null }),
+    /repo root could not be determined/,
+  );
+});
+test('[MEDIUM] non-path flags are allowed even when repoRoot is null', () => {
+  // Non-path flags don't need repo root check.
+  assert.doesNotThrow(
+    () => buildSafeArgs(['--headless'], { repoRoot: null }),
+  );
+});
+
+// ── env-var expansion failure rejected ──────────────────────────────────────
+test('rejects unresolved %VAR% in path (hard fail, no silent passthrough)', () => {
+  assert.throws(
+    () => gate(['--storage-state=%NOPE_UNDEFINED%/auth.json'], {}),
+    /unresolved environment variable/,
+  );
+});
+test('rejects unresolved $VAR in path', () => {
+  assert.throws(
+    () => gate(['--storage-state=$NOPE_UNDEFINED/auth.json'], {}),
+    /unresolved environment variable/,
+  );
+});
+test('expands %VAR% from env then validates', () => {
+  const env = { LOCALAPPDATA: process.platform === 'win32' ? 'D:/Users/agent/AppData/Local' : '/home/agent/.local' };
+  const base = process.platform === 'win32' ? 'D:/Users/agent/AppData/Local' : '/home/agent/.local';
+  const expanded = expandEnv('%LOCALAPPDATA%/mercury/auth.json', env);
+  assert.equal(normPath(expanded), normPath(`${base}/mercury/auth.json`));
+});
+
+// ── legal config passes + --isolated injected ───────────────────────────────
+test('valid config passes and --isolated is injected when absent', () => {
+  const out = gate(['--caps=storage', `--storage-state=${SAFE_ABS}`]);
+  assert.ok(out.includes('--isolated'), 'injects --isolated');
+  assert.ok(out.includes('--caps=storage'), 'keeps --caps=storage');
+  const ss = out.find((a) => a.startsWith('--storage-state='));
+  assert.ok(ss, 'keeps --storage-state');
+  assert.equal(normPath(ss.split('=')[1]), normPath(path.resolve(SAFE_ABS)));
+});
+test('does not double-inject --isolated when caller already provided it', () => {
+  const out = gate(['--isolated', '--caps=storage', `--storage-state=${SAFE_ABS}`]);
+  assert.equal(out.filter((a) => a === '--isolated').length, 1);
+});
+test('space-separated path value form is validated and absolutized', () => {
+  const out = gate(['--storage-state', SAFE_ABS]);
+  const idx = out.indexOf('--storage-state');
+  assert.ok(idx >= 0);
+  assert.equal(normPath(out[idx + 1]), normPath(path.resolve(SAFE_ABS)));
+});
+
+// ── path-norm robustness (slash + case) ─────────────────────────────────────
+test('assertPathAllowed is robust to mixed slashes and case for repo prefix', () => {
+  assert.throws(
+    () => assertPathAllowed('D:\\Mercury\\Mercury\\x\\y.json', 'D:/Mercury/Mercury'),
+    /inside repo working tree/,
+  );
+});
+test('assertPathAllowed allows a private path outside repo and outside profiles', () => {
+  assert.doesNotThrow(() => assertPathAllowed(path.resolve(SAFE_ABS), REPO));
+});
+
+// ── HIGH-1 regression: root must be canonicalized (8.3 short-name / junction bypass) ──
+// Codex finding: assertPathAllowed(repo-inside-path, repo-root-as-8.3-short-name) was
+// incorrectly ALLOWED because only absPath was canonicalized, not root.
+// Fix: root is now passed through canonicalize() before comparison.
+test('[HIGH] rejects repo-inside path when root is passed as uppercase/mixed-slash equivalent', () => {
+  // Use a root that is lexically different from REPO but after normPath is equivalent.
+  // On Windows REPO = 'D:/Mercury/Mercury'; mixed case + backslash form is equivalent after normPath.
+  const rootVariant = process.platform === 'win32'
+    ? 'D:\\Mercury\\Mercury'   // backslash form — normPath makes it identical to REPO after canonicalize
+    : REPO.toUpperCase();      // uppercase form (non-Windows FS may not resolve, but normPath catches it)
+  assert.throws(
+    () => assertPathAllowed(
+      path.join(REPO, 'secrets', 'auth.json'),
+      rootVariant,
+    ),
+    /inside repo working tree/,
+  );
+});
+test('[HIGH] rejects repo-inside path when root has trailing slash(es)', () => {
+  assert.throws(
+    () => assertPathAllowed(
+      path.join(REPO, 'secrets', 'auth.json'),
+      REPO + '/',
+    ),
+    /inside repo working tree/,
+  );
+});
+
+// ── isAttachValue covers value-smuggling ─────────────────────────────────────
+test('isAttachValue detects cdp token in value', () => {
+  assert.ok(isAttachValue('cdp://localhost:9222'));
+});
+test('isAttachValue detects endpoint token in value', () => {
+  assert.ok(isAttachValue('ws-endpoint://foo'));
+});
+test('isAttachValue does not flag safe value', () => {
+  assert.ok(!isAttachValue('https://example.com'));
+});
+
+// ── allowlist shape verification ─────────────────────────────────────────────
+test('FLAG_ALLOWLIST does not contain removed dangerous flags', () => {
+  const removed = ['--config', '--port', '--host', '--help', '--version',
+    '--save-trace', '--save-session', '--output-dir', '--no-sandbox',
+    '--timeout-action', '--timeout-navigation', '--user-data-dir'];
+  for (const f of removed) {
+    assert.ok(!FLAG_ALLOWLIST.has(f), `${f} must not be in allowlist`);
+  }
+});
+test('BROWSER_ALLOWLIST contains only Playwright engine names', () => {
+  assert.ok(BROWSER_ALLOWLIST.has('chromium'));
+  assert.ok(BROWSER_ALLOWLIST.has('firefox'));
+  assert.ok(BROWSER_ALLOWLIST.has('webkit'));
+  assert.ok(!BROWSER_ALLOWLIST.has('chrome'));
+  assert.ok(!BROWSER_ALLOWLIST.has('msedge'));
+  assert.ok(!BROWSER_ALLOWLIST.has('cdp'));
+});
+
+// ── resolveCli fail-closed (no network, no auto-install) ────────────────────
+test('[resolveCli] throws with provision command when cache absent', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-resolve-test-'));
+  try {
+    // Point at a non-existent cache dir — cli.js will not be found.
+    let thrown = null;
+    try {
+      resolveCli({ cacheDir: path.join(tmpDir, 'nonexistent') });
+    } catch (e) {
+      thrown = e;
+    }
+    assert.ok(thrown, 'resolveCli must throw when cache is absent');
+    assert.match(thrown.message, /not provisioned/i, 'error message must mention "not provisioned"');
+    assert.match(thrown.message, /npm install/, 'error message must include npm install command');
+    assert.match(thrown.message, /adapters\/playwright-mcp\/README\.md/, 'error message must reference README');
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('[resolveCli] returns cli.js path when cache is present', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-resolve-hit-'));
+  const cliPath = path.join(tmpDir, 'node_modules', '@playwright', 'mcp', 'cli.js');
+  try {
+    fs.mkdirSync(path.dirname(cliPath), { recursive: true });
+    fs.writeFileSync(cliPath, '// stub\n');
+    const result = resolveCli({ cacheDir: tmpDir });
+    assert.equal(result, cliPath, 'resolveCli must return cli.js path on cache hit');
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('[resolveCli] does not attempt network access or spawn npm (fail-closed, not auto-install)', () => {
+  // Verify that resolveCli throws immediately rather than blocking on npm install.
+  // We measure elapsed time: auto-install would take seconds; fail-closed should be <100ms.
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-timing-test-'));
+  try {
+    const start = Date.now();
+    try { resolveCli({ cacheDir: path.join(tmpDir, 'absent') }); } catch (_) { /* expected */ }
+    const elapsed = Date.now() - start;
+    assert.ok(elapsed < 500, `resolveCli must fail-closed instantly (elapsed ${elapsed}ms ≥ 500ms suggests auto-install)`);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});

--- a/adapters/playwright-mcp/test/launch.test.cjs
+++ b/adapters/playwright-mcp/test/launch.test.cjs
@@ -13,10 +13,9 @@ const {
 } = require('../launch.cjs');
 
 // A repo root + safe outside-repo private path to reuse across tests.
-const REPO = process.platform === 'win32' ? 'D:/Mercury/Mercury' : '/repo/mercury';
-const SAFE_ABS = process.platform === 'win32'
-  ? 'D:/Users/agent/AppData/Local/mercury/playwright-mcp/auth-state.json'
-  : '/home/agent/.local/mercury/playwright-mcp/auth-state.json';
+// Use os.tmpdir()-based synthetic paths — no hardcoded local machine paths.
+const REPO = path.join(os.tmpdir(), 'fakerepo', 'mercury');
+const SAFE_ABS = path.join(os.tmpdir(), 'mercury-private', 'playwright-mcp', 'auth-state.json');
 
 function gate(args, env = {}) {
   return buildSafeArgs(args, { env, repoRoot: REPO, cwd: REPO });
@@ -99,17 +98,36 @@ test('[HIGH] allows --browser webkit (Playwright engine)', () => {
 });
 
 // ── HIGH: value-smuggling via non-path flag values ───────────────────────────
-test('[HIGH] rejects --allowed-origins=cdp://x (attach token in value)', () => {
-  assert.throws(() => gate(['--allowed-origins=cdp://x']), /attach\/connect token/);
+// --allowed-origins/--blocked-origins are excluded from attach-token value scan:
+// their values are origin lists that legitimately contain substrings like "remote"
+// or "endpoint" (ADR §4.3). The real attach vector is flag-name-based and already
+// covered by the whole-class reject. So cdp:// and ws-endpoint:// values are allowed
+// by the value scanner for origin flags (though they are semantically unusual).
+test('[HIGH] allows --allowed-origins=cdp://x (origin flag: value scan excluded per ADR §4.3)', () => {
+  assert.doesNotThrow(() => gate(['--allowed-origins=cdp://x']));
 });
-test('[HIGH] rejects --allowed-origins with ws-endpoint value (attach token)', () => {
-  assert.throws(() => gate(['--allowed-origins=ws-endpoint://x']), /attach\/connect token/);
+test('[HIGH] allows --allowed-origins=ws-endpoint://x (origin flag: value scan excluded)', () => {
+  assert.doesNotThrow(() => gate(['--allowed-origins=ws-endpoint://x']));
 });
 test('[HIGH] rejects --caps value containing connect token', () => {
   assert.throws(() => gate(['--caps=connect']), /attach\/connect token/);
 });
 test('[HIGH] allows --allowed-origins=https://example.com (no attach token)', () => {
   assert.doesNotThrow(() => gate(['--allowed-origins=https://example.com']));
+});
+test('[HIGH] allows --allowed-origins=https://remote.example.com (hostname with "remote" substring)', () => {
+  assert.doesNotThrow(() => gate(['--allowed-origins=https://remote.example.com']));
+});
+test('[HIGH] allows --allowed-origins=https://endpoint.example.com (hostname with "endpoint" substring)', () => {
+  assert.doesNotThrow(() => gate(['--allowed-origins=https://endpoint.example.com']));
+});
+
+// ── positional arguments rejected ───────────────────────────────────────────
+test('[Critical] rejects positional argument (non-flag)', () => {
+  assert.throws(() => gate(['foo']), /positional arguments are not allowed/);
+});
+test('[Critical] rejects positional argument: bare value that looks like a path', () => {
+  assert.throws(() => gate(['somefile.json']), /positional arguments are not allowed/);
 });
 
 // ── HIGH: removed artifact path flags ───────────────────────────────────────
@@ -136,11 +154,13 @@ test('rejects --storage-state pointing inside repo working tree', () => {
 
 // ── real browser profile path rejected ──────────────────────────────────────
 test('rejects --storage-state pointing at a real Chrome profile', () => {
-  const chrome = 'C:/Users/me/AppData/Local/Google/Chrome/User Data/Default/state.json';
+  // Synthetic path containing the PROFILE_FRAGMENTS substring — no real machine path needed.
+  const chrome = path.join(os.tmpdir(), 'fakehome', 'Google', 'Chrome', 'User Data', 'Default', 'state.json');
   assert.throws(() => gate([`--storage-state=${chrome}`]), /real browser profile/);
 });
 test('rejects --storage-state pointing at a real Edge profile (backslash + case insensitive)', () => {
-  const edge = 'C:\\Users\\Me\\AppData\\Local\\Microsoft\\Edge\\USER DATA\\state.json';
+  // Mixed slashes + uppercase to exercise normPath; still hits PROFILE_FRAGMENTS substring.
+  const edge = path.join(os.tmpdir(), 'fakehome', 'Microsoft', 'Edge', 'USER DATA', 'state.json');
   assert.throws(() => gate([`--storage-state=${edge}`]), /real browser profile/);
 });
 
@@ -158,20 +178,14 @@ test('[HIGH] rejects --user-data-dir space form (default-deny)', () => {
 // On non-Windows we simulate with a symlink/known-path test instead.
 test('[HIGH] rejects 8.3 short-name path pointing at Chrome User Data (Windows)', () => {
   if (process.platform !== 'win32') {
-    // On non-Windows: verify normPath + profile fragment matching catches case variations
-    const tricky = 'C:/Users/me/GOOGLE~1/Chrome/User Data/Default/state.json';
-    // Without canonicalization, GOOGLE~1 doesn't match fragment "google/chrome/user data"
-    // With our implementation, 8.3 short names are resolved by fs.realpathSync.native() on Windows.
-    // On Linux/Mac the path doesn't exist so canonicalize returns the path as-is,
-    // but the fragment check still catches "user data" in the fragment list if the
-    // canonical path (after resolution) contains the profile fragment.
-    // Since the path doesn't exist on non-Windows, we test the logic directly:
-    const n = normPath('C:/Users/me/GOOGLE~1/Chrome/User Data/Default/state.json');
-    // "user data" is in the path — it will be caught if 8.3 resolves to the real name.
-    // On non-Windows we can't resolve 8.3; document that this test is Windows-specific.
-    // Instead verify assertPathAllowed catches the fragment match for the resolved form.
+    // On non-Windows: 8.3 short names (e.g. GOOGLE~1) cannot be resolved by the OS.
+    // canonicalize() uses fs.realpathSync.native() which resolves them on Windows only.
+    // On Linux/Mac the path doesn't exist so canonicalize returns it as-is.
+    // Instead verify assertPathAllowed catches the fragment match for a resolved-form
+    // synthetic path (no real machine path needed).
+    // Synthetic path containing profile fragment — no real machine path needed.
     assert.throws(
-      () => assertPathAllowed('C:/Users/me/AppData/Local/Google/Chrome/User Data/Default/state.json', REPO),
+      () => assertPathAllowed(path.join(os.tmpdir(), 'fakehome', 'Google', 'Chrome', 'User Data', 'Default', 'state.json'), REPO),
       /real browser profile/,
     );
     return;
@@ -190,11 +204,10 @@ test('[HIGH] rejects 8.3 short-name path pointing at Chrome User Data (Windows)'
       /real browser profile/,
     );
   }
-  // Verify that a constructed 8.3-style path that after normPath contains the fragment
-  // is caught — simulated since real 8.3 names vary per filesystem.
+  // Verify that a synthetic path whose normPath contains the profile fragment is caught.
   // The key invariant: after canonicalize, profile fragments are matched case-insensitively.
   assert.throws(
-    () => assertPathAllowed('C:\\Users\\me\\AppData\\Local\\Google\\Chrome\\User Data\\Default', REPO),
+    () => assertPathAllowed(path.join(os.tmpdir(), 'fakehome', 'Google', 'Chrome', 'User Data', 'Default'), REPO),
     /real browser profile/,
   );
 });
@@ -300,8 +313,11 @@ test('space-separated path value form is validated and absolutized', () => {
 
 // ── path-norm robustness (slash + case) ─────────────────────────────────────
 test('assertPathAllowed is robust to mixed slashes and case for repo prefix', () => {
+  // Use synthetic REPO with backslash form to verify normPath handles mixed slashes.
+  const repoBackslash = REPO.replace(/\//g, '\\');
+  const insidePath = REPO.replace(/\//g, '\\') + '\\x\\y.json';
   assert.throws(
-    () => assertPathAllowed('D:\\Mercury\\Mercury\\x\\y.json', 'D:/Mercury/Mercury'),
+    () => assertPathAllowed(insidePath, repoBackslash),
     /inside repo working tree/,
   );
 });
@@ -315,10 +331,11 @@ test('assertPathAllowed allows a private path outside repo and outside profiles'
 // Fix: root is now passed through canonicalize() before comparison.
 test('[HIGH] rejects repo-inside path when root is passed as uppercase/mixed-slash equivalent', () => {
   // Use a root that is lexically different from REPO but after normPath is equivalent.
-  // On Windows REPO = 'D:/Mercury/Mercury'; mixed case + backslash form is equivalent after normPath.
+  // On Windows: replace forward slashes with backslashes in the synthetic REPO path.
+  // On non-Windows: uppercase the synthetic REPO path — normPath lowercases both sides.
   const rootVariant = process.platform === 'win32'
-    ? 'D:\\Mercury\\Mercury'   // backslash form — normPath makes it identical to REPO after canonicalize
-    : REPO.toUpperCase();      // uppercase form (non-Windows FS may not resolve, but normPath catches it)
+    ? REPO.replace(/\//g, '\\')   // backslash form — normPath makes it identical to REPO
+    : REPO.toUpperCase();         // uppercase form — normPath lowercases both, so they match
   assert.throws(
     () => assertPathAllowed(
       path.join(REPO, 'secrets', 'auth.json'),


### PR DESCRIPTION
## Summary

Phase 2 **Slice A** of #154 web-automation PoC (design ADR: `.mercury/docs/research/issue-154-web-automation-2026-05.md`, PR #444). Mounts Microsoft's official `@playwright/mcp@0.0.75` (Apache-2.0) as a Claude Code **stdio** MCP server behind a Mercury security **config-gate** wrapper. Tracks #458.

### Governance gate (ADR §6 step 0 / V9)
`npx @playwright/mcp@<version>` resolves an npm tarball by version — neither git submodule nor `uvx git+SHA`. Registered as the **third runtime-only mount mode** in `DIRECTION.md §四` + `adapters/README.md §约束` (version-pin rule forbids `@latest`; license gate + provenance + drift required).

### adapter `adapters/playwright-mcp/` (config封装 only, `launch.cjs` 199 LOC ≤200 cap)
- **default-deny flag allowlist** + whole-class attach-flag reject (ADR §4.2(b), token-based so future upstream attach flags auto-deny)
- `--browser` engine-only whitelist (`chromium/firefox/webkit`) + **value** attach-token scan (blocks `chrome`/`msedge`/`cdp` channel smuggling)
- env-var path resolution (hard-fail on unresolved `%VAR%`/`$VAR`), **realpath canonicalization** (symlink/8.3/junction), repo-inside + real-browser-profile path reject, **fail-closed** repo-root
- forced `--isolated` injection (ADR §4.3 least-privilege)
- **fail-closed cli resolution** — never runs `npm install` at runtime (no network / no stdout noise on JSON-RPC); provisioned once (README §Setup)
- 55 `node:test` tests covering every bypass vector
- `.mcp.json` `playwright` entry; manifest + `UPSTREAM.md` provenance (exec contract = npm 0.0.75; `upstream_sha_at_import` = git tag `v0.0.75` commit `8116437…`, audit metadata — `gh api`-verified 2026-05-26)

### Research (MANDATORY web-verify 2026-05-26)
npm `dist-tags.latest`=0.0.75 / Apache-2.0 (`registry.npmjs.org`); CLI flags vs official README; git tag SHA via `gh api`.

## dual-verify (pre-commit gate — Claude code-reviewer ∥ Codex code-audit, cross-model, 3 rounds)
Found + fixed: **CRITICAL** `--config` content-unvalidated backdoor; **5 HIGH** (cold-start `npm install` stdio:'inherit' MCP-handshake corruption; symlink/8.3 path bypass; `--browser` channel value-smuggling; `--port`/`--host` network listener; `--user-data-dir` persistent-profile re-opening non-isolated boundary); **3 MEDIUM** (repoRoot fail-open; artifact paths; brittle npm resolution + cold-start race).

**Residual HIGH-1 (Codex) — short-name *repo-root operand* — assessed unreachable, not blocking:** production repo root always derives from `__dirname` long-form and always canonicalizes (verified `resolveRepoRoot()` → `D:\Mercury\Mercury`); candidate-side paths ARE canonicalized + rejected for any case/slash form into the repo or a real profile (verified 5/5); the synthetic short-name string is `ENOENT` on this volume (8.3 disabled) so it denotes no real target. `canonicalize(root)` added as defense-in-depth for 8.3-enabled volumes.

## Test plan
- [x] `node --test adapters/playwright-mcp/test/*.cjs` → 55/55 pass
- [x] gate-reject smokes: `--config`/`--port`/`--host`/`--help`/`--save-trace`/`--user-data-dir` → exit 2; `--browser=chrome` → exit 2
- [x] candidate-side: repo-inside (backslash/case/slash) + real Chrome profile → rejected; repo-external sibling → allowed
- [x] fail-closed: absent cache → exit 3 with one-time provision command (no network)
- [x] good config → `--isolated` injected
- [ ] Slice B (needs session restart + manual login): V1 live navigate/screenshot, V2 auth-state reuse, V6 storageState domain scope

Refs #458
Refs #154

Generated with Claude Code
