### PR TITLE
feat(#468): 双向中文语音 agent 交互系统(voice-agent)

### DIFF
--- a/.claude/commands/secretary.md
+++ b/.claude/commands/secretary.md
@@ -1,0 +1,17 @@
+---
+description: 切换语音交互到秘书模式（快速记录+总结，不执行任务）
+---
+
+切换到**秘书模式**（Mercury #468 双向语音 agent）。
+
+1. 调用 voice MCP server 的 `set_mode` 工具，参数 `mode="secretary"`。
+2. 进入秘书模式后，你的职责是**快速记录和总结用户发言，不执行任何任务**：
+   - 用 `listen` 工具拉取用户的中文语音（每次一句）。秘书模式下 `listen` 会自动把转写
+     记入笔记文件。
+   - 对关键信息用 `record_note` 工具结构化沉淀：`kind="requirement"`（需求）/
+     `decision`（决策）/ `summary`（总结）。
+   - **不要主动推进或执行任务**——只做信息录入渠道。
+3. 当用户表示已说清某任务的需求/目标/细节/规范，提示用户：说「切工作模式」或用 `/work`
+   显式切换后你才开始推进。
+
+如果 voice MCP server 未注册，告诉用户先运行 `claude mcp add voice -- <venv-python> scripts/voice/mcp_server.py`（详见 `scripts/voice/README.md`）。

--- a/.claude/commands/work.md
+++ b/.claude/commands/work.md
@@ -1,0 +1,18 @@
+---
+description: 切换语音交互到工作模式（基于已掌握需求自主推进任务，遇 check-in 主动语音提示）
+---
+
+切换到**工作模式**（Mercury #468 双向语音 agent）。
+
+1. 调用 voice MCP server 的 `set_mode` 工具，参数 `mode="work"`，并把本次要推进的任务
+   写入 `task_context`（取自秘书模式记录的需求/目标/细节/规范）。
+2. 进入工作模式后，你**基于已掌握的需求自主推进具体任务**。先读取秘书模式的记录文件
+   （`get_status` 返回的记录文件路径）确认需求全貌。
+3. **双向交互**——遇到以下情形时，用 `announce` 工具主动语音提示用户回到交互：
+   - **决策需求**：需要用户在多个方案间拍板。
+   - **额外信息确认**：缺少推进所需的信息。
+   - **完成**：任务阶段性完成，播报结果。
+   提示后如需用户口头回应，紧接着调用 `listen` 拉取用户语音。
+4. 不确定时优先 `announce` + `listen` 双向确认，而不是擅自假设。
+
+如果 voice MCP server 未注册，告诉用户先运行 `claude mcp add voice -- <venv-python> scripts/voice/mcp_server.py`（详见 `scripts/voice/README.md`）。

--- a/.claude/hooks/voice-stop-notify.sh
+++ b/.claude/hooks/voice-stop-notify.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# voice-stop-notify — Stop hook: speak the agent's reply at turn end (Issue #468).
+#
+# Opt-in: NOT registered in .claude/settings.json by default (would spawn a Python
+# process every turn for the whole team + require .venv-voice). Enable it yourself by
+# adding a Stop matcher entry — see scripts/voice/README.md. The worker self-guards:
+# it no-ops unless a voice mode is active (mode != idle), so even if registered it is
+# silent for non-voice sessions.
+#
+# Reads the Stop-hook JSON on stdin and pipes it to the voice venv's stop_notify.py.
+# Always exits 0 — a TTS hiccup must never block Claude Code.
+set -euo pipefail
+
+PROJ="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+PY="$PROJ/.venv-voice/Scripts/python.exe"          # native Windows venv
+[ -x "$PY" ] || PY="$PROJ/.venv-voice/bin/python"  # posix venv fallback
+
+# voice venv not installed -> nothing to do
+if [ ! -x "$PY" ]; then
+  cat >/dev/null 2>&1 || true   # drain stdin
+  exit 0
+fi
+
+"$PY" "$PROJ/scripts/voice/stop_notify.py" || true
+exit 0

--- a/.mercury/docs/research/issue-468-voice-agent-adr-2026-06.md
+++ b/.mercury/docs/research/issue-468-voice-agent-adr-2026-06.md
@@ -85,9 +85,10 @@ scripts/voice-zh-input.py           # #465 daemon:重构为 import scripts.voice
 | `last_assistant_message` 官方 hooks doc 未列(仅二手源+社区先例),version/condition-specific | 兜底解析 `transcript_path` JSONL;实测确认字段存在性 |
 | Stop hook 用户中断/取消是否触发 = UNVERIFIED | 实现期实测;`stop_hook_active` 防死循环 |
 | Kokoro `<3.13` 锁绕过运行行为无实测 | Kokoro-FastAPI 独立服务/venv 隔离(已成立) |
-| `/clear` 损坏 transcript 破坏解析 | 优先用 `last_assistant_message` 字段规避 |
-| 快速连续响应音频重叠 | TTS 播放前 kill 前一进程 |
-| MCP `listen()` 阻塞与 Claude Code 工具超时 | 设合理 `listen_duration_max`;实测工具调用超时边界 |
+| `/clear` 损坏 transcript 破坏解析(fail-open 读旧回复) | 优先用 `last_assistant_message` 字段规避主路径;残留经 README 文档化 |
+| 音频重叠 —— announce(MCP server 进程)与 stop_notify(Stop hook 进程)**跨进程** | 已实现:状态目录 `voice-tts.lock` 跨进程文件锁(O_EXCL + 90s 过期窃取 + `VOICE_TTS_LOCK_WAIT` 等待/跳过);in-process 另有 `_play_lock`(dual-verify Codex High 修复) |
+| 状态 read-modify-write 跨进程竞争 | 实际单写者(单线程 MCP server),概率极低;JSON 写原子;经 README 文档化为已知限制 |
+| MCP `listen()` 阻塞与 Claude Code 工具超时 | onset 窗口 `VOICE_LISTEN_ONSET_GRACE`(默认 10s);最长阻塞 ≈ `max_seconds + onset_grace`;实测工具超时边界 |
 
 ## 7. 验收标准
 

--- a/.mercury/docs/research/issue-468-voice-agent-adr-2026-06.md
+++ b/.mercury/docs/research/issue-468-voice-agent-adr-2026-06.md
@@ -1,0 +1,111 @@
+# ADR — #468 voice-zh-input 升级为双向语音 agent 交互系统
+
+> 状态:ACCEPTED(2026-06-03,项目 owner 定方向:完整三组件一次做完 + Kokoro-FastAPI 独立服务)
+> 上游调研:`.research/reports/RESEARCH-468-voice-agent-2026-06-03.md`(autoresearch 4 轮,gate PASS,verify 加权 5.0)
+> 关联:#465(已交付 voice-zh-input 输入 daemon,PR #467 → `71aabe4`);本 Issue #468 升级
+
+---
+
+## 1. 背景与需求
+
+#465 交付了外围中文语音**输入**(`scripts/voice-zh-input.py`:连续 VAD 听写 + 剪贴板+Ctrl+V 注入,faster-whisper large-v3 GPU)。#468 升级为**双向语音 agent 交互系统**,项目 owner 明确三点需求:
+
+1. **从 Claude Code CLI 内用指令直接调用**中文语音(slash command / 会话内集成,而非只独立终端 daemon)。
+2. **按问题深度分流 + 快响应**,≥2 模式:
+   - **秘书模式**:高速,同步记录+总结用户发言(信息快速录入,**不执行任务**)。
+   - **工作模式**:基于已掌握的需求/目标/细节/规范**自主推进任务**;遇决策/补充信息/完成时**主动提示用户**回到语音交互(双向)。
+   - **显式声明切换**。
+
+## 2. 决策
+
+### 2.1 mount-vs-build:**架构 B(`scripts/` 自研粘合)延续,NOT mount VoiceMode**
+
+**决定性理由**:VoiceMode(mbailey/voicemode,MIT,最值得参考)官方**原生 Windows 不支持(仅 WSL2)**,其后端服务管理走 launchd/systemd(无 Windows),与 Mercury 原生 Windows 11 + Python 3.14 + RTX 4060 直接冲突 [https://pypi.org/project/voice-mode/]。直接 mount(submodule + 薄适配)代价过高且与目标平台冲突。
+
+**但按层借鉴 VoiceMode 接口设计**:① `converse` 工具的 `wait_for_response` 语义(true=说+听阻塞返回转写;false=仅 TTS 播报);② STT/TTS 经 OpenAI 兼容 HTTP 端点解耦的思想。
+
+### 2.2 TTS 选型:**Kokoro-FastAPI 独立服务**
+
+本地隐私优先 → Kokoro-FastAPI(Apache-2.0、离线、4060 上 ~300ms 首音、8 普通话音色 zf_*/zm_*)作为独立 HTTP 服务运行,**用其自带 `.python-version` 隔离 Kokoro 的 `Requires-Python <3.13` 硬锁**(主 voice 模块留 Python 3.14)[https://github.com/remsky/Kokoro-FastAPI] [https://pypi.org/project/kokoro/]。`edge-tts`(在线、copyleft)仅作零配置应急回退,默认不启用。
+
+> Kokoro-FastAPI 作为**运行时外部服务**(类似数据库),非代码 vendor —— 经其文档化 Docker/uv 部署,不入 git、不走 cherry-pick 协议;setup 步骤记 README。TTS 客户端只发 OpenAI 兼容 `/v1/audio/speech` HTTP 请求。
+
+### 2.3 三组件架构(全 Mercury-internal `scripts/`,无 LOC 上限)
+
+```
+scripts/voice/                      # 新增可拆卸 package
+  __init__.py
+  stt.py        # STT 层:faster-whisper 加载 + 转写 + 麦克风/VAD(抽取自 #465,共享)
+  tts.py        # TTS 层:Kokoro-FastAPI OpenAI 兼容客户端 + edge-tts 回退 + 播放
+  state.py      # 双模式状态机 + 秘书结构化记录
+  mcp_server.py # stdio MCP server:listen / announce / set_mode / record_note 工具
+scripts/voice-zh-input.py           # #465 daemon:重构为 import scripts.voice.stt(不重复 STT)
+.claude/hooks/voice-stop-notify.sh  # Stop hook:读 last_assistant_message → 信号 → TTS 播报
+.claude/commands/secretary.md       # /secretary 切秘书模式
+.claude/commands/work.md            # /work 切工作模式
+```
+
+**模块化合规**:`scripts/voice/` 整体可拆卸(在任何 repo 复制 package + `claude mcp add` 即用);不依赖 Mercury 其他模块。
+
+## 3. CLI 内调用机制:自建 stdio MCP server
+
+`claude mcp add voice -- python scripts/voice/mcp_server.py`(stdio 为本地默认,原生 Windows 可行,`python script.py` 真实 PATH 二进制无需 `cmd /c` 包裹)[https://code.claude.com/docs/en/mcp]。用 PyPI `mcp` / FastMCP 高层 API [https://github.com/modelcontextprotocol/python-sdk]。
+
+暴露工具(借鉴 converse 语义,模型在会话内调用):
+- `listen()` → 阻塞录音 + faster-whisper 转写,返回中文字符串(借鉴 `converse(wait_for_response=true)`)。
+- `announce(text)` → 仅 Kokoro TTS 播报,不监听(借鉴 `wait_for_response=false`,= agent check-in 播报原语)。
+- `set_mode(mode)` → secretary | work,切状态机。
+- `record_note(text)` → 秘书模式结构化记录(写笔记文件)。
+
+## 4. 双向闭环(keystone):两条互补机制
+
+- **(A) 模型主动(主)**:工作模式遇决策/缺信息/完成时,模型自身调 `announce()` 播报 + 可选 `listen()` 拉用户语音回应。模型可控 check-in 时机。
+- **(B) Stop hook 兜底**:`.claude/hooks/voice-stop-notify.sh` 在每回合结束自动读 `last_assistant_message`(兜底解析 `transcript_path` JSONL `.message.content[0].text`)→ 写信号文件 → voice daemon 监听 → Kokoro 播报。先例 `ktaletsk/claude-code-tts` 已用 Kokoro 同构实现 [https://github.com/ktaletsk/claude-code-tts]。
+
+> **agent 无法回合间自发输出**——主动 ping 必经 harness 层(hook)或模型调工具,设计已遵循 [https://code.claude.com/docs/en/hooks]。
+
+## 5. 双模式状态机
+
+```
+[IDLE] --/secretary--> [SECRETARY]
+[SECRETARY]: 低延迟 STT(medium/large-v3-turbo) 连续转写 → record_note 结构化记录,不执行任务
+[SECRETARY] --用户显式声明(/work)--> [WORK]
+[WORK]: 模型基于秘书阶段掌握的需求/目标/规范自主推进任务
+[WORK] --决策点/缺信息/完成--> announce(TTS check-in) --> listen(拉语音) --> 回 [WORK] 或 [SECRETARY]
+```
+
+- 秘书→工作切换:**显式**(用户声明 `/work` 或语音口令),非自动推断。
+- 秘书模式可降模型尺寸(medium 2.9% WER / large-v3-turbo ~2.7x 快)降延迟。
+- 状态持久化:状态文件 `.mercury/state/voice-mode.json`(mode + 当前任务上下文 + 笔记路径),hook 与 MCP server 共享读。
+
+## 6. 风险登记(实现期实测项)
+
+| 风险 | 缓解 |
+|---|---|
+| `last_assistant_message` 官方 hooks doc 未列(仅二手源+社区先例),version/condition-specific | 兜底解析 `transcript_path` JSONL;实测确认字段存在性 |
+| Stop hook 用户中断/取消是否触发 = UNVERIFIED | 实现期实测;`stop_hook_active` 防死循环 |
+| Kokoro `<3.13` 锁绕过运行行为无实测 | Kokoro-FastAPI 独立服务/venv 隔离(已成立) |
+| `/clear` 损坏 transcript 破坏解析 | 优先用 `last_assistant_message` 字段规避 |
+| 快速连续响应音频重叠 | TTS 播放前 kill 前一进程 |
+| MCP `listen()` 阻塞与 Claude Code 工具超时 | 设合理 `listen_duration_max`;实测工具调用超时边界 |
+
+## 7. 验收标准
+
+1. `claude mcp add voice -- python scripts/voice/mcp_server.py` 后,会话内模型可调 `listen`/`announce`/`set_mode`/`record_note`。
+2. `announce("测试")` 触发 Kokoro 中文 TTS 实际出声。
+3. `listen()` 录音并返回中文转写。
+4. 秘书模式:连续转写 + 结构化记录到笔记文件,不执行任务。
+5. 工作模式:模型遇 check-in 点调 `announce` + `listen` 双向。
+6. Stop hook 在回合结束播报 agent 回复(兜底机制)。
+7. `scripts/voice/` 可独立拆出;#465 daemon 重构后无回归。
+8. dual-verify 通过;所有外部 SDK/API web-verified。
+
+## 8. 引用
+
+- VoiceMode 原生 Windows 不支持:[https://pypi.org/project/voice-mode/]
+- converse 签名(主源):[https://raw.githubusercontent.com/mbailey/voicemode/master/voice_mode/tools/converse.py]
+- Kokoro 中文音色 + Apache-2.0:[https://huggingface.co/hexgrad/Kokoro-82M/raw/main/VOICES.md] [https://pypi.org/project/kokoro/]
+- Kokoro-FastAPI 独立服务:[https://github.com/remsky/Kokoro-FastAPI]
+- Claude Code MCP / hooks:[https://code.claude.com/docs/en/mcp] [https://code.claude.com/docs/en/hooks]
+- Python MCP SDK:[https://github.com/modelcontextprotocol/python-sdk]
+- Stop hook → Kokoro TTS 先例:[https://github.com/ktaletsk/claude-code-tts]

--- a/scripts/voice-zh-input.py
+++ b/scripts/voice-zh-input.py
@@ -60,11 +60,9 @@ bin dirs are prepended to PATH as well.
 """
 import os
 import sys
-import site
 import time
 import queue
 import threading
-from pathlib import Path
 
 sys.stdout.reconfigure(encoding="utf-8")
 
@@ -108,39 +106,14 @@ CONT_BEEP = os.environ.get("VOICE_ZH_CONT_BEEP", "0") == "1"  # continuous-mode 
 # hallucination / non-speech gating (whisper confidence-based)
 NO_SPEECH_MAX = _env_num("VOICE_ZH_NOSPEECH_MAX", 0.6, float)  # drop seg if no_speech_prob >=
 LOGPROB_MIN = _env_num("VOICE_ZH_LOGPROB_MIN", -1.0, float)  # drop seg if avg_logprob <=
-# signature phrases Whisper emits on silence/noise — never legitimate dictation here
-HALLUCINATION_MARKERS = (
-    "字幕志愿者", "字幕由", "amara.org", "明镜与点点", "点点栏目",
-    "请不吝点赞", "点赞订阅", "订阅转发", "谢谢观看", "谢谢大家观看",
-)
+# HALLUCINATION_MARKERS now live in scripts/voice/stt.py (shared with the #468 MCP server)
 
 
-def _register_cuda_dll_dirs():
-    """Make the bundled NVIDIA CUDA/cuDNN DLLs loadable by ctranslate2 on Windows."""
-    if os.name != "nt":
-        return  # Windows-only workaround; never mutate PATH elsewhere
-    bins = []
-    for base in site.getsitepackages():
-        base_real = os.path.realpath(base)
-        for sub in ("cublas", "cudnn", "cuda_nvrtc", "cuda_runtime"):
-            p = Path(base) / "nvidia" / sub / "bin"
-            if not p.is_dir():
-                continue
-            real = os.path.realpath(str(p))
-            # only accept real dirs that stay under the site-packages root, and dedupe,
-            # to avoid widening the DLL search path via stray symlinks / repeats
-            if not real.startswith(base_real) or real in bins:
-                continue
-            try:
-                os.add_dll_directory(real)
-            except (OSError, AttributeError):
-                pass
-            bins.append(real)
-    if bins:
-        os.environ["PATH"] = os.pathsep.join(bins) + os.pathsep + os.environ.get("PATH", "")
-
-
-_register_cuda_dll_dirs()
+# Shared STT primitives live in scripts/voice/stt.py (#468). Importing it runs the
+# Windows CUDA/cuDNN DLL-dir registration (must happen before faster_whisper loads),
+# so this single import replaces the daemon's former inline _register_cuda_dll_dirs().
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from voice.stt import resample_to_16k, is_hallucination  # noqa: E402
 
 import numpy as np
 import sounddevice as sd
@@ -180,22 +153,7 @@ def _capture_samplerate():
         return SAMPLERATE
 
 
-def _resample_to_16k(audio, src_sr):
-    """Linear resample mono float32 audio to 16kHz (good enough for STT)."""
-    if src_sr == SAMPLERATE or len(audio) == 0:
-        return audio
-    n = int(round(len(audio) * SAMPLERATE / src_sr))
-    if n <= 0:
-        return audio
-    x_old = np.linspace(0.0, 1.0, num=len(audio), endpoint=False)
-    x_new = np.linspace(0.0, 1.0, num=n, endpoint=False)
-    return np.interp(x_new, x_old, audio).astype(np.float32)
-
-
-def _is_hallucination(text):
-    """True if text matches a known Whisper-on-silence hallucination signature."""
-    t = "".join(text.lower().split())
-    return any(m in t for m in HALLUCINATION_MARKERS)
+# resample_to_16k / is_hallucination are imported from voice.stt (shared with #468).
 
 
 def transcribe_segment(model, audio_native, capture_sr):
@@ -208,7 +166,7 @@ def transcribe_segment(model, audio_native, capture_sr):
     near-silent input.
     """
     peak = float(np.max(np.abs(audio_native))) if len(audio_native) else 0.0
-    audio = _resample_to_16k(audio_native, capture_sr)
+    audio = resample_to_16k(audio_native, capture_sr)
     if NORMALIZE and peak > 1e-4:
         audio = (audio / peak * 0.3).astype(np.float32)  # rescue low-gain mics
     segments, _ = model.transcribe(
@@ -230,7 +188,7 @@ def transcribe_segment(model, audio_native, capture_sr):
             continue
         kept.append(s.text)
     text = "".join(kept).strip()
-    if _is_hallucination(text):
+    if is_hallucination(text):
         return "", peak
     return text, peak
 

--- a/scripts/voice/README.md
+++ b/scripts/voice/README.md
@@ -110,5 +110,13 @@ worker 自守卫:仅当语音模式 active(mode ≠ idle)时才播报,非语音�
 ## 已知限制(实测项,见 ADR §6)
 
 - `last_assistant_message` 字段官方 hooks 文档未列(社区先例),stop_notify 兜底解析 transcript。
+- **stop_notify 兜底 fail-open**:`last_assistant_message` 缺失且 transcript 被 `/clear` 损坏/截断时,
+  解析可能读出较旧的回复(而非保持静默)。优先用 `last_assistant_message` 字段已规避主路径。
+- **TTS 防重叠**:announce(MCP server 进程)与 stop_notify(Stop hook 进程)经状态目录下的
+  `voice-tts.lock` 跨进程文件锁串行播放;抢不到锁(`VOICE_TTS_LOCK_WAIT` 秒内)则跳过本次播报。
+- **状态写非全局加锁**:`set_mode`/`record_note` 为 read-modify-write,JSON 写本身原子(读者不会读到半包),
+  但实际写者只有单进程单线程的 MCP server,跨进程并发写概率极低;如未来多写者需加锁。
 - Kokoro-FastAPI GPU 在原生 Windows 经 Docker 需 WSL2 后端;纯原生走 uv/uvicorn 路线。
 - 秘书模式"快响应"可按需把 `VOICE_ZH_MODEL_SECRETARY` 降到更小模型。
+- MCP `listen` 阻塞:等待开口的 onset 窗口由 `VOICE_LISTEN_ONSET_GRACE`(默认 10s)控制,
+  静默时最长阻塞 ≈ `max_seconds + onset_grace`,留意 Claude Code 工具调用超时预算。

--- a/scripts/voice/README.md
+++ b/scripts/voice/README.md
@@ -1,0 +1,114 @@
+# voice — 双向中文语音 agent 交互 (Mercury #468)
+
+在 Claude Code **会话内**用指令直接调用中文语音交互的一套可拆卸组件,建立在 #465
+`scripts/voice-zh-input.py`(外围中文语音输入)之上。提供:
+
+- **会话内调用**:本地 stdio MCP server,模型可在会话中调用 `listen` / `announce` 等工具。
+- **秘书 / 工作双模式**:秘书模式快速记录+总结(不执行任务),工作模式自主推进任务并在
+  决策/缺信息/完成时主动语音提示(双向)。
+- **双向闭环**:模型主动 `announce`+`listen`(主),Stop hook 回合末播报回复(兜底)。
+
+设计决策见 ADR:`.mercury/docs/research/issue-468-voice-agent-adr-2026-06.md`。
+调研报告:`.research/reports/RESEARCH-468-voice-agent-2026-06-03.md`。
+
+> **本地隐私**:STT(faster-whisper)与首选 TTS(Kokoro-FastAPI)全部本地离线运行,
+> 音频不出本机。edge-tts 回退是在线服务,默认关闭。
+
+---
+
+## 架构
+
+```
+scripts/voice/
+  stt.py        STT 层:faster-whisper 加载 + 转写 + 单句阻塞录音(复用 #465 原语)
+  tts.py        TTS 层:Kokoro-FastAPI(OpenAI 兼容)客户端 + edge-tts 回退 + 播放
+  state.py      双模式状态机 + 秘书结构化记录(.mercury/state/voice-mode.json)
+  mcp_server.py stdio MCP server:listen / announce / set_mode / record_note / get_status
+  stop_notify.py Stop-hook worker:回合末读 last_assistant_message → TTS 播报
+.claude/hooks/voice-stop-notify.sh   Stop hook 包装(opt-in,默认不注册)
+.claude/commands/secretary.md|work.md  /secretary、/work 模式切换 slash command
+```
+
+`scripts/voice/` 整体可拆卸:复制该目录 + 装依赖 + `claude mcp add` 即可在任意 repo 使用。
+
+---
+
+## 安装
+
+### 1. 依赖(装进 #465 共享 venv)
+
+```bash
+uv pip install --python .venv-voice/Scripts/python.exe -r scripts/voice/requirements-voice-agent.txt
+```
+
+### 2. TTS 服务:Kokoro-FastAPI(首选,本地离线)
+
+Kokoro 的 pip 包锁 Python `<3.13`,与本 venv 的 3.14 冲突,因此 TTS 作为**独立服务**运行
+(自带 Python 环境,隔离版本锁)。两种部署(任选其一):
+
+- **Docker(GPU,需 Docker Desktop + WSL2 后端做 GPU 直通)**:
+  ```bash
+  docker run --gpus all -p 8880:8880 ghcr.io/remsky/kokoro-fastapi-gpu:latest
+  ```
+- **本地 uv/uvicorn(原生 Windows)**:克隆 `github.com/remsky/Kokoro-FastAPI`,装 astral-uv +
+  espeak-ng,运行其 GPU 启动脚本(见该 repo README;启动后监听 :8880)。
+
+验证:`curl http://localhost:8880/v1/audio/voices` 应返回音色列表(含 `zf_xiaobei` 等普通话音色)。
+
+> 来源:<https://github.com/remsky/Kokoro-FastAPI>(Apache-2.0)。OpenAI 兼容端点
+> `POST /v1/audio/speech`,请求 `{"model":"kokoro","input":...,"voice":"zf_xiaobei","response_format":"wav"}`。
+
+### 3. 注册 MCP server
+
+```bash
+claude mcp add voice -- D:/Mercury/Mercury/.venv-voice/Scripts/python.exe D:/Mercury/Mercury/scripts/voice/mcp_server.py
+```
+
+(stdio 为默认传输;真实 PATH `python` 二进制在原生 Windows 上无需 `cmd /c` 包裹。)
+注册后在会话内即可让模型调用 `listen` / `announce` / `set_mode` / `record_note` / `get_status`。
+
+### 4. (可选)Stop hook 双向兜底
+
+默认**不注册**(避免给全团队每回合 spawn 进程)。要启用,在 `.claude/settings.json` 的
+`hooks.Stop` 数组追加:
+
+```json
+{ "hooks": [ { "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/voice-stop-notify.sh\"", "timeout": 10 } ] }
+```
+
+worker 自守卫:仅当语音模式 active(mode ≠ idle)时才播报,非语音会话静默 no-op。
+
+---
+
+## 使用
+
+1. `/secretary` — 进入秘书模式:模型用 `listen` 拉你的语音并自动 `record_note`,只记录总结
+   不执行任务。说清某任务需求后,显式 `/work` 切换。
+2. `/work` — 进入工作模式:模型基于秘书记录自主推进任务,遇决策/缺信息/完成时 `announce`
+   主动语音提示,需要你回应时紧接 `listen`。
+3. `voice-zh-input`(#465)本身仍可独立作纯输入用:`python scripts/voice-zh-input.py`。
+
+---
+
+## 配置(env)
+
+| 变量 | 默认 | 说明 |
+|---|---|---|
+| `VOICE_ZH_MODEL` | `large-v3` | 工作/idle 模式 faster-whisper 模型 |
+| `VOICE_ZH_MODEL_SECRETARY` | (同上) | 秘书模式模型(可设 `medium` / `large-v3-turbo` 降延迟) |
+| `VOICE_ZH_DEVICE` | `auto` | `auto` / `cuda` / `cpu` |
+| `VOICE_ZH_DEVICE_INDEX` | 系统默认 | 显式输入设备序号(`voice-zh-input.py --list-devices` 查看) |
+| `VOICE_TTS_BASE_URL` | `http://127.0.0.1:8880/v1` | Kokoro-FastAPI 基址 |
+| `VOICE_TTS_VOICE` | `zf_xiaobei` | 普通话音色(`zf_*` 女 / `zm_*` 男) |
+| `VOICE_TTS_FALLBACK` | (空=关) | 设 `edge` 启用 edge-tts 在线回退 |
+| `VOICE_TTS_EDGE_VOICE` | `zh-CN-XiaoxiaoNeural` | edge-tts 音色 |
+| `VOICE_STATE_DIR` | `<repo>/.mercury/state` | 状态/笔记目录 |
+| `VOICE_STOP_MAX_CHARS` | `400` | Stop hook 播报截断长度 |
+
+---
+
+## 已知限制(实测项,见 ADR §6)
+
+- `last_assistant_message` 字段官方 hooks 文档未列(社区先例),stop_notify 兜底解析 transcript。
+- Kokoro-FastAPI GPU 在原生 Windows 经 Docker 需 WSL2 后端;纯原生走 uv/uvicorn 路线。
+- 秘书模式"快响应"可按需把 `VOICE_ZH_MODEL_SECRETARY` 降到更小模型。

--- a/scripts/voice/README.md
+++ b/scripts/voice/README.md
@@ -70,13 +70,26 @@ claude mcp add voice -- "$CLAUDE_PROJECT_DIR/.venv-voice/Scripts/python.exe" "$C
 
 ### 4. (可选)Stop hook 双向兜底
 
-默认**不注册**(避免给全团队每回合 spawn 进程)。要启用,在 `.claude/settings.json` 的
-`hooks.Stop` 数组追加:
+默认**不注册**(避免给全团队每回合 spawn 进程)。要启用,**往现有 `hooks.Stop[0].hooks`
+数组里追加一条 command hook**(与现有 `stop-guard.sh` 并列,不要替换整个 `Stop`,否则会
+破坏现有 hook)。本仓库当前结构是:
 
 ```json
-{ "hooks": [ { "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/voice-stop-notify.sh\"", "timeout": 10 } ] }
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          { "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/stop-guard.sh\"", "timeout": 10 },
+          { "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/voice-stop-notify.sh\"", "timeout": 10 }
+        ]
+      }
+    ]
+  }
+}
 ```
 
+(上面只新增了 `voice-stop-notify.sh` 那一行,`stop-guard.sh` 原样保留。)
 worker 自守卫:仅当语音模式 active(mode ≠ idle)时才播报,非语音会话静默 no-op。
 
 ---

--- a/scripts/voice/README.md
+++ b/scripts/voice/README.md
@@ -114,9 +114,15 @@ worker 自守卫:仅当语音模式 active(mode ≠ idle)时才播报,非语音�
 | `VOICE_ZH_DEVICE_INDEX` | 系统默认 | 显式输入设备序号(`voice-zh-input.py --list-devices` 查看) |
 | `VOICE_TTS_BASE_URL` | `http://127.0.0.1:8880/v1` | Kokoro-FastAPI 基址 |
 | `VOICE_TTS_VOICE` | `zf_xiaobei` | 普通话音色(`zf_*` 女 / `zm_*` 男) |
+| `VOICE_TTS_MODEL` | `kokoro` | Kokoro 模型 id |
+| `VOICE_TTS_SPEED` | `1.0` | 语速 |
 | `VOICE_TTS_FALLBACK` | (空=关) | 设 `edge` 启用 edge-tts 在线回退 |
 | `VOICE_TTS_EDGE_VOICE` | `zh-CN-XiaoxiaoNeural` | edge-tts 音色 |
-| `VOICE_STATE_DIR` | `<repo>/.mercury/state` | 状态/笔记目录 |
+| `VOICE_TTS_TIMEOUT` | `30` | Kokoro HTTP 超时(秒) |
+| `VOICE_TTS_LOCK_WAIT` | `8` | 跨进程播放锁等待秒数(超时则跳过本次播报) |
+| `VOICE_TTS_MAX_CHARS` | `600` | `speak()` 播报文本截断长度(所有调用方) |
+| `VOICE_LISTEN_ONSET_GRACE` | `10` | `listen` 等待用户开口的 onset 窗口(秒) |
+| `VOICE_STATE_DIR` | `<repo>/.mercury/state` | 状态/笔记目录(也存跨进程播放锁) |
 | `VOICE_STOP_MAX_CHARS` | `400` | Stop hook 播报截断长度 |
 
 ---

--- a/scripts/voice/README.md
+++ b/scripts/voice/README.md
@@ -61,10 +61,11 @@ Kokoro 的 pip 包锁 Python `<3.13`,与本 venv 的 3.14 冲突,因此 TTS 作�
 ### 3. 注册 MCP server
 
 ```bash
-claude mcp add voice -- D:/Mercury/Mercury/.venv-voice/Scripts/python.exe D:/Mercury/Mercury/scripts/voice/mcp_server.py
+# 从仓库根运行;$CLAUDE_PROJECT_DIR 在 Claude Code 内即仓库根(也可换成你的仓库绝对路径)
+claude mcp add voice -- "$CLAUDE_PROJECT_DIR/.venv-voice/Scripts/python.exe" "$CLAUDE_PROJECT_DIR/scripts/voice/mcp_server.py"
 ```
 
-(stdio 为默认传输;真实 PATH `python` 二进制在原生 Windows 上无需 `cmd /c` 包裹。)
+(stdio 为默认传输;真实 PATH `python` 二进制在原生 Windows 上无需 `cmd /c` 包裹。`claude mcp add` 会把命令按当前工作目录解析,故在仓库根执行;若你的 venv 在别处,替换为对应绝对路径。)
 注册后在会话内即可让模型调用 `listen` / `announce` / `set_mode` / `record_note` / `get_status`。
 
 ### 4. (可选)Stop hook 双向兜底

--- a/scripts/voice/__init__.py
+++ b/scripts/voice/__init__.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+"""Mercury voice — 双向中文语音 agent 交互 (Issue #468).
+
+A detachable package layering on top of #465's voice-zh-input:
+  stt        — faster-whisper STT engine + single-utterance blocking capture
+  tts        — Kokoro-FastAPI (OpenAI-compatible) client + edge-tts fallback
+  state      — secretary/work dual-mode state machine + secretary note-taking
+  mcp_server — stdio MCP server exposing listen / announce / set_mode / record_note
+
+ADR: .mercury/docs/research/issue-468-voice-agent-adr-2026-06.md
+"""
+__all__ = ["stt", "tts", "state"]

--- a/scripts/voice/mcp_server.py
+++ b/scripts/voice/mcp_server.py
@@ -57,12 +57,15 @@ def _engine_for_mode(mode):
         model = default_model
     if model not in _engines:
         device = os.environ.get("VOICE_ZH_DEVICE", "auto")
-        idx = os.environ.get("VOICE_ZH_DEVICE_INDEX")
-        engine = _stt.SttEngine(
-            model=model,
-            device=device,
-            device_index=int(idx) if idx not in (None, "") else None,
-        )
+        idx_raw = os.environ.get("VOICE_ZH_DEVICE_INDEX")
+        try:
+            device_index = int(idx_raw) if idx_raw not in (None, "") else None
+        except (TypeError, ValueError):
+            # an invalid index must not take the whole voice chain down — warn + fall back
+            print(f"[voice-mcp] invalid VOICE_ZH_DEVICE_INDEX={idx_raw!r}, using default input device",
+                  file=sys.stderr, flush=True)
+            device_index = None
+        engine = _stt.SttEngine(model=model, device=device, device_index=device_index)
         engine.load()
         _engines[model] = engine
     return _engines[model]
@@ -93,6 +96,11 @@ def announce(text: str) -> str:
     优先用本地 Kokoro-FastAPI（离线、隐私），不可达时按 VOICE_TTS_FALLBACK 回退。
     返回播报结果状态（不会因 TTS 失败而抛错）。
     """
+    # keep spoken length bounded so playback stays well under the TTS cross-process lock's
+    # stale window (a check-in prompt should be short anyway); long detail belongs on screen
+    cap = int(os.environ.get("VOICE_TTS_MAX_CHARS", "600") or "600")
+    if len(text) > cap:
+        text = text[:cap] + "……（详情见屏幕）"
     result = _tts.speak(text, blocking=True)
     if result["ok"]:
         return f"已播报（{result['backend']}）"

--- a/scripts/voice/mcp_server.py
+++ b/scripts/voice/mcp_server.py
@@ -96,11 +96,7 @@ def announce(text: str) -> str:
     优先用本地 Kokoro-FastAPI（离线、隐私），不可达时按 VOICE_TTS_FALLBACK 回退。
     返回播报结果状态（不会因 TTS 失败而抛错）。
     """
-    # keep spoken length bounded so playback stays well under the TTS cross-process lock's
-    # stale window (a check-in prompt should be short anyway); long detail belongs on screen
-    cap = int(os.environ.get("VOICE_TTS_MAX_CHARS", "600") or "600")
-    if len(text) > cap:
-        text = text[:cap] + "……（详情见屏幕）"
+    # length is bounded inside tts.speak() (VOICE_TTS_MAX_CHARS) for all callers
     result = _tts.speak(text, blocking=True)
     if result["ok"]:
         return f"已播报（{result['backend']}）"

--- a/scripts/voice/mcp_server.py
+++ b/scripts/voice/mcp_server.py
@@ -1,0 +1,143 @@
+# -*- coding: utf-8 -*-
+"""mcp_server — in-session voice MCP server for Claude Code (Issue #468).
+
+A local stdio MCP server (PyPI `mcp` / FastMCP, verified 1.27.2 on Python 3.14) that
+lets the model drive Chinese voice interaction from inside a Claude Code session.
+Register it once:
+
+    claude mcp add voice -- <repo>/.venv-voice/Scripts/python.exe <repo>/scripts/voice/mcp_server.py
+
+(stdio is the default transport; a real PATH `python` binary needs no `cmd /c`
+wrapper on native Windows — verified at code.claude.com/docs/en/mcp.)
+
+Tools exposed to the model (borrowing VoiceMode's converse semantics — ADR §3):
+  listen()            — block, record one Chinese utterance, return the transcript
+                        (≈ converse(wait_for_response=True))
+  announce(text)      — speak text via local TTS, do NOT listen
+                        (≈ converse(wait_for_response=False); the agent check-in primitive)
+  set_mode(mode, ...) — switch secretary | work (explicit; ADR §5)
+  record_note(text)   — append a structured entry to the secretary notes file
+  get_status()        — current mode + TTS service health
+
+The faster-whisper model is loaded lazily on the first listen() so a server used only
+for announcements never pays the model-load cost. STT/TTS are fully local + private.
+
+Config: STT via VOICE_ZH_MODEL / VOICE_ZH_DEVICE / VOICE_ZH_DEVICE_INDEX (shared with
+#465's daemon); TTS via VOICE_TTS_* (see tts.py); state via VOICE_STATE_DIR (state.py).
+Secretary mode can use a smaller/faster model via VOICE_ZH_MODEL_SECRETARY.
+"""
+import os
+import sys
+
+# this file is scripts/voice/mcp_server.py — import flat siblings (sys.path[0] == voice/)
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from mcp.server.fastmcp import FastMCP  # noqa: E402
+
+import stt as _stt  # noqa: E402
+import tts as _tts  # noqa: E402
+import state as _state  # noqa: E402
+
+mcp = FastMCP("voice")
+
+# lazily-loaded warm engines, keyed by model name (secretary may use a smaller model)
+_engines = {}
+
+
+def _engine_for_mode(mode):
+    """Return a warm SttEngine for the given mode, loading it on first use.
+
+    Work/idle use VOICE_ZH_MODEL (default large-v3, best accuracy). Secretary uses
+    VOICE_ZH_MODEL_SECRETARY if set (e.g. `medium` / `large-v3-turbo`) to cut latency.
+    """
+    default_model = os.environ.get("VOICE_ZH_MODEL", "large-v3")
+    if mode == "secretary":
+        model = os.environ.get("VOICE_ZH_MODEL_SECRETARY", default_model)
+    else:
+        model = default_model
+    if model not in _engines:
+        device = os.environ.get("VOICE_ZH_DEVICE", "auto")
+        idx = os.environ.get("VOICE_ZH_DEVICE_INDEX")
+        engine = _stt.SttEngine(
+            model=model,
+            device=device,
+            device_index=int(idx) if idx not in (None, "") else None,
+        )
+        engine.load()
+        _engines[model] = engine
+    return _engines[model]
+
+
+@mcp.tool()
+def listen(max_seconds: float = 20.0, silence_sec: float = 0.8) -> str:
+    """录制用户的一句中文语音并返回转写文本（阻塞直到一句话说完或超时）。
+
+    用于在会话内主动拉取用户的语音输入。录音从检测到说话开始，到出现 `silence_sec`
+    秒静音结束，最长 `max_seconds` 秒。返回识别出的中文（静音/超时返回空字符串）。
+    遇决策点/需补充信息时在工作模式下调用它，与 announce 配合实现双向交互。
+    """
+    mode = _state.get_mode()
+    engine = _engine_for_mode(mode)
+    text = engine.listen_once(max_seconds=max_seconds, silence_sec=silence_sec)
+    # in secretary mode, transcribed speech is auto-recorded as a note
+    if mode == "secretary" and text:
+        _state.record_note(text, kind="note")
+    return text
+
+
+@mcp.tool()
+def announce(text: str) -> str:
+    """用本地中文 TTS 朗读 `text`，仅播报不监听（agent 主动提示用户的原语）。
+
+    工作模式遇到决策需求/需补充信息/任务完成时调用，主动语音提示用户回到交互。
+    优先用本地 Kokoro-FastAPI（离线、隐私），不可达时按 VOICE_TTS_FALLBACK 回退。
+    返回播报结果状态（不会因 TTS 失败而抛错）。
+    """
+    result = _tts.speak(text, blocking=True)
+    if result["ok"]:
+        return f"已播报（{result['backend']}）"
+    return f"播报失败：{result['error']}（请确认 Kokoro-FastAPI 服务在 {os.environ.get('VOICE_TTS_BASE_URL', 'http://127.0.0.1:8880/v1')} 运行）"
+
+
+@mcp.tool()
+def set_mode(mode: str, task_context: str = "") -> str:
+    """显式切换语音交互模式：secretary（秘书：快速记录总结，不执行任务）或
+    work（工作：基于已掌握需求自主推进任务，遇 check-in 点主动提示）。
+
+    切换由用户显式声明驱动（如 /secretary、/work）。切到 work 时可带 task_context
+    描述本次要推进的任务。返回切换后的状态描述。
+    """
+    try:
+        st = _state.set_mode(mode, task_context=task_context or None)
+    except ValueError as e:
+        return f"切换失败：{e}"
+    ctx = f"，任务：{st['task_context']}" if st.get("task_context") else ""
+    notes = f"，记录文件：{st['notes_path']}" if st.get("notes_path") else ""
+    return f"已切换到 {st['mode']} 模式{ctx}{notes}"
+
+
+@mcp.tool()
+def record_note(text: str, kind: str = "note") -> str:
+    """在秘书模式记录文件中追加一条结构化、带时间戳的条目。
+
+    `kind` 取 note（记录）/ requirement（需求）/ decision（决策）/ summary（总结）。
+    用于秘书模式把用户发言结构化沉淀，供后续工作模式读取。返回记录文件路径。
+    """
+    path = _state.record_note(text, kind=kind)
+    return f"已记录到 {path}" if path else "未记录（文本为空）"
+
+
+@mcp.tool()
+def get_status() -> str:
+    """返回当前语音交互状态：模式 + 任务上下文 + 记录文件 + 本地 TTS 服务是否在线。"""
+    st = _state.get_state()
+    tts_ok = _tts.health()
+    return (
+        f"模式：{st.get('mode')}；任务：{st.get('task_context') or '—'}；"
+        f"记录文件：{st.get('notes_path') or '—'}；"
+        f"Kokoro-FastAPI：{'在线' if tts_ok else '离线（announce 将尝试回退或失败）'}"
+    )
+
+
+if __name__ == "__main__":
+    mcp.run()  # stdio is the default transport

--- a/scripts/voice/requirements-voice-agent.txt
+++ b/scripts/voice/requirements-voice-agent.txt
@@ -1,0 +1,18 @@
+# voice-agent dependencies (Mercury #468) — the in-session MCP layer on top of #465.
+# Verified on Windows 11 + Python 3.14.3 + RTX 4060 (2026-06-03).
+#
+# Install into the shared #465 venv:
+#   uv pip install --python .venv-voice/Scripts/python.exe -r scripts/voice/requirements-voice-agent.txt
+#
+# This pulls in the STT/injection stack from #465 too (-r below). The MCP SDK adds
+# pydantic / starlette / pywin32 (Windows). edge-tts is the OPTIONAL online fallback
+# (off by default; enable with VOICE_TTS_FALLBACK=edge).
+#
+# TTS primary backend (Kokoro-FastAPI) is a SEPARATE local service, NOT a pip dep —
+# see README.md §TTS setup. It runs in its own Python env (sidesteps Kokoro's
+# Requires-Python <3.13 pin), exposing an OpenAI-compatible endpoint on :8880.
+
+-r ../../requirements-voice-zh.txt   # #465 STT + clipboard injection stack
+
+mcp==1.27.2            # Python MCP SDK / FastMCP; verified import+stdio on Python 3.14
+# edge-tts>=7.2.8      # OPTIONAL online TTS fallback (LGPLv3). Uncomment to enable.

--- a/scripts/voice/state.py
+++ b/scripts/voice/state.py
@@ -1,0 +1,137 @@
+# -*- coding: utf-8 -*-
+"""state — secretary/work dual-mode state machine + secretary note-taking (Issue #468).
+
+Two modes (ADR §5):
+  secretary — low-latency transcription + structured note-taking. Records/summarizes
+              what the user says; does NOT execute tasks. The fast information-intake
+              channel.
+  work      — the agent autonomously advances a concrete task using the requirements
+              gathered in secretary mode. On a decision point / missing info /
+              completion, it does a TTS check-in (announce) and may listen back.
+
+Switching is EXPLICIT (the user declares /secretary or /work) — never auto-inferred.
+
+State is persisted to a JSON file shared by the MCP server (in-session, writes) and
+the Stop hook (reads the mode to decide whether to announce). Secretary notes are
+appended to a timestamped markdown file so the work-mode agent can read the gathered
+requirements back.
+
+Config (env):
+    VOICE_STATE_DIR   state dir (default <repo>/.mercury/state)
+"""
+import os
+import json
+import tempfile
+from pathlib import Path
+from datetime import datetime, timezone
+
+MODES = ("idle", "secretary", "work")
+
+
+def _state_dir():
+    override = os.environ.get("VOICE_STATE_DIR")
+    if override:
+        d = Path(override)
+    else:
+        # scripts/voice/state.py -> parents[2] == repo root
+        d = Path(__file__).resolve().parents[2] / ".mercury" / "state"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _state_path():
+    return _state_dir() / "voice-mode.json"
+
+
+def _now_iso():
+    return datetime.now(timezone.utc).astimezone().isoformat(timespec="seconds")
+
+
+def _atomic_write(path, text):
+    """Write text to path atomically (write temp + replace) so a concurrent reader
+    (the Stop hook) never sees a half-written file."""
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=".tmp-", suffix=".json")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(text)
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.remove(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def get_state():
+    """Return the current state dict. Defaults to idle if no state file exists."""
+    p = _state_path()
+    if not p.exists():
+        return {"mode": "idle", "task_context": None, "notes_path": None, "updated_at": None}
+    try:
+        return json.loads(p.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {"mode": "idle", "task_context": None, "notes_path": None, "updated_at": None}
+
+
+def get_mode():
+    return get_state().get("mode", "idle")
+
+
+def set_mode(mode, task_context=None):
+    """Switch mode (explicit). Entering secretary mode opens a fresh notes file.
+
+    Returns the new state dict. Raises ValueError on an unknown mode.
+    """
+    if mode not in MODES:
+        raise ValueError(f"invalid mode {mode!r} (allowed: {', '.join(MODES)})")
+    state = get_state()
+    state["mode"] = mode
+    state["updated_at"] = _now_iso()
+    if task_context is not None:
+        state["task_context"] = task_context
+    if mode == "secretary" and not state.get("notes_path"):
+        state["notes_path"] = str(_new_notes_file())
+    _atomic_write(_state_path(), json.dumps(state, ensure_ascii=False, indent=2))
+    return state
+
+
+def _new_notes_file():
+    """Create a fresh timestamped secretary-notes markdown file and return its path."""
+    notes_dir = _state_dir() / "voice-notes"
+    notes_dir.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    p = notes_dir / f"secretary-{stamp}.md"
+    if not p.exists():
+        p.write_text(f"# 秘书模式记录 — {_now_iso()}\n\n", encoding="utf-8")
+    return p
+
+
+def record_note(text, kind="note"):
+    """Append a structured, timestamped entry to the current secretary notes file.
+
+    `kind` tags the entry (note / requirement / decision / summary). If no notes file
+    is open (not in secretary mode), one is created on demand. Returns the notes path.
+    """
+    text = (text or "").strip()
+    if not text:
+        return None
+    state = get_state()
+    notes_path = state.get("notes_path")
+    if not notes_path or not Path(notes_path).exists():
+        notes_path = str(_new_notes_file())
+        state["notes_path"] = notes_path
+        state["updated_at"] = _now_iso()
+        _atomic_write(_state_path(), json.dumps(state, ensure_ascii=False, indent=2))
+    stamp = datetime.now().strftime("%H:%M:%S")
+    tag = {"requirement": "需求", "decision": "决策", "summary": "总结"}.get(kind, "记录")
+    with open(notes_path, "a", encoding="utf-8") as f:
+        f.write(f"- **[{stamp}] {tag}**：{text}\n")
+    return notes_path
+
+
+def reset():
+    """Reset to idle (keeps notes files on disk; just clears the active session)."""
+    _atomic_write(_state_path(), json.dumps(
+        {"mode": "idle", "task_context": None, "notes_path": None, "updated_at": _now_iso()},
+        ensure_ascii=False, indent=2))

--- a/scripts/voice/state.py
+++ b/scripts/voice/state.py
@@ -131,11 +131,14 @@ def record_note(text, kind="note"):
     if notes_path:
         try:
             p = Path(notes_path).resolve()
-            if p != notes_root and not str(p).startswith(str(notes_root) + os.sep):
+            # must be strictly UNDER the root (reject the root dir itself) and be a regular
+            # file — a tampered state pointing at a directory (e.g. the notes root) would
+            # otherwise make open(..,"a") fail; reject → re-create a fresh notes file
+            if not str(p).startswith(str(notes_root) + os.sep) or (p.exists() and not p.is_file()):
                 notes_path = None
         except OSError:
             notes_path = None
-    if not notes_path or not Path(notes_path).exists():
+    if not notes_path or not Path(notes_path).is_file():
         notes_path = str(_new_notes_file())
         state["notes_path"] = notes_path
         state["updated_at"] = _now_iso()

--- a/scripts/voice/state.py
+++ b/scripts/voice/state.py
@@ -86,11 +86,15 @@ def set_mode(mode, task_context=None):
     if mode not in MODES:
         raise ValueError(f"invalid mode {mode!r} (allowed: {', '.join(MODES)})")
     state = get_state()
+    prev_mode = state.get("mode", "idle")
     state["mode"] = mode
     state["updated_at"] = _now_iso()
     if task_context is not None:
         state["task_context"] = task_context
-    if mode == "secretary" and not state.get("notes_path"):
+    # Open a fresh notes file when ENTERING secretary from a non-secretary mode (a new
+    # intake session). Re-entering secretary from work (secretary->work->secretary,
+    # same task) keeps the existing notes file so the task's intake stays in one place.
+    if mode == "secretary" and (prev_mode not in ("secretary", "work") or not state.get("notes_path")):
         state["notes_path"] = str(_new_notes_file())
     _atomic_write(_state_path(), json.dumps(state, ensure_ascii=False, indent=2))
     return state
@@ -100,7 +104,9 @@ def _new_notes_file():
     """Create a fresh timestamped secretary-notes markdown file and return its path."""
     notes_dir = _state_dir() / "voice-notes"
     notes_dir.mkdir(parents=True, exist_ok=True)
-    stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    # microsecond stamp so two sessions created within the same second never collide
+    # onto one file (second-resolution names would reuse the prior session's notes)
+    stamp = datetime.now().strftime("%Y%m%d-%H%M%S-%f")
     p = notes_dir / f"secretary-{stamp}.md"
     if not p.exists():
         p.write_text(f"# 秘书模式记录 — {_now_iso()}\n\n", encoding="utf-8")

--- a/scripts/voice/state.py
+++ b/scripts/voice/state.py
@@ -124,6 +124,17 @@ def record_note(text, kind="note"):
         return None
     state = get_state()
     notes_path = state.get("notes_path")
+    # security: notes_path comes from the (potentially tampered) state file — confine it
+    # under the voice-notes dir before appending, so a doctored path can't traverse out
+    # and write/overwrite arbitrary files. A path outside the root is rejected (re-created).
+    notes_root = (_state_dir() / "voice-notes").resolve()
+    if notes_path:
+        try:
+            p = Path(notes_path).resolve()
+            if p != notes_root and not str(p).startswith(str(notes_root) + os.sep):
+                notes_path = None
+        except OSError:
+            notes_path = None
     if not notes_path or not Path(notes_path).exists():
         notes_path = str(_new_notes_file())
         state["notes_path"] = notes_path

--- a/scripts/voice/stop_notify.py
+++ b/scripts/voice/stop_notify.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+"""stop_notify — Stop-hook worker: speak the agent's reply at turn end (Issue #468).
+
+The fallback half of the bidirectional loop (ADR §4 path B). Claude Code fires the
+Stop hook when the agent finishes a turn; this worker reads the hook's stdin JSON,
+and — only while a voice mode is active (mode != idle) — speaks the agent's last
+message via local TTS so the user is prompted to resume voice interaction.
+
+Extracting the reply text (ADR §6 risk): prefer the `last_assistant_message` field
+if the hook payload carries it (community-observed, NOT in the official hooks-doc
+field list — so treated as best-effort); otherwise fall back to parsing the last
+assistant message out of the transcript_path JSONL (`.message.content[].text`). The
+`/clear`-corrupts-transcript caveat is why last_assistant_message is preferred.
+
+Self-guards (never disrupt a non-voice session):
+  - mode == idle            -> exit silently
+  - stop_hook_active == true -> exit (avoid any re-entrancy)
+  - any error               -> exit 0 (a TTS hiccup must never block Claude)
+
+Invoked by .claude/hooks/voice-stop-notify.sh (opt-in; not registered by default).
+"""
+import os
+import sys
+import json
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+
+def _last_assistant_from_transcript(path):
+    """Return the text of the last assistant message in a Claude Code transcript JSONL."""
+    if not path or not os.path.exists(path):
+        return ""
+    last = ""
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                msg = obj.get("message") or {}
+                if msg.get("role") != "assistant":
+                    continue
+                content = msg.get("content")
+                if isinstance(content, str):
+                    last = content
+                elif isinstance(content, list):
+                    parts = [c.get("text", "") for c in content
+                             if isinstance(c, dict) and c.get("type") == "text"]
+                    if parts:
+                        last = "".join(parts)
+    except OSError:
+        return ""
+    return last
+
+
+def _strip_markdown(text):
+    """Light markdown cleanup so TTS does not read code fences / heading marks aloud."""
+    import re
+    text = re.sub(r"```.*?```", "（代码块略）", text, flags=re.DOTALL)
+    text = re.sub(r"`([^`]*)`", r"\1", text)
+    text = re.sub(r"^#{1,6}\s*", "", text, flags=re.MULTILINE)
+    text = re.sub(r"[*_>]+", "", text)
+    return text.strip()
+
+
+def main():
+    raw = sys.stdin.read()
+    try:
+        payload = json.loads(raw) if raw.strip() else {}
+    except json.JSONDecodeError:
+        return 0
+
+    if payload.get("stop_hook_active"):
+        return 0  # avoid any re-entrancy
+
+    try:
+        import state as _state
+    except Exception:
+        return 0
+    if _state.get_mode() == "idle":
+        return 0  # voice interaction not active — no-op
+
+    text = (payload.get("last_assistant_message") or "").strip()
+    if not text:
+        text = _last_assistant_from_transcript(payload.get("transcript_path"))
+    text = _strip_markdown(text)
+    if not text:
+        return 0
+
+    # cap spoken length so a long reply does not monopolize playback
+    cap = int(os.environ.get("VOICE_STOP_MAX_CHARS", "400") or "400")
+    if len(text) > cap:
+        text = text[:cap] + "……（后续内容请看屏幕）"
+
+    try:
+        import tts as _tts
+        _tts.speak(text, blocking=True)
+    except Exception:
+        return 0
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/voice/stt.py
+++ b/scripts/voice/stt.py
@@ -1,0 +1,276 @@
+# -*- coding: utf-8 -*-
+"""stt — faster-whisper STT engine + single-utterance blocking capture (Issue #468).
+
+Carries forward the empirically-verified STT primitives from #465
+(`scripts/voice-zh-input.py`): the Windows CUDA/cuDNN DLL-dir registration,
+native-rate capture + linear resample to 16 kHz (forcing 16 kHz on the Realtek
+driver returns digital silence), and the no_speech_prob / avg_logprob +
+signature-blocklist hallucination gate that kills Whisper's "字幕志愿者"-style
+silence hallucinations.
+
+This module is the shared core: `scripts/voice-zh-input.py` (the input daemon)
+and `scripts/voice/mcp_server.py` (the in-session MCP server) both use it, so the
+hard-won primitives live in exactly one place.
+
+Local + private: no audio leaves the machine. All STT runs on the local
+faster-whisper model (GPU float16 / CPU int8 fallback).
+"""
+import os
+import sys
+import site
+import time
+import queue
+import threading
+from pathlib import Path
+
+SAMPLERATE = 16000  # faster-whisper expects 16 kHz mono float32
+
+# signature phrases Whisper emits on silence/noise — never legitimate dictation here
+# (carried over from #465; extend here and both daemon + MCP server benefit)
+HALLUCINATION_MARKERS = (
+    "字幕志愿者", "字幕由", "amara.org", "明镜与点点", "点点栏目",
+    "请不吝点赞", "点赞订阅", "订阅转发", "谢谢观看", "谢谢大家观看",
+)
+
+
+def _register_cuda_dll_dirs():
+    """Make the bundled NVIDIA CUDA/cuDNN DLLs loadable by ctranslate2 on Windows.
+
+    add_dll_directory alone is NOT enough on Windows — ctranslate2's internal loader
+    resolves the CUDA DLLs via PATH, so the bin dirs are prepended to PATH as well.
+    Must run BEFORE faster_whisper is imported. (Verified in #465.)
+    """
+    if os.name != "nt":
+        return  # Windows-only workaround; never mutate PATH elsewhere
+    bins = []
+    for base in site.getsitepackages():
+        base_real = os.path.realpath(base)
+        for sub in ("cublas", "cudnn", "cuda_nvrtc", "cuda_runtime"):
+            p = Path(base) / "nvidia" / sub / "bin"
+            if not p.is_dir():
+                continue
+            real = os.path.realpath(str(p))
+            # only accept real dirs that stay under the site-packages root, and dedupe,
+            # to avoid widening the DLL search path via stray symlinks / repeats
+            if not real.startswith(base_real) or real in bins:
+                continue
+            try:
+                os.add_dll_directory(real)
+            except (OSError, AttributeError):
+                pass
+            bins.append(real)
+    if bins:
+        os.environ["PATH"] = os.pathsep.join(bins) + os.pathsep + os.environ.get("PATH", "")
+
+
+_register_cuda_dll_dirs()
+
+import numpy as np  # noqa: E402  (after DLL-dir registration)
+
+try:
+    import sounddevice as sd  # noqa: E402
+except OSError:  # PortAudio not present (e.g. headless CI) — capture disabled, transcribe still works
+    sd = None
+from faster_whisper import WhisperModel  # noqa: E402
+
+
+def resample_to_16k(audio, src_sr):
+    """Linear resample mono float32 audio to 16 kHz (good enough for STT)."""
+    if src_sr == SAMPLERATE or len(audio) == 0:
+        return audio
+    n = int(round(len(audio) * SAMPLERATE / src_sr))
+    if n <= 0:
+        return audio
+    x_old = np.linspace(0.0, 1.0, num=len(audio), endpoint=False)
+    x_new = np.linspace(0.0, 1.0, num=n, endpoint=False)
+    return np.interp(x_new, x_old, audio).astype(np.float32)
+
+
+def is_hallucination(text):
+    """True if text matches a known Whisper-on-silence hallucination signature."""
+    t = "".join(text.lower().split())
+    return any(m in t for m in HALLUCINATION_MARKERS)
+
+
+class SttEngine:
+    """Persistent faster-whisper engine: load once, transcribe / listen many times.
+
+    Parametrized (no module-level config globals) so a long-lived process such as the
+    MCP server can hold one warm model and switch model size per mode (e.g. a smaller
+    model for low-latency secretary mode). Mirrors #465's transcribe/load behavior.
+    """
+
+    def __init__(self, model="large-v3", device="auto", normalize=True, vad=False,
+                 no_speech_max=0.6, logprob_min=-1.0, device_index=None):
+        self.model_name = model
+        self.device = device
+        self.normalize = normalize
+        self.vad = vad
+        self.no_speech_max = no_speech_max
+        self.logprob_min = logprob_min
+        self.device_index = device_index
+        self.model = None
+
+    def load(self):
+        """Load WhisperModel, honoring device ('auto' tries CUDA then CPU).
+
+        The CUDA cuBLAS failure only surfaces at inference time (not at construction),
+        so 'auto' validates the device with a tiny warmup transcription before
+        committing to it. Raises RuntimeError if no device is usable.
+        """
+        device_map = {
+            "cuda": [("cuda", "float16")],
+            "cpu": [("cpu", "int8")],
+            "auto": [("cuda", "float16"), ("cpu", "int8")],
+        }
+        if self.device not in device_map:
+            raise ValueError(f"invalid device {self.device!r} (allowed: {', '.join(device_map)})")
+        warmup = np.zeros(SAMPLERATE, dtype=np.float32)  # 1s of silence
+        for dev, comp in device_map[self.device]:
+            try:
+                print(f"[voice-stt] loading {self.model_name} on {dev}/{comp} ...", file=sys.stderr, flush=True)
+                t0 = time.time()
+                model = WhisperModel(self.model_name, device=dev, compute_type=comp)
+                list(model.transcribe(warmup, language="zh")[0])  # validate device end-to-end
+                print(f"[voice-stt] ready on {dev}/{comp} ({time.time() - t0:.1f}s)", file=sys.stderr, flush=True)
+                self.model = model
+                return self
+            except Exception as e:
+                print(f"[voice-stt] {dev} unavailable: {type(e).__name__}: {e}", file=sys.stderr, flush=True)
+        raise RuntimeError("no usable STT device (cuda/cpu)")
+
+    def transcribe(self, audio_native, capture_sr):
+        """Resample + optional peak-normalize native-rate audio, then transcribe zh.
+
+        Non-speech / hallucination segments are dropped via Whisper's per-segment
+        no_speech_prob + avg_logprob, backed by a signature blocklist. Returns
+        (text, peak); peak is measured on the raw native capture so callers can warn
+        on near-silent input.
+        """
+        if self.model is None:
+            raise RuntimeError("SttEngine.load() not called")
+        peak = float(np.max(np.abs(audio_native))) if len(audio_native) else 0.0
+        audio = resample_to_16k(audio_native, capture_sr)
+        if self.normalize and peak > 1e-4:
+            audio = (audio / peak * 0.3).astype(np.float32)  # rescue low-gain mics
+        segments, _ = self.model.transcribe(
+            audio,
+            language="zh",
+            beam_size=5,
+            vad_filter=self.vad,
+            condition_on_previous_text=False,  # don't carry hallucinations across calls
+            no_speech_threshold=self.no_speech_max,
+            log_prob_threshold=self.logprob_min,
+        )
+        kept = []
+        for s in segments:
+            # fail-safe: if a faster-whisper build omits these fields, drop the segment
+            # rather than admit a potential hallucination
+            if getattr(s, "no_speech_prob", 1.0) >= self.no_speech_max:
+                continue
+            if getattr(s, "avg_logprob", -10.0) <= self.logprob_min:
+                continue
+            kept.append(s.text)
+        text = "".join(kept).strip()
+        if is_hallucination(text):
+            return "", peak
+        return text, peak
+
+    def capture_samplerate(self):
+        """Native samplerate of the chosen input device (forcing 16 kHz returns silence
+        on the Realtek driver, so we capture native + resample)."""
+        if sd is None:
+            return SAMPLERATE
+        try:
+            d = (sd.query_devices(self.device_index, kind="input")
+                 if self.device_index is not None else sd.query_devices(kind="input"))
+            return int(d["default_samplerate"])
+        except Exception:
+            return SAMPLERATE
+
+    def listen_once(self, max_seconds=20.0, silence_sec=0.8, min_sec=0.4,
+                    vad_thresh="auto", onset_blocks=3):
+        """Block until one utterance is captured (energy-VAD-segmented), then transcribe.
+
+        Records continuously; an utterance is the audio between speech onset (after
+        `onset_blocks` consecutive voiced blocks) and a trailing silence gap
+        (`silence_sec`), capped at `max_seconds`. Returns the transcribed zh text
+        (empty string on silence/timeout/hallucination). This is the blocking
+        record-and-return primitive behind the MCP `listen` tool (mirrors #465's
+        ContinuousListener VAD, simplified to a single utterance).
+        """
+        if sd is None:
+            raise RuntimeError("sounddevice/PortAudio unavailable — cannot capture audio")
+        if self.model is None:
+            raise RuntimeError("SttEngine.load() not called")
+        capture_sr = self.capture_samplerate()
+        blocksize = max(256, int(0.05 * capture_sr))  # ~50ms blocks
+        block_dur = blocksize / capture_sr
+        q = queue.Queue()
+
+        def _on_audio(indata, frames, time_info, status):
+            block = indata.copy().flatten()
+            rms = float(np.sqrt(np.mean(block ** 2)))
+            q.put((block, rms))
+
+        threshold = self._calibrate(capture_sr, vad_thresh)
+        seg, seg_samples, silence_run = [], 0, 0.0
+        pending, pending_samples, voiced_run = [], 0, 0
+        in_speech = False
+        deadline = time.time() + max_seconds + 30.0  # absolute wall cap incl. wait-for-onset
+        cap = int(max_seconds * capture_sr)
+
+        with sd.InputStream(samplerate=capture_sr, channels=1, dtype="float32",
+                            blocksize=blocksize, device=self.device_index, callback=_on_audio):
+            while time.time() < deadline:
+                try:
+                    block, rms = q.get(timeout=0.1)
+                except queue.Empty:
+                    continue
+                voiced = rms > threshold
+                if not in_speech:
+                    if voiced:
+                        voiced_run += 1
+                        pending.append(block)
+                        pending_samples += len(block)
+                        if voiced_run >= onset_blocks:
+                            in_speech = True
+                            seg, seg_samples = pending, pending_samples
+                            pending, pending_samples, voiced_run = [], 0, 0
+                            silence_run = 0.0
+                    else:
+                        pending, pending_samples, voiced_run = [], 0, 0
+                    continue
+                seg.append(block)
+                seg_samples += len(block)
+                if voiced:
+                    silence_run = 0.0
+                else:
+                    silence_run += block_dur
+                    if silence_run >= silence_sec:
+                        break
+                if seg_samples >= cap:
+                    break
+
+        if seg_samples < min_sec * capture_sr:
+            return ""
+        audio = np.concatenate(seg, axis=0).flatten()
+        text, _peak = self.transcribe(audio, capture_sr)
+        return text
+
+    def _calibrate(self, capture_sr, vad_thresh):
+        """Energy-VAD threshold: explicit float, or ~1s ambient-noise auto-calibration."""
+        if vad_thresh != "auto":
+            try:
+                return float(vad_thresh)
+            except (ValueError, TypeError):
+                pass
+        fallback = 1.5e-3
+        try:
+            n = int(1.0 * capture_sr)
+            a = sd.rec(n, samplerate=capture_sr, channels=1, dtype="float32", device=self.device_index)
+            sd.wait()
+            noise = float(np.sqrt(np.mean(a.flatten() ** 2)))
+        except Exception:
+            return fallback
+        return max(noise * 4.0, fallback)  # well above the noise floor to avoid false triggers

--- a/scripts/voice/stt.py
+++ b/scripts/voice/stt.py
@@ -217,7 +217,11 @@ class SttEngine:
         seg, seg_samples, silence_run = [], 0, 0.0
         pending, pending_samples, voiced_run = [], 0, 0
         in_speech = False
-        deadline = time.time() + max_seconds + 30.0  # absolute wall cap incl. wait-for-onset
+        # absolute wall cap = recording cap + a wait-for-onset grace. The grace bounds how
+        # long we block waiting for the user to START speaking; keep it modest so a silent
+        # listen() returns well within Claude Code's tool-call timeout (ADR §6 risk).
+        onset_grace = float(os.environ.get("VOICE_LISTEN_ONSET_GRACE", "10") or "10")
+        deadline = time.time() + max_seconds + onset_grace
         cap = int(max_seconds * capture_sr)
 
         with sd.InputStream(samplerate=capture_sr, channels=1, dtype="float32",

--- a/scripts/voice/stt.py
+++ b/scripts/voice/stt.py
@@ -51,8 +51,11 @@ def _register_cuda_dll_dirs():
                 continue
             real = os.path.realpath(str(p))
             # only accept real dirs that stay under the site-packages root, and dedupe,
-            # to avoid widening the DLL search path via stray symlinks / repeats
-            if not real.startswith(base_real) or real in bins:
+            # to avoid widening the DLL search path via stray symlinks / repeats.
+            # normcase both sides: on Windows the prefix compare must be case-insensitive
+            # (and drive-letter/sep normalized) or a legitimate CUDA dir gets wrongly
+            # rejected (→ GPU load fails, needless CPU fallback).
+            if not os.path.normcase(real).startswith(os.path.normcase(base_real)) or real in bins:
                 continue
             try:
                 os.add_dll_directory(real)

--- a/scripts/voice/tts.py
+++ b/scripts/voice/tts.py
@@ -12,8 +12,10 @@ ONLINE — disabled by default; opt in with VOICE_TTS_FALLBACK=edge. Use only fo
 dev / when the local Kokoro service is unavailable.
 
 Playback (no heavy deps): WAV/PCM via sounddevice; MP3 via the Windows winmm MCI
-interface (ctypes). A new speak() stops any in-flight playback first, so rapid
-successive agent turns never overlap audio.
+interface (ctypes). Overlap is prevented BOTH in-process (a threading lock) AND
+across processes (a file lock in the state dir): announce() runs in the long-lived
+MCP-server process while the Stop hook's stop_notify.py runs in a separate per-turn
+process, so an in-process lock alone would let the two speak over each other.
 
 Config (env):
     VOICE_TTS_BASE_URL   Kokoro-FastAPI base   (default http://127.0.0.1:8880/v1)
@@ -23,16 +25,20 @@ Config (env):
     VOICE_TTS_FALLBACK   "edge" enables edge-tts fallback (default "" = off)
     VOICE_TTS_EDGE_VOICE edge-tts voice        (default zh-CN-XiaoxiaoNeural)
     VOICE_TTS_TIMEOUT    Kokoro HTTP timeout s (default 30)
+    VOICE_TTS_LOCK_WAIT  cross-proc lock wait s (default 8; 0 = skip if busy)
+    VOICE_STATE_DIR      dir holding the cross-process playback lock (default <repo>/.mercury/state)
 """
 import io
 import os
 import sys
 import json
+import time
 import wave
 import tempfile
 import threading
 import urllib.request
 import urllib.error
+from pathlib import Path
 
 _BASE_URL = os.environ.get("VOICE_TTS_BASE_URL", "http://127.0.0.1:8880/v1").rstrip("/")
 _VOICE = os.environ.get("VOICE_TTS_VOICE", "zf_xiaobei")
@@ -41,10 +47,70 @@ _SPEED = float(os.environ.get("VOICE_TTS_SPEED", "1.0") or "1.0")
 _FALLBACK = os.environ.get("VOICE_TTS_FALLBACK", "").strip().lower()
 _EDGE_VOICE = os.environ.get("VOICE_TTS_EDGE_VOICE", "zh-CN-XiaoxiaoNeural")
 _TIMEOUT = float(os.environ.get("VOICE_TTS_TIMEOUT", "30") or "30")
+_LOCK_WAIT = float(os.environ.get("VOICE_TTS_LOCK_WAIT", "8") or "8")
+_LOCK_STALE = 90.0  # a lockfile older than this is considered abandoned and stolen
 
 # serialize playback + track the in-flight player so a new utterance can stop it
-_play_lock = threading.Lock()
+_play_lock = threading.Lock()  # in-process
 _current = {"stream": None, "mci_alias": None}
+
+
+def _lock_path():
+    override = os.environ.get("VOICE_STATE_DIR")
+    d = Path(override) if override else Path(__file__).resolve().parents[2] / ".mercury" / "state"
+    d.mkdir(parents=True, exist_ok=True)
+    return d / "voice-tts.lock"
+
+
+class _CrossProcLock:
+    """Cross-process exclusive lock for audio playback (a lockfile created O_EXCL).
+
+    announce() (MCP-server process) and stop_notify.py (per-turn Stop-hook process)
+    are separate processes, so the in-process _play_lock cannot keep them from
+    speaking simultaneously — this file lock does. Waits up to `wait` seconds for the
+    holder to release; on timeout `acquired` is False and the caller skips playback
+    (sequential-not-simultaneous: no garbled overlap). A lockfile older than
+    _LOCK_STALE is treated as abandoned (crashed holder) and stolen.
+    """
+
+    def __init__(self, wait):
+        self.wait = wait
+        self.fd = None
+        self.path = _lock_path()
+
+    @property
+    def acquired(self):
+        return self.fd is not None
+
+    def __enter__(self):
+        deadline = time.time() + self.wait
+        while True:
+            try:
+                self.fd = os.open(str(self.path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+                os.write(self.fd, str(os.getpid()).encode())
+                return self
+            except FileExistsError:
+                try:
+                    if time.time() - os.path.getmtime(self.path) > _LOCK_STALE:
+                        os.remove(self.path)  # steal an abandoned lock
+                        continue
+                except OSError:
+                    pass  # lock vanished between checks — retry the open
+                if time.time() >= deadline:
+                    return self  # acquired == False
+                time.sleep(0.1)
+
+    def __exit__(self, *exc):
+        if self.fd is not None:
+            try:
+                os.close(self.fd)
+            except OSError:
+                pass
+            try:
+                os.remove(self.path)
+            except OSError:
+                pass
+            self.fd = None
 
 
 # ----------------------------------------------------------------------------- synth
@@ -117,9 +183,12 @@ def _play_wav_bytes(data):
     if ch > 1:
         audio = audio.reshape(-1, ch)
     _current["stream"] = True
-    sd.play(audio, sr)
-    sd.wait()
-    _current["stream"] = None
+    try:
+        sd.play(audio, sr)
+        sd.wait()
+    finally:
+        # reset even if play/wait raises, so a later _stop_current() won't sd.stop() spuriously
+        _current["stream"] = None
 
 
 def _mci(command):
@@ -160,44 +229,52 @@ def _play_mp3_file(path):
 def speak(text, blocking=True):
     """Speak `text` in Chinese. Tries Kokoro-FastAPI, then edge-tts (if enabled).
 
-    Stops any in-flight playback first (no overlap on rapid agent turns). Returns a
-    dict {ok, backend, error} describing the outcome (never raises on a TTS failure —
-    a missing voice service must not crash the agent loop).
+    No-overlap guarantee: serialized by an in-process lock (`_play_lock`) AND a
+    cross-process file lock (`_CrossProcLock`), because announce() and the Stop hook's
+    stop_notify.py run in different processes. If another process is already speaking
+    and the lock can't be acquired within VOICE_TTS_LOCK_WAIT seconds, this call skips
+    playback (returns ok=False, error="busy") rather than overlap. Returns a dict
+    {ok, backend, error}; never raises on a TTS failure — a missing voice service must
+    not crash the agent loop.
     """
     text = (text or "").strip()
     if not text:
         return {"ok": False, "backend": None, "error": "empty text"}
 
     def _do():
-        with _play_lock:
-            _stop_current()
-            # primary: Kokoro-FastAPI (local, offline)
-            try:
-                data = _kokoro_synthesize(text, response_format="wav")
-                _play_wav_bytes(data)
-                return {"ok": True, "backend": "kokoro", "error": None}
-            except Exception as e:
-                kokoro_err = f"{type(e).__name__}: {e}"
-                print(f"[voice-tts] kokoro unavailable: {kokoro_err}", file=sys.stderr, flush=True)
-            # fallback: edge-tts (online), only if opted in
-            if _FALLBACK == "edge":
+        with _play_lock:                       # in-process exclusion
+            with _CrossProcLock(_LOCK_WAIT) as cpl:  # cross-process exclusion
+                if not cpl.acquired:
+                    return {"ok": False, "backend": None,
+                            "error": "busy (another voice process is speaking)"}
+                _stop_current()
+                # primary: Kokoro-FastAPI (local, offline)
                 try:
-                    mp3 = _edge_synthesize(text)
-                    fd, path = tempfile.mkstemp(suffix=".mp3", prefix="voicetts_")
-                    os.close(fd)
-                    with open(path, "wb") as f:
-                        f.write(mp3)
-                    try:
-                        _play_mp3_file(path)
-                    finally:
-                        try:
-                            os.remove(path)
-                        except OSError:
-                            pass
-                    return {"ok": True, "backend": "edge", "error": None}
+                    data = _kokoro_synthesize(text, response_format="wav")
+                    _play_wav_bytes(data)
+                    return {"ok": True, "backend": "kokoro", "error": None}
                 except Exception as e:
-                    return {"ok": False, "backend": "edge", "error": f"{type(e).__name__}: {e}"}
-            return {"ok": False, "backend": "kokoro", "error": kokoro_err}
+                    kokoro_err = f"{type(e).__name__}: {e}"
+                    print(f"[voice-tts] kokoro unavailable: {kokoro_err}", file=sys.stderr, flush=True)
+                # fallback: edge-tts (online), only if opted in
+                if _FALLBACK == "edge":
+                    try:
+                        mp3 = _edge_synthesize(text)
+                        fd, path = tempfile.mkstemp(suffix=".mp3", prefix="voicetts_")
+                        os.close(fd)
+                        with open(path, "wb") as f:
+                            f.write(mp3)
+                        try:
+                            _play_mp3_file(path)
+                        finally:
+                            try:
+                                os.remove(path)
+                            except OSError:
+                                pass
+                        return {"ok": True, "backend": "edge", "error": None}
+                    except Exception as e:
+                        return {"ok": False, "backend": "edge", "error": f"{type(e).__name__}: {e}"}
+                return {"ok": False, "backend": "kokoro", "error": kokoro_err}
 
     if blocking:
         return _do()

--- a/scripts/voice/tts.py
+++ b/scripts/voice/tts.py
@@ -82,6 +82,16 @@ class _CrossProcLock:
     def acquired(self):
         return self.fd is not None
 
+    def touch(self):
+        """Refresh the lockfile mtime — call right before playback so the stale clock
+        measures playback time (not synth/download), preventing a long synth from
+        pushing total hold time past _LOCK_STALE and triggering a false steal."""
+        if self.fd is not None:
+            try:
+                os.utime(self.path, None)
+            except OSError:
+                pass
+
     def __enter__(self):
         deadline = time.time() + self.wait
         while True:
@@ -251,6 +261,7 @@ def speak(text, blocking=True):
                 # primary: Kokoro-FastAPI (local, offline)
                 try:
                     data = _kokoro_synthesize(text, response_format="wav")
+                    cpl.touch()  # reset stale clock to playback start (synth time already spent)
                     _play_wav_bytes(data)
                     return {"ok": True, "backend": "kokoro", "error": None}
                 except Exception as e:
@@ -264,6 +275,7 @@ def speak(text, blocking=True):
                         os.close(fd)
                         with open(path, "wb") as f:
                             f.write(mp3)
+                        cpl.touch()  # reset stale clock to playback start
                         try:
                             _play_mp3_file(path)
                         finally:

--- a/scripts/voice/tts.py
+++ b/scripts/voice/tts.py
@@ -62,6 +62,31 @@ def _lock_path():
     return d / "voice-tts.lock"
 
 
+def _pid_alive(pid):
+    """True if process `pid` is still running. Used to avoid stealing a lock from a
+    LIVE holder that is merely mid-long-playback (a stale mtime alone must not trigger
+    a steal while the holder is alive — that would cause the overlap we're preventing).
+    Returns False on any uncertainty so a genuinely-dead holder's lock can still be stolen."""
+    if not pid or pid <= 0:
+        return False
+    try:
+        if os.name == "nt":
+            import ctypes
+            PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+            STILL_ACTIVE = 259
+            h = ctypes.windll.kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+            if not h:
+                return False  # no such process (or access denied → treat as dead/steal-able)
+            code = ctypes.c_ulong()
+            ok = ctypes.windll.kernel32.GetExitCodeProcess(h, ctypes.byref(code))
+            ctypes.windll.kernel32.CloseHandle(h)
+            return bool(ok) and code.value == STILL_ACTIVE
+        os.kill(pid, 0)
+        return True
+    except (OSError, ValueError, OverflowError):
+        return False
+
+
 class _CrossProcLock:
     """Cross-process exclusive lock for audio playback (a lockfile created O_EXCL).
 
@@ -102,8 +127,16 @@ class _CrossProcLock:
             except FileExistsError:
                 try:
                     if time.time() - os.path.getmtime(self.path) > _LOCK_STALE:
-                        os.remove(self.path)  # steal an abandoned lock
-                        continue
+                        # only steal if the holder is actually dead — a live holder
+                        # mid-long-playback keeps its lock no matter how old the mtime,
+                        # so a slow synth/long utterance never triggers a false steal
+                        try:
+                            holder = int(open(self.path, encoding="utf-8").read().strip() or "0")
+                        except (OSError, ValueError):
+                            holder = 0
+                        if not _pid_alive(holder):
+                            os.remove(self.path)  # steal an abandoned (dead-holder) lock
+                            continue
                 except OSError:
                     pass  # lock vanished between checks — retry the open
                 if time.time() >= deadline:
@@ -210,12 +243,14 @@ def _mci(command):
 
 
 def _play_mp3_file(path):
-    """Play an MP3 file via the Windows winmm MCI interface (no extra deps)."""
+    """Play an MP3 file via the Windows winmm MCI interface (no extra deps), BLOCKING
+    until playback finishes (so the cross-process lock is held for the real duration)."""
     if os.name != "nt":
-        # non-Windows best-effort: let the OS open it (rarely hit; edge fallback is dev-only)
-        import subprocess
-        subprocess.Popen(["xdg-open", path])
-        return
+        # Mercury target is native Windows. A detached `xdg-open` would return immediately
+        # and release the playback lock while audio is still playing (breaking the
+        # no-overlap guarantee), and macOS has no xdg-open anyway. Fail loudly instead of
+        # a misleading "spoken" result — speak() catches this and reports ok=False.
+        raise NotImplementedError("mp3 fallback playback is unsupported on non-Windows")
     import time
     alias = "voicetts"
     _mci(f'open "{path}" type mpegvideo alias {alias}')
@@ -250,6 +285,12 @@ def speak(text, blocking=True):
     text = (text or "").strip()
     if not text:
         return {"ok": False, "backend": None, "error": "empty text"}
+    # Bound spoken length at the speak() layer so EVERY caller (announce, stop_notify, …)
+    # produces playback short enough to stay well under the cross-process lock's stale
+    # window — long detail belongs on screen, not read aloud.
+    cap = int(os.environ.get("VOICE_TTS_MAX_CHARS", "600") or "600")
+    if len(text) > cap:
+        text = text[:cap] + "……（详情见屏幕）"
 
     def _do():
         with _play_lock:                       # in-process exclusion

--- a/scripts/voice/tts.py
+++ b/scripts/voice/tts.py
@@ -1,0 +1,215 @@
+# -*- coding: utf-8 -*-
+"""tts — Chinese text-to-speech for agent->user announcements (Issue #468).
+
+Primary backend: Kokoro-FastAPI, an OpenAI-compatible local TTS service
+(`POST /v1/audio/speech`, verified at github.com/remsky/Kokoro-FastAPI). Local +
+offline + Apache-2.0; ~300ms first-token on an RTX 4060. Run it as a standalone
+service (its own Python env, which sidesteps Kokoro's `Requires-Python <3.13` pin —
+this daemon stays on 3.14). See scripts/voice/README.md for setup.
+
+Fallback backend: edge-tts (Microsoft Edge online TTS, LGPLv3). Zero-config but
+ONLINE — disabled by default; opt in with VOICE_TTS_FALLBACK=edge. Use only for
+dev / when the local Kokoro service is unavailable.
+
+Playback (no heavy deps): WAV/PCM via sounddevice; MP3 via the Windows winmm MCI
+interface (ctypes). A new speak() stops any in-flight playback first, so rapid
+successive agent turns never overlap audio.
+
+Config (env):
+    VOICE_TTS_BASE_URL   Kokoro-FastAPI base   (default http://127.0.0.1:8880/v1)
+    VOICE_TTS_VOICE      Mandarin voice        (default zf_xiaobei)
+    VOICE_TTS_MODEL      Kokoro model id       (default kokoro)
+    VOICE_TTS_SPEED      speech speed          (default 1.0)
+    VOICE_TTS_FALLBACK   "edge" enables edge-tts fallback (default "" = off)
+    VOICE_TTS_EDGE_VOICE edge-tts voice        (default zh-CN-XiaoxiaoNeural)
+    VOICE_TTS_TIMEOUT    Kokoro HTTP timeout s (default 30)
+"""
+import io
+import os
+import sys
+import json
+import wave
+import tempfile
+import threading
+import urllib.request
+import urllib.error
+
+_BASE_URL = os.environ.get("VOICE_TTS_BASE_URL", "http://127.0.0.1:8880/v1").rstrip("/")
+_VOICE = os.environ.get("VOICE_TTS_VOICE", "zf_xiaobei")
+_MODEL = os.environ.get("VOICE_TTS_MODEL", "kokoro")
+_SPEED = float(os.environ.get("VOICE_TTS_SPEED", "1.0") or "1.0")
+_FALLBACK = os.environ.get("VOICE_TTS_FALLBACK", "").strip().lower()
+_EDGE_VOICE = os.environ.get("VOICE_TTS_EDGE_VOICE", "zh-CN-XiaoxiaoNeural")
+_TIMEOUT = float(os.environ.get("VOICE_TTS_TIMEOUT", "30") or "30")
+
+# serialize playback + track the in-flight player so a new utterance can stop it
+_play_lock = threading.Lock()
+_current = {"stream": None, "mci_alias": None}
+
+
+# ----------------------------------------------------------------------------- synth
+def _kokoro_synthesize(text, response_format="wav"):
+    """POST to Kokoro-FastAPI's OpenAI-compatible speech endpoint. Returns audio bytes.
+
+    Raises urllib.error.URLError if the service is unreachable (caller falls back).
+    """
+    payload = json.dumps({
+        "model": _MODEL,
+        "input": text,
+        "voice": _VOICE,
+        "response_format": response_format,
+        "speed": _SPEED,
+    }).encode("utf-8")
+    req = urllib.request.Request(
+        f"{_BASE_URL}/audio/speech",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:
+        return resp.read()
+
+
+def _edge_synthesize(text):
+    """Synthesize via edge-tts (online). Returns MP3 bytes. Requires `edge-tts` installed."""
+    import asyncio
+    import edge_tts
+
+    async def _run():
+        communicate = edge_tts.Communicate(text, _EDGE_VOICE)
+        buf = bytearray()
+        async for chunk in communicate.stream():
+            if chunk["type"] == "audio":
+                buf.extend(chunk["data"])
+        return bytes(buf)
+
+    return asyncio.run(_run())
+
+
+# --------------------------------------------------------------------------- playback
+def _stop_current():
+    """Stop any in-flight playback (sounddevice stream or MCI mp3)."""
+    st = _current.get("stream")
+    if st is not None:
+        try:
+            import sounddevice as sd
+            sd.stop()
+        except Exception:
+            pass
+        _current["stream"] = None
+    alias = _current.get("mci_alias")
+    if alias is not None:
+        _mci(f"stop {alias}")
+        _mci(f"close {alias}")
+        _current["mci_alias"] = None
+
+
+def _play_wav_bytes(data):
+    """Play WAV bytes via sounddevice (blocking)."""
+    import numpy as np
+    import sounddevice as sd
+    with wave.open(io.BytesIO(data), "rb") as wf:
+        sr = wf.getframerate()
+        n = wf.getnframes()
+        ch = wf.getnchannels()
+        raw = wf.readframes(n)
+    audio = np.frombuffer(raw, dtype=np.int16).astype(np.float32) / 32768.0
+    if ch > 1:
+        audio = audio.reshape(-1, ch)
+    _current["stream"] = True
+    sd.play(audio, sr)
+    sd.wait()
+    _current["stream"] = None
+
+
+def _mci(command):
+    """Send a Windows MCI string command via winmm (best-effort). Returns 0 on success."""
+    if os.name != "nt":
+        return -1
+    import ctypes
+    return ctypes.windll.winmm.mciSendStringW(command, None, 0, None)
+
+
+def _play_mp3_file(path):
+    """Play an MP3 file via the Windows winmm MCI interface (no extra deps)."""
+    if os.name != "nt":
+        # non-Windows best-effort: let the OS open it (rarely hit; edge fallback is dev-only)
+        import subprocess
+        subprocess.Popen(["xdg-open", path])
+        return
+    import time
+    alias = "voicetts"
+    _mci(f'open "{path}" type mpegvideo alias {alias}')
+    _current["mci_alias"] = alias
+    # length in ms, then play and wait
+    import ctypes
+    buf = ctypes.create_unicode_buffer(64)
+    ctypes.windll.winmm.mciSendStringW(f"status {alias} length", buf, 64, None)
+    try:
+        length_ms = int(buf.value)
+    except ValueError:
+        length_ms = 0
+    _mci(f"play {alias}")
+    if length_ms > 0:
+        time.sleep(length_ms / 1000.0 + 0.2)
+    _mci(f"close {alias}")
+    _current["mci_alias"] = None
+
+
+# ------------------------------------------------------------------------------- API
+def speak(text, blocking=True):
+    """Speak `text` in Chinese. Tries Kokoro-FastAPI, then edge-tts (if enabled).
+
+    Stops any in-flight playback first (no overlap on rapid agent turns). Returns a
+    dict {ok, backend, error} describing the outcome (never raises on a TTS failure —
+    a missing voice service must not crash the agent loop).
+    """
+    text = (text or "").strip()
+    if not text:
+        return {"ok": False, "backend": None, "error": "empty text"}
+
+    def _do():
+        with _play_lock:
+            _stop_current()
+            # primary: Kokoro-FastAPI (local, offline)
+            try:
+                data = _kokoro_synthesize(text, response_format="wav")
+                _play_wav_bytes(data)
+                return {"ok": True, "backend": "kokoro", "error": None}
+            except Exception as e:
+                kokoro_err = f"{type(e).__name__}: {e}"
+                print(f"[voice-tts] kokoro unavailable: {kokoro_err}", file=sys.stderr, flush=True)
+            # fallback: edge-tts (online), only if opted in
+            if _FALLBACK == "edge":
+                try:
+                    mp3 = _edge_synthesize(text)
+                    fd, path = tempfile.mkstemp(suffix=".mp3", prefix="voicetts_")
+                    os.close(fd)
+                    with open(path, "wb") as f:
+                        f.write(mp3)
+                    try:
+                        _play_mp3_file(path)
+                    finally:
+                        try:
+                            os.remove(path)
+                        except OSError:
+                            pass
+                    return {"ok": True, "backend": "edge", "error": None}
+                except Exception as e:
+                    return {"ok": False, "backend": "edge", "error": f"{type(e).__name__}: {e}"}
+            return {"ok": False, "backend": "kokoro", "error": kokoro_err}
+
+    if blocking:
+        return _do()
+    threading.Thread(target=_do, daemon=True).start()
+    return {"ok": True, "backend": "async", "error": None}
+
+
+def health():
+    """Best-effort check that the Kokoro-FastAPI service is reachable. Returns bool."""
+    try:
+        req = urllib.request.Request(f"{_BASE_URL}/audio/voices", method="GET")
+        with urllib.request.urlopen(req, timeout=3) as resp:
+            return resp.status == 200
+    except Exception:
+        return False

--- a/scripts/voice/tts.py
+++ b/scripts/voice/tts.py
@@ -131,7 +131,8 @@ class _CrossProcLock:
                         # mid-long-playback keeps its lock no matter how old the mtime,
                         # so a slow synth/long utterance never triggers a false steal
                         try:
-                            holder = int(open(self.path, encoding="utf-8").read().strip() or "0")
+                            with open(self.path, encoding="utf-8") as lf:  # close before remove (Windows)
+                                holder = int(lf.read().strip() or "0")
                         except (OSError, ValueError):
                             holder = 0
                         if not _pid_alive(holder):


### PR DESCRIPTION
## Summary

在 #465 voice-zh-input(外围中文语音**输入**)之上,升级为**双向语音 agent 交互系统**:CLI 会话内调用 + 秘书/工作双模式 + 双向闭环。

### mount-vs-build 决策
架构 B(`scripts/` 自研粘合)延续,**NOT mount VoiceMode** —— VoiceMode 官方原生 Windows 不支持(仅 WSL2),与 Mercury 原生 Windows 11 + Python 3.14 冲突;按层借鉴其 `converse` 语义(`wait_for_response` true=说+听 / false=仅播报)+ OpenAI 兼容后端解耦思想。

### 三组件(全 `scripts/voice/`,可拆卸 package)
- **stt.py** — faster-whisper STT 引擎 + 单句阻塞录音,复用 #465 验证过的硬核原语(CUDA DLL 注册顺序 / native-rate 采集+重采样 / 幻觉门控)
- **tts.py** — Kokoro-FastAPI(OpenAI 兼容 `/v1/audio/speech`)客户端(stdlib urllib,无新依赖)+ edge-tts 在线回退;wav→sounddevice / mp3→winmm MCI 播放;**跨进程文件锁防重叠**
- **state.py** — secretary/work 双模式状态机 + 原子写状态 + 秘书结构化记录
- **mcp_server.py** — FastMCP stdio server:`listen`/`announce`/`set_mode`/`record_note`/`get_status`
- **stop_notify.py** + `.claude/hooks/voice-stop-notify.sh`(opt-in)— Stop hook 读 `last_assistant_message`(兜底解析 transcript)→ TTS 播报回复
- `.claude/commands/secretary.md`|`work.md` — `/secretary`、`/work` 显式模式切换

### TTS 选型
Kokoro-FastAPI **独立服务**运行(Apache-2.0、离线、4060 上 ~300ms 首音、8 普通话音色),自带 `.python-version` 隔离 Kokoro 的 `<3.13` 锁;作为运行时外部依赖(非代码 vendor,**不走 cherry-pick 协议**)。全部本地隐私,音频不出本机。

### 地基实测(keystone)
`mcp` 1.27.2 + FastMCP 在 Python 3.14 上 stdio JSON-RPC 握手端到端跑通(initialize/tools-list/tools-call);各模块 smoke 通过(状态机、stop gate、跨进程锁互斥)。

## Test plan
- [x] py_compile 全部模块 + daemon 重构无导入回归(共享 voice.stt,CUDA-DLL-before-faster_whisper 不变式保持)
- [x] MCP server end-to-end stdio smoke(5 工具)
- [x] 状态机:秘书重入保留笔记 / 新会话新建 / 微秒防碰撞
- [x] stop_notify gate(idle no-op / stop_hook_active / transcript 兜底)
- [x] 跨进程 TTS 锁互斥
- [ ] 真实语音端到端验收(需 Kokoro-FastAPI 服务 + 麦克风;#468 保持 OPEN 待此验收)

## Review
**dual-verify: PASS**(Claude PASS + Codex PASS)。Codex 第一轮 High(announce 与 stop_notify 跨进程音频重叠)已修 = `tts.py` 跨进程文件锁(O_EXCL + 90s 过期窃取 + 等待/跳过);Codex 第二轮复核 0/0/0/0 PASS。两条已知限制文档化(stop_notify fail-open / 状态 RMW race,见 README + ADR §6)。

ADR:`.mercury/docs/research/issue-468-voice-agent-adr-2026-06.md`。

Refs #468(不 Close,保持 OPEN 待真实语音端到端验收)。

Generated with Claude Code