### PR TITLE
feat(#465): 外围中文语音输入 daemon (voice-zh-input)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,9 @@ mercury.config.json
 # mem0 test venv (Phase A)
 .venv-mem0/
 
+# voice-zh-input venv (#465)
+.venv-voice/
+
 # Python build artifacts
 __pycache__/
 *.py[cod]

--- a/requirements-voice-zh.txt
+++ b/requirements-voice-zh.txt
@@ -11,7 +11,7 @@
 #   (ctranslate2 >=4.5 requires CUDA 12 + cuDNN 9; the script auto-registers the
 #    bundled DLL dirs on PATH. CPU fallback is automatic if CUDA is unavailable.)
 
-faster-whisper==1.2.1   # pulls ctranslate2==4.7.2 (cp314 wheel), tokenizers, onnxruntime
+faster-whisper==1.2.1   # pulls ctranslate2 (>=4,<5; verified 4.7.2 cp314 wheel), tokenizers, onnxruntime
 sounddevice==0.5.5      # PortAudio bindings for mic capture
 pyperclip==1.11.0       # Unicode-safe clipboard write
 keyboard==0.13.5        # global hotkey + simulated Ctrl+V

--- a/requirements-voice-zh.txt
+++ b/requirements-voice-zh.txt
@@ -1,0 +1,18 @@
+# voice-zh-input dependencies (Mercury #465)
+# Verified on Windows 11 + Python 3.14.3 (2026-06-02).
+#
+# Install (CPU-only works out of the box):
+#   uv venv .venv-voice --python 3.14
+#   uv pip install --python .venv-voice -r requirements-voice-zh.txt
+#
+# GPU (optional, ~7x faster: 1.8s vs 13.7s per utterance on RTX 4060):
+#   uv pip install --python .venv-voice nvidia-cublas-cu12 "nvidia-cudnn-cu12==9.*" \
+#       nvidia-cuda-runtime-cu12 nvidia-cuda-nvrtc-cu12
+#   (ctranslate2 >=4.5 requires CUDA 12 + cuDNN 9; the script auto-registers the
+#    bundled DLL dirs on PATH. CPU fallback is automatic if CUDA is unavailable.)
+
+faster-whisper==1.2.1   # pulls ctranslate2==4.7.2 (cp314 wheel), tokenizers, onnxruntime
+sounddevice==0.5.5      # PortAudio bindings for mic capture
+pyperclip==1.11.0       # Unicode-safe clipboard write
+keyboard==0.13.5        # global hotkey + simulated Ctrl+V
+numpy>=1.26             # in-memory audio buffer (also a transitive dep; declared because imported directly)

--- a/scripts/voice-zh-input.README.md
+++ b/scripts/voice-zh-input.README.md
@@ -1,0 +1,115 @@
+# voice-zh-input — 外围中文语音输入 (#465)
+
+给 Claude Code TUI(及任意聚焦文本框)加**中文**语音输入。
+绕开原生 `/voice` —— 后者服务端写死 20 语言、**无中文**。本地运行,音频不出本机。
+
+**两种模式**(`VOICE_ZH_MODE`):
+- **连续模式(默认)**:常驻监听,能量 VAD 自动分句。直接说话,每句(说话到一段静音为止)
+  自动转写并注入,短暂确认窗口后自动回车。`Ctrl+Alt+P` 暂停/恢复。
+- **推键模式(toggle)**:按热键开始录音,再按一次停止。
+
+## 为什么是「外围」+ 剪贴板注入
+
+- **原生 /voice 无中文**:语言列表服务端硬编码,无 `zh`。
+- **注入机制 = 剪贴板 + Ctrl+V**:Windows Terminal/ConHost 对模拟 Unicode 键击乱码
+  ([microsoft/terminal#12977](https://github.com/microsoft/terminal/issues/12977));
+  而 TUI 通过 bracketed paste 正确接收粘贴的中文。剪贴板承载 Unicode,Ctrl+V 只是
+  ASCII 级虚拟键(不触发 Unicode bug)。逐字键击 / stdin / IPC 注入均不可行。
+- 架构 B(`scripts/` 自研轻量粘合),实证选定见 Issue #465。
+
+## 安装
+
+```bash
+# 1) 建专用 venv(Python 3.9+;实测 3.14.3)
+uv venv .venv-voice --python 3.14
+
+# 2) 核心依赖(CPU 开箱即用)
+uv pip install --python .venv-voice -r requirements-voice-zh.txt
+
+# 3) (可选)GPU 加速 —— RTX 4060 实测 1.8s/句 vs CPU 13.7s/句
+uv pip install --python .venv-voice nvidia-cublas-cu12 "nvidia-cudnn-cu12==9.*" \
+    nvidia-cuda-runtime-cu12 nvidia-cuda-nvrtc-cu12
+```
+
+首次运行会从 HuggingFace 下载 `large-v3` 模型(约 3GB),之后走本地缓存。
+
+## 用法
+
+```bash
+.venv-voice/Scripts/python.exe scripts/voice-zh-input.py
+```
+
+### 连续模式(默认)
+
+1. 启动后会先校准 ~1 秒环境噪声(**保持安静**),打印 `vad_threshold`。
+2. **直接说话** —— 说完停顿 ~0.8 秒即视为一句,自动转写并粘进当前聚焦的输入框。
+3. 粘贴后约 2 秒确认窗口,期间不打断就**自动回车发送**;想取消发送/编辑就按 `Ctrl+Alt+P` 暂停。
+4. `Ctrl+Alt+P` 暂停/恢复监听;`Ctrl+Alt+Q` 退出。连续模式默认**不响 beep**(可设 `VOICE_ZH_CONT_BEEP=1` 开启语音起止提示音)。
+
+> 关掉自动回车:`VOICE_ZH_AUTO_ENTER=0`(只粘不发送)。漏字/分句太碎:把麦克风电平拉高,
+> 或降低 `VOICE_ZH_VAD_THRESH`、调大 `VOICE_ZH_SILENCE_SEC`。
+
+### 推键模式(toggle)
+
+```bash
+$env:VOICE_ZH_MODE="toggle"; .venv-voice/Scripts/python.exe scripts/voice-zh-input.py
+```
+按 `Ctrl+Alt+Space` 开始录音,再按一次停止 → 转写粘到输入框(无自动回车)。`Ctrl+Alt+Q` 退出。
+
+独立运行,与 Claude Code 解耦 —— 在任意聚焦的文本框都能用。建议**另开一个终端窗口**常驻运行,在 Claude Code 窗口里说话。
+
+## 配置(环境变量)
+
+| 变量 | 默认 | 说明 |
+|------|------|------|
+| `VOICE_ZH_MODE`   | `continuous` | `continuous`(VAD 自动分句)/ `toggle`(推键录音) |
+| `VOICE_ZH_PAUSE`  | `ctrl+alt+p` | 连续模式暂停/恢复热键 |
+| `VOICE_ZH_AUTO_ENTER` | `1` | 连续模式每句确认窗口后自动回车;`0` 只粘不发送 |
+| `VOICE_ZH_GRACE_SEC` | `2.0` | 自动回车前的确认窗口秒数(期间按暂停可取消) |
+| `VOICE_ZH_SILENCE_SEC` | `0.8` | 尾随静音多少秒判定一句结束 |
+| `VOICE_ZH_MIN_SEC` | `0.4` | 短于此秒数的片段忽略(防误触) |
+| `VOICE_ZH_VAD_THRESH` | `auto` | 能量 VAD 阈值;`auto` 按启动校准的噪声底自适应,或填固定 float |
+| `VOICE_ZH_ONSET_BLOCKS` | `3` | 需连续多少块(~50ms/块)语音才判定起音(防噪声尖峰误触) |
+| `VOICE_ZH_NOSPEECH_MAX` | `0.6` | 段 `no_speech_prob` ≥ 此值丢弃(滤非语音/幻觉) |
+| `VOICE_ZH_LOGPROB_MIN` | `-1.0` | 段 `avg_logprob` ≤ 此值丢弃(滤低置信幻觉) |
+| `VOICE_ZH_CONT_BEEP` | `0` | `1` 开启连续模式语音起止提示音 |
+| `VOICE_ZH_HOTKEY` | `ctrl+alt+space` | 推键模式录音热键(避开原生 /voice 占用的 Space) |
+| `VOICE_ZH_QUIT`   | `ctrl+alt+q` | 退出热键(避开 TUI 常用的 Esc) |
+| `VOICE_ZH_MODEL`  | `large-v3` | faster-whisper 模型(可改 `medium`/`small` 降显存/提速) |
+| `VOICE_ZH_DEVICE` | `auto` | `auto`(cuda→cpu 回退) / `cuda` / `cpu`(非法值会启动报错并列出允许值) |
+| `VOICE_ZH_BEEP`   | `1` | `0` 关闭提示音 |
+| `VOICE_ZH_PASTE`  | `1` | `1` 自动 Ctrl+V 粘贴;`0` 仅复制到剪贴板(安全模式,手动粘贴) |
+| `VOICE_ZH_MAX_SEC`| `120` | 单次录音内存上限秒数,超出丢弃多余音频并告警(防 RAM 无界) |
+| `VOICE_ZH_VAD`    | `0` | `1` 开启 Silero VAD 静音裁剪;默认关(VAD 对低增益麦克风会过度裁剪成空) |
+| `VOICE_ZH_NORMALIZE` | `1` | `1` 对录音做峰值归一化(救低增益麦克风);`0` 关闭 |
+| `VOICE_ZH_DEVICE_INDEX` | *(空)* | 强制指定输入设备序号(默认用系统默认输入)。用 `tmp/scan_devices2.py` 找出有信号的序号 |
+
+> **粘贴安全**:`VOICE_ZH_PASTE=1` 时,转写完成(可能数秒后)会把文本 Ctrl+V 进**当时聚焦的任意窗口**。
+> 保持目标输入框聚焦,或设 `VOICE_ZH_PASTE=0` 走仅复制模式(手动粘贴),避免误粘到无关窗口/终端/管理员工具。
+
+## 技术要点(#465 实证)
+
+- **STT**:`faster-whisper` 1.2.1 + `large-v3`,显式 `language="zh"`(语言概率 1.00)。
+  SAPI 中文样本转写内容 100% 正确(仅标点风格 + 数字归一化 `一二三四五→12345`)。
+- **延迟**:GPU `cuda/float16` 约 1.8s/句;CPU `cpu/int8` 约 13.7s/句(均 large-v3)。
+- **GPU DLL**:ctranslate2 ≥4.5 需 CUDA 12 + cuDNN 9。脚本自动注册 bundled
+  `nvidia/*/bin` 到 DLL 目录**并前置 PATH** —— 仅 `add_dll_directory` 不够,
+  ctranslate2 内部加载器走 PATH 才能找到 `cublas64_12.dll`。缺 GPU 库自动回退 CPU。
+- **录音**:`sounddevice` InputStream 按设备**原生采样率**录单声道,送内存后线性重采样到 16kHz
+  喂 whisper(不落盘)。**强制 16kHz 直采会被 Realtek 驱动返回数字静音(peak 0.0000)而非报错**,
+  故必须原生采样率 + 后重采样。默认设备静音时设 `VOICE_ZH_DEVICE_INDEX`(见故障排查)。
+- **低增益**:部分笔记本麦克风电平极低(peak ~0.01),默认开启峰值归一化拉到 ~0.3 再转写;
+  VAD 默认关(会把低增益语音裁成空)。
+- **编码**:脚本须 UTF-8 + `sys.stdout.reconfigure(encoding="utf-8")`;勿用 shell 内联
+  `python -c` 传中文(Windows console GBK 编码会乱码)。
+
+## 故障排查
+
+- **热键无反应**:`keyboard` 库的全局钩子在个别 Windows 配置下需管理员权限 —— 用管理员
+  终端重跑。发送 Ctrl+V(SendInput)本身不需管理员(已实测)。
+- **`cublas64_12.dll not found / cannot be loaded`**:GPU 库没装全。需要
+  cublas + cudnn(9.x) + cuda-runtime + cuda-nvrtc 四件套;或设 `VOICE_ZH_DEVICE=cpu` 走 CPU。
+- **转写为空 `''` / `peak=0.0000` 静音**:① 先确认麦克风在 Windows 没被静音、电平拉高(设置 → 声音 →
+  输入);② 跑 `tmp/scan_devices2.py`(边说边扫)找出标 `<-- SIGNAL` 的输入设备序号,设
+  `VOICE_ZH_DEVICE_INDEX=<序号>` 重启 daemon;③ 注意脚本已按原生采样率录音 + 归一化,无需手动改。
+- **粘贴落错窗口**:停止录音后转写需 ~2s,期间别切换焦点 —— 保持目标输入框聚焦,或用 `VOICE_ZH_PASTE=0`。

--- a/scripts/voice-zh-input.README.md
+++ b/scripts/voice-zh-input.README.md
@@ -82,7 +82,7 @@ $env:VOICE_ZH_MODE="toggle"; .venv-voice/Scripts/python.exe scripts/voice-zh-inp
 | `VOICE_ZH_MAX_SEC`| `120` | 单次录音内存上限秒数,超出丢弃多余音频并告警(防 RAM 无界) |
 | `VOICE_ZH_VAD`    | `0` | `1` 开启 Silero VAD 静音裁剪;默认关(VAD 对低增益麦克风会过度裁剪成空) |
 | `VOICE_ZH_NORMALIZE` | `1` | `1` 对录音做峰值归一化(救低增益麦克风);`0` 关闭 |
-| `VOICE_ZH_DEVICE_INDEX` | *(空)* | 强制指定输入设备序号(默认用系统默认输入)。用 `tmp/scan_devices2.py` 找出有信号的序号 |
+| `VOICE_ZH_DEVICE_INDEX` | *(空)* | 强制指定输入设备序号(默认用系统默认输入)。跑 `python scripts/voice-zh-input.py --list-devices` 列出设备序号 |
 
 > **粘贴安全**:`VOICE_ZH_PASTE=1` 时,转写完成(可能数秒后)会把文本 Ctrl+V 进**当时聚焦的任意窗口**。
 > 保持目标输入框聚焦,或设 `VOICE_ZH_PASTE=0` 走仅复制模式(手动粘贴),避免误粘到无关窗口/终端/管理员工具。
@@ -110,6 +110,6 @@ $env:VOICE_ZH_MODE="toggle"; .venv-voice/Scripts/python.exe scripts/voice-zh-inp
 - **`cublas64_12.dll not found / cannot be loaded`**:GPU 库没装全。需要
   cublas + cudnn(9.x) + cuda-runtime + cuda-nvrtc 四件套;或设 `VOICE_ZH_DEVICE=cpu` 走 CPU。
 - **转写为空 `''` / `peak=0.0000` 静音**:① 先确认麦克风在 Windows 没被静音、电平拉高(设置 → 声音 →
-  输入);② 跑 `tmp/scan_devices2.py`(边说边扫)找出标 `<-- SIGNAL` 的输入设备序号,设
+  输入);② 跑 `python scripts/voice-zh-input.py --list-devices` 列出输入设备,挑对的麦克风序号设
   `VOICE_ZH_DEVICE_INDEX=<序号>` 重启 daemon;③ 注意脚本已按原生采样率录音 + 归一化,无需手动改。
 - **粘贴落错窗口**:停止录音后转写需 ~2s,期间别切换焦点 —— 保持目标输入框聚焦,或用 `VOICE_ZH_PASTE=0`。

--- a/scripts/voice-zh-input.py
+++ b/scripts/voice-zh-input.py
@@ -68,6 +68,20 @@ from pathlib import Path
 
 sys.stdout.reconfigure(encoding="utf-8")
 
+
+def _env_num(name, default, cast):
+    """Parse a numeric env var; on an invalid value warn and fall back to default,
+    so a typo in config never crashes the daemon at module load."""
+    v = os.environ.get(name)
+    if v in (None, ""):
+        return default
+    try:
+        return cast(v)
+    except (ValueError, TypeError):
+        print(f"[voice-zh] WARNING: invalid {name}={v!r}, using default {default}", flush=True)
+        return default
+
+
 MODE = os.environ.get("VOICE_ZH_MODE", "continuous")  # "continuous" (VAD) | "toggle" (push-key)
 HOTKEY = os.environ.get("VOICE_ZH_HOTKEY", "ctrl+alt+space")  # toggle-mode record key
 QUIT = os.environ.get("VOICE_ZH_QUIT", "ctrl+alt+q")
@@ -78,23 +92,22 @@ BEEP = os.environ.get("VOICE_ZH_BEEP", "1") == "1"
 PASTE = os.environ.get("VOICE_ZH_PASTE", "1") == "1"  # 0 = copy-only (no auto Ctrl+V)
 VAD = os.environ.get("VOICE_ZH_VAD", "0") == "1"  # default off: VAD over-trims quiet mics -> empty
 NORMALIZE = os.environ.get("VOICE_ZH_NORMALIZE", "1") == "1"  # peak-normalize low-gain capture
-_DEV_IDX = os.environ.get("VOICE_ZH_DEVICE_INDEX")  # optional explicit input device index
-DEVICE_INDEX = int(_DEV_IDX) if _DEV_IDX not in (None, "") else None
+DEVICE_INDEX = _env_num("VOICE_ZH_DEVICE_INDEX", None, int)  # optional explicit input device index
 SAMPLERATE = 16000  # whisper target rate; capture happens at the device's NATIVE rate
-MAX_SEC = int(os.environ.get("VOICE_ZH_MAX_SEC", "120"))  # cap in-memory recording length
+MAX_SEC = _env_num("VOICE_ZH_MAX_SEC", 120, int)  # cap in-memory recording length
 
 # continuous-mode (VAD) tuning
 AUTO_ENTER = os.environ.get("VOICE_ZH_AUTO_ENTER", "1") == "1"  # press Enter after grace
-GRACE_SEC = float(os.environ.get("VOICE_ZH_GRACE_SEC", "2.0"))  # confirm window before Enter
-SILENCE_SEC = float(os.environ.get("VOICE_ZH_SILENCE_SEC", "0.8"))  # trailing silence ends utterance
-MIN_UTT_SEC = float(os.environ.get("VOICE_ZH_MIN_SEC", "0.4"))  # ignore shorter blips
+GRACE_SEC = _env_num("VOICE_ZH_GRACE_SEC", 2.0, float)  # confirm window before Enter
+SILENCE_SEC = _env_num("VOICE_ZH_SILENCE_SEC", 0.8, float)  # trailing silence ends utterance
+MIN_UTT_SEC = _env_num("VOICE_ZH_MIN_SEC", 0.4, float)  # ignore shorter blips
 _VAD_THRESH = os.environ.get("VOICE_ZH_VAD_THRESH", "auto")  # "auto" calibrates ambient noise
-ONSET_BLOCKS = int(os.environ.get("VOICE_ZH_ONSET_BLOCKS", "3"))  # consec. voiced blocks to start
+ONSET_BLOCKS = _env_num("VOICE_ZH_ONSET_BLOCKS", 3, int)  # consec. voiced blocks to start
 CONT_BEEP = os.environ.get("VOICE_ZH_CONT_BEEP", "0") == "1"  # continuous-mode onset/end beeps (off)
 
 # hallucination / non-speech gating (whisper confidence-based)
-NO_SPEECH_MAX = float(os.environ.get("VOICE_ZH_NOSPEECH_MAX", "0.6"))  # drop seg if no_speech_prob >=
-LOGPROB_MIN = float(os.environ.get("VOICE_ZH_LOGPROB_MIN", "-1.0"))  # drop seg if avg_logprob <=
+NO_SPEECH_MAX = _env_num("VOICE_ZH_NOSPEECH_MAX", 0.6, float)  # drop seg if no_speech_prob >=
+LOGPROB_MIN = _env_num("VOICE_ZH_LOGPROB_MIN", -1.0, float)  # drop seg if avg_logprob <=
 # signature phrases Whisper emits on silence/noise — never legitimate dictation here
 HALLUCINATION_MARKERS = (
     "字幕志愿者", "字幕由", "amara.org", "明镜与点点", "点点栏目",
@@ -419,7 +432,14 @@ class ContinuousListener:
 
     def _calibrate(self):
         if _VAD_THRESH != "auto":
-            return float(_VAD_THRESH)
+            try:
+                return float(_VAD_THRESH)
+            except (ValueError, TypeError):
+                print(
+                    f"[voice-zh] WARNING: invalid VOICE_ZH_VAD_THRESH={_VAD_THRESH!r}, "
+                    "falling back to auto-calibration",
+                    flush=True,
+                )
         print("[voice-zh] calibrating ambient noise ~1s — stay quiet ...", flush=True)
         n = int(1.0 * self.capture_sr)
         a = sd.rec(n, samplerate=self.capture_sr, channels=1, dtype="float32", device=DEVICE_INDEX)

--- a/scripts/voice-zh-input.py
+++ b/scripts/voice-zh-input.py
@@ -117,16 +117,25 @@ HALLUCINATION_MARKERS = (
 
 def _register_cuda_dll_dirs():
     """Make the bundled NVIDIA CUDA/cuDNN DLLs loadable by ctranslate2 on Windows."""
+    if os.name != "nt":
+        return  # Windows-only workaround; never mutate PATH elsewhere
     bins = []
     for base in site.getsitepackages():
+        base_real = os.path.realpath(base)
         for sub in ("cublas", "cudnn", "cuda_nvrtc", "cuda_runtime"):
             p = Path(base) / "nvidia" / sub / "bin"
-            if p.is_dir():
-                try:
-                    os.add_dll_directory(str(p))
-                except (OSError, AttributeError):
-                    pass
-                bins.append(str(p))
+            if not p.is_dir():
+                continue
+            real = os.path.realpath(str(p))
+            # only accept real dirs that stay under the site-packages root, and dedupe,
+            # to avoid widening the DLL search path via stray symlinks / repeats
+            if not real.startswith(base_real) or real in bins:
+                continue
+            try:
+                os.add_dll_directory(real)
+            except (OSError, AttributeError):
+                pass
+            bins.append(real)
     if bins:
         os.environ["PATH"] = os.pathsep.join(bins) + os.pathsep + os.environ.get("PATH", "")
 
@@ -374,7 +383,7 @@ class Recorder:
             if peak < 1e-3:
                 print(
                     "[voice-zh] WARNING: near-silent capture — raise mic level or set "
-                    "VOICE_ZH_DEVICE_INDEX (run tmp/scan_devices2.py to find the right index)",
+                    "VOICE_ZH_DEVICE_INDEX (run this script with --list-devices to find the index)",
                     flush=True,
                 )
             if text:
@@ -441,11 +450,21 @@ class ContinuousListener:
                     flush=True,
                 )
         print("[voice-zh] calibrating ambient noise ~1s — stay quiet ...", flush=True)
-        n = int(1.0 * self.capture_sr)
-        a = sd.rec(n, samplerate=self.capture_sr, channels=1, dtype="float32", device=DEVICE_INDEX)
-        sd.wait()
-        noise = float(np.sqrt(np.mean(a.flatten() ** 2)))
-        thr = max(noise * 4.0, 1.5e-3)  # well above the noise floor to avoid false triggers
+        fallback = 1.5e-3
+        try:
+            n = int(1.0 * self.capture_sr)
+            a = sd.rec(n, samplerate=self.capture_sr, channels=1, dtype="float32", device=DEVICE_INDEX)
+            sd.wait()
+            noise = float(np.sqrt(np.mean(a.flatten() ** 2)))
+        except Exception as e:
+            # mic busy / device unavailable: don't block startup, use a conservative default
+            print(
+                f"[voice-zh] WARNING: calibration failed ({type(e).__name__}: {e}); "
+                f"using default vad_threshold={fallback} (set VOICE_ZH_VAD_THRESH to override)",
+                flush=True,
+            )
+            return fallback
+        thr = max(noise * 4.0, fallback)  # well above the noise floor to avoid false triggers
         print(
             f"[voice-zh] noise_rms={noise:.5f} -> vad_threshold={thr:.5f} "
             "(raise mic level / set VOICE_ZH_VAD_THRESH if it mis-triggers)",
@@ -623,9 +642,30 @@ class ContinuousListener:
             self.worker = None
 
 
+def _list_devices():
+    """Print input-capable devices so the user can pick VOICE_ZH_DEVICE_INDEX."""
+    print("=== input devices (use the index as VOICE_ZH_DEVICE_INDEX) ===", flush=True)
+    hostapis = sd.query_hostapis()
+    for i, d in enumerate(sd.query_devices()):
+        if d["max_input_channels"] >= 1:
+            api = hostapis[d["hostapi"]]["name"]
+            print(f"  [{i}] {api} {int(d['default_samplerate'])}Hz {d['name']}", flush=True)
+
+
 def main():
+    if "--list-devices" in sys.argv:
+        _list_devices()
+        return
+    mode = MODE
+    if mode not in ("continuous", "toggle"):
+        print(
+            f"[voice-zh] WARNING: unknown VOICE_ZH_MODE={MODE!r}, using 'continuous' "
+            "(valid: continuous, toggle)",
+            flush=True,
+        )
+        mode = "continuous"
     model = _load_model()
-    if MODE == "toggle":
+    if mode == "toggle":
         rec = Recorder(model)
         keyboard.add_hotkey(HOTKEY, rec.toggle)
         print(f"[voice-zh] toggle mode | {HOTKEY} = record | {QUIT} = quit", flush=True)

--- a/scripts/voice-zh-input.py
+++ b/scripts/voice-zh-input.py
@@ -1,0 +1,638 @@
+# -*- coding: utf-8 -*-
+"""voice-zh-input — 外围中文语音输入 (Mercury #465)
+
+A standalone, detachable daemon that adds Chinese (zh) voice input to Claude Code's
+TUI (or any focused text field), working around the native `/voice` feature which is
+server-hardcoded to 20 languages with no Chinese.
+
+Two modes (VOICE_ZH_MODE):
+  continuous (default) — always-on, energy-VAD-segmented dictation. Just speak; each
+      utterance (speech up to a trailing silence gap) is transcribed and delivered,
+      then Enter is auto-pressed after a short confirm window. Pause/resume hotkey.
+  toggle — push-key: press the hotkey to start recording, press again to stop.
+
+Pipeline (architecture B, all steps empirically verified in #465):
+  mic capture (sounddevice, device-native rate, in-memory)
+  -> resample to 16kHz + peak-normalize
+  -> faster-whisper large-v3 (language="zh", GPU float16 / CPU int8 fallback)
+  -> pyperclip clipboard write -> simulated Ctrl+V (bracketed paste) [-> Enter]
+
+Why clipboard + Ctrl+V and not per-character keystrokes: Windows Terminal/ConHost
+mangles simulated Unicode keystrokes (microsoft/terminal#12977), while the TUI
+accepts pasted Chinese via bracketed paste. The clipboard carries the Unicode;
+Ctrl+V is plain ASCII-level virtual keys (no Unicode bug). Capture is at the device
+native rate because forcing 16kHz on the Realtek driver returns digital silence.
+
+Local + private: no audio leaves the machine.
+
+Usage:
+    python scripts/voice-zh-input.py        # continuous mode: just speak
+    # pause/resume: Ctrl+Alt+P   quit: Ctrl+Alt+Q
+
+Config via env vars:
+    VOICE_ZH_MODE        "continuous" | "toggle"     (default "continuous")
+    VOICE_ZH_PAUSE       continuous pause/resume     (default "ctrl+alt+p")
+    VOICE_ZH_HOTKEY      toggle-mode record key      (default "ctrl+alt+space")
+    VOICE_ZH_QUIT        quit combo                  (default "ctrl+alt+q")
+    VOICE_ZH_AUTO_ENTER  "1" press Enter after utt.  (default "1")
+    VOICE_ZH_GRACE_SEC   confirm window before Enter (default "2.0")
+    VOICE_ZH_SILENCE_SEC trailing silence ends utt.  (default "0.8")
+    VOICE_ZH_MIN_SEC     ignore shorter blips        (default "0.4")
+    VOICE_ZH_VAD_THRESH  "auto" | float energy thr.  (default "auto")
+    VOICE_ZH_ONSET_BLOCKS consec. voiced blocks/onset (default "3")
+    VOICE_ZH_NOSPEECH_MAX drop seg if no_speech_prob>= (default "0.6")
+    VOICE_ZH_LOGPROB_MIN drop seg if avg_logprob <=   (default "-1.0")
+    VOICE_ZH_CONT_BEEP   "1" continuous onset/end beep (default "0")
+    VOICE_ZH_MODEL       faster-whisper model        (default "large-v3")
+    VOICE_ZH_DEVICE      "auto" | "cuda" | "cpu"     (default "auto")
+    VOICE_ZH_DEVICE_INDEX explicit input device idx  (default: system default)
+    VOICE_ZH_NORMALIZE   "1" peak-normalize capture  (default "1")
+    VOICE_ZH_VAD         "1" Silero VAD in whisper   (default "0")
+    VOICE_ZH_PASTE       "1" auto Ctrl+V else copy   (default "1")
+    VOICE_ZH_MAX_SEC     in-memory recording cap     (default "120")
+    VOICE_ZH_BEEP        "1" toggle-mode beeps       (default "1")
+
+Dependencies: see requirements-voice-zh.txt. GPU additionally needs the bundled
+nvidia-* cu12 wheels (cublas / cudnn 9.x / cuda-runtime / cuda-nvrtc); this script
+registers their DLL dirs automatically. add_dll_directory alone is NOT enough on
+Windows — ctranslate2's internal loader resolves the CUDA DLLs via PATH, so the
+bin dirs are prepended to PATH as well.
+"""
+import os
+import sys
+import site
+import time
+import queue
+import threading
+from pathlib import Path
+
+sys.stdout.reconfigure(encoding="utf-8")
+
+MODE = os.environ.get("VOICE_ZH_MODE", "continuous")  # "continuous" (VAD) | "toggle" (push-key)
+HOTKEY = os.environ.get("VOICE_ZH_HOTKEY", "ctrl+alt+space")  # toggle-mode record key
+QUIT = os.environ.get("VOICE_ZH_QUIT", "ctrl+alt+q")
+PAUSE_HOTKEY = os.environ.get("VOICE_ZH_PAUSE", "ctrl+alt+p")  # continuous-mode pause/resume
+MODEL = os.environ.get("VOICE_ZH_MODEL", "large-v3")
+DEVICE = os.environ.get("VOICE_ZH_DEVICE", "auto")
+BEEP = os.environ.get("VOICE_ZH_BEEP", "1") == "1"
+PASTE = os.environ.get("VOICE_ZH_PASTE", "1") == "1"  # 0 = copy-only (no auto Ctrl+V)
+VAD = os.environ.get("VOICE_ZH_VAD", "0") == "1"  # default off: VAD over-trims quiet mics -> empty
+NORMALIZE = os.environ.get("VOICE_ZH_NORMALIZE", "1") == "1"  # peak-normalize low-gain capture
+_DEV_IDX = os.environ.get("VOICE_ZH_DEVICE_INDEX")  # optional explicit input device index
+DEVICE_INDEX = int(_DEV_IDX) if _DEV_IDX not in (None, "") else None
+SAMPLERATE = 16000  # whisper target rate; capture happens at the device's NATIVE rate
+MAX_SEC = int(os.environ.get("VOICE_ZH_MAX_SEC", "120"))  # cap in-memory recording length
+
+# continuous-mode (VAD) tuning
+AUTO_ENTER = os.environ.get("VOICE_ZH_AUTO_ENTER", "1") == "1"  # press Enter after grace
+GRACE_SEC = float(os.environ.get("VOICE_ZH_GRACE_SEC", "2.0"))  # confirm window before Enter
+SILENCE_SEC = float(os.environ.get("VOICE_ZH_SILENCE_SEC", "0.8"))  # trailing silence ends utterance
+MIN_UTT_SEC = float(os.environ.get("VOICE_ZH_MIN_SEC", "0.4"))  # ignore shorter blips
+_VAD_THRESH = os.environ.get("VOICE_ZH_VAD_THRESH", "auto")  # "auto" calibrates ambient noise
+ONSET_BLOCKS = int(os.environ.get("VOICE_ZH_ONSET_BLOCKS", "3"))  # consec. voiced blocks to start
+CONT_BEEP = os.environ.get("VOICE_ZH_CONT_BEEP", "0") == "1"  # continuous-mode onset/end beeps (off)
+
+# hallucination / non-speech gating (whisper confidence-based)
+NO_SPEECH_MAX = float(os.environ.get("VOICE_ZH_NOSPEECH_MAX", "0.6"))  # drop seg if no_speech_prob >=
+LOGPROB_MIN = float(os.environ.get("VOICE_ZH_LOGPROB_MIN", "-1.0"))  # drop seg if avg_logprob <=
+# signature phrases Whisper emits on silence/noise — never legitimate dictation here
+HALLUCINATION_MARKERS = (
+    "字幕志愿者", "字幕由", "amara.org", "明镜与点点", "点点栏目",
+    "请不吝点赞", "点赞订阅", "订阅转发", "谢谢观看", "谢谢大家观看",
+)
+
+
+def _register_cuda_dll_dirs():
+    """Make the bundled NVIDIA CUDA/cuDNN DLLs loadable by ctranslate2 on Windows."""
+    bins = []
+    for base in site.getsitepackages():
+        for sub in ("cublas", "cudnn", "cuda_nvrtc", "cuda_runtime"):
+            p = Path(base) / "nvidia" / sub / "bin"
+            if p.is_dir():
+                try:
+                    os.add_dll_directory(str(p))
+                except (OSError, AttributeError):
+                    pass
+                bins.append(str(p))
+    if bins:
+        os.environ["PATH"] = os.pathsep.join(bins) + os.pathsep + os.environ.get("PATH", "")
+
+
+_register_cuda_dll_dirs()
+
+import numpy as np
+import sounddevice as sd
+import pyperclip
+import keyboard
+from faster_whisper import WhisperModel
+
+try:
+    import winsound  # Windows-only; beeps are best-effort
+
+    def _beep(freq, dur):
+        if BEEP:
+            try:
+                winsound.Beep(freq, dur)
+            except RuntimeError:
+                pass
+except ImportError:  # non-Windows: no beep
+    def _beep(freq, dur):
+        pass
+
+
+def _capture_samplerate():
+    """Native samplerate of the chosen input device.
+
+    Forcing 16kHz directly on the Realtek capture driver returns digital silence
+    (peak 0.0000) instead of erroring, so we always capture at the device's native
+    rate and resample to 16kHz afterwards.
+    """
+    try:
+        d = (
+            sd.query_devices(DEVICE_INDEX, kind="input")
+            if DEVICE_INDEX is not None
+            else sd.query_devices(kind="input")
+        )
+        return int(d["default_samplerate"])
+    except Exception:
+        return SAMPLERATE
+
+
+def _resample_to_16k(audio, src_sr):
+    """Linear resample mono float32 audio to 16kHz (good enough for STT)."""
+    if src_sr == SAMPLERATE or len(audio) == 0:
+        return audio
+    n = int(round(len(audio) * SAMPLERATE / src_sr))
+    if n <= 0:
+        return audio
+    x_old = np.linspace(0.0, 1.0, num=len(audio), endpoint=False)
+    x_new = np.linspace(0.0, 1.0, num=n, endpoint=False)
+    return np.interp(x_new, x_old, audio).astype(np.float32)
+
+
+def _is_hallucination(text):
+    """True if text matches a known Whisper-on-silence hallucination signature."""
+    t = "".join(text.lower().split())
+    return any(m in t for m in HALLUCINATION_MARKERS)
+
+
+def transcribe_segment(model, audio_native, capture_sr):
+    """Resample + (optional) peak-normalize native-rate audio, then transcribe zh.
+
+    Non-speech / hallucination segments are dropped via Whisper's per-segment
+    no_speech_prob + avg_logprob (the mechanical gate that kills "字幕志愿者"-style
+    hallucinations on silence), backed by a signature blocklist. Returns
+    (text, peak); peak is measured on the raw native capture so callers can warn on
+    near-silent input.
+    """
+    peak = float(np.max(np.abs(audio_native))) if len(audio_native) else 0.0
+    audio = _resample_to_16k(audio_native, capture_sr)
+    if NORMALIZE and peak > 1e-4:
+        audio = (audio / peak * 0.3).astype(np.float32)  # rescue low-gain mics
+    segments, _ = model.transcribe(
+        audio,
+        language="zh",
+        beam_size=5,
+        vad_filter=VAD,
+        condition_on_previous_text=False,  # don't carry hallucinations across calls
+        no_speech_threshold=NO_SPEECH_MAX,
+        log_prob_threshold=LOGPROB_MIN,
+    )
+    kept = []
+    for s in segments:
+        # fail-safe defaults: if a faster-whisper build omits these fields, drop the
+        # segment rather than admit a potential hallucination
+        if getattr(s, "no_speech_prob", 1.0) >= NO_SPEECH_MAX:
+            continue
+        if getattr(s, "avg_logprob", -10.0) <= LOGPROB_MIN:
+            continue
+        kept.append(s.text)
+    text = "".join(kept).strip()
+    if _is_hallucination(text):
+        return "", peak
+    return text, peak
+
+
+def deliver_text(text):
+    """Deliver transcribed text to the focused field.
+
+    VOICE_ZH_PASTE=0 -> copy-only: leave text on the clipboard for the user to paste
+    manually. This is the safe mode, because auto-paste targets whatever window
+    happens to be focused when transcription finishes (which can be seconds later) —
+    keep the target focused, or use copy-only to avoid pasting into an unintended
+    window.
+
+    VOICE_ZH_PASTE=1 (default) -> copy + Ctrl+V, then best-effort restore of the
+    prior clipboard *text* (non-text clipboard formats are not preserved). Restore
+    runs in a finally so a paste failure can't leave the clipboard overwritten.
+    """
+    if not PASTE:
+        pyperclip.copy(text)
+        print("[voice-zh] copied to clipboard (paste manually; VOICE_ZH_PASTE=0)", flush=True)
+        return
+    try:
+        saved = pyperclip.paste()
+    except Exception:
+        saved = None
+    try:
+        pyperclip.copy(text)
+        time.sleep(0.05)
+        keyboard.press_and_release("ctrl+v")
+        time.sleep(0.2)  # let the paste land before restoring
+    finally:
+        if saved is not None:
+            try:
+                pyperclip.copy(saved)
+            except Exception:
+                pass
+
+
+def _load_model():
+    """Load WhisperModel, honoring VOICE_ZH_DEVICE. 'auto' tries CUDA then CPU.
+
+    The CUDA cuBLAS failure only surfaces at inference time (not at construction),
+    so 'auto' validates the device with a tiny warmup transcription before
+    committing to it.
+    """
+    device_map = {
+        "cuda": [("cuda", "float16")],
+        "cpu": [("cpu", "int8")],
+        "auto": [("cuda", "float16"), ("cpu", "int8")],
+    }
+    if DEVICE not in device_map:
+        print(
+            f"[voice-zh] FATAL: invalid VOICE_ZH_DEVICE={DEVICE!r} "
+            f"(allowed: {', '.join(device_map)})",
+            flush=True,
+        )
+        sys.exit(2)
+    candidates = device_map[DEVICE]
+    warmup = np.zeros(SAMPLERATE, dtype=np.float32)  # 1s of silence
+    for dev, comp in candidates:
+        try:
+            print(f"[voice-zh] loading {MODEL} on {dev}/{comp} ...", flush=True)
+            t0 = time.time()
+            model = WhisperModel(MODEL, device=dev, compute_type=comp)
+            # force a real inference pass to validate the device end-to-end
+            list(model.transcribe(warmup, language="zh")[0])
+            print(f"[voice-zh] ready on {dev}/{comp} ({time.time() - t0:.1f}s)", flush=True)
+            return model
+        except Exception as e:
+            print(f"[voice-zh] {dev} unavailable: {type(e).__name__}: {e}", flush=True)
+    print("[voice-zh] FATAL: no usable device (cuda/cpu)", flush=True)
+    sys.exit(2)
+
+
+class Recorder:
+    """Toggle-driven mic recorder. State machine across hotkey presses."""
+
+    def __init__(self, model):
+        self.model = model
+        self.stream = None
+        self.frames = []
+        self.recording = False
+        self._samples = 0
+        self.capture_sr = _capture_samplerate()  # device native rate; resampled later
+        self._max_samples = MAX_SEC * self.capture_sr
+        self._capped = False
+        self._shutdown = threading.Event()  # set by close() to abort in-flight deliver
+        self._deliver_lock = threading.Lock()  # serialize deliver vs shutdown atomically
+        dev = DEVICE_INDEX if DEVICE_INDEX is not None else "default"
+        print(f"[voice-zh] input device = {dev} @ {self.capture_sr}Hz -> 16kHz", flush=True)
+
+    def _on_audio(self, indata, frames, time_info, status):
+        if status:
+            print(f"[voice-zh] audio status: {status}", flush=True)
+        if self._samples >= self._max_samples:
+            if not self._capped:  # warn once, then drop overflow to bound RAM
+                self._capped = True
+                print(
+                    f"[voice-zh] recording hit {MAX_SEC}s cap — extra audio dropped; "
+                    "press hotkey to stop",
+                    flush=True,
+                )
+            return
+        self.frames.append(indata.copy())
+        self._samples += len(indata)
+
+    def toggle(self):
+        if not self.recording:
+            self._start()
+        else:
+            self._stop_and_inject()
+
+    def _start(self):
+        self.frames = []
+        self._samples = 0
+        self._capped = False
+        self.stream = sd.InputStream(
+            samplerate=self.capture_sr,
+            channels=1,
+            dtype="float32",
+            device=DEVICE_INDEX,
+            callback=self._on_audio,
+        )
+        self.stream.start()
+        self.recording = True
+        _beep(880, 120)
+        print("[voice-zh] ● recording... (press hotkey again to stop)", flush=True)
+
+    def _stop_and_inject(self):
+        self.recording = False
+        try:
+            self.stream.stop()
+            self.stream.close()
+        finally:
+            self.stream = None  # never orphan the PortAudio stream, even on stop() error
+        _beep(440, 120)
+        if not self.frames:
+            print("[voice-zh] (no audio captured)", flush=True)
+            return
+        if self._samples < MIN_UTT_SEC * self.capture_sr:
+            print("[voice-zh] (too short)", flush=True)
+            return
+        try:
+            audio = np.concatenate(self.frames, axis=0).flatten()
+            dur = self._samples / self.capture_sr
+            print(f"[voice-zh] transcribing {dur:.1f}s ...", flush=True)
+            t0 = time.time()
+            text, peak = transcribe_segment(self.model, audio, self.capture_sr)
+            print(f"[voice-zh] -> {text!r} (peak={peak:.4f}, {time.time() - t0:.1f}s)", flush=True)
+            if peak < 1e-3:
+                print(
+                    "[voice-zh] WARNING: near-silent capture — raise mic level or set "
+                    "VOICE_ZH_DEVICE_INDEX (run tmp/scan_devices2.py to find the right index)",
+                    flush=True,
+                )
+            if text:
+                with self._deliver_lock:
+                    if not self._shutdown.is_set():  # don't paste after quit
+                        deliver_text(text)
+        except Exception as e:
+            # keep the daemon alive on any transcribe/inject failure; next toggle works
+            print(f"[voice-zh] transcribe failed: {type(e).__name__}: {e}", flush=True)
+
+    def close(self):
+        """Guaranteed teardown of any active stream (called on daemon exit)."""
+        self._shutdown.set()
+        with self._deliver_lock:
+            pass  # wait for any in-flight deliver to finish; block new ones
+        self.recording = False
+        if self.stream is not None:
+            try:
+                self.stream.stop()
+                self.stream.close()
+            except Exception:
+                pass
+            finally:
+                self.stream = None
+
+
+class ContinuousListener:
+    """Always-on, energy-VAD-segmented dictation.
+
+    Listens continuously; an utterance is the audio between speech onset and a
+    trailing silence gap (SILENCE_SEC). Each utterance is transcribed and delivered;
+    with AUTO_ENTER, Enter is pressed after a GRACE_SEC confirm window (cancellable
+    by pressing the pause hotkey). The pause hotkey toggles listening on/off.
+
+    Energy VAD threshold is calibrated from ~1s of ambient noise at startup (or set
+    explicitly via VOICE_ZH_VAD_THRESH). Low-gain mics work best with the mic level
+    raised in Windows — if utterances are missed, raise the mic level or lower
+    VOICE_ZH_VAD_THRESH.
+    """
+
+    def __init__(self, model):
+        self.model = model
+        self.capture_sr = _capture_samplerate()
+        self.blocksize = max(256, int(0.05 * self.capture_sr))  # ~50ms blocks
+        self.q = queue.Queue()
+        self.stream = None
+        self.worker = None
+        self.running = False
+        self.paused = False
+        self._cancel_send = threading.Event()  # set on pause; reset per-utterance in _finalize
+        self._busy = threading.Event()  # set while a finalize is running (gates capture)
+        self._shutdown = threading.Event()  # set by close() to abort in-flight deliver/Enter
+        self._deliver_lock = threading.Lock()  # serialize deliver vs shutdown atomically
+        self.threshold = None  # set in start()
+
+    def _calibrate(self):
+        if _VAD_THRESH != "auto":
+            return float(_VAD_THRESH)
+        print("[voice-zh] calibrating ambient noise ~1s — stay quiet ...", flush=True)
+        n = int(1.0 * self.capture_sr)
+        a = sd.rec(n, samplerate=self.capture_sr, channels=1, dtype="float32", device=DEVICE_INDEX)
+        sd.wait()
+        noise = float(np.sqrt(np.mean(a.flatten() ** 2)))
+        thr = max(noise * 4.0, 1.5e-3)  # well above the noise floor to avoid false triggers
+        print(
+            f"[voice-zh] noise_rms={noise:.5f} -> vad_threshold={thr:.5f} "
+            "(raise mic level / set VOICE_ZH_VAD_THRESH if it mis-triggers)",
+            flush=True,
+        )
+        return thr
+
+    def _on_audio(self, indata, frames, time_info, status):
+        if status:
+            print(f"[voice-zh] audio status: {status}", flush=True)
+        if self.paused or self._busy.is_set():
+            return  # drop capture while paused or while a finalize is in flight (no backlog)
+        block = indata.copy().flatten()
+        rms = float(np.sqrt(np.mean(block ** 2)))
+        self.q.put((block, rms))
+
+    def _finalize(self, seg, seg_samples):
+        if seg_samples < MIN_UTT_SEC * self.capture_sr:
+            return
+        self._busy.set()  # stop capture during transcribe+grace so no stale backlog builds
+        self._cancel_send.clear()  # per-utterance reset (pause during grace re-sets it)
+        try:
+            audio = np.concatenate(seg, axis=0).flatten()
+            dur = seg_samples / self.capture_sr
+            print(f"[voice-zh] transcribing {dur:.1f}s ...", flush=True)
+            t0 = time.time()
+            text, peak = transcribe_segment(self.model, audio, self.capture_sr)
+            print(f"[voice-zh] -> {text!r} (peak={peak:.4f}, {time.time() - t0:.1f}s)", flush=True)
+            if not text:
+                return
+            with self._deliver_lock:
+                if self._shutdown.is_set():
+                    return  # never paste into the focused window during quit
+                deliver_text(text)
+            if not AUTO_ENTER:
+                return
+            if self._grace_cancelled():
+                print("[voice-zh] auto-enter cancelled", flush=True)
+                return
+            with self._deliver_lock:  # Enter under the same lock + shutdown recheck (atomic)
+                if self._shutdown.is_set():
+                    print("[voice-zh] auto-enter cancelled", flush=True)
+                else:
+                    keyboard.press_and_release("enter")
+                    print("[voice-zh] ↵ sent", flush=True)
+        except Exception as e:
+            print(f"[voice-zh] segment failed: {type(e).__name__}: {e}", flush=True)
+        finally:
+            self._busy.clear()
+            self._drain_queue()  # discard anything captured in the gap before busy took effect
+
+    def _drain_queue(self):
+        try:
+            while True:
+                self.q.get_nowait()
+        except queue.Empty:
+            pass
+
+    def _grace_cancelled(self):
+        """Wait GRACE_SEC; True if the user cancelled (pause) or the daemon is quitting."""
+        deadline = time.time() + GRACE_SEC
+        while time.time() < deadline:
+            if self._cancel_send.is_set() or self.paused or self._shutdown.is_set():
+                return True
+            time.sleep(0.05)
+        return False
+
+    def _run(self):
+        in_speech = False
+        seg, seg_samples, silence_run = [], 0, 0.0
+        pending, pending_samples, voiced_run = [], 0, 0  # onset debounce buffer
+        block_dur = self.blocksize / self.capture_sr
+        cap = MAX_SEC * self.capture_sr
+        while self.running:
+            try:
+                try:
+                    block, rms = self.q.get(timeout=0.1)
+                    got = True
+                except queue.Empty:
+                    got = False
+                if self.paused:  # drop any partial utterance while paused
+                    # reset even on an empty queue, else a partial utterance captured
+                    # right before pause would survive and merge with post-resume speech
+                    in_speech = False
+                    seg, seg_samples, silence_run = [], 0, 0.0
+                    pending, pending_samples, voiced_run = [], 0, 0
+                    continue
+                if not got:
+                    continue
+                voiced = rms > self.threshold
+                if not in_speech:
+                    # require ONSET_BLOCKS consecutive voiced blocks before starting,
+                    # so a single noise spike does not open an utterance (kills false beeps)
+                    if voiced:
+                        voiced_run += 1
+                        pending.append(block)
+                        pending_samples += len(block)
+                        if voiced_run >= ONSET_BLOCKS:
+                            in_speech = True
+                            seg, seg_samples = pending, pending_samples
+                            pending, pending_samples, voiced_run = [], 0, 0
+                            silence_run = 0.0
+                            if CONT_BEEP:
+                                _beep(880, 80)
+                    else:
+                        pending, pending_samples, voiced_run = [], 0, 0
+                    continue
+                # in_speech
+                seg.append(block)
+                seg_samples += len(block)
+                if voiced:
+                    silence_run = 0.0
+                else:
+                    silence_run += block_dur
+                    if silence_run >= SILENCE_SEC:
+                        if CONT_BEEP:
+                            _beep(440, 80)
+                        self._finalize(seg, seg_samples)
+                        in_speech = False
+                        seg, seg_samples, silence_run = [], 0, 0.0
+                        continue
+                if seg_samples >= cap:  # safety: bound a runaway utterance
+                    self._finalize(seg, seg_samples)
+                    in_speech = False
+                    seg, seg_samples, silence_run = [], 0, 0.0
+            except Exception as e:
+                # never let the consumer thread die — that would zombie the daemon
+                print(f"[voice-zh] listener error: {type(e).__name__}: {e}", flush=True)
+                in_speech = False
+                seg, seg_samples, silence_run = [], 0, 0.0
+                pending, pending_samples, voiced_run = [], 0, 0
+
+    def toggle_pause(self):
+        self.paused = not self.paused
+        if self.paused:
+            self._cancel_send.set()  # cancel any pending auto-enter (latched until next utterance)
+            print("[voice-zh] ⏸ paused", flush=True)
+        else:
+            # do NOT clear _cancel_send here: a pause within a grace window must keep the
+            # auto-Enter cancelled even after a quick resume. It is reset per-utterance in _finalize.
+            print("[voice-zh] ▶ resumed", flush=True)
+
+    def start(self):
+        self.threshold = self._calibrate()
+        self.running = True
+        self.worker = threading.Thread(target=self._run, daemon=True)
+        self.worker.start()
+        self.stream = sd.InputStream(
+            samplerate=self.capture_sr,
+            channels=1,
+            dtype="float32",
+            blocksize=self.blocksize,
+            device=DEVICE_INDEX,
+            callback=self._on_audio,
+        )
+        self.stream.start()
+
+    def close(self):
+        # set shutdown first so an in-flight _finalize aborts before delivering/Enter,
+        # and so any partially-captured utterance is intentionally dropped on quit
+        self._shutdown.set()
+        with self._deliver_lock:
+            pass  # wait for any in-flight deliver to finish; block new ones
+        self.running = False
+        if self.stream is not None:
+            try:
+                self.stream.stop()
+                self.stream.close()
+            except Exception:
+                pass
+            finally:
+                self.stream = None
+        if self.worker is not None:
+            self.worker.join(timeout=2.0)
+            self.worker = None
+
+
+def main():
+    model = _load_model()
+    if MODE == "toggle":
+        rec = Recorder(model)
+        keyboard.add_hotkey(HOTKEY, rec.toggle)
+        print(f"[voice-zh] toggle mode | {HOTKEY} = record | {QUIT} = quit", flush=True)
+        try:
+            keyboard.wait(QUIT)
+        except KeyboardInterrupt:
+            pass
+        finally:
+            rec.close()
+    else:  # continuous
+        lis = ContinuousListener(model)
+        lis.start()
+        keyboard.add_hotkey(PAUSE_HOTKEY, lis.toggle_pause)
+        enter_note = "auto-Enter after {:.0f}s grace".format(GRACE_SEC) if AUTO_ENTER else "no auto-Enter"
+        print(
+            f"[voice-zh] continuous mode | just speak ({enter_note}) | "
+            f"{PAUSE_HOTKEY} = pause/resume | {QUIT} = quit",
+            flush=True,
+        )
+        try:
+            keyboard.wait(QUIT)
+        except KeyboardInterrupt:
+            pass
+        finally:
+            lis.close()
+    print("[voice-zh] bye", flush=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 概述

独立可拆卸的**中文语音输入** daemon (`scripts/voice-zh-input.py`)，绕开原生 `/voice`（服务端写死 20 语言、**无中文**）。本地运行，音频不出本机。落 `scripts/`（Mercury 内部工具，无 LOC 上限，零 Mercury 耦合）。

Closes #465

## 两种模式

- **连续模式（默认）**：常驻能量 VAD 自动分句 —— 直接说话，说完停顿即转写并注入，确认窗口后自动回车。`Ctrl+Alt+P` 暂停/恢复，`Ctrl+Alt+Q` 退出。
- **推键模式**（`VOICE_ZH_MODE=toggle`）：`Ctrl+Alt+Space` 开始/停止录音。

## 管线（架构 B，全步骤 #465 实证）

1. `sounddevice` 按设备**原生采样率**录音（强制 16k 会被 Realtek 驱动返回数字静音）→ 重采样 16k + 峰值归一化（救低增益麦克风）
2. `faster-whisper` 1.2.1 `large-v3`（`language="zh"`，GPU float16 / CPU int8 自动回退）
3. `pyperclip` 剪贴板 + 模拟 `Ctrl+V`（bracketed paste）注入 —— 逐字键击对中文乱码（[microsoft/terminal#12977](https://github.com/microsoft/terminal/issues/12977)），剪贴板+Ctrl+V 是唯一可行路径
4. 幻觉门控：`no_speech_prob`/`avg_logprob` + 短语黑名单（滤 whisper 静音幻觉，如「字幕志愿者」）
5. 退出/暂停**原子门控**（`threading.Lock` + `Event`）：退出绝不粘贴/回车进焦点窗口

GPU：自动注册 bundled `nvidia` cu12 DLL 目录并**前置 PATH**（`add_dll_directory` 单独不够，ctranslate2 内部加载器走 PATH）。

## 验证

- **keystone**：中文 `Ctrl+V` 注入 Claude Code TUI 正确（用户实测 ✅）
- **STT 准确度**：faster-whisper zh ~100%（SAPI 样本仅标点/数字归一化差异），GPU 1.8s/句 vs CPU 13.7s/句
- **连续模式端到端**：用户实测通过（peak 0.45，无误触、无幻觉、自动回车）
- **离线测试**：分句+投递+回车 / 噪声拒绝→零投递 / 退出门控→不投递不回车，全 PASS
- **dual-verify**：**Claude PASS + Codex PASS**（真实 Codex 运行，非 fallback）。跨多轮迭代修复：worker 线程韧性、退出门控原子化（双模式 paste+Enter）、队列背压、pause 空队列重置、幻觉门控、文档一致性

## 依赖

`requirements-voice-zh.txt`（faster-whisper 1.2.1 / sounddevice 0.5.5 / pyperclip 1.11.0 / keyboard 0.13.5 / numpy）+ 可选 GPU 四件套（cublas/cudnn 9.x/cuda-runtime/cuda-nvrtc）。实测 Windows 11 + Python 3.14.3。

🤖 Generated with [Claude Code](https://claude.com/claude-code)