### PR TITLE
docs(#469): handoff auto-mode 强约束止血 — 必须跑启动器

### DIFF
--- a/.claude/skills/handoff/SKILL.md
+++ b/.claude/skills/handoff/SKILL.md
@@ -11,6 +11,23 @@ allowed-tools: Read, Write, Bash, Glob, Grep
 You are executing the handoff skill. This is the **only** entry point for
 handoff — nothing triggers automatically. Follow these steps precisely.
 
+> ## ⚠️ #1 RECURRING FAILURE MODE — READ BEFORE ANYTHING ELSE
+>
+> In **auto mode** (`/handoff auto`, or any autorun/ralph/ultrawork run the user
+> told to auto-handoff at the end), the single most common bug is: the agent
+> **writes the handoff doc + prints the Starting Prompt, then STOPS** — without
+> ever invoking the launcher. **That is a FAILED handoff, not a completed one.**
+>
+> Outputting the prompt text is NOT the deliverable in auto mode. The deliverable
+> is a **spawned new session**. Auto mode is NOT complete until you have actually
+> run `bash scripts/handoff-launch.sh ...` (Step 5 Auto mode) and seen it report
+> `spawned new tab`. Printing text and ending the turn = the bug the user keeps
+> hitting. There is no hook that does this for you (Stop hook is empty) — the
+> launcher call is YOUR responsibility and MUST be the last tool call you make.
+>
+> Self-check before you end an auto-mode turn: "Did I run handoff-launch.sh and
+> see it succeed?" If no → you are not done; run it now.
+
 ## Invocation modes
 
 Parse `$ARGUMENTS`:
@@ -281,6 +298,13 @@ Optional: offer to launch if the user later says so (Step 6).
 
 ### Auto mode (`/handoff auto`)
 
+**MANDATORY**: auto mode is only complete once `scripts/handoff-launch.sh` has
+actually run and reported `spawned new tab`. Do NOT end the turn after merely
+printing the prompt — running the launcher is the whole point of auto mode (see
+the ⚠️ banner at the top of this skill). This applies equally when an
+autorun/ralph/ultrawork run was told to auto-handoff on completion: the loop's
+final act MUST be the launcher call, not a printed prompt.
+
 After Step 5.1 + 5.2, and Pre-Termination Checklist passed:
 
 **Required launch pattern — use a SHORT reference prompt, never inline the
@@ -465,8 +489,14 @@ the auto path from Step 5 (auto mode).
 - Include specific file paths, line numbers, commands.
 - Never include secrets, API keys, credentials.
 - The chat-output prompt is the PRIMARY deliverable — never skip it.
+- **Auto mode is NOT done until the launcher ran.** In auto mode, printing the
+  prompt is necessary but NOT sufficient — `scripts/handoff-launch.sh` MUST run
+  and report `spawned new tab` as the final action. Ending the turn after only
+  printing text is the #1 recurring auto-handoff bug (see top-of-skill banner).
 - Do NOT add automatic hooks for SessionEnd or PreCompact — handoff is
-  **explicit only**.
+  **explicit only**. (The reliable mechanical fix — an armed Stop-hook — is
+  tracked in Mercury Issue #469; until it lands, the behavioral rule above is
+  the stopgap.)
 - **Mode-scoped termination**: auto mode treats handoff as a terminal
   event for the old session (spawn new → /exit old). Manual mode does
   NOT terminate; the user decides. Never apply auto-mode termination to

--- a/.claude/skills/handoff/SKILL.md
+++ b/.claude/skills/handoff/SKILL.md
@@ -13,17 +13,22 @@ handoff — nothing triggers automatically. Follow these steps precisely.
 
 > ## ⚠️ #1 RECURRING FAILURE MODE — READ BEFORE ANYTHING ELSE
 >
-> In **auto mode** (`/handoff auto`, or any autorun/ralph/ultrawork run the user
-> told to auto-handoff at the end), the single most common bug is: the agent
+> In **auto mode** (`/handoff auto`, or any autorun/ralph/ultrawork run that the
+> user told to auto-handoff at the end), the single most common bug is: the agent
 > **writes the handoff doc + prints the Starting Prompt, then STOPS** — without
 > ever invoking the launcher. **That is a FAILED handoff, not a completed one.**
 >
-> Outputting the prompt text is NOT the deliverable in auto mode. The deliverable
-> is a **spawned new session**. Auto mode is NOT complete until you have actually
-> run `bash scripts/handoff-launch.sh ...` (Step 5 Auto mode) and seen it report
-> `spawned new tab`. Printing text and ending the turn = the bug the user keeps
-> hitting. There is no hook that does this for you (Stop hook is empty) — the
-> launcher call is YOUR responsibility and MUST be the last tool call you make.
+> In auto mode, outputting the prompt text is necessary but NOT sufficient. The
+> deliverable is a **spawned new session**. Auto mode is NOT complete until you
+> have actually run `bash scripts/handoff-launch.sh ...` (Step 5 Auto mode; a
+> bash script — on Windows it runs via Git Bash / the Bash tool) and seen it
+> **exit 0 with its success report** (currently `spawned new tab`). Printing
+> text and ending the turn = the bug the user keeps hitting. No hook invokes the
+> launcher for you (the registered Stop hook, `stop-guard.sh`, does not
+> auto-handoff) — the launcher call is YOUR responsibility and MUST be the final
+> substantive action of the turn (trivial state writes/cleanup may follow, but
+> no further task work). This behavioral rule is the stopgap for Issue #469; the
+> permanent mechanical fix (armed Stop-hook) is tracked there.
 >
 > Self-check before you end an auto-mode turn: "Did I run handoff-launch.sh and
 > see it succeed?" If no → you are not done; run it now.
@@ -299,11 +304,12 @@ Optional: offer to launch if the user later says so (Step 6).
 ### Auto mode (`/handoff auto`)
 
 **MANDATORY**: auto mode is only complete once `scripts/handoff-launch.sh` has
-actually run and reported `spawned new tab`. Do NOT end the turn after merely
-printing the prompt — running the launcher is the whole point of auto mode (see
-the ⚠️ banner at the top of this skill). This applies equally when an
-autorun/ralph/ultrawork run was told to auto-handoff on completion: the loop's
-final act MUST be the launcher call, not a printed prompt.
+actually run and succeeded — exit code 0 plus its success report (currently
+`spawned new tab`). Do NOT end the turn after merely printing the prompt —
+running the launcher is the whole point of auto mode (see the ⚠️ banner at the
+top of this skill). This applies equally to an autorun/ralph/ultrawork run that
+was told to auto-handoff on completion: the loop's final substantive act MUST
+be the launcher call, not a printed prompt.
 
 After Step 5.1 + 5.2, and Pre-Termination Checklist passed:
 
@@ -488,11 +494,14 @@ the auto path from Step 5 (auto mode).
   new session.
 - Include specific file paths, line numbers, commands.
 - Never include secrets, API keys, credentials.
-- The chat-output prompt is the PRIMARY deliverable — never skip it.
-- **Auto mode is NOT done until the launcher ran.** In auto mode, printing the
-  prompt is necessary but NOT sufficient — `scripts/handoff-launch.sh` MUST run
-  and report `spawned new tab` as the final action. Ending the turn after only
-  printing text is the #1 recurring auto-handoff bug (see top-of-skill banner).
+- The chat-output prompt is required in BOTH modes — never skip it. Completion
+  is mode-scoped: in **manual mode** the prompt IS the primary deliverable; in
+  **auto mode** the prompt is necessary but completion additionally requires
+  the launcher to have run.
+- **Auto mode is NOT done until the launcher ran.** `scripts/handoff-launch.sh`
+  MUST run and succeed (exit 0 + success report, currently `spawned new tab`)
+  as the final substantive action. Ending the turn after only printing text is
+  the #1 recurring auto-handoff bug (see top-of-skill banner).
 - Do NOT add automatic hooks for SessionEnd or PreCompact — handoff is
   **explicit only**. (The reliable mechanical fix — an armed Stop-hook — is
   tracked in Mercury Issue #469; until it lands, the behavioral rule above is


### PR DESCRIPTION
## 问题(复发)

用户配置 autorun + `/handoff auto`,但**每次 session 结束只打印 handoff 文案就停下,不自动转接新 session**。复发性。

## 根因(实证)

auto-handoff 无 hook 强制:`settings.json` 的 `Stop` hook 为空 `[]`,`SessionEnd`/`PreCompact` 只挂 mem0 flush,全配置无 auto-handoff 接线。唯一自动拉起路径 = 模型主动调 `scripts/handoff-launch.sh`,而模型易把"打印 Starting Prompt"当交付物就结束 turn。

## 本 PR(行为层止血,doc-only)

用户已选「先只加行为强约束(轻量止血)」。改 `.claude/skills/handoff/SKILL.md`:
- 顶部加 **⚠️ #1 RECURRING FAILURE MODE banner**(skill 加载即见):打印文案≠完成,auto 模式只有 launcher 报 `spawned new tab` 才算完成。
- Step 5 Auto mode 加 MANDATORY 同义强约束(含 autorun/ralph/ultrawork 结束自动 handoff 场景)。
- Rules 加约束 + 结束前自检("我跑启动器了吗?看到 spawned 了吗?")。

## 永久解(分开跟踪)

armed Stop-hook 机械强制 → **Issue #469**(借鉴 ralph "boulder never stops" Stop-hook 模式 + 完成条件守卫 + 防 ghost 终端 + #259 用户级治理)。

Refs #469

🤖 Generated with [Claude Code](https://claude.com/claude-code)