### PR TITLE
feat(#479,#480): .claude/workflows/ 脚手架 + 4 编排模板 + 四原语选型矩阵 (P0 harness 现代化)

### DIFF
--- a/.claude/agents/main.md
+++ b/.claude/agents/main.md
@@ -45,3 +45,48 @@ User requests, dev receipts, acceptance verdicts, research summaries, design pro
 ## Output
 
 Task descriptions, review decisions, session summaries
+
+---
+
+## 编排升级:四原语选型矩阵 + budget-scaling
+
+> 立项 [#480](https://github.com/392fyc/Mercury/issues/480)(umbrella [#478](https://github.com/392fyc/Mercury/issues/478) harness 现代化 P0)· 护栏 [#385](https://github.com/392fyc/Mercury/issues/385) · 模板库 `.claude/workflows/README.md`
+>
+> Main 默认走线性 dev-pipeline(Main→Dev→Acceptance)。下表是**何时升级到更重编排**的判据 —— 不要因为「能并行」就盲目 fan-out,也不要因为默认线性就把该并行的大任务串起来跑。
+
+### 四原语选型矩阵
+
+| 原语 | 谁持有计划 | 中间结果在哪 | 规模 | Mercury 何时用 |
+|---|---|---|---|---|
+| **Subagents**(dev/acceptance/critic/research/design) | Main 逐轮决定 | Main context | 每轮几个 | 默认:well-scoped 任务、receipt 审查、acceptance flow |
+| **Skills**(autoresearch/dual-verify/pr-flow…) | Claude 跟提示 | Main context | 同 subagent | 已固化的重复流程,有触发词 |
+| **Agent Teams** | lead agent 逐轮 | 共享任务列表 | 少量长跑 peer | peer-to-peer 协作 PoC(承接 [#319](https://github.com/392fyc/Mercury/issues/319) CLOSED 可行性 + [#155](https://github.com/392fyc/Mercury/issues/155);需 `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`) |
+| **Workflows**(`.claude/workflows/*.js`) | **脚本本身** | **脚本变量** | **几十到几百 agent/run** | context 装不下 / 编排值得沉淀成可重跑脚本(见下「升级判据」) |
+
+**升级到 Workflow 的判据**:repo 级审计扫描、大规模迁移(数十+站点)、≥3 源交叉核查研究、多角度起草再裁决的硬计划、需对抗式验证滤除「看似对实则错」结论的审查。反之单文件改、1-2 源查证、机械单步 → 不升级,走 subagent/skill。完整触发方式 + 硬护栏见 CLAUDE.md §Ultracode 与 Dynamic Workflows。
+
+### budget-scaling 量化规则(agent 数 × call 数随任务复杂度伸缩)
+
+| 任务类型 | 配置 | 说明 |
+|---|---|---|
+| **事实核查 / 单点查证** | 1 agent × 3-10 calls | 单 research/document-specialist agent 多次 web 调用;不 fan-out |
+| **直接比较 / 选型** | 2-4 agent | 每个候选/视角一个 agent 并行,再 Main 综合 |
+| **复杂研究 / repo 级审计** | 10+ agent(Workflow) | fan-out + adversarial-verify;对齐 #385 fan-out 上限,被丢工作量必 log |
+
+预算可由 budget directive(`+500k` 等)动态伸缩:`const FLEET = budget.total ? Math.floor(budget.total / 100_000) : 5`。Workflow runtime 兜底 ≤16 并发 / 1000 agent per run。
+
+### 六大编排模式 — 一句话索引
+
+- **fan-out**:把工作切片,每片一个 agent 并行扫(repo 审计)。
+- **adversarial-verify**:每条 finding 派 N 个独立 skeptic 试图 refute,多数 refute 即杀(滤除 plausible-but-wrong)。
+- **tournament / judge-panel**:N 个独立方案 → 评审团打分 → 综合优胜 + 嫁接亚军亮点(硬计划)。
+- **generate-and-filter**:先广撒生成候选,再逐条过滤/投票存活(研究 claim 交叉核查)。
+- **classify-and-act**:先分类再按类分派不同处理(混合工作流)。
+- **loop-until-done**:未知规模发现类,循环派 finder 直到 K 轮无新增(大迁移收敛)。
+
+模式 ↔ 模板映射见 `.claude/workflows/README.md`。
+
+### 与 multi-lane / agent view 共存
+
+- Workflow 是**单 lane 内**的编排原语(main lane 跑 Workflow 不动 side-multi-lane #292 soak);Workflow 后台 run 与 lane-as-process 多 session 并行是两层正交机制。
+- 跨 lane / 后台 session 的 dispatch + 监控约定见 `.mercury/docs/guides/agent-view-dispatch.md`(Path B primary,Closes [#386](https://github.com/392fyc/Mercury/issues/386));Workflow 的 `/workflows` 进度视图与 agent view 的 background session 监控并行使用,互不替代。

--- a/.claude/workflows/README.md
+++ b/.claude/workflows/README.md
@@ -62,7 +62,7 @@ fan-out(`codebase-audit`)· adversarial-verify(`codebase-audit` 的 Verify / `ad
 2. **fan-out 设上限 + 不静默截断**:每个模板有显式 cap(`FAN_OUT_CAP`/`ANGLE_CAP`/`BATCH_CAP`/`MAX_ROUNDS`),被丢弃的工作量一律 `log()` 出来(静默截断会被误读成「全覆盖」)。
 3. **Haiku 路径 50K 硬顶**:若某 stage 路由到 haiku-tier(`game-researcher` 等),注入切片必须 ≤50K token(Haiku 4.5 是 200K ctx 硬 cliff)。模板默认继承会话 model 且只传路径,远低于此线。
 4. **Codex/GPT-5.5 路径 272K cliff**:越线一次整 session 计费翻倍 —— Workflow agent 跑 Claude 不直接受此约束,但若模板被改造去调 Codex 路径需重新评估。
-5. runtime 硬上限:≤16 并发 / 1000 agent per run(runaway 兜底)。
+5. runtime 硬上限:≤16 并发 / 1000 agent per run(runaway 兜底)。模板自身额外做**总量自限**:`codebase-audit` 与 `large-migration` 按 cap 组合算最坏 agent 数并钳制(`AGENT_BUDGET=800` 留余量),即使 operator 把 cap 调到上限也不会撞 1000 而被中途截断(migration 钳 `MAX_ROUNDS`、audit 钳 `MAX_FINDINGS`,触发时 `log()`)。
 
 ## Mercury 治理约束
 

--- a/.claude/workflows/README.md
+++ b/.claude/workflows/README.md
@@ -1,0 +1,72 @@
+# `.claude/workflows/` — Mercury Dynamic Workflow 模板库
+
+> 立项: Issue [#479](https://github.com/392fyc/Mercury/issues/479)(umbrella [#478](https://github.com/392fyc/Mercury/issues/478) harness 现代化 P0)
+> 护栏: [`.mercury/docs/research/context-strategy-2026-05.md`](../../.mercury/docs/research/context-strategy-2026-05.md)(#385,生效中)
+> 调查: [`.mercury/docs/research/harness-modernization-survey-2026-06.md`](../../.mercury/docs/research/harness-modernization-survey-2026-06.md)
+
+Dynamic Workflow 是 Claude Code 原生的「**确定性多 agent 编排**」原语:一段 JS 脚本把扇出/流水线/裁决写进代码,runtime 在后台跑数十到数百个 subagent,中间结果留在脚本变量里,主会话只收最终结果。本目录是 Mercury 把这一能力**固化进 repo** 的宿主 —— 项目级 `.claude/workflows/` 随 repo 分发,clone 即得。
+
+**环境要求**: Claude Code **v2.1.154+**(Dynamic Workflows + `args` 参数化);monorepo 多 `.claude/` 目录的「就近保存」行为另需 v2.1.178+。可用性按 `/config` 的 Dynamic workflows 开关;关闭后本目录模板与 `ultracode` 关键词均失效。来源: [code.claude.com/docs/en/workflows](https://code.claude.com/docs/en/workflows)。
+
+---
+
+## 何时用 Workflow(而非 subagent / skill / team)
+
+| | Subagents | Skills | Agent Teams | **Workflows** |
+|---|---|---|---|---|
+| 谁持有计划 | Claude 逐轮决定 | Claude 跟着提示 | lead agent 逐轮 | **脚本本身** |
+| 中间结果在哪 | Claude context | Claude context | 共享任务列表 | **脚本变量** |
+| 可复用的是 | worker 定义 | 指令 | team 定义 | **编排本身** |
+| 规模 | 每轮几个 | 同左 | 少量长跑 peer | **每次几十到几百 agent** |
+
+**判据**:当任务「一个会话的 context 装不下」或「值得把编排沉淀成可重跑脚本」时升级到 Workflow。典型:repo 级 bug 扫描、500 文件迁移、需多源交叉核查的研究、需多角度起草再裁决的硬计划。详见 `.claude/agents/main.md` §四原语选型矩阵(#480)。
+
+## 触发方式
+
+1. **单任务 opt-in**:prompt 里含关键词 `ultracode`(v2.1.160 前是 `workflow`),或自然语言「use a workflow / 用 workflow 跑」。
+2. **会话持久**:`/effort ultracode` = xhigh + 每个实质任务自动编排 Workflow。会话级,新会话重置;`/effort high` 退回。
+3. **复用已存模板**:`/<name>`(本目录每个脚本的 `meta.name` 即命令名)。bundled 的 `/deep-research` 同理。
+
+## 保存与复用约定
+
+- **手写模板**(如本目录 4 个):文件名 = `meta.name`,放 `.claude/workflows/<name>.js` → 直接 `/<name>` 调用。
+- **从运行保存**:跑出满意的一次后 `/workflows` → 选中 → 按 `s` → Tab 切换保存位置(`.claude/workflows/` 项目级随 repo / `~/.claude/workflows/` 个人级)→ Enter。
+- **同名优先级**:项目级 > 个人级。
+- **传参**:`/<name>` 后跟参数,脚本里读全局 `args`(字符串/数组/对象原样传入,无需解析)。每个 Mercury 模板都对 `args` 缺省做了优雅降级。
+- **后台 + 监控**:Workflow 默认后台跑,会话不阻塞;`/workflows` 看每 phase 的 agent 数 / token / 耗时,可暂停(`p`)/停止(`x`)/重启 agent(`r`);同会话内可 resume(已完成 agent 返缓存结果),退出 Claude Code 则下次重跑。
+
+---
+
+## Mercury 模板清单
+
+| 命令 | 模式 | 用途 |
+|---|---|---|
+| `/mercury-codebase-audit` | fan-out + adversarial-verify | repo 级多维度审计(security/correctness/resource),每条 finding 经对抗式核查存活才上报 |
+| `/mercury-multi-source-research` | multi-modal sweep + cross-check | 多角度 web 研究 + 逐条 claim 独立交叉核查 + 引用合成,替代 autoresearch 串行单 context;UNVERIFIED 显式标注 |
+| `/mercury-adversarial-plan-review` | judge-panel | N 个独立角度起草计划 → 对抗评审团打分 → 综合优胜方案 + 嫁接亚军亮点;只产计划,实现仍回 Main→dev |
+| `/mercury-large-migration` | loop-until-done | 数十到数百文件机械迁移,按文件归属并行改造(每 agent 独占一文件,工作树原地编辑)+ 逐文件验证 + 循环至收敛;edits 不 commit,由 operator 合并提交 |
+
+各模板的 `args` 入参见脚本顶部常量(如 `maxAngles` / `batchCap` / `contextPaths`)。
+
+### 六大编排模式 ↔ 模板
+
+fan-out(`codebase-audit`)· adversarial-verify(`codebase-audit` 的 Verify / `adversarial-plan-review` 的 Judge)· judge-panel/tournament(`adversarial-plan-review`)· generate-and-filter(`multi-source-research` 的 sweep→crosscheck)· classify-and-act(可组合)· loop-until-done(`large-migration`)。
+
+---
+
+## #385 护栏(所有模板必须遵守 — 改模板时核对)
+
+大规模 fan-out **不等于**「1M ctx 随便塞」。每个模板内嵌以下硬约束(脚本顶部注释 + 实现):
+
+1. **不 pre-inject 全量文档**:agent 拿到的是**路径 + 任务**,自己去 Read/Grep,绝不把整文件内容塞进 prompt。bulk injection 永久抢占 cache slot,即使物理装得下也浪费(#385 §4.5)。
+2. **fan-out 设上限 + 不静默截断**:每个模板有显式 cap(`FAN_OUT_CAP`/`ANGLE_CAP`/`BATCH_CAP`/`MAX_ROUNDS`),被丢弃的工作量一律 `log()` 出来(静默截断会被误读成「全覆盖」)。
+3. **Haiku 路径 50K 硬顶**:若某 stage 路由到 haiku-tier(`game-researcher` 等),注入切片必须 ≤50K token(Haiku 4.5 是 200K ctx 硬 cliff)。模板默认继承会话 model 且只传路径,远低于此线。
+4. **Codex/GPT-5.5 路径 272K cliff**:越线一次整 session 计费翻倍 —— Workflow agent 跑 Claude 不直接受此约束,但若模板被改造去调 Codex 路径需重新评估。
+5. runtime 硬上限:≤16 并发 / 1000 agent per run(runaway 兜底)。
+
+## Mercury 治理约束
+
+- **dual-verify 仍是合并门**:Workflow 产出的代码改动,提交前照样跑 `/dual-verify` + 走 PR 到 develop(Workflow 不绕过任何 hook 回归)。
+- **成本**:一次 run 可能比对话方式多用数倍 token。先在小切片上试(单目录 / 窄问题)估开销;`/workflows` 实时看 token。
+- **model**:每个 agent 用会话 model,除非脚本 `opts.model` 显式路由。大 run 前先核对 `/model`。
+- **不重写既有 skill**:autoresearch/dual-verify 等暂不全量改写为 Workflow(large effort);先用本模板库验证价值再渐进迁移(调查文档 §不建议吸收 #7)。

--- a/.claude/workflows/README.md
+++ b/.claude/workflows/README.md
@@ -32,7 +32,7 @@ Dynamic Workflow 是 Claude Code 原生的「**确定性多 agent 编排**」原
 - **手写模板**(如本目录 4 个):文件名 = `meta.name`,放 `.claude/workflows/<name>.js` → 直接 `/<name>` 调用。
 - **从运行保存**:跑出满意的一次后 `/workflows` → 选中 → 按 `s` → Tab 切换保存位置(`.claude/workflows/` 项目级随 repo / `~/.claude/workflows/` 个人级)→ Enter。
 - **同名优先级**:项目级 > 个人级。
-- **传参**:`/<name>` 后跟参数,脚本里读全局 `args`(字符串/数组/对象原样传入,无需解析)。每个 Mercury 模板都对 `args` 缺省做了优雅降级。
+- **传参**:`/<name>` 后跟参数,脚本里读全局 `args`(运行时把字符串/数组/对象**原样**传入,无需解析)。**注意**:`args` 的具体**形状是每个模板自定义的**(见各脚本顶部常量),不是每个模板都接受三种形状 —— 例如 research/plan-review/migration 接受「字符串 或 `{字段…}` 对象」,audit 接受对象;传入不符合该模板契约的形状(如给只认字符串/对象的模板传顶层数组)会落入缺参分支并打印用法提示。每个模板都对缺省/不符做了优雅降级(返回 error + hint,不抛错)。
 - **后台 + 监控**:Workflow 默认后台跑,会话不阻塞;`/workflows` 看每 phase 的 agent 数 / token / 耗时,可暂停(`p`)/停止(`x`)/重启 agent(`r`);同会话内可 resume(已完成 agent 返缓存结果),退出 Claude Code 则下次重跑。
 
 ---

--- a/.claude/workflows/mercury-adversarial-plan-review.js
+++ b/.claude/workflows/mercury-adversarial-plan-review.js
@@ -26,9 +26,9 @@ if (!task) {
 const contextPaths = [].concat((args && args.contextPaths) || [])
 const ctxLine = contextPaths.length ? `\nRead these for context (do not assume their contents): ${contextPaths.join(', ')}` : ''
 
-// Clamped to a hard ceiling so the #385 fan-out cap holds even under an oversized override
-// (also bounded by the ANGLES array length below).
-const ANGLE_CAP = Math.min((args && args.maxAngles) || 4, 6)
+// Clamped to [1, ceiling] so the #385 fan-out cap holds under an oversized override AND a
+// negative/zero value can't silently no-op the stage (also bounded by ANGLES length below).
+const ANGLE_CAP = Math.max(1, Math.min((args && args.maxAngles) || 4, 6))
 const ANGLES = [
   { key: 'mvp-first', lens: 'ship the smallest correct thing first; defer everything deferrable' },
   { key: 'risk-first', lens: 'minimize blast radius and irreversibility; prioritize rollback and guardrails' },

--- a/.claude/workflows/mercury-adversarial-plan-review.js
+++ b/.claude/workflows/mercury-adversarial-plan-review.js
@@ -22,10 +22,13 @@ if (!task) {
   return { error: 'missing task' }
 }
 // Optional: paths the drafters should read for context (lean — paths only, not contents).
-const contextPaths = (args && args.contextPaths) || []
+// Normalize to an array so a string or single value doesn't throw on .join below.
+const contextPaths = [].concat((args && args.contextPaths) || [])
 const ctxLine = contextPaths.length ? `\nRead these for context (do not assume their contents): ${contextPaths.join(', ')}` : ''
 
-const ANGLE_CAP = (args && args.maxAngles) || 4
+// Clamped to a hard ceiling so the #385 fan-out cap holds even under an oversized override
+// (also bounded by the ANGLES array length below).
+const ANGLE_CAP = Math.min((args && args.maxAngles) || 4, 6)
 const ANGLES = [
   { key: 'mvp-first', lens: 'ship the smallest correct thing first; defer everything deferrable' },
   { key: 'risk-first', lens: 'minimize blast radius and irreversibility; prioritize rollback and guardrails' },

--- a/.claude/workflows/mercury-adversarial-plan-review.js
+++ b/.claude/workflows/mercury-adversarial-plan-review.js
@@ -49,7 +49,9 @@ const PLAN_SCHEMA = {
 
 const SCORE_SCHEMA = {
   type: 'object',
-  required: ['scores', 'overall', 'killer'],
+  // bestIdea is required: the synthesis grafts it from runners-up, so a missing value would
+  // inject `undefined` into the synthesis prompt and degrade output.
+  required: ['scores', 'overall', 'killer', 'bestIdea'],
   properties: {
     scores: {
       type: 'object',

--- a/.claude/workflows/mercury-adversarial-plan-review.js
+++ b/.claude/workflows/mercury-adversarial-plan-review.js
@@ -1,0 +1,112 @@
+export const meta = {
+  name: 'mercury-adversarial-plan-review',
+  description: 'Draft a plan from several independent angles, score them with an adversarial judge panel, then synthesize from the winner while grafting the best ideas from runners-up',
+  whenToUse: 'A hard, wide-solution-space decision worth more than one pass: architecture choice, migration strategy, risky refactor plan. Beats one-attempt-iterated because the judge panel surfaces failure modes a single drafter misses. Hands the synthesized plan back to Main for dispatch — does NOT implement.',
+  phases: [
+    { title: 'Draft', detail: 'independent plans, each from a different angle' },
+    { title: 'Judge', detail: 'adversarial panel scores every draft' },
+    { title: 'Synthesize', detail: 'winner + grafted best ideas + residual risks' },
+  ],
+}
+
+// ── Mercury guardrails (#385) ──
+// 1. LEAN DISPATCH: drafters/judges are given the task statement + paths to read, not
+//    the full contents of context files. Each agent reads the cited files itself.
+// 2. ANGLE_CAP bounds how many independent drafts are produced.
+// 3. Read-only: this workflow produces a plan + risk analysis. Implementation stays with
+//    Main -> dev (CLAUDE.md: never self-approve; authoring and review are separate passes).
+
+const task = (args && (args.task || args.question)) || (typeof args === 'string' ? args : null)
+if (!task) {
+  log('No task/plan provided. Pass one via args, e.g. /mercury-adversarial-plan-review "how should we shard the event store?"')
+  return { error: 'missing task' }
+}
+// Optional: paths the drafters should read for context (lean — paths only, not contents).
+const contextPaths = (args && args.contextPaths) || []
+const ctxLine = contextPaths.length ? `\nRead these for context (do not assume their contents): ${contextPaths.join(', ')}` : ''
+
+const ANGLE_CAP = (args && args.maxAngles) || 4
+const ANGLES = [
+  { key: 'mvp-first', lens: 'ship the smallest correct thing first; defer everything deferrable' },
+  { key: 'risk-first', lens: 'minimize blast radius and irreversibility; prioritize rollback and guardrails' },
+  { key: 'user-first', lens: 'optimize the end-user / operator experience and observable behavior' },
+  { key: 'maintenance-first', lens: 'optimize long-term maintainability, modularity, and detachability' },
+].slice(0, ANGLE_CAP)
+
+const PLAN_SCHEMA = {
+  type: 'object',
+  required: ['summary', 'steps', 'risks'],
+  properties: {
+    summary: { type: 'string' },
+    steps: { type: 'array', items: { type: 'string' } },
+    risks: { type: 'array', items: { type: 'string' } },
+    tradeoffs: { type: 'string' },
+  },
+}
+
+const SCORE_SCHEMA = {
+  type: 'object',
+  required: ['scores', 'overall', 'killer'],
+  properties: {
+    scores: {
+      type: 'object',
+      properties: {
+        correctness: { type: 'number' },
+        risk: { type: 'number' },
+        feasibility: { type: 'number' },
+        maintainability: { type: 'number' },
+      },
+    },
+    overall: { type: 'number', description: '0-10 weighted overall' },
+    killer: { type: 'string', description: 'the single strongest reason this plan could fail' },
+    bestIdea: { type: 'string', description: 'the one idea from this plan worth keeping even if it loses' },
+  },
+}
+
+phase('Draft')
+const drafts = await parallel(ANGLES.map(a => () =>
+  agent(
+    `Draft a concrete plan for this task through the **${a.key}** lens (${a.lens}):\n"${task}"${ctxLine}\n` +
+    `Return a summary, ordered steps, explicit risks, and the key trade-off. Be specific and opinionated for this lens.`,
+    { label: `draft:${a.key}`, phase: 'Draft', schema: PLAN_SCHEMA, agentType: 'design' }
+  ).then(p => ({ angle: a.key, plan: p }))
+))
+const validDrafts = drafts.filter(d => d && d.plan)
+log(`${validDrafts.length} drafts produced`)
+
+phase('Judge')
+// Each draft is scored by an independent adversarial judge (different lane than the
+// drafter — no self-congratulation). Judges are told to hunt for the killer failure mode.
+const judged = await parallel(validDrafts.map(d => () =>
+  agent(
+    `Adversarially evaluate this plan for the task: "${task}".\n` +
+    `Plan (${d.angle}): ${JSON.stringify(d.plan)}\n` +
+    `Score correctness/risk/feasibility/maintainability (0-10 each) and an overall. ` +
+    `Identify the single strongest reason it could FAIL (killer), and the one idea worth keeping even if it loses (bestIdea). Be skeptical.`,
+    { label: `judge:${d.angle}`, phase: 'Judge', schema: SCORE_SCHEMA, agentType: 'critic' }
+  ).then(s => ({ ...d, score: s }))
+))
+
+phase('Synthesize')
+const scored = judged.filter(j => j && j.score).sort((a, b) => (b.score.overall || 0) - (a.score.overall || 0))
+if (!scored.length) return { task, error: 'no scored drafts' }
+const winner = scored[0]
+const runnersUp = scored.slice(1)
+
+const synthesis = await agent(
+  `Synthesize the final recommended plan for: "${task}".\n` +
+  `Winning approach (${winner.angle}, overall ${winner.score.overall}): ${JSON.stringify(winner.plan)}\n` +
+  `Killer risk to neutralize: ${winner.score.killer}\n` +
+  `Best ideas to graft from runners-up: ${runnersUp.map(r => `[${r.angle}] ${r.score.bestIdea}`).join(' | ') || '(none)'}\n` +
+  `Produce one coherent plan that takes the winner as the spine, grafts the best runner-up ideas, and explicitly addresses the killer risk. ` +
+  `End with residual risks that survive synthesis.`,
+  { label: 'synthesize', phase: 'Synthesize', schema: PLAN_SCHEMA, agentType: 'design' }
+)
+
+return {
+  task,
+  winningAngle: winner.angle,
+  scoreboard: scored.map(s => ({ angle: s.angle, overall: s.score.overall, killer: s.score.killer })),
+  recommendedPlan: synthesis,
+  note: 'Plan only — dispatch implementation to dev via Main; do not self-implement.',
+}

--- a/.claude/workflows/mercury-codebase-audit.js
+++ b/.claude/workflows/mercury-codebase-audit.js
@@ -28,8 +28,10 @@ const DIMENSIONS = (args && args.dimensions) || [
 // Cap how many modules Discover may feed downstream, and how many findings per
 // dimension flow into the (more expensive) verify stage. Both are enforced in code
 // below (not just requested of the agent) and dropped overflow is log()'d.
-const MODULE_CAP = (args && args.moduleCap) || 60
-const MAX_FINDINGS = (args && args.maxFindings) || 40
+// Operator-overridable but clamped to a hard ceiling so the #385 fan-out cap holds even
+// under an oversized override.
+const MODULE_CAP = Math.min((args && args.moduleCap) || 60, 200)
+const MAX_FINDINGS = Math.min((args && args.maxFindings) || 40, 100)
 
 const FINDINGS_SCHEMA = {
   type: 'object',

--- a/.claude/workflows/mercury-codebase-audit.js
+++ b/.claude/workflows/mercury-codebase-audit.js
@@ -36,7 +36,14 @@ if (requestedDimensions.length > DIMENSIONS.length) log(`Dropped ${requestedDime
 // flow into the (more expensive) verify stage. Clamped to [1, ceiling] and enforced in code
 // (not just requested of the agent); dropped overflow is log()'d.
 const MODULE_CAP = Math.max(1, Math.min((args && args.moduleCap) || 60, 200))
-const MAX_FINDINGS = Math.max(1, Math.min((args && args.maxFindings) || 40, 100))
+// Worst-case agents ≈ 1 (Discover) + D (Audit) + D*MAX_FINDINGS (Verify). Clamp MAX_FINDINGS
+// so that total stays under the runtime's 1000-agent hard cap (AGENT_BUDGET margin), keeping
+// the documented "≤1000 agents" guardrail self-consistent even at the max cap combination.
+const AGENT_BUDGET = 800
+const _verifyPerDim = Math.max(1, Math.floor((AGENT_BUDGET - 1 - DIMENSIONS.length) / DIMENSIONS.length))
+const _maxFindings = Math.max(1, Math.min((args && args.maxFindings) || 40, 100))
+const MAX_FINDINGS = Math.min(_maxFindings, _verifyPerDim)
+if (MAX_FINDINGS < _maxFindings) log(`MAX_FINDINGS clamped ${_maxFindings}->${MAX_FINDINGS} to keep total agents under the ${AGENT_BUDGET}-agent budget`)
 
 const FINDINGS_SCHEMA = {
   type: 'object',
@@ -122,12 +129,14 @@ const verified = await pipeline(
 )
 
 phase('Report')
-// Dedup by file+title so the same issue surfaced by two dimensions is reported once
-// (matches the Report phase's "dedup survivors" contract), then sort by severity.
+// Dedup so the same issue surfaced by two dimensions is reported once (matches the Report
+// phase's "dedup survivors" contract), then sort by severity. The key includes an evidence
+// snippet so two DIFFERENT issues that share a file+title (e.g., same check missing at two
+// locations) are NOT merged — `file` is path:line, but evidence disambiguates further.
 const seen = new Set()
 const confirmed = verified.flat().filter(Boolean)
   .filter(f => f.verdict && f.verdict.isReal)
-  .filter(f => { const k = `${f.file}::${f.title}`; if (seen.has(k)) return false; seen.add(k); return true })
+  .filter(f => { const k = `${f.file}::${f.title}::${(f.evidence || '').slice(0, 60)}`; if (seen.has(k)) return false; seen.add(k); return true })
 const order = { high: 0, medium: 1, low: 2 }
 confirmed.sort((a, b) => (order[a.severity] ?? 3) - (order[b.severity] ?? 3))
 log(`${confirmed.length} confirmed findings after adversarial verification + dedup`)

--- a/.claude/workflows/mercury-codebase-audit.js
+++ b/.claude/workflows/mercury-codebase-audit.js
@@ -111,10 +111,15 @@ const verified = await pipeline(
 )
 
 phase('Report')
-const confirmed = verified.flat().filter(Boolean).filter(f => f.verdict && f.verdict.isReal)
+// Dedup by file+title so the same issue surfaced by two dimensions is reported once
+// (matches the Report phase's "dedup survivors" contract), then sort by severity.
+const seen = new Set()
+const confirmed = verified.flat().filter(Boolean)
+  .filter(f => f.verdict && f.verdict.isReal)
+  .filter(f => { const k = `${f.file}::${f.title}`; if (seen.has(k)) return false; seen.add(k); return true })
 const order = { high: 0, medium: 1, low: 2 }
 confirmed.sort((a, b) => (order[a.severity] ?? 3) - (order[b.severity] ?? 3))
-log(`${confirmed.length} confirmed findings after adversarial verification`)
+log(`${confirmed.length} confirmed findings after adversarial verification + dedup`)
 
 return {
   target,

--- a/.claude/workflows/mercury-codebase-audit.js
+++ b/.claude/workflows/mercury-codebase-audit.js
@@ -1,0 +1,123 @@
+export const meta = {
+  name: 'mercury-codebase-audit',
+  description: 'Fan-out audit of a codebase across dimensions, with adversarial verification of each finding before it is reported',
+  whenToUse: 'A repo-wide sweep that one conversation cannot hold: security/correctness/perf audit across many files. Each finding is adversarially verified so plausible-but-wrong findings are filtered out.',
+  phases: [
+    { title: 'Discover', detail: 'enumerate the audit work-list (capped)' },
+    { title: 'Audit', detail: 'one agent per dimension — reads files itself' },
+    { title: 'Verify', detail: 'adversarial skeptics refute each finding' },
+    { title: 'Report', detail: 'dedup survivors + synthesize' },
+  ],
+}
+
+// ── Mercury guardrails (see .mercury/docs/research/context-strategy-2026-05.md, #385) ──
+// 1. LEAN DISPATCH: agents are given PATHS + a task, never the full file contents.
+//    The agent reads what it needs itself — no bulk pre-injection into the prompt.
+// 2. FAN-OUT CAP: the audit work-list is bounded; anything dropped is log()'d, never
+//    silently truncated (a silent cap reads as "covered everything" when it didn't).
+// 3. If a stage is ever routed to a haiku-tier model, keep its injected slice <= 50K
+//    tokens (Haiku 4.5 is a 200K-ctx hard cliff). These templates inherit the session
+//    model and pass only paths, so they stay well under that.
+
+const target = (args && args.target) || '.'
+const DIMENSIONS = (args && args.dimensions) || [
+  { key: 'security', prompt: 'injection, authz/authn gaps, unsafe deserialization, secrets in code, SSRF, path traversal' },
+  { key: 'correctness', prompt: 'logic defects, off-by-one, null/undefined handling, race conditions, error-swallowing' },
+  { key: 'resource', prompt: 'unbounded loops/allocations, leaked handles, N+1 queries, missing timeouts/back-pressure' },
+]
+// Cap how many modules Discover may feed downstream, and how many findings per
+// dimension flow into the (more expensive) verify stage. Both are enforced in code
+// below (not just requested of the agent) and dropped overflow is log()'d.
+const MODULE_CAP = (args && args.moduleCap) || 60
+const MAX_FINDINGS = (args && args.maxFindings) || 40
+
+const FINDINGS_SCHEMA = {
+  type: 'object',
+  required: ['findings'],
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['title', 'file', 'severity', 'evidence'],
+        properties: {
+          title: { type: 'string' },
+          file: { type: 'string', description: 'path:line' },
+          severity: { type: 'string', enum: ['high', 'medium', 'low'] },
+          evidence: { type: 'string', description: 'concrete code evidence, not speculation' },
+        },
+      },
+    },
+  },
+}
+
+const VERDICT_SCHEMA = {
+  type: 'object',
+  required: ['isReal', 'reason'],
+  properties: {
+    isReal: { type: 'boolean' },
+    reason: { type: 'string' },
+  },
+}
+
+phase('Discover')
+const inventory = await agent(
+  `Enumerate the audit work-list for target \`${target}\`. Use Glob/Grep to list the source modules/directories worth auditing. ` +
+  `Do NOT read file bodies in full — return a structured list of paths + a one-line role for each. Cap the list at the ${MODULE_CAP} highest-signal entries; ` +
+  `if you had to drop entries, say how many.`,
+  { phase: 'Discover', schema: {
+    type: 'object',
+    required: ['modules'],
+    properties: {
+      modules: { type: 'array', items: { type: 'object', required: ['path', 'role'], properties: { path: { type: 'string' }, role: { type: 'string' } } } },
+      droppedCount: { type: 'number' },
+    },
+  } }
+)
+const rawModules = (inventory && inventory.modules) || []
+// Enforce MODULE_CAP in code (don't trust the agent to honor the instruction), and
+// surface every dropped module so partial coverage never reads as full coverage.
+const modules = rawModules.slice(0, MODULE_CAP)
+const overflow = rawModules.length - modules.length + ((inventory && inventory.droppedCount) || 0)
+if (overflow > 0) log(`Discover capped at ${MODULE_CAP} modules — ${overflow} lower-signal modules dropped (fan-out cap)`)
+log(`Auditing ${modules.length} modules across ${DIMENSIONS.length} dimensions`)
+const moduleList = modules.map(m => `- ${m.path} (${m.role})`).join('\n')
+
+// Pipeline: each dimension audits as soon as its findings are in, then each finding is
+// adversarially verified — dimension B keeps auditing while dimension A's findings verify.
+const verified = await pipeline(
+  DIMENSIONS,
+  d => agent(
+    `Audit target \`${target}\` for the **${d.key}** dimension: ${d.prompt}. ` +
+    `These are the modules in scope (read the ones relevant to this dimension yourself; do not assume their contents):\n${moduleList}\n` +
+    `Return only findings backed by concrete code evidence with a path:line citation.`,
+    { label: `audit:${d.key}`, phase: 'Audit', schema: FINDINGS_SCHEMA }
+  ).then(r => {
+    const all = (r && r.findings) || []
+    const kept = all.slice(0, MAX_FINDINGS)
+    if (all.length > kept.length) log(`${d.key}: ${all.length - kept.length} findings dropped at MAX_FINDINGS=${MAX_FINDINGS} (rerun narrower to verify them)`)
+    return { dimension: d.key, findings: kept }
+  }),
+  res => parallel((res.findings || []).map(f => () =>
+    agent(
+      `Adversarially verify this ${res.dimension} finding. Read the cited code and try to REFUTE it. ` +
+      `Default to isReal=false if the evidence does not clearly hold.\n` +
+      `Finding: ${f.title}\nFile: ${f.file}\nClaimed evidence: ${f.evidence}`,
+      { label: `verify:${f.file}`, phase: 'Verify', schema: VERDICT_SCHEMA }
+    ).then(v => ({ ...f, dimension: res.dimension, verdict: v }))
+  ))
+)
+
+phase('Report')
+const confirmed = verified.flat().filter(Boolean).filter(f => f.verdict && f.verdict.isReal)
+const order = { high: 0, medium: 1, low: 2 }
+confirmed.sort((a, b) => (order[a.severity] ?? 3) - (order[b.severity] ?? 3))
+log(`${confirmed.length} confirmed findings after adversarial verification`)
+
+return {
+  target,
+  dimensions: DIMENSIONS.map(d => d.key),
+  modulesAudited: modules.length,
+  confirmedCount: confirmed.length,
+  findings: confirmed,
+}

--- a/.claude/workflows/mercury-codebase-audit.js
+++ b/.claude/workflows/mercury-codebase-audit.js
@@ -29,7 +29,18 @@ const DEFAULT_DIMENSIONS = [
 // must be capped too (not just the inner module/finding fan-outs) or an oversized override
 // spawns arbitrary audit lanes. Cap + log dropped (#385: every fan-out is bounded).
 const DIMENSION_CAP = Math.max(1, Math.min((args && args.dimensionCap) || 8, 12))
-const requestedDimensions = (args && Array.isArray(args.dimensions) && args.dimensions.length) ? args.dimensions : DEFAULT_DIMENSIONS
+// Normalize caller-supplied dimensions: accept a non-empty string (coerced to {key, prompt})
+// or an object with string key+prompt; drop anything malformed so a bad override can't
+// inject `undefined` into audit prompts. Fall back to defaults if nothing valid remains.
+function normDimension(d) {
+  if (typeof d === 'string' && d.trim()) return { key: d.trim().slice(0, 40), prompt: d.trim() }
+  if (d && typeof d.key === 'string' && d.key.trim() && typeof d.prompt === 'string' && d.prompt.trim()) return { key: d.key.trim(), prompt: d.prompt.trim() }
+  return null
+}
+const suppliedDimensions = (args && Array.isArray(args.dimensions)) ? args.dimensions : []
+const normalizedDimensions = suppliedDimensions.map(normDimension).filter(Boolean)
+if (suppliedDimensions.length > normalizedDimensions.length) log(`Dropped ${suppliedDimensions.length - normalizedDimensions.length} malformed dimension entries (need a non-empty string or {key, prompt})`)
+const requestedDimensions = normalizedDimensions.length ? normalizedDimensions : DEFAULT_DIMENSIONS
 const DIMENSIONS = requestedDimensions.slice(0, DIMENSION_CAP)
 if (requestedDimensions.length > DIMENSIONS.length) log(`Dropped ${requestedDimensions.length - DIMENSIONS.length} dimensions beyond DIMENSION_CAP=${DIMENSION_CAP}`)
 // Cap how many modules Discover may feed downstream, and how many findings per dimension
@@ -37,8 +48,8 @@ if (requestedDimensions.length > DIMENSIONS.length) log(`Dropped ${requestedDime
 // (not just requested of the agent); dropped overflow is log()'d.
 const MODULE_CAP = Math.max(1, Math.min((args && args.moduleCap) || 60, 200))
 // Worst-case agents ≈ 1 (Discover) + D (Audit) + D*MAX_FINDINGS (Verify). Clamp MAX_FINDINGS
-// so that total stays under the runtime's 1000-agent hard cap (AGENT_BUDGET margin), keeping
-// the documented "≤1000 agents" guardrail self-consistent even at the max cap combination.
+// so that worst case is <= AGENT_BUDGET (800), leaving a ~200 margin under the runtime's
+// 1000-agent hard cap, keeping the documented guardrail self-consistent at the max override.
 const AGENT_BUDGET = 800
 const _verifyPerDim = Math.max(1, Math.floor((AGENT_BUDGET - 1 - DIMENSIONS.length) / DIMENSIONS.length))
 const _maxFindings = Math.max(1, Math.min((args && args.maxFindings) || 40, 100))

--- a/.claude/workflows/mercury-codebase-audit.js
+++ b/.claude/workflows/mercury-codebase-audit.js
@@ -20,18 +20,23 @@ export const meta = {
 //    model and pass only paths, so they stay well under that.
 
 const target = (args && args.target) || '.'
-const DIMENSIONS = (args && args.dimensions) || [
+const DEFAULT_DIMENSIONS = [
   { key: 'security', prompt: 'injection, authz/authn gaps, unsafe deserialization, secrets in code, SSRF, path traversal' },
   { key: 'correctness', prompt: 'logic defects, off-by-one, null/undefined handling, race conditions, error-swallowing' },
   { key: 'resource', prompt: 'unbounded loops/allocations, leaked handles, N+1 queries, missing timeouts/back-pressure' },
 ]
-// Cap how many modules Discover may feed downstream, and how many findings per
-// dimension flow into the (more expensive) verify stage. Both are enforced in code
-// below (not just requested of the agent) and dropped overflow is log()'d.
-// Operator-overridable but clamped to a hard ceiling so the #385 fan-out cap holds even
-// under an oversized override.
-const MODULE_CAP = Math.min((args && args.moduleCap) || 60, 200)
-const MAX_FINDINGS = Math.min((args && args.maxFindings) || 40, 100)
+// The dimensions list is itself the OUTER fan-out, so a caller-supplied `args.dimensions`
+// must be capped too (not just the inner module/finding fan-outs) or an oversized override
+// spawns arbitrary audit lanes. Cap + log dropped (#385: every fan-out is bounded).
+const DIMENSION_CAP = Math.max(1, Math.min((args && args.dimensionCap) || 8, 12))
+const requestedDimensions = (args && Array.isArray(args.dimensions) && args.dimensions.length) ? args.dimensions : DEFAULT_DIMENSIONS
+const DIMENSIONS = requestedDimensions.slice(0, DIMENSION_CAP)
+if (requestedDimensions.length > DIMENSIONS.length) log(`Dropped ${requestedDimensions.length - DIMENSIONS.length} dimensions beyond DIMENSION_CAP=${DIMENSION_CAP}`)
+// Cap how many modules Discover may feed downstream, and how many findings per dimension
+// flow into the (more expensive) verify stage. Clamped to [1, ceiling] and enforced in code
+// (not just requested of the agent); dropped overflow is log()'d.
+const MODULE_CAP = Math.max(1, Math.min((args && args.moduleCap) || 60, 200))
+const MAX_FINDINGS = Math.max(1, Math.min((args && args.maxFindings) || 40, 100))
 
 const FINDINGS_SCHEMA = {
   type: 'object',
@@ -82,6 +87,12 @@ const rawModules = (inventory && inventory.modules) || []
 const modules = rawModules.slice(0, MODULE_CAP)
 const overflow = rawModules.length - modules.length + ((inventory && inventory.droppedCount) || 0)
 if (overflow > 0) log(`Discover capped at ${MODULE_CAP} modules — ${overflow} lower-signal modules dropped (fan-out cap)`)
+// Short-circuit on an empty work-list: otherwise every dimension fans out with an empty
+// scope and an agent could ignore it and scan the whole repo, bypassing the module cap.
+if (!modules.length) {
+  log(`Discover found no auditable modules for \`${target}\` — skipping audit`)
+  return { target, dimensions: DIMENSIONS.map(d => d.key), modulesAudited: 0, confirmedCount: 0, findings: [] }
+}
 log(`Auditing ${modules.length} modules across ${DIMENSIONS.length} dimensions`)
 const moduleList = modules.map(m => `- ${m.path} (${m.role})`).join('\n')
 

--- a/.claude/workflows/mercury-large-migration.js
+++ b/.claude/workflows/mercury-large-migration.js
@@ -28,8 +28,20 @@ if (!rule) {
   return { error: 'missing migration rule' }
 }
 
-const BATCH_CAP = (args && args.batchCap) || 12      // files transformed per round
-const MAX_ROUNDS = (args && args.maxRounds) || 5     // loop-until-dry safety bound
+// Caps are operator-overridable via args but clamped to a hard ceiling, so the #385
+// "explicit upper bound" guardrail holds even when a caller passes an oversized value.
+const BATCH_CAP = Math.min((args && args.batchCap) || 12, 50)   // files transformed per round
+const MAX_ROUNDS = Math.min((args && args.maxRounds) || 5, 20)  // loop-until-dry safety bound
+
+// The script has no filesystem access, so this is a string-level guard: keep migration
+// inside the repo by rejecting absolute paths (POSIX `/`, Windows drive/UNC) and any `..`
+// traversal segment in a discovered path. Defense-in-depth — the agent's own tool
+// allowlist is the real boundary, but a copyable template should not blindly trust paths.
+function isSafeRelPath(p) {
+  if (typeof p !== 'string' || !p) return false
+  if (p.startsWith('/') || p.startsWith('\\') || /^[A-Za-z]:/.test(p)) return false
+  return !p.replace(/\\/g, '/').split('/').some(seg => seg === '..')
+}
 
 const FILES_SCHEMA = {
   type: 'object',
@@ -57,6 +69,7 @@ const VERIFY_SCHEMA = {
 
 const patternHint = pattern ? ` within \`${pattern}\`` : ''
 const completed = []
+const completedSet = new Set()   // dedup discovered files against ones already migrated
 const failures = []
 let round = 0
 let remaining = 0
@@ -71,11 +84,17 @@ while (round < MAX_ROUNDS) {
     { label: `discover:r${round}`, phase: 'Discover', schema: FILES_SCHEMA }
   )
   const rawFiles = (found && found.files) || []
-  const files = rawFiles.slice(0, BATCH_CAP)
-  // If Discover over-returns past BATCH_CAP, the extras are NOT lost: they go un-migrated
+  // Drop unsafe paths and already-migrated files BEFORE the per-round cap, so the cap
+  // budgets real remaining work rather than duplicates or out-of-repo paths. Without the
+  // dedup, a Discover that re-returns a completed file could re-migrate it and burn rounds.
+  const candidates = rawFiles.filter(x => x && isSafeRelPath(x.file) && !completedSet.has(x.file))
+  const droppedBad = rawFiles.length - candidates.length
+  if (droppedBad > 0) log(`Round ${round}: dropped ${droppedBad} discovered entries (unsafe path or already-migrated)`)
+  const files = candidates.slice(0, BATCH_CAP)
+  // If valid candidates exceed BATCH_CAP, the extras are NOT lost: they go un-migrated
   // this round and the loop re-discovers them next round. Log it so the cap is never a
   // silent drop (consistent with the audit template's overflow accounting).
-  const overReturned = rawFiles.length - files.length
+  const overReturned = candidates.length - files.length
   if (overReturned > 0) log(`Round ${round}: Discover over-returned — ${overReturned} files beyond BATCH_CAP=${BATCH_CAP} deferred (counted in remaining; loop re-discovers them)`)
   // Fold over-returned files into `remaining` so the round-cap boundary cannot exit with
   // "Converged / remainingEstimate: 0" while sliced-off files are still un-migrated. The
@@ -104,7 +123,7 @@ while (round < MAX_ROUNDS) {
   )
 
   for (const r of results.filter(Boolean)) {
-    if (r.verify && r.verify.ok && r.migrate && r.migrate.status === 'migrated') completed.push(r.site)
+    if (r.verify && r.verify.ok && r.migrate && r.migrate.status === 'migrated') { completed.push(r.site); completedSet.add(r.site) }
     else failures.push({ site: r.site, reason: (r.verify && r.verify.reason) || (r.migrate && r.migrate.detail) || 'unknown' })
   }
 }

--- a/.claude/workflows/mercury-large-migration.js
+++ b/.claude/workflows/mercury-large-migration.js
@@ -28,10 +28,11 @@ if (!rule) {
   return { error: 'missing migration rule' }
 }
 
-// Caps are operator-overridable via args but clamped to a hard ceiling, so the #385
-// "explicit upper bound" guardrail holds even when a caller passes an oversized value.
-const BATCH_CAP = Math.min((args && args.batchCap) || 12, 50)   // files transformed per round
-const MAX_ROUNDS = Math.min((args && args.maxRounds) || 5, 20)  // loop-until-dry safety bound
+// Caps are operator-overridable but clamped to [1, ceiling]: the upper bound keeps the #385
+// fan-out guardrail under an oversized override; the lower bound stops a negative/zero value
+// from silently no-op'ing the stage (a negative slice arg would behave nonsensically).
+const BATCH_CAP = Math.max(1, Math.min((args && args.batchCap) || 12, 50))   // files transformed per round
+const MAX_ROUNDS = Math.max(1, Math.min((args && args.maxRounds) || 5, 20))  // loop-until-dry safety bound
 
 // The script has no filesystem access, so this is a string-level guard: keep migration
 // inside the repo by rejecting absolute paths (POSIX `/`, Windows drive/UNC) and any `..`
@@ -72,8 +73,10 @@ const completed = []
 const completedSet = new Set()   // dedup discovered files against ones already handled
 const skipped = []               // verified no-ops / already-migrated — not failures
 const failures = []
+const unsafeSeen = new Set()      // out-of-repo / traversal paths we refuse to touch
 let round = 0
 let remaining = 0
+let stoppedEarly = false          // broke because a round had no actionable files (not converged)
 
 while (round < MAX_ROUNDS) {
   round++
@@ -85,23 +88,39 @@ while (round < MAX_ROUNDS) {
     { label: `discover:r${round}`, phase: 'Discover', schema: FILES_SCHEMA }
   )
   const rawFiles = (found && found.files) || []
-  // Drop unsafe paths and already-migrated files BEFORE the per-round cap, so the cap
-  // budgets real remaining work rather than duplicates or out-of-repo paths. Without the
-  // dedup, a Discover that re-returns a completed file could re-migrate it and burn rounds.
-  const candidates = rawFiles.filter(x => x && isSafeRelPath(x.file) && !completedSet.has(x.file))
+  // True convergence is ONLY when Discover returns nothing at all. (A non-empty batch that
+  // filters down to nothing is handled separately below — it is NOT clean convergence.)
+  if (!rawFiles.length) { remaining = 0; log(`Round ${round}: Discover found no files — migration converged`); break }
+  // Build the actionable set: drop unsafe/out-of-repo paths, files already handled in a
+  // prior round, AND duplicates within THIS round. The within-round dedup is essential —
+  // if Discover returns the same file twice, two agents would edit it in parallel and
+  // clobber each other, breaking the one-agent-per-file ownership the design relies on.
+  const roundSeen = new Set()
+  const candidates = []
+  for (const x of rawFiles) {
+    if (!x || typeof x.file !== 'string' || !x.file) continue
+    if (!isSafeRelPath(x.file)) { unsafeSeen.add(x.file); continue }
+    if (completedSet.has(x.file) || roundSeen.has(x.file)) continue
+    roundSeen.add(x.file)
+    candidates.push(x)
+  }
   const droppedBad = rawFiles.length - candidates.length
-  if (droppedBad > 0) log(`Round ${round}: dropped ${droppedBad} discovered entries (unsafe path or already-migrated)`)
+  if (droppedBad > 0) log(`Round ${round}: dropped ${droppedBad} discovered entries (unsafe path, duplicate, or already-migrated)`)
   const files = candidates.slice(0, BATCH_CAP)
-  // If valid candidates exceed BATCH_CAP, the extras are NOT lost: they go un-migrated
-  // this round and the loop re-discovers them next round. Log it so the cap is never a
-  // silent drop (consistent with the audit template's overflow accounting).
+  // Valid candidates beyond BATCH_CAP are NOT lost: they go un-migrated this round and the
+  // loop re-discovers them. Fold them into `remaining` so the round cap can't exit clean
+  // while files are still pending (consistent with the audit template's overflow accounting).
   const overReturned = candidates.length - files.length
-  if (overReturned > 0) log(`Round ${round}: Discover over-returned — ${overReturned} files beyond BATCH_CAP=${BATCH_CAP} deferred (counted in remaining; loop re-discovers them)`)
-  // Fold over-returned files into `remaining` so the round-cap boundary cannot exit with
-  // "Converged / remainingEstimate: 0" while sliced-off files are still un-migrated. The
-  // loop re-discovers them on the next round; at the round cap they surface in the return.
+  if (overReturned > 0) log(`Round ${round}: ${overReturned} valid files beyond BATCH_CAP=${BATCH_CAP} deferred to next round (counted in remaining)`)
   remaining = ((found && found.remainingEstimate) || 0) + overReturned
-  if (!files.length) { log(`Round ${round}: no files left — migration converged`); break }
+  if (!files.length) {
+    // rawFiles was non-empty but nothing is actionable (all already-done, duplicates, or
+    // unsafe). Stop to avoid an infinite loop, but do NOT claim clean convergence — the
+    // residual (remainingEstimate + unsafe paths) surfaces in the return below.
+    stoppedEarly = true
+    log(`Round ${round}: no actionable files (all already-migrated, duplicate, or unsafe) — stopping`)
+    break
+  }
   log(`Round ${round}: migrating ${files.length} files (${remaining} estimated beyond this batch)`)
 
   // One agent owns each file (distinct files → no concurrent same-file clobber), edits in
@@ -134,20 +153,37 @@ while (round < MAX_ROUNDS) {
   }
 }
 
+// Honest residual: `remaining` carries the last round's estimate+overflow only when we hit
+// the round cap or stopped early on a non-actionable batch; a clean break (Discover empty)
+// reset it to 0. `converged` is true ONLY when nothing is left by any measure.
+const unsafeSkipped = [...unsafeSeen]
 const hitRoundCap = round >= MAX_ROUNDS && remaining > 0
-if (hitRoundCap) log(`Stopped at MAX_ROUNDS=${MAX_ROUNDS} with ~${remaining} files still estimated remaining (not dropped — rerun to continue)`)
+const estRemaining = (hitRoundCap || stoppedEarly) ? remaining : 0
+const converged = !stoppedEarly && !hitRoundCap && estRemaining === 0 && failures.length === 0 && unsafeSkipped.length === 0
+if (hitRoundCap) log(`Stopped at MAX_ROUNDS=${MAX_ROUNDS} with ~${remaining} files still estimated remaining (rerun to continue)`)
+if (unsafeSkipped.length) log(`${unsafeSkipped.length} discovered paths refused as unsafe/out-of-repo — never migrated (need manual handling)`)
 
 const consolidateNote = 'Edits are in the working tree, uncommitted — review the diff and commit (Main manages git).'
+let note
+if (converged) {
+  note = `Converged. ${consolidateNote}`
+} else {
+  const parts = []
+  if (estRemaining > 0) parts.push(`~${estRemaining} files still estimated remaining`)
+  if (failures.length) parts.push(`${failures.length} failed`)
+  if (unsafeSkipped.length) parts.push(`${unsafeSkipped.length} unsafe paths refused`)
+  note = `NOT fully converged (${parts.join('; ') || 'no actionable files this round'}) — rerun for retriable files; unsafe paths need manual handling. ${consolidateNote}`
+}
 return {
   rule,
   pattern,
   rounds: round,
+  converged,
   migratedCount: completed.length,
   migratedFiles: completed,
   skippedFiles: skipped,
   failures,
-  remainingEstimate: hitRoundCap ? remaining : 0,
-  note: hitRoundCap
-    ? `Round cap reached — rerun the workflow to migrate the rest. ${consolidateNote}`
-    : `Converged. ${consolidateNote}`,
+  unsafeSkipped,
+  remainingEstimate: estRemaining,
+  note,
 }

--- a/.claude/workflows/mercury-large-migration.js
+++ b/.claude/workflows/mercury-large-migration.js
@@ -69,7 +69,8 @@ const VERIFY_SCHEMA = {
 
 const patternHint = pattern ? ` within \`${pattern}\`` : ''
 const completed = []
-const completedSet = new Set()   // dedup discovered files against ones already migrated
+const completedSet = new Set()   // dedup discovered files against ones already handled
+const skipped = []               // verified no-ops / already-migrated — not failures
 const failures = []
 let round = 0
 let remaining = 0
@@ -123,7 +124,12 @@ while (round < MAX_ROUNDS) {
   )
 
   for (const r of results.filter(Boolean)) {
-    if (r.verify && r.verify.ok && r.migrate && r.migrate.status === 'migrated') { completed.push(r.site); completedSet.add(r.site) }
+    const okVerify = r.verify && r.verify.ok
+    const st = r.migrate && r.migrate.status
+    // Verification is the correctness gate. A verified 'skipped' (already-migrated / no-op)
+    // is NOT a failure — bucket it separately and dedup it so it isn't re-discovered.
+    if (okVerify && st === 'migrated') { completed.push(r.site); completedSet.add(r.site) }
+    else if (okVerify && st === 'skipped') { skipped.push(r.site); completedSet.add(r.site) }
     else failures.push({ site: r.site, reason: (r.verify && r.verify.reason) || (r.migrate && r.migrate.detail) || 'unknown' })
   }
 }
@@ -138,6 +144,7 @@ return {
   rounds: round,
   migratedCount: completed.length,
   migratedFiles: completed,
+  skippedFiles: skipped,
   failures,
   remainingEstimate: hitRoundCap ? remaining : 0,
   note: hitRoundCap

--- a/.claude/workflows/mercury-large-migration.js
+++ b/.claude/workflows/mercury-large-migration.js
@@ -1,0 +1,127 @@
+export const meta = {
+  name: 'mercury-large-migration',
+  description: 'Migrate many files by discovering the ones that need a change, transforming each in the working tree (one agent per file), verifying every change, and looping until none remain (loop-until-done)',
+  whenToUse: 'A mechanical change applied across dozens to hundreds of files: API rename, import rewrite, config-key migration, codemod. One agent owns each file so parallel transforms never touch the same file; the loop catches files a single discovery pass misses. Edits land in the working tree — the operator reviews and commits.',
+  phases: [
+    { title: 'Discover', detail: 'find files still needing the migration (capped per round)' },
+    { title: 'Migrate', detail: 'transform each file in the working tree, then verify' },
+  ],
+}
+
+// ── Mercury guardrails (#385 + CLAUDE.md modular-design) ──
+// 1. LEAN DISPATCH: each transform agent gets ONE file + the rule, and reads that file
+//    itself. The migration rule is a short instruction, never a dump of every file.
+// 2. BATCH_CAP bounds files-per-round; MAX_ROUNDS bounds the loop. Anything left when the
+//    caps are hit is reported as `remaining`, never silently dropped.
+// 3. PER-FILE OWNERSHIP, NOT WORKTREE ISOLATION: Discover returns ONE entry per file, so
+//    the concurrent agents never edit the same file — there is no clobber to isolate
+//    against. Edits land directly in the working tree (verifiable), and the operator
+//    consolidates + commits. Worktree isolation is deliberately avoided here: the runtime
+//    auto-removes an isolated worktree and its merge-back semantics are undocumented, so
+//    an isolated transform could report success without its change reaching the checkout.
+//    (If two sites share a file, one agent migrates all of them — see the Discover prompt.)
+
+const rule = (args && (args.rule || args.transform)) || (typeof args === 'string' ? args : null)
+const pattern = (args && args.pattern) || null
+if (!rule) {
+  log('No migration rule provided. Pass one via args, e.g. /mercury-large-migration { rule: "replace foo() with bar()", pattern: "src/**/*.ts" }')
+  return { error: 'missing migration rule' }
+}
+
+const BATCH_CAP = (args && args.batchCap) || 12      // files transformed per round
+const MAX_ROUNDS = (args && args.maxRounds) || 5     // loop-until-dry safety bound
+
+const FILES_SCHEMA = {
+  type: 'object',
+  required: ['files'],
+  properties: {
+    files: { type: 'array', items: { type: 'object', required: ['file'], properties: { file: { type: 'string', description: 'path of a file still needing migration (one entry per file, even if it has several sites)' }, note: { type: 'string', description: 'which site(s) in the file need the change' } } } },
+    remainingEstimate: { type: 'number', description: 'files known to remain beyond those returned' },
+  },
+}
+
+const MIGRATE_SCHEMA = {
+  type: 'object',
+  required: ['status'],
+  properties: {
+    status: { type: 'string', enum: ['migrated', 'skipped', 'failed'] },
+    detail: { type: 'string' },
+  },
+}
+
+const VERIFY_SCHEMA = {
+  type: 'object',
+  required: ['ok'],
+  properties: { ok: { type: 'boolean' }, reason: { type: 'string' } },
+}
+
+const patternHint = pattern ? ` within \`${pattern}\`` : ''
+const completed = []
+const failures = []
+let round = 0
+let remaining = 0
+
+while (round < MAX_ROUNDS) {
+  round++
+  phase('Discover')
+  const found = await agent(
+    `Find files that still need this migration${patternHint}: ${rule}. ` +
+    `Use Grep/Glob to locate them. Return ONE entry per file (even if a file has several sites), only files NOT yet migrated, capped at ${BATCH_CAP}; ` +
+    `set remainingEstimate to how many more files you believe exist beyond the returned list.`,
+    { label: `discover:r${round}`, phase: 'Discover', schema: FILES_SCHEMA }
+  )
+  const rawFiles = (found && found.files) || []
+  const files = rawFiles.slice(0, BATCH_CAP)
+  // If Discover over-returns past BATCH_CAP, the extras are NOT lost: they go un-migrated
+  // this round and the loop re-discovers them next round. Log it so the cap is never a
+  // silent drop (consistent with the audit template's overflow accounting).
+  const overReturned = rawFiles.length - files.length
+  if (overReturned > 0) log(`Round ${round}: Discover over-returned — ${overReturned} files beyond BATCH_CAP=${BATCH_CAP} deferred (counted in remaining; loop re-discovers them)`)
+  // Fold over-returned files into `remaining` so the round-cap boundary cannot exit with
+  // "Converged / remainingEstimate: 0" while sliced-off files are still un-migrated. The
+  // loop re-discovers them on the next round; at the round cap they surface in the return.
+  remaining = ((found && found.remainingEstimate) || 0) + overReturned
+  if (!files.length) { log(`Round ${round}: no files left — migration converged`); break }
+  log(`Round ${round}: migrating ${files.length} files (${remaining} estimated beyond this batch)`)
+
+  // One agent owns each file (distinct files → no concurrent same-file clobber), edits in
+  // the working tree, then a separate verify agent gates it. No commit here — the operator
+  // reviews the consolidated diff and commits (Mercury: Main manages git).
+  const results = await pipeline(
+    files,
+    f => agent(
+      `Apply this migration to exactly one file and nothing else: ${rule}.\n` +
+      `File: ${f.file}${f.note ? ` (sites: ${f.note})` : ''}\n` +
+      `Read the file, migrate every site in it that the rule covers, run any scoped check available, and SAVE the edits in place. ` +
+      `Do NOT commit and do NOT touch any other file.`,
+      { label: `migrate:${f.file}`, phase: 'Migrate', schema: MIGRATE_SCHEMA }
+    ).then(r => ({ site: f.file, result: r })),
+    (prev, f) => agent(
+      `Verify the migration of \`${f.file}\` is correct and complete for the rule: ${rule}. ` +
+      `Read the current state of the file and confirm the change applied and nothing unrelated broke. Report ok=false with a reason if not.`,
+      { label: `verify:${f.file}`, phase: 'Migrate', schema: VERIFY_SCHEMA }
+    ).then(v => ({ site: f.file, migrate: prev && prev.result, verify: v }))
+  )
+
+  for (const r of results.filter(Boolean)) {
+    if (r.verify && r.verify.ok && r.migrate && r.migrate.status === 'migrated') completed.push(r.site)
+    else failures.push({ site: r.site, reason: (r.verify && r.verify.reason) || (r.migrate && r.migrate.detail) || 'unknown' })
+  }
+}
+
+const hitRoundCap = round >= MAX_ROUNDS && remaining > 0
+if (hitRoundCap) log(`Stopped at MAX_ROUNDS=${MAX_ROUNDS} with ~${remaining} files still estimated remaining (not dropped — rerun to continue)`)
+
+const consolidateNote = 'Edits are in the working tree, uncommitted — review the diff and commit (Main manages git).'
+return {
+  rule,
+  pattern,
+  rounds: round,
+  migratedCount: completed.length,
+  migratedFiles: completed,
+  failures,
+  remainingEstimate: hitRoundCap ? remaining : 0,
+  note: hitRoundCap
+    ? `Round cap reached — rerun the workflow to migrate the rest. ${consolidateNote}`
+    : `Converged. ${consolidateNote}`,
+}

--- a/.claude/workflows/mercury-large-migration.js
+++ b/.claude/workflows/mercury-large-migration.js
@@ -33,9 +33,10 @@ if (!rule) {
 // from silently no-op'ing the stage (a negative slice arg would behave nonsensically).
 const BATCH_CAP = Math.max(1, Math.min((args && args.batchCap) || 12, 50))   // files transformed per round
 // Each file spends 2 agents (migrate + verify), so the whole-run worst case is
-// BATCH_CAP * MAX_ROUNDS * 2. Clamp MAX_ROUNDS so that stays under the runtime's 1000-agent
-// hard cap (AGENT_BUDGET margin) — otherwise a max-configured run would be cut off mid-way
-// instead of returning a clean resumable state. The loop is resumable: rerun to continue.
+// BATCH_CAP * MAX_ROUNDS * 2. Clamp MAX_ROUNDS so that worst case is <= AGENT_BUDGET (800),
+// which leaves a ~200 margin under the runtime's 1000-agent hard cap — otherwise a max-
+// configured run would be cut off mid-way instead of returning a clean resumable state.
+// The loop is resumable: rerun to continue.
 const AGENT_BUDGET = 800
 const _maxRounds = Math.max(1, Math.min((args && args.maxRounds) || 5, 20))  // loop-until-dry safety bound
 const MAX_ROUNDS = Math.max(1, Math.min(_maxRounds, Math.floor(AGENT_BUDGET / (BATCH_CAP * 2))))

--- a/.claude/workflows/mercury-large-migration.js
+++ b/.claude/workflows/mercury-large-migration.js
@@ -32,7 +32,14 @@ if (!rule) {
 // fan-out guardrail under an oversized override; the lower bound stops a negative/zero value
 // from silently no-op'ing the stage (a negative slice arg would behave nonsensically).
 const BATCH_CAP = Math.max(1, Math.min((args && args.batchCap) || 12, 50))   // files transformed per round
-const MAX_ROUNDS = Math.max(1, Math.min((args && args.maxRounds) || 5, 20))  // loop-until-dry safety bound
+// Each file spends 2 agents (migrate + verify), so the whole-run worst case is
+// BATCH_CAP * MAX_ROUNDS * 2. Clamp MAX_ROUNDS so that stays under the runtime's 1000-agent
+// hard cap (AGENT_BUDGET margin) — otherwise a max-configured run would be cut off mid-way
+// instead of returning a clean resumable state. The loop is resumable: rerun to continue.
+const AGENT_BUDGET = 800
+const _maxRounds = Math.max(1, Math.min((args && args.maxRounds) || 5, 20))  // loop-until-dry safety bound
+const MAX_ROUNDS = Math.max(1, Math.min(_maxRounds, Math.floor(AGENT_BUDGET / (BATCH_CAP * 2))))
+if (MAX_ROUNDS < _maxRounds) log(`MAX_ROUNDS clamped ${_maxRounds}->${MAX_ROUNDS} to keep BATCH_CAP*MAX_ROUNDS*2 under the ${AGENT_BUDGET}-agent budget (rerun to continue)`)
 
 // The script has no filesystem access, so this is a string-level guard: keep migration
 // inside the repo by rejecting absolute paths (POSIX `/`, Windows drive/UNC) and any `..`

--- a/.claude/workflows/mercury-multi-source-research.js
+++ b/.claude/workflows/mercury-multi-source-research.js
@@ -58,11 +58,14 @@ const CLAIMS_SCHEMA = {
 
 const VOTE_SCHEMA = {
   type: 'object',
-  required: ['status', 'reason'],
+  required: ['status', 'reason', 'bestSource'],
   properties: {
     status: { type: 'string', enum: ['verified', 'contradicted', 'unverified'] },
     reason: { type: 'string' },
-    bestSource: { type: 'string' },
+    // Required so a verified claim always carries the authoritative URL the verdict rests
+    // on (not the originally-cited, possibly non-primary source). For unverified, give the
+    // best source checked or "none".
+    bestSource: { type: 'string', description: 'authoritative URL the verdict rests on, or "none"' },
   },
 }
 

--- a/.claude/workflows/mercury-multi-source-research.js
+++ b/.claude/workflows/mercury-multi-source-research.js
@@ -23,10 +23,12 @@ if (!question) {
   return { error: 'missing question', hint: 'pass args as a string or { question }' }
 }
 
-const ANGLE_CAP = (args && args.maxAngles) || 5
+// Caps are operator-overridable but clamped to a hard ceiling, so the #385 fan-out bound
+// holds even under an oversized override (ANGLE_CAP is also bounded by the ANGLES array).
+const ANGLE_CAP = Math.min((args && args.maxAngles) || 5, 8)
 // Bound the SECOND fan-out too: a noisy question can surface dozens of claims, and
 // cross-checking each spawns an agent. Cap + log dropped (#385: every fan-out is bounded).
-const CLAIM_CAP = (args && args.maxClaims) || 24
+const CLAIM_CAP = Math.min((args && args.maxClaims) || 24, 100)
 const ANGLES = [
   'official vendor documentation and API reference',
   'package registry (npm/PyPI) version + publish status + changelog',

--- a/.claude/workflows/mercury-multi-source-research.js
+++ b/.claude/workflows/mercury-multi-source-research.js
@@ -102,13 +102,15 @@ log(`Cross-checking ${claims.length} of ${allClaims.length} distinct claims acro
 phase('CrossCheck')
 // Each claim is independently re-verified against fresh sources (not the ones that
 // produced it) so a single angle cannot self-confirm.
-const voted = await parallel(claims.map(c => () =>
+const voted = await parallel(claims.map((c, i) => () =>
   agent(
     `Independently cross-check this claim against fresh authoritative sources (do NOT just trust the cited ones):\n` +
     `Claim: "${c.claim}"\nOriginally cited: ${(c.sources || []).join(', ') || '(none)'}\n` +
     `Use WebSearch/WebFetch. Return verified only if an official/primary source confirms it; contradicted if a source refutes it; ` +
     `unverified if you cannot confirm against a primary source.`,
-    { label: 'crosscheck', phase: 'CrossCheck', schema: VOTE_SCHEMA, agentType: 'research' }
+    // Unique per-claim label (index + slug) so concurrent cross-checks are distinguishable
+    // in the /workflows panel and logs — a shared label makes per-claim triage impossible.
+    { label: `crosscheck:${i + 1}:${(c.claim || '').slice(0, 20)}`, phase: 'CrossCheck', schema: VOTE_SCHEMA, agentType: 'research' }
   ).then(v => ({ ...c, vote: v }))
 ))
 

--- a/.claude/workflows/mercury-multi-source-research.js
+++ b/.claude/workflows/mercury-multi-source-research.js
@@ -1,0 +1,111 @@
+export const meta = {
+  name: 'mercury-multi-source-research',
+  description: 'Fan out web research across independent angles, cross-check each claim against multiple sources, and synthesize a cited report with unverified claims flagged',
+  whenToUse: 'A research question that needs >=3 sources cross-checked against each other (SDK/API behavior, vendor pricing, version facts). The parallel cross-check replaces autoresearch\'s serial single-context loop. For a 1-2 source quick lookup, use the web-research skill instead.',
+  phases: [
+    { title: 'Sweep', detail: 'parallel agents, each a different research angle' },
+    { title: 'CrossCheck', detail: 'vote each claim against independent sources' },
+    { title: 'Synthesize', detail: 'cited report, UNVERIFIED claims flagged' },
+  ],
+}
+
+// ── Mercury guardrails (#385 + CLAUDE.md "Web search before SDK/API code") ──
+// 1. Each angle agent does its OWN WebSearch/WebFetch — the question is passed lean,
+//    no pre-fetched page dumps are injected into sibling agents.
+// 2. ANGLE_CAP bounds the sweep. Vendor/official sources are preferred; a claim that
+//    cannot be web-verified is reported as UNVERIFIED rather than dropped or asserted.
+// 3. Mirrors the bundled /deep-research but Mercury-flavored: official-docs-first,
+//    explicit UNVERIFIED tagging per Mercury's mandatory research protocol.
+
+const question = (args && (args.question || args.q)) || (typeof args === 'string' ? args : null)
+if (!question) {
+  log('No research question provided. Pass one via args, e.g. /mercury-multi-source-research "does X SDK support Y?"')
+  return { error: 'missing question', hint: 'pass args as a string or { question }' }
+}
+
+const ANGLE_CAP = (args && args.maxAngles) || 5
+// Bound the SECOND fan-out too: a noisy question can surface dozens of claims, and
+// cross-checking each spawns an agent. Cap + log dropped (#385: every fan-out is bounded).
+const CLAIM_CAP = (args && args.maxClaims) || 24
+const ANGLES = [
+  'official vendor documentation and API reference',
+  'package registry (npm/PyPI) version + publish status + changelog',
+  'release notes / changelogs / migration guides',
+  'authoritative third-party write-ups that corroborate or contradict the official line',
+  'known issues, breaking changes, and community-reported gotchas',
+].slice(0, ANGLE_CAP)
+
+const CLAIMS_SCHEMA = {
+  type: 'object',
+  required: ['claims'],
+  properties: {
+    claims: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['claim', 'sources'],
+        properties: {
+          claim: { type: 'string' },
+          sources: { type: 'array', items: { type: 'string', description: 'source URL' } },
+          confidence: { type: 'string', enum: ['high', 'medium', 'low'] },
+        },
+      },
+    },
+  },
+}
+
+const VOTE_SCHEMA = {
+  type: 'object',
+  required: ['status', 'reason'],
+  properties: {
+    status: { type: 'string', enum: ['verified', 'contradicted', 'unverified'] },
+    reason: { type: 'string' },
+    bestSource: { type: 'string' },
+  },
+}
+
+phase('Sweep')
+const swept = await parallel(ANGLES.map(angle => () =>
+  agent(
+    `Research this question from the angle of **${angle}**:\n"${question}"\n` +
+    `Use WebSearch + WebFetch yourself. Prefer official/primary sources. Return each finding as a discrete claim with its source URL(s). ` +
+    `Do not speculate beyond what a source supports.`,
+    { label: `sweep:${angle.slice(0, 24)}`, phase: 'Sweep', schema: CLAIMS_SCHEMA, agentType: 'research' }
+  )
+))
+const allClaims = swept.filter(Boolean).flatMap(r => (r && r.claims) || [])
+// Prefer higher-confidence claims when the cap bites, so the cross-check budget is
+// spent on the most load-bearing claims rather than an arbitrary prefix.
+const rank = { high: 0, medium: 1, low: 2 }
+allClaims.sort((a, b) => (rank[a.confidence] ?? 1) - (rank[b.confidence] ?? 1))
+const claims = allClaims.slice(0, CLAIM_CAP)
+if (allClaims.length > claims.length) log(`${allClaims.length - claims.length} lower-confidence claims dropped at CLAIM_CAP=${CLAIM_CAP} (rerun narrower to cross-check them)`)
+log(`Cross-checking ${claims.length} of ${allClaims.length} candidate claims across ${ANGLES.length} angles`)
+
+phase('CrossCheck')
+// Each claim is independently re-verified against fresh sources (not the ones that
+// produced it) so a single angle cannot self-confirm.
+const voted = await parallel(claims.map(c => () =>
+  agent(
+    `Independently cross-check this claim against fresh authoritative sources (do NOT just trust the cited ones):\n` +
+    `Claim: "${c.claim}"\nOriginally cited: ${(c.sources || []).join(', ') || '(none)'}\n` +
+    `Use WebSearch/WebFetch. Return verified only if an official/primary source confirms it; contradicted if a source refutes it; ` +
+    `unverified if you cannot confirm against a primary source.`,
+    { label: 'crosscheck', phase: 'CrossCheck', schema: VOTE_SCHEMA, agentType: 'research' }
+  ).then(v => ({ ...c, vote: v }))
+))
+
+phase('Synthesize')
+const results = voted.filter(Boolean)
+const verifiedClaims = results.filter(c => c.vote && c.vote.status === 'verified')
+const contradicted = results.filter(c => c.vote && c.vote.status === 'contradicted')
+const unverified = results.filter(c => c.vote && c.vote.status === 'unverified')
+log(`${verifiedClaims.length} verified · ${contradicted.length} contradicted · ${unverified.length} UNVERIFIED`)
+
+return {
+  question,
+  verified: verifiedClaims.map(c => ({ claim: c.claim, source: c.vote.bestSource || (c.sources || [])[0], reason: c.vote.reason })),
+  contradicted: contradicted.map(c => ({ claim: c.claim, reason: c.vote.reason })),
+  unverified: unverified.map(c => ({ claim: c.claim, reason: c.vote.reason })),
+  note: 'Claims under `unverified` MUST be marked [UNVERIFIED] if used in code/docs (Mercury research protocol).',
+}

--- a/.claude/workflows/mercury-multi-source-research.js
+++ b/.claude/workflows/mercury-multi-source-research.js
@@ -23,12 +23,13 @@ if (!question) {
   return { error: 'missing question', hint: 'pass args as a string or { question }' }
 }
 
-// Caps are operator-overridable but clamped to a hard ceiling, so the #385 fan-out bound
-// holds even under an oversized override (ANGLE_CAP is also bounded by the ANGLES array).
-const ANGLE_CAP = Math.min((args && args.maxAngles) || 5, 8)
+// Caps are operator-overridable but clamped to [1, ceiling]: upper bound keeps the #385
+// fan-out guardrail under an oversized override; lower bound stops a negative/zero value
+// from silently no-op'ing a stage (ANGLE_CAP is also bounded by the ANGLES array).
+const ANGLE_CAP = Math.max(1, Math.min((args && args.maxAngles) || 5, 8))
 // Bound the SECOND fan-out too: a noisy question can surface dozens of claims, and
 // cross-checking each spawns an agent. Cap + log dropped (#385: every fan-out is bounded).
-const CLAIM_CAP = Math.min((args && args.maxClaims) || 24, 100)
+const CLAIM_CAP = Math.max(1, Math.min((args && args.maxClaims) || 24, 100))
 const ANGLES = [
   'official vendor documentation and API reference',
   'package registry (npm/PyPI) version + publish status + changelog',
@@ -78,14 +79,25 @@ const swept = await parallel(ANGLES.map(angle => () =>
     { label: `sweep:${angle.slice(0, 24)}`, phase: 'Sweep', schema: CLAIMS_SCHEMA, agentType: 'research' }
   )
 ))
-const allClaims = swept.filter(Boolean).flatMap(r => (r && r.claims) || [])
+// Dedup the same claim emitted by multiple angles BEFORE the cap, so duplicates don't
+// consume CLAIM_CAP budget or reappear across verified/contradicted/unverified buckets.
+const sweptClaims = swept.filter(Boolean).flatMap(r => (r && r.claims) || [])
+const seenClaims = new Set()
+const allClaims = []
+for (const c of sweptClaims) {
+  const k = (c && c.claim || '').trim().toLowerCase().replace(/\s+/g, ' ')
+  if (!k || seenClaims.has(k)) continue
+  seenClaims.add(k)
+  allClaims.push(c)
+}
+if (sweptClaims.length > allClaims.length) log(`Deduped ${sweptClaims.length - allClaims.length} duplicate claims across angles`)
 // Prefer higher-confidence claims when the cap bites, so the cross-check budget is
 // spent on the most load-bearing claims rather than an arbitrary prefix.
 const rank = { high: 0, medium: 1, low: 2 }
 allClaims.sort((a, b) => (rank[a.confidence] ?? 1) - (rank[b.confidence] ?? 1))
 const claims = allClaims.slice(0, CLAIM_CAP)
 if (allClaims.length > claims.length) log(`${allClaims.length - claims.length} lower-confidence claims dropped at CLAIM_CAP=${CLAIM_CAP} (rerun narrower to cross-check them)`)
-log(`Cross-checking ${claims.length} of ${allClaims.length} candidate claims across ${ANGLES.length} angles`)
+log(`Cross-checking ${claims.length} of ${allClaims.length} distinct claims across ${ANGLES.length} angles`)
 
 phase('CrossCheck')
 // Each claim is independently re-verified against fresh sources (not the ones that

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,28 @@ Read these docs on demand when you need the corresponding information:
 | Dispatch prompt templates | `.mercury/templates/` |
 | Architecture research (PR #162) | `.mercury/docs/research/issue-158-architecture-evaluation.md` |
 | Agent view dispatch convention (multi-lane × bg sessions) | `.mercury/docs/guides/agent-view-dispatch.md` |
+| **Dynamic Workflow 模板库 + 触发/保存/复用约定** | `.claude/workflows/README.md` |
+| 四原语选型矩阵 + budget-scaling 规则 | `.claude/agents/main.md` §编排升级 |
+
+## Ultracode 与 Dynamic Workflows
+
+Mercury 用 Claude Code 原生 **Dynamic Workflow**(确定性多 agent 编排,JS 脚本,后台跑数十到数百 subagent,中间结果留脚本变量)处理「一个会话 context 装不下」或「编排值得沉淀成可重跑脚本」的任务。模板库宿主在 `.claude/workflows/`(随 repo 分发),约定与护栏见该目录 README。环境要求 Claude Code v2.1.154+。
+
+**何时触发 Workflow(升级判据)**:
+- **应触发**:repo 级审计/扫描(多文件 fan-out)、大规模迁移/codemod(数十+站点)、需多源交叉核查的研究(≥3 源对照)、需多角度起草再裁决的硬计划、需对抗式验证以滤除「看似对实则错」结论的审查。
+- **不必触发**(用线性 dev-pipeline / 单 subagent / skill):单文件改动、1-2 源快速查证、机械单步操作、已 well-scoped 的单任务实现。
+- 选型矩阵(Subagents vs Skills vs Agent Teams vs Workflows)+ budget-scaling 量化规则见 `.claude/agents/main.md` §编排升级。
+
+**触发方式**:① prompt 含关键词 `ultracode`(单任务 opt-in;v2.1.160 前为 `workflow`)或自然语言「用 workflow 跑」;② `/effort ultracode`(会话持久 = xhigh + 每个实质任务自动编排,新会话重置,`/effort high` 退回);③ `/<name>` 复用已存模板。
+
+> **持久 ultracode 仅 `/effort ultracode` 内置命令可设** —— handoff `--startup-keyword ultracode` 只触发单轮 opt-in,不激活持久模式(见记忆 `reference_ultracode_launch_activation`)。
+
+**硬护栏(对齐 [#385](https://github.com/392fyc/Mercury/issues/385) context 经济学,所有 Workflow 模板必须遵守)**:
+- 不 pre-inject 全量文档进 subagent context —— 传**路径 + 任务**,agent 自己 Read(bulk injection 永久抢占 cache slot)。
+- fan-out 设显式上限 + 被丢弃工作量必 `log()`(禁静默截断)。
+- Haiku 路径注入切片 ≤50K token(200K ctx 硬 cliff);Codex/GPT-5.5 路径 272K cliff 越线整 session 翻倍。
+- runtime 兜底 ≤16 并发 / 1000 agent per run。
+- **dual-verify 仍是合并门**:Workflow 产出代码改动照样跑 `/dual-verify` + PR 到 develop,不绕过任何 hook 回归。
 
 ## Related Repositories
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Mercury 用 Claude Code 原生 **Dynamic Workflow**(确定性多 agent 编排,JS
 
 **触发方式**:① prompt 含关键词 `ultracode`(单任务 opt-in;v2.1.160 前为 `workflow`)或自然语言「用 workflow 跑」;② `/effort ultracode`(会话持久 = xhigh + 每个实质任务自动编排,新会话重置,`/effort high` 退回);③ `/<name>` 复用已存模板。
 
-> **持久 ultracode 仅 `/effort ultracode` 内置命令可设** —— handoff `--startup-keyword ultracode` 只触发单轮 opt-in,不激活持久模式(见记忆 `reference_ultracode_launch_activation`)。
+> **持久 ultracode 仅 `/effort ultracode` 内置命令可设**(官方文档:ultracode 是会话级 effort 设置,新会话重置)。handoff `--startup-keyword ultracode` 等关键词注入只触发**单轮** opt-in,不激活持久模式。触发方式全表见 `.claude/workflows/README.md` §触发方式。
 
 **硬护栏(对齐 [#385](https://github.com/392fyc/Mercury/issues/385) context 经济学,所有 Workflow 模板必须遵守)**:
 - 不 pre-inject 全量文档进 subagent context —— 传**路径 + 任务**,agent 自己 Read(bulk injection 永久抢占 cache slot)。


### PR DESCRIPTION
Closes #479
Closes #480
Refs #478, #385, #101

## 概要

#478 harness 现代化 **第一波 P0**:把 Claude Code 原生 **Dynamic Workflow**(确定性多 agent 编排,JS 脚本,后台跑数十到数百 subagent,中间结果留脚本变量)能力固化进 Mercury repo。这是三大未吸收编排原语里最大的系统空白(`.claude/workflows/` 此前不存在)。

## #479 — `.claude/workflows/` 脚手架 + 模板库

- **4 个 Mercury 编排模板**(随 repo 分发,`/<name>` 复用,已被 harness 注册为 workflow 命令):
  | 命令 | 模式 |
  |---|---|
  | `/mercury-codebase-audit` | fan-out + adversarial-verify |
  | `/mercury-multi-source-research` | multi-modal sweep + cross-check(替代 autoresearch 串行) |
  | `/mercury-adversarial-plan-review` | judge-panel(N 角度起草→评审团→综合) |
  | `/mercury-large-migration` | loop-until-done(按文件归属 + operator 提交) |
- **README**:触发(`ultracode` 关键词 / `/effort ultracode` / `/name`)、保存复用约定、六大模式↔模板映射、#385 护栏、治理约束。
- **CLAUDE.md**:新增「Ultracode 与 Dynamic Workflows」触发规范段落 + 2 个 Navigation 行。

## #480 — `main.md` 编排升级段落(依赖 #479)

- 四原语选型矩阵(Subagents vs Skills vs Agent Teams vs Workflows + 升级判据)
- budget-scaling 量化规则(事实核查 1agent×3-10calls / 直接比较 2-4 / 复杂研究 10+)
- 六大编排模式一句话索引
- 与 multi-lane / agent view(#386 CLOSED)共存说明

## #385 护栏(所有模板内嵌)

不 pre-inject 全量文档(传**路径**,agent 自读)· fan-out 设**显式上限** + 被丢工作量必 `log()`(禁静默截断)· Haiku 50K / Codex 272K cliff 标注 · runtime ≤16 并发 / 1000 agent。

## 验证

- **dual-verify: PASS**(Claude critic: PASS, Codex code-audit: PASS)。
- 4 轮 Codex 迭代修复 **3 High + 4 Medium**(均为真 logic gap,非 nit):
  1. (High) `mercury-large-migration` worktree merge-back 语义无文档支撑 → 改**按文件归属**(每 agent 独占一文件,无并发同文件冲突)+ 工作树原地编辑 + operator 合并提交。
  2. (High) `mercury-multi-source-research` 第二段 fan-out 无上限 → 加 `CLAIM_CAP` + 置信度排序截断 + log。
  3. (High) `mercury-codebase-audit` 静默截断 findings → per-dimension log 丢弃数。
  4. (Med) audit Discover cap 非命名常量/未强制 → `MODULE_CAP` + 代码 slice 强制 + 溢出 log。
  5. (Med) README `args` v2.1.178 归属不准 → 修正(v2.1.154+ 为 Workflows+args,v2.1.178+ 仅 monorepo 就近保存)。
  6. (Med) migration `BATCH_CAP` 溢出未 log → 加溢出 log。
  7. (Med) migration round-cap 边界 silent-drop → `overReturned` 折进 `remaining`,边界浮现到返回值。
- 4 个模板均通过 runtime 执行模型下的 `node --check`(async wrapper,top-level await/return 合法)。

## 环境

Claude Code v2.1.154+(Dynamic Workflows + args);monorepo 就近保存 v2.1.178+。来源:[code.claude.com/docs/en/workflows](https://code.claude.com/docs/en/workflows)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
