### PR TITLE
feat(#474,#469): handoff doc 迁到工作区/KB + armed Stop-hook 机械强制 auto 转接

### DIFF
--- a/.claude/hooks/auto-handoff-stop.sh
+++ b/.claude/hooks/auto-handoff-stop.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Armed auto-handoff Stop hook — Mercury Issue #469.
+#
+# Problem (recurring): in /handoff auto, the agent writes the doc + prints the
+# Starting Prompt, then STOPS without running the launcher → no new session
+# spawns. Behavioral SKILL.md banners (#470) are a stopgap; per the user's own
+# CLAUDE.md principle ("end-of-turn automation must be a hook, not model
+# memory"), only a mechanical Stop-hook reliably forces the handoff.
+#
+# Mechanism:
+#   - /handoff auto ARMS a pending launch by writing the flag below (lane /
+#     handoff_doc / worktree) BEFORE printing the prompt. The normal path then
+#     runs `handoff-launch.sh && rm -f <flag>` atomically, so a complying agent
+#     leaves no flag → this hook no-ops.
+#   - If the agent stops while still armed (the bug), this hook mechanically
+#     runs the canonical launcher and disarms (model B). On launcher failure it
+#     blocks-with-reason ONCE so the agent can retry with full context
+#     (model A fallback); a second armed stop is then allowed (own retry marker)
+#     to avoid an infinite loop / runaway spawn.
+#
+# Stale-flag safety (every terminal path must end armed=false unless a live
+# launch is pending): a flag can leak across sessions if a path exits while
+# armed. Three guards prevent a leaked flag from later ghost-spawning:
+#   (1) break-glass disarms instead of pure no-op;
+#   (2) an mtime staleness guard disarms flags older than the live-turn window;
+#   (3) the staged-change deferral is bypass-aware — it only defers when
+#       stop-guard.sh will actually block (interactive mode); in bypass /
+#       dontAsk mode stop-guard does NOT block, so we must not leave a stale
+#       flag — fall through and launch.
+#
+# Zero hard deps beyond sed/git + the shared permission-mode.sh lib (same one
+# stop-guard.sh uses). Break-glass: MERCURY_AUTO_HANDOFF_STOP_DISABLED=1.
+
+_PROJECT="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+cd "$_PROJECT" 2>/dev/null || exit 0
+
+FLAG="$_PROJECT/.mercury/state/auto-handoff-armed"
+RETRY="$_PROJECT/.mercury/state/auto-handoff-retried"
+[ -f "$FLAG" ] || { rm -f "$RETRY" 2>/dev/null; exit 0; }   # not armed → allow stop
+
+# Break-glass: disable the mechanism AND disarm, so a pending flag cannot leak
+# into a later session and ghost-spawn (Codex audit M2).
+if [ "${MERCURY_AUTO_HANDOFF_STOP_DISABLED:-}" = "1" ]; then
+  rm -f "$FLAG" "$RETRY"
+  echo "auto-handoff: disabled via MERCURY_AUTO_HANDOFF_STOP_DISABLED — disarmed pending flag." >&2
+  exit 0
+fi
+
+STOP_INPUT=$(cat 2>/dev/null || true)
+
+# Staleness guard: an armed turn fires within minutes; a flag older than the
+# live-turn window is a cross-session leak, not a live handoff. Disarm, never
+# launch (defense-in-depth against any path that leaves a flag armed).
+if [ -n "$(find "$FLAG" -mmin +120 2>/dev/null)" ]; then
+  rm -f "$FLAG" "$RETRY"
+  echo "auto-handoff: armed flag is stale (>120m, likely a prior session) — disarmed, not launching." >&2
+  exit 0
+fi
+
+# Defer to stop-guard.sh ONLY when it will actually block. With changes staged
+# but uncommitted, stop-guard blocks in interactive mode (agent commits, the
+# next stop re-enters here cleanly) — but in bypass/dontAsk mode it does NOT
+# block, so deferring would strand a stale flag (Codex audit H1). In that case
+# fall through and launch.
+if [ -n "$(git diff --cached --name-only 2>/dev/null)" ]; then
+  # shellcheck source=/dev/null
+  . "$(dirname "$0")/lib/permission-mode.sh" 2>/dev/null || true
+  PERM_MODE=""
+  if command -v get_permission_mode >/dev/null 2>&1; then
+    PERM_MODE=$(get_permission_mode "$STOP_INPUT")
+  fi
+  if command -v is_bypass_mode >/dev/null 2>&1 && is_bypass_mode "$PERM_MODE"; then
+    : # bypass mode: stop-guard won't block → fall through to launch (no stale flag)
+  else
+    exit 0   # interactive: stop-guard will block; we launch after the agent commits
+  fi
+fi
+
+# Loop guard (own marker, NOT stop_hook_active — stop-guard sets that flag when
+# it blocks for uncommitted changes, which would wrongly trip us). If we already
+# intervened once, disarm and allow the stop so we never spin / spawn twice.
+if [ -f "$RETRY" ]; then
+  rm -f "$FLAG" "$RETRY"
+  echo "WARNING: auto-handoff launcher still not complete after one retry — disarmed to avoid loop. Run scripts/handoff-launch.sh manually." >&2
+  exit 0
+fi
+
+# Parse the flag (key=value).
+_get() { sed -n "s/^[[:space:]]*$1[[:space:]]*=[[:space:]]*//p" "$FLAG" | head -1; }
+LANE=$(_get lane)
+HANDOFF_DOC=$(_get handoff_doc)
+WORKTREE=$(_get worktree)
+
+# Incomplete arm or missing doc → cannot safely launch; disarm + allow stop.
+if [ -z "$LANE" ] || [ -z "$HANDOFF_DOC" ] || [ -z "$WORKTREE" ] || [ ! -f "$HANDOFF_DOC" ]; then
+  rm -f "$FLAG" "$RETRY"
+  echo "WARNING: auto-handoff armed but flag incomplete or handoff doc missing — disarmed, not launching." >&2
+  exit 0
+fi
+
+# Mechanical launch via the canonical, dual-verified launcher (#377).
+if LAUNCH_OUT=$(bash "$_PROJECT/scripts/handoff-launch.sh" \
+      --lane "$LANE" --worktree "$WORKTREE" --handoff-doc "$HANDOFF_DOC" 2>&1); then
+  rm -f "$FLAG" "$RETRY"
+  echo "auto-handoff: launcher spawned new session (#469 armed Stop-hook): ${LAUNCH_OUT}" >&2
+  exit 0
+fi
+
+# Launcher failed: mark one retry + block ONCE so the agent retries with full
+# tool context. Static reason string → always valid JSON (Windows paths contain
+# backslashes and MUST NOT be interpolated into JSON). Next armed stop hits the
+# retry guard above and is allowed.
+: > "$RETRY"
+echo "auto-handoff launcher failed: ${LAUNCH_OUT}" >&2
+echo '{"decision":"block","reason":"Auto-handoff is ARMED but scripts/handoff-launch.sh failed. Read .mercury/state/auto-handoff-armed for lane/worktree/handoff_doc, run scripts/handoff-launch.sh with those args, then delete that flag file. Do NOT stop until the new session is spawned (see stderr for the launcher error)."}'
+exit 0

--- a/.claude/hooks/auto-handoff-stop.sh
+++ b/.claude/hooks/auto-handoff-stop.sh
@@ -91,10 +91,14 @@ LANE=$(_get lane)
 HANDOFF_DOC=$(_get handoff_doc)
 WORKTREE=$(_get worktree)
 
-# Incomplete arm or missing doc → cannot safely launch; disarm + allow stop.
-if [ -z "$LANE" ] || [ -z "$HANDOFF_DOC" ] || [ -z "$WORKTREE" ] || [ ! -f "$HANDOFF_DOC" ]; then
+# Incomplete arm, missing doc, or non-existent worktree → cannot safely launch;
+# disarm + allow stop. Validating WORKTREE is a real directory (not just
+# non-empty) also defangs a corrupted/traversal value in the writable flag file
+# before it reaches handoff-launch.sh (Argus audit: untrusted state input).
+if [ -z "$LANE" ] || [ -z "$HANDOFF_DOC" ] || [ -z "$WORKTREE" ] \
+   || [ ! -f "$HANDOFF_DOC" ] || [ ! -d "$WORKTREE" ]; then
   rm -f "$FLAG" "$RETRY"
-  echo "WARNING: auto-handoff armed but flag incomplete or handoff doc missing — disarmed, not launching." >&2
+  echo "WARNING: auto-handoff armed but flag incomplete, handoff doc missing, or worktree not a dir — disarmed, not launching." >&2
   exit 0
 fi
 

--- a/.claude/hooks/auto-handoff-stop.sh
+++ b/.claude/hooks/auto-handoff-stop.sh
@@ -91,10 +91,20 @@ LANE=$(_get lane)
 HANDOFF_DOC=$(_get handoff_doc)
 WORKTREE=$(_get worktree)
 
+# Reject unsafe content in the writable flag file before it reaches the launcher:
+# path traversal (`..`) or embedded newline/CR (which could split the launcher
+# invocation). Disarm + allow stop (Argus audit: untrusted state input).
+case "${LANE}:${HANDOFF_DOC}:${WORKTREE}" in
+  *..*|*$'\n'*|*$'\r'*)
+    rm -f "$FLAG" "$RETRY"
+    echo "WARNING: auto-handoff flag contains unsafe content (.. or newline/CR) — disarmed, not launching." >&2
+    exit 0 ;;
+esac
+
 # Incomplete arm, missing doc, or non-existent worktree → cannot safely launch;
 # disarm + allow stop. Validating WORKTREE is a real directory (not just
-# non-empty) also defangs a corrupted/traversal value in the writable flag file
-# before it reaches handoff-launch.sh (Argus audit: untrusted state input).
+# non-empty) also defangs a corrupted value in the writable flag file before it
+# reaches handoff-launch.sh.
 if [ -z "$LANE" ] || [ -z "$HANDOFF_DOC" ] || [ -z "$WORKTREE" ] \
    || [ ! -f "$HANDOFF_DOC" ] || [ ! -d "$WORKTREE" ]; then
   rm -f "$FLAG" "$RETRY"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -116,7 +116,7 @@
           {
             "type": "command",
             "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/auto-handoff-stop.sh\"",
-            "timeout": 20
+            "timeout": 30
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -112,6 +112,11 @@
             "type": "command",
             "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/stop-guard.sh\"",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/auto-handoff-stop.sh\"",
+            "timeout": 20
           }
         ]
       }

--- a/.claude/skills/handoff/SKILL.md
+++ b/.claude/skills/handoff/SKILL.md
@@ -199,9 +199,9 @@ HANDOFF_PATH="$HANDOFF_DIR/session-handoff.md"   # multi-lane: append -<lane> be
 ```
 
 `.handoff-config` format (one `kb_dir=` line; use **forward slashes** so Git
-Bash resolves it; absolute path):
+Bash resolves it; absolute path — substitute your own KB location):
 ```
-kb_dir=D:/ShipOfTheseus/ShipOfTheseus-KB
+kb_dir=/absolute/path/to/your-project-KB
 ```
 No marker file ⇒ no KB ⇒ handoff falls back to `<workspace>/.handoff/`.
 

--- a/.claude/skills/handoff/SKILL.md
+++ b/.claude/skills/handoff/SKILL.md
@@ -23,12 +23,13 @@ handoff — nothing triggers automatically. Follow these steps precisely.
 > have actually run `bash scripts/handoff-launch.sh ...` (Step 5 Auto mode; a
 > bash script — on Windows it runs via Git Bash / the Bash tool) and seen it
 > **exit 0 with its success report** (currently `spawned new tab`). Printing
-> text and ending the turn = the bug the user keeps hitting. No hook invokes the
-> launcher for you (the registered Stop hook, `stop-guard.sh`, does not
-> auto-handoff) — the launcher call is YOUR responsibility and MUST be the final
-> substantive action of the turn (trivial state writes/cleanup may follow, but
-> no further task work). This behavioral rule is the stopgap for Issue #469; the
-> permanent mechanical fix (armed Stop-hook) is tracked there.
+> text and ending the turn = the bug the user keeps hitting. A mechanical safety
+> net now exists (`.claude/hooks/auto-handoff-stop.sh`, Issue #469): if you ARM
+> it first (Step 5-auto.0) and then stop while still armed, it runs the launcher
+> for you. But the net only catches you if you armed BEFORE printing the prompt,
+> and it does not replace your duty — the launcher call is still YOUR
+> responsibility and MUST be the final substantive action of the turn (trivial
+> state writes/cleanup may follow, but no further task work).
 >
 > Self-check before you end an auto-mode turn: "Did I run handoff-launch.sh and
 > see it succeed?" If no → you are not done; run it now.
@@ -82,14 +83,19 @@ You have the full conversation in context. Synthesize:
 
 ### Layer 2: Memory search (agentic)
 
-Search the project's auto-memory directory:
-```
-~/.claude/projects/<encoded_cwd>/memory/
-```
-Where `<encoded_cwd>` is the cwd with `:` `\` `/` replaced by `-`, leading
-`-` stripped.
+Two sources:
 
-Glob for `*.md`. Read previous handoffs, checkpoints, project memories.
+1. **Durable memory** — the auto-memory directory holds `MEMORY.md`,
+   `LANES.md`, and checkpoints:
+   ```
+   ~/.claude/projects/<encoded_cwd>/memory/
+   ```
+   Where `<encoded_cwd>` is the cwd with `:` `\` `/` replaced by `-`, leading
+   `-` stripped. Glob for `*.md`. Read checkpoints + project memories.
+2. **Previous handoff doc** — resolve via Step 2.0 (`<workspace>/.handoff/` or
+   `<kb_dir>/handoff/`) and read the prior `session-handoff*.md` there. Legacy
+   sessions may still have it under the memory dir above — read whichever
+   exists (prefer the Step 2.0 location).
 
 ### Layer 3: Project documentation (if present)
 
@@ -157,10 +163,51 @@ Pick **one** primary task + one secondary fallback. Never produce a menu.
 
 ## Step 2: Generate Handoff Document
 
-Write to:
+### Step 2.0: Resolve handoff storage location (run once; reused by Step 5)
+
+The handoff doc is **transient working state**, so it lives **with the
+workspace/KB — never** under the global `~/.claude/projects/<encoded>/memory/`
+dir (that path holds only durable memory: `MEMORY.md`, `LANES.md`, checkpoints).
+Resolve the storage dir in this order and reuse `$HANDOFF_PATH` everywhere:
+
+```bash
+# Order:
+#   1. <workspace>/.handoff-config (gitignored marker) with `kb_dir=<path>`
+#      pointing at an existing dir  → HANDOFF_DIR=<kb_dir>/handoff
+#   2. otherwise                    → HANDOFF_DIR=<workspace>/.handoff
+# Both dirs + .handoff-config itself are gitignored. Never committed.
+WORKSPACE="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+KB_DIR=""
+if [ -f "$WORKSPACE/.handoff-config" ]; then
+  KB_DIR=$(sed -n 's/^[[:space:]]*kb_dir[[:space:]]*=[[:space:]]*//p' \
+            "$WORKSPACE/.handoff-config" | head -1)
+  # Cleanup order matters: trailing whitespace FIRST, then quotes, then slashes
+  # (a trailing space after a closing quote would otherwise defeat quote-strip).
+  KB_DIR="${KB_DIR%"${KB_DIR##*[![:space:]]}"}"       # 1) strip trailing whitespace
+  KB_DIR="${KB_DIR%\"}"; KB_DIR="${KB_DIR#\"}"        # 2) strip wrapping quotes
+  KB_DIR=$(printf '%s' "$KB_DIR" | tr '\134' '/')     # 3) backslash → forward slash (octal \134; bash ${//\\} is unreliable)
+fi
+if [ -n "$KB_DIR" ] && [ -d "$KB_DIR" ]; then
+  HANDOFF_DIR="$KB_DIR/handoff"
+else
+  HANDOFF_DIR="$WORKSPACE/.handoff"
+fi
+mkdir -p "$HANDOFF_DIR"
+
+# Filename: main lane = session-handoff.md; named lane = session-handoff-<lane>.md
+HANDOFF_PATH="$HANDOFF_DIR/session-handoff.md"   # multi-lane: append -<lane> before .md
 ```
-~/.claude/projects/<encoded_cwd>/memory/session-handoff.md
+
+`.handoff-config` format (one `kb_dir=` line; use **forward slashes** so Git
+Bash resolves it; absolute path):
 ```
+kb_dir=D:/ShipOfTheseus/ShipOfTheseus-KB
+```
+No marker file ⇒ no KB ⇒ handoff falls back to `<workspace>/.handoff/`.
+
+### Step 2.1: Write the document
+
+Write to `$HANDOFF_PATH` (resolved above):
 
 ```markdown
 ---
@@ -270,7 +317,8 @@ old session — once the new session is spawned, the old session should
 itself a terminal event; the output is a stable snapshot that the next
 session (or the current session continuing) can pick up from. In either
 mode, nothing carries over automatically to the next session unless it
-goes through the written handoff document + auto-memory path.
+goes through the written handoff document (read via the SHORT_PROMPT's
+explicit `Read` directive in auto mode, or pasted by the user in manual mode).
 
 Confirm each:
 
@@ -290,8 +338,10 @@ Always do **both** of these — never skip either:
 
 1. **Output the Starting Prompt section directly in chat** — PRIMARY
    artifact. User pastes it verbatim as the first message of a new session.
-2. **Save the full handoff document** to the memory path above. The auto-
-   memory system will load it at next session start.
+2. **Save the full handoff document** to `$HANDOFF_PATH` (resolved in Step 2.0
+   — `<workspace>/.handoff/` or `<kb_dir>/handoff/`). The next session loads it
+   via the explicit `Read` directive in the SHORT_PROMPT (auto mode) or by the
+   user pasting the prompt (manual mode) — NOT via auto-memory injection.
 
 ### Manual mode (`/handoff` default)
 
@@ -310,6 +360,36 @@ running the launcher is the whole point of auto mode (see the ⚠️ banner at t
 top of this skill). This applies equally to an autorun/ralph/ultrawork run that
 was told to auto-handoff on completion: the loop's final substantive act MUST
 be the launcher call, not a printed prompt.
+
+#### Step 5-auto.0: ARM the mechanical safety net FIRST (Mercury #469)
+
+There is a Stop hook (`.claude/hooks/auto-handoff-stop.sh`) that mechanically
+runs the launcher if you stop while a handoff is *armed*. It is a safety net for
+exactly the recurring bug above — but it can only catch you if you **arm it
+before you print the prompt**. So, the moment you enter auto mode (right after
+Step 2 wrote the doc):
+
+1. Resolve `LANE_NAME`, `WORKTREE_PATH`, `HANDOFF_PATH` — run the resolution
+   block in the launch pattern below **now** (it needs no spawn).
+2. Write the arm flag (key=value; consumed + deleted by the Stop hook). This
+   snippet defines `REPO_ROOT` itself — do NOT rely on it being set by the later
+   launch snippet, which runs after this point:
+
+```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+mkdir -p "$REPO_ROOT/.mercury/state"
+{
+  printf 'lane=%s\n' "$LANE_NAME"
+  printf 'handoff_doc=%s\n' "$HANDOFF_PATH"
+  printf 'worktree=%s\n' "$WORKTREE_PATH"
+} > "$REPO_ROOT/.mercury/state/auto-handoff-armed"
+```
+
+Now even if you stop early, the new session still spawns. The arm flag lives in
+`.mercury/state/` (already gitignored) and is cleared on launch. This is the
+permanent mechanical fix for Issue #469 — but it does NOT excuse you from
+running the launcher yourself: arming is the net, the launcher call below is
+still your job (and it disarms atomically on success).
 
 After Step 5.1 + 5.2, and Pre-Termination Checklist passed:
 
@@ -398,8 +478,11 @@ WORKTREE_PATH="$WORKTREE_PATH_RAW"
 SHORT_PROMPT="[LANE=${LANE_NAME}] Continue from session handoff. Read ${HANDOFF_PATH} as your first action."
 ```
 
-`<encoded_cwd>` for the handoff doc path uses the same `encode_project_path()`
-logic referenced earlier (`:` `\` `/` → `-`, strip leading `-`).
+`$HANDOFF_PATH` is the location resolved in **Step 2.0** (`<workspace>/.handoff/`
+or `<kb_dir>/handoff/`, never the global memory dir). Shell variables do NOT
+persist across separate Bash tool calls — if Step 5 runs in a fresh shell,
+re-run the Step 2.0 resolution block first so `$HANDOFF_PATH` is set, or inline
+the concrete resolved path into the `--handoff-doc` argument below.
 
 **SHORT_PROMPT must remain free of `wt`/`tmux` metacharacters** —
 `;` (command separator), `&` (background), `|` (pipe), `\` outside quotes,
@@ -435,8 +518,14 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 bash "$REPO_ROOT/scripts/handoff-launch.sh" \
   --lane "$LANE_NAME" \
   --worktree "$WORKTREE_PATH" \
-  --handoff-doc "$HANDOFF_PATH"
+  --handoff-doc "$HANDOFF_PATH" \
+  && rm -f "$REPO_ROOT/.mercury/state/auto-handoff-armed"
 ```
+
+The `&& rm -f ...auto-handoff-armed` disarms the Step 5-auto.0 safety net
+**atomically** in the same command — on launcher success the flag is gone before
+you can yield, so the Stop hook sees no flag and does not double-spawn. If the
+launcher fails, the flag stays armed and the Stop hook handles the retry.
 
 This script:
 - Constructs SHORT_PROMPT canonically with `[LANE=<name>]` marker preserved
@@ -503,9 +592,10 @@ the auto path from Step 5 (auto mode).
   as the final substantive action. Ending the turn after only printing text is
   the #1 recurring auto-handoff bug (see top-of-skill banner).
 - Do NOT add automatic hooks for SessionEnd or PreCompact — handoff is
-  **explicit only**. (The reliable mechanical fix — an armed Stop-hook — is
-  tracked in Mercury Issue #469; until it lands, the behavioral rule above is
-  the stopgap.)
+  **explicit only**. The mechanical reliability fix is a *Stop* hook
+  (`.claude/hooks/auto-handoff-stop.sh`, Issue #469) that fires ONLY when auto
+  mode has explicitly armed it (Step 5-auto.0) — it never auto-handoffs an
+  un-armed session, so "explicit only" is preserved.
 - **Mode-scoped termination**: auto mode treats handoff as a terminal
   event for the old session (spawn new → /exit old). Manual mode does
   NOT terminate; the user decides. Never apply auto-mode termination to

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,11 @@ pnpm-debug.log*
 # Scratch / per-session ephemera (skill prompt files, audit outputs, etc.)
 .tmp/
 
+# handoff skill — transient session-handoff docs + local KB-pointer marker (#474)
+# handoff docs live with the workspace/KB, never in global ~/.claude; always gitignored.
+.handoff/
+.handoff-config
+
 # Environment / Secrets
 .env
 .env.*


### PR DESCRIPTION
@
## 概述

side lane 排查"为什么 `/handoff auto` 总是只打印文案、不自动拉起新 session"引出的两项根治改动。

## #474 — handoff doc 存储迁移到工作区/KB

**问题**:handoff doc 写在全局 `~/.claude/projects/<encoded>/memory/session-handoff.md` —— 项目专属工作态却堆在全局用户目录(概念耦合,SoT 等多项目尤其明显)。

**改动**:
- `SKILL.md` Step 2.0 路径解析:`<workspace>/.handoff-config`(gitignored marker,`kb_dir=`)→ `<kb>/handoff`;无 marker → `<workspace>/.handoff`。废弃全局 memory 路径。
- handoff(transient)与 durable memory 索引(`MEMORY.md`/`LANES.md`)解耦;两者 + marker 一律 gitignored。
- `.gitignore` 加 `.handoff/` + `.handoff-config`;Layer2/Step5/banner/Rules 同步。
- **安全性**:`grep -rl session-handoff ~/.claude/hooks ~/.claude/scripts` 为空 → 无 hook 硬依赖旧路径;新 session 靠 SHORT_PROMPT 显式 `Read` 兜底(SKILL.md 本就规定别依赖 hook 注入)。

**落点验证**:Mercury 无兄弟 KB → `.handoff/` fallback;SoT 有 `ShipOfTheseus-KB` → marker 指向 → `<KB>/handoff`。

## #469 — armed Stop-hook(永久机械解,替代 #470 纯行为止血)

**根因**:auto-handoff 无 hook 强制,唯一拉起路径是模型主动跑 launcher;模型易把"打印 prompt"当交付物就停。按用户 CLAUDE.md 原则,"结束时 X"的自动行为必须 hook 化。

**改动**:
- 新增 `.claude/hooks/auto-handoff-stop.sh`:auto 模式 arm 后若 agent 提前停 → 机械跑 `scripts/handoff-launch.sh` + disarm(模型B);launcher 失败 → block-once 让 agent 带上下文重试(模型A 兜底)。
- 注册到**项目级** `.claude/settings.json` Stop 链(用户级 Stop 为空 `[]` → 无需 #259 用户级 governance,走正常 PR)。
- `SKILL.md` Step 5-auto.0:打印 prompt **之前**先 arm(否则"打印完就停"兜不住);launcher 成功 `&& rm -f` 原子 disarm 防 double-spawn。
- 防护:retry 标记防循环(刻意**不用** stop_hook_active —— 它会被 stop-guard 的 block 污染)、mtime>120m staleness 守卫、staged 让位 stop-guard 改 **bypass-aware**、break-glass disarm。

## 验证

- **dual-verify**: Claude PASS + **Dual-verify Codex side: PASS**(3 轮:1H+2M → 修 → 1M → 修 → 0/0/0/0)。
- 路径解析 7 场景(无 marker / 正斜杠 / 引号+尾空格 / 反斜杠规范化 / 坏路径降级 / 无 kb_dir 行)全 PASS。
- hook 8 场景(成功 disarm / break-glass disarm / staleness / staged×interactive 让位 / staged×bypass 拉起 / 失败 block JSON / 防循环 / 无 flag no-op)全 PASS。
- 真 `handoff-launch.sh --dry-run` 确认参数接口 + 新 `.handoff/` 路径端到端贯通。

## 残余风险(soak 项,故 #469 保持 OPEN)

hook 从 Stop 子进程**真实 spawn `wt`** 未做活测(仅桩 + dry-run);代码路径与 skill 既有 launcher 调用一致(#377 dual-verified)。建议真实跑一次 `/handoff auto` 确认后再关 #469。

## 关闭

Closes #474
Refs #469

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@