### PR TITLE
fix(#472): voice 实测调优 — VAD 阈值倍率 4→2.5 + env 钩子 + 默认音色 zf_xiaoyi

### DIFF
--- a/scripts/voice/README.md
+++ b/scripts/voice/README.md
@@ -53,10 +53,10 @@ Kokoro 的 pip 包锁 Python `<3.13`,与本 venv 的 3.14 冲突,因此 TTS 作�
 - **本地 uv/uvicorn(原生 Windows)**:克隆 `github.com/remsky/Kokoro-FastAPI`,装 astral-uv +
   espeak-ng,运行其 GPU 启动脚本(见该 repo README;启动后监听 :8880)。
 
-验证:`curl http://localhost:8880/v1/audio/voices` 应返回音色列表(含 `zf_xiaobei` 等普通话音色)。
+验证:`curl http://localhost:8880/v1/audio/voices` 应返回音色列表(含 `zf_xiaoyi` 等普通话音色)。
 
 > 来源:<https://github.com/remsky/Kokoro-FastAPI>(Apache-2.0)。OpenAI 兼容端点
-> `POST /v1/audio/speech`,请求 `{"model":"kokoro","input":...,"voice":"zf_xiaobei","response_format":"wav"}`。
+> `POST /v1/audio/speech`,请求 `{"model":"kokoro","input":...,"voice":"zf_xiaoyi","response_format":"wav"}`。
 
 ### 3. 注册 MCP server
 
@@ -113,7 +113,7 @@ worker 自守卫:仅当语音模式 active(mode ≠ idle)时才播报,非语音�
 | `VOICE_ZH_DEVICE` | `auto` | `auto` / `cuda` / `cpu` |
 | `VOICE_ZH_DEVICE_INDEX` | 系统默认 | 显式输入设备序号(`voice-zh-input.py --list-devices` 查看) |
 | `VOICE_TTS_BASE_URL` | `http://127.0.0.1:8880/v1` | Kokoro-FastAPI 基址 |
-| `VOICE_TTS_VOICE` | `zf_xiaobei` | 普通话音色(`zf_*` 女 / `zm_*` 男) |
+| `VOICE_TTS_VOICE` | `zf_xiaoyi` | 普通话音色(`zf_*` 女 / `zm_*` 男;`zf_xiaobei` 带北方口音,#472 实测弃用) |
 | `VOICE_TTS_MODEL` | `kokoro` | Kokoro 模型 id |
 | `VOICE_TTS_SPEED` | `1.0` | 语速 |
 | `VOICE_TTS_FALLBACK` | (空=关) | 设 `edge` 启用 edge-tts 在线回退 |
@@ -122,6 +122,8 @@ worker 自守卫:仅当语音模式 active(mode ≠ idle)时才播报,非语音�
 | `VOICE_TTS_LOCK_WAIT` | `8` | 跨进程播放锁等待秒数(超时则跳过本次播报) |
 | `VOICE_TTS_MAX_CHARS` | `600` | `speak()` 播报文本截断长度(所有调用方) |
 | `VOICE_LISTEN_ONSET_GRACE` | `10` | `listen` 等待用户开口的 onset 窗口(秒) |
+| `VOICE_VAD_FACTOR` | `2.5` | 能量 VAD 阈值=噪声地板×该倍率(低增益麦克风语音仅 ~3.5× 噪声,故默认 2.5;#472) |
+| `VOICE_VAD_THRESH` | (空=自动校准) | 能量 VAD 绝对阈值覆盖(RMS,设置后跳过自动校准) |
 | `VOICE_STATE_DIR` | `<repo>/.mercury/state` | 状态/笔记目录(也存跨进程播放锁) |
 | `VOICE_STOP_MAX_CHARS` | `400` | Stop hook 播报截断长度 |
 

--- a/scripts/voice/stt.py
+++ b/scripts/voice/stt.py
@@ -266,12 +266,51 @@ class SttEngine:
         return text
 
     def _calibrate(self, capture_sr, vad_thresh):
-        """Energy-VAD threshold: explicit float, or ~1s ambient-noise auto-calibration."""
+        """Energy-VAD threshold: explicit float, env override, or ~1s ambient-noise
+        auto-calibration (`noise * VOICE_VAD_FACTOR`).
+
+        Resolution order: `vad_thresh` argument → `VOICE_VAD_THRESH` env (absolute)
+        → auto-calibration. The default factor is 2.5: low-gain laptop mic arrays
+        (e.g. Realtek at max +30dB boost) produce normal-speech block RMS only
+        ~3.5x the noise floor, so the previous 4.0 sat ABOVE real speech and listen()
+        silently dropped utterances (#472). 2.5 keeps headroom against the floor
+        while admitting quiet-but-real speech.
+        """
         if vad_thresh != "auto":
             try:
-                return float(vad_thresh)
+                v = float(vad_thresh)
+                if np.isfinite(v) and v > 0:
+                    return v
             except (ValueError, TypeError):
                 pass
+            print(f"[voice-stt] invalid vad_thresh={vad_thresh!r} (need finite > 0), "
+                  "falling back to env/auto", file=sys.stderr, flush=True)
+        # env overrides must be finite AND positive: 0/negative makes every block voiced
+        # (listen self-triggers on room noise), nan/inf makes `rms > threshold` never
+        # succeed (listen silently drops ALL speech — the exact failure mode #472 fixes).
+        # A mistyped env var must warn + fall back, never silently break the chain.
+        env_thresh = os.environ.get("VOICE_VAD_THRESH")
+        if env_thresh:
+            try:
+                v = float(env_thresh)
+                if np.isfinite(v) and v > 0:
+                    return v
+            except ValueError:
+                pass
+            print(f"[voice-stt] invalid VOICE_VAD_THRESH={env_thresh!r} (need finite > 0), "
+                  "falling back to auto", file=sys.stderr, flush=True)
+        factor = 2.5
+        env_factor = os.environ.get("VOICE_VAD_FACTOR")
+        if env_factor:
+            try:
+                f = float(env_factor)
+                if np.isfinite(f) and f > 0:
+                    factor = f
+                else:
+                    raise ValueError(env_factor)
+            except ValueError:
+                print(f"[voice-stt] invalid VOICE_VAD_FACTOR={env_factor!r} (need finite > 0), "
+                      f"using default {factor}", file=sys.stderr, flush=True)
         fallback = 1.5e-3
         try:
             n = int(1.0 * capture_sr)
@@ -280,4 +319,4 @@ class SttEngine:
             noise = float(np.sqrt(np.mean(a.flatten() ** 2)))
         except Exception:
             return fallback
-        return max(noise * 4.0, fallback)  # well above the noise floor to avoid false triggers
+        return max(noise * factor, fallback)  # above the noise floor to avoid false triggers

--- a/scripts/voice/tts.py
+++ b/scripts/voice/tts.py
@@ -19,7 +19,8 @@ process, so an in-process lock alone would let the two speak over each other.
 
 Config (env):
     VOICE_TTS_BASE_URL   Kokoro-FastAPI base   (default http://127.0.0.1:8880/v1)
-    VOICE_TTS_VOICE      Mandarin voice        (default zf_xiaobei)
+    VOICE_TTS_VOICE      Mandarin voice        (default zf_xiaoyi; zf_xiaobei has a
+                         regional northern accent — user-rejected in #472)
     VOICE_TTS_MODEL      Kokoro model id       (default kokoro)
     VOICE_TTS_SPEED      speech speed          (default 1.0)
     VOICE_TTS_FALLBACK   "edge" enables edge-tts fallback (default "" = off)
@@ -41,7 +42,7 @@ import urllib.error
 from pathlib import Path
 
 _BASE_URL = os.environ.get("VOICE_TTS_BASE_URL", "http://127.0.0.1:8880/v1").rstrip("/")
-_VOICE = os.environ.get("VOICE_TTS_VOICE", "zf_xiaobei")
+_VOICE = os.environ.get("VOICE_TTS_VOICE", "zf_xiaoyi")
 _MODEL = os.environ.get("VOICE_TTS_MODEL", "kokoro")
 _SPEED = float(os.environ.get("VOICE_TTS_SPEED", "1.0") or "1.0")
 _FALLBACK = os.environ.get("VOICE_TTS_FALLBACK", "").strip().lower()


### PR DESCRIPTION
## Summary

#468 voice agent 首次真实环境 dogfood（秘书模式）暴露两项实测问题，本 PR 修复：

1. **listen 能量 VAD 阈值过紧**：低增益笔记本麦克风（Realtek 阵列，增益顶满 +30dB）下正常说话块 RMS p95≈0.0032，低于阈值 `noise×4≈0.0036`，语音被静默丢弃（`listen` 反复返回空串）。
   - 校准倍率 `4.0 → 2.5`（实测语音仅 ~3.5× 噪声地板）
   - 新增 `VOICE_VAD_FACTOR`（倍率）/ `VOICE_VAD_THRESH`（绝对值）env 覆盖钩子
   - 三条解析路径（arg → `VOICE_VAD_THRESH` → factor 自动校准）统一 finite-and-positive 校验，无效值警告并回落——不再静默复刻"listen 永远空"的故障模式
2. **默认 TTS 音色带方言口音**：`zf_xiaobei` 北方腔，用户试听对比（xiaoxiao/xiaoyi/yunxi）后选定 `zf_xiaoyi`；tts.py 默认值 + README 示例与 env 表同步。

## Test plan

- [x] `_calibrate` 行为测试：arg 优先级、env 覆盖、0/负/nan/inf/垃圾值/空白全部回落正确（两轮共 9 项断言通过）
- [x] tts 默认音色 = zf_xiaoyi（import 验证）
- [x] 实机验证 STT 链路：5 句中文/英文连续转写成功（修复 MCP 注册路径 + 系统麦克风静音后）
- [ ] 重启会话后实机验证新阈值下 listen 收音改善（MCP server 进程需重启加载新代码）

## Review

dual-verify: PASS (Claude: PASS, Codex: PASS @ iteration 4, 3 findings fixed)
Dual-verify Codex side: PASS

Closes #472

🤖 Generated with [Claude Code](https://claude.com/claude-code)