### PR TITLE
docs(#476): hoist Closes/Refs to top of generated PR bodies + recommend top placement

### DIFF
--- a/.claude/skills/pr-flow/SKILL.md
+++ b/.claude/skills/pr-flow/SKILL.md
@@ -83,6 +83,14 @@ PR_ARGS=(
   --base "$BASE_BRANCH"
   --title "<type>(<scope>): description (#issue)"
   --body "$(cat <<'BODY'
+## Issue
+Closes #<issue>
+<!-- Issue reference FIRST so it survives any future token-clip in the kept HEAD
+     (Argus/pr-agent clips long PR bodies head-first; trailing refs get dropped).
+     Use "Refs #<issue>" instead of "Closes" when the issue should stay open after
+     merge. Pure chore/doc PRs with no functional change may omit this block
+     (see .pr_agent.toml rule 1). -->
+
 ## Summary
 - bullet points
 

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -6,8 +6,10 @@
 extra_instructions = """
 Mercury project review rules (MUST check every PR):
 
-1. **Issue reference**: PR description must contain Closes/Fixes/Resolves/Refs #N.
-   Flag as blocker if missing. Exception: pure chore/doc PRs with no functional code
+1. **Issue reference**: PR description must contain Closes/Fixes/Resolves/Refs #N,
+   preferably near the TOP of the body (a leading `## Issue` block) so the reference
+   survives any head-first token-clip of long descriptions. Flag as blocker if missing.
+   Exception: pure chore/doc PRs with no functional code
    changes (e.g., typo fixes, README updates) may omit the issue reference.
 
 2. **Modular design**: Every new feature must be independently detachable.


### PR DESCRIPTION
## Issue
Refs #476

## Summary
Defense-in-depth for #476 **Line C** (Argus clipped trailing Closes/Refs out of long PR bodies via `max_description_tokens`). Move the issue reference to the TOP of every generated PR body so it survives any future head-first token-clip in the kept HEAD.

- `.claude/skills/pr-flow/SKILL.md`: the gh-pr-create `--body` heredoc now leads with a `## Issue\nCloses #<issue>` block before `## Summary` (inline note on Refs-vs-Closes + the chore/doc exception). Previously the template had NO issue-ref block at all (ref lived only in the title placeholder) — this also closes a gap where a verbatim-template body could fail `pr-create-guard.sh`.
- `.pr_agent.toml` rule 1: keep the existing "description must contain" requirement (NOT broadened to title-only — dual-verify Codex flagged that as an enforcement bypass) and add a recommendation to place the ref near the TOP of the body.

## Scope / risk
Templates + docs only. No code path, no runtime behavior, no Argus deploy. `pr-create-guard.sh` already greps the whole gh command (title+body) so no hook change is needed.

## Test plan
- [x] `.pr_agent.toml` parses via `tomllib`
- [x] heredoc renders well-formed (`## Issue` before `## Summary`, BODY terminator at col 0)
- [x] dual-verify: Claude PASS; Codex 1 Low (rule-1 broadening) → fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)