### PR TITLE
feat(#484): SubagentStop additionalContext 强化 + research opt-in nudge (P2 harness 现代化)

### DIFF
--- a/.claude/hooks/research-stop-nudge.sh
+++ b/.claude/hooks/research-stop-nudge.sh
@@ -4,6 +4,8 @@
 # Set MERCURY_RESEARCH_STOP_NUDGE=1 to inject a source/[UNVERIFIED] reminder
 # into additionalContext so main sees the Mercury research protocol note.
 # Always exits 0 (non-blocking); stdin parse failures are tolerated silently.
+# Payload validation: only emits when hook_event_name=="SubagentStop" AND
+# agent_type=="research". Other event/agent combinations exit silently.
 
 set -euo pipefail
 
@@ -11,6 +13,23 @@ set -euo pipefail
 input="$(cat 2>/dev/null || true)"
 
 if [ "${MERCURY_RESEARCH_STOP_NUDGE:-}" != "1" ]; then
+  exit 0
+fi
+
+# Validate payload fields using grep/sed (no jq dependency).
+# Match "hook_event_name": "SubagentStop" (allows optional whitespace around colon).
+event_ok=false
+if printf '%s' "$input" | grep -qE '"hook_event_name"\s*:\s*"SubagentStop"'; then
+  event_ok=true
+fi
+
+# Match "agent_type": "research"
+agent_ok=false
+if printf '%s' "$input" | grep -qE '"agent_type"\s*:\s*"research"'; then
+  agent_ok=true
+fi
+
+if [ "$event_ok" != "true" ] || [ "$agent_ok" != "true" ]; then
   exit 0
 fi
 

--- a/.claude/hooks/research-stop-nudge.sh
+++ b/.claude/hooks/research-stop-nudge.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# research-stop-nudge.sh — opt-in SubagentStop nudge for research agents
+# Fires when a research subagent stops. Default: silent (non-blocking).
+# Set MERCURY_RESEARCH_STOP_NUDGE=1 to inject a source/[UNVERIFIED] reminder
+# into additionalContext so main sees the Mercury research protocol note.
+# Always exits 0 (non-blocking); stdin parse failures are tolerated silently.
+
+set -euo pipefail
+
+# Read stdin (SubagentStop payload); ignore parse errors — always non-blocking.
+input="$(cat 2>/dev/null || true)"
+
+if [ "${MERCURY_RESEARCH_STOP_NUDGE:-}" != "1" ]; then
+  exit 0
+fi
+
+# Emit additionalContext nudge to stdout for Claude to see.
+printf '%s\n' '{"hookSpecificOutput":{"hookEventName":"SubagentStop","additionalContext":"research subagent finished — before using its findings, ensure SDK/API/version claims carry source URLs or are tagged [UNVERIFIED] (Mercury research protocol)."}}'
+exit 0

--- a/.claude/hooks/research-stop-nudge.sh
+++ b/.claude/hooks/research-stop-nudge.sh
@@ -6,6 +6,8 @@
 # Always exits 0 (non-blocking); stdin parse failures are tolerated silently.
 # Payload validation: only emits when hook_event_name=="SubagentStop" AND
 # agent_type=="research". Other event/agent combinations exit silently.
+# Field matching uses node JSON.parse (node is already a hook runtime dep) to
+# avoid false positives from literal field strings embedded in other values.
 
 set -euo pipefail
 
@@ -16,22 +18,10 @@ if [ "${MERCURY_RESEARCH_STOP_NUDGE:-}" != "1" ]; then
   exit 0
 fi
 
-# Validate payload fields using grep/sed (no jq dependency).
-# Match "hook_event_name": "SubagentStop" (allows optional whitespace around colon).
-event_ok=false
-if printf '%s' "$input" | grep -qE '"hook_event_name"\s*:\s*"SubagentStop"'; then
-  event_ok=true
-fi
-
-# Match "agent_type": "research"
-agent_ok=false
-if printf '%s' "$input" | grep -qE '"agent_type"\s*:\s*"research"'; then
-  agent_ok=true
-fi
-
-if [ "$event_ok" != "true" ] || [ "$agent_ok" != "true" ]; then
-  exit 0
-fi
+# Validate payload fields via true JSON parsing (node).
+# Malformed JSON or missing node → "0" → silent exit 0 (graceful degradation).
+matches="$(printf '%s' "$input" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{const j=JSON.parse(s);process.stdout.write(j&&j.hook_event_name==="SubagentStop"&&j.agent_type==="research"?"1":"0")}catch(e){process.stdout.write("0")}})' 2>/dev/null || echo 0)"
+[ "$matches" = "1" ] || exit 0
 
 # Emit additionalContext nudge to stdout for Claude to see.
 printf '%s\n' '{"hookSpecificOutput":{"hookEventName":"SubagentStop","additionalContext":"research subagent finished — before using its findings, ensure SDK/API/version claims carry source URLs or are tagged [UNVERIFIED] (Mercury research protocol)."}}'

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -131,6 +131,16 @@
             "timeout": 360
           }
         ]
+      },
+      {
+        "matcher": "research",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/research-stop-nudge.sh\"",
+            "timeout": 5
+          }
+        ]
       }
     ]
   },

--- a/adapters/mercury-test-gate/README.md
+++ b/adapters/mercury-test-gate/README.md
@@ -11,7 +11,11 @@ When a `dev` sub-agent tries to stop, Claude Code fires the `SubagentStop` event
 3. Resolves the test command — convention file first, then auto-detect.
 4. Runs the test command with a configurable timeout.
 5. If tests fail or time out — emits `{"decision":"block","reason":"..."}` on stdout + exit 0.
-6. If tests pass — emits `{"hookSpecificOutput":{"hookEventName":"SubagentStop","additionalContext":"✓ Mercury test gate: `<cmd>` passed (exit 0)"}}` on stdout + exit 0, surfacing a positive signal to main (non-blocking; never combined with `decision`).
+6. If tests pass — emits the following on stdout + exit 0, surfacing a fixed positive signal to main (non-blocking; never combined with `decision`; `testCmd` is intentionally not interpolated to prevent prompt injection):
+
+```json
+{"hookSpecificOutput":{"hookEventName":"SubagentStop","additionalContext":"✓ Mercury test gate: tests passed (exit 0)"}}
+```
 7. If no test command resolves (fail-open) — exits 0 with no output (spec-safe "no opinion"); strict mode (`MERCURY_TEST_GATE_STRICT=1`) blocks instead.
 
 ## Setup

--- a/adapters/mercury-test-gate/README.md
+++ b/adapters/mercury-test-gate/README.md
@@ -62,6 +62,14 @@ Set this in your shell environment or in a project-level `.env` (loaded before C
 
 Remove or comment out the `SubagentStop` entry in `.claude/settings.json`.
 
+## 为何只 gate dev（设计判定）
+
+`mercury-test-gate` 仅对 `dev` agent 生效，不对 `acceptance`、`critic`、`research` 等角色加阻塞门，原因如下：
+
+- **acceptance / critic**：产出结构化 verdict（APPROVED / NEEDS-REVISION 等），由 Main 直接 dispatch 并以最终消息作为产出。对它们执行 `decision:block` 会阻止 Main 收到 verdict，属于错误行为。其停止行为本身即正确——无需外部检查可运行。
+- **research**：产出 research summary，同样由 Main 消费。是否携带 source URL / `[UNVERIFIED]` 标签属于内容质量问题，不能用阻塞门强制（会造成 research agent 无法正常退出）。对应的提醒做成 opt-in nudge（见 `.claude/hooks/research-stop-nudge.sh`，`MERCURY_RESEARCH_STOP_NUDGE=1` 启用），默认关闭以避免噪音。
+- **机械门的边界**：`SubagentStop` 阻塞门适合「有外部可执行检查（测试套件）且失败必须阻止停止」的场景。dev agent 满足此条件；其他角色不满足，故不加门。
+
 ## Layer model
 
 This hook is orthogonal to OMC's `persistent-mode.cjs`. Both can be registered simultaneously. Claude Code runs all matching hooks; a stop is blocked if any hook returns `decision: "block"`. Mercury's adapter provides the mechanical exit-code check; OMC (if installed) provides the Ralph/UltraQA cycle-counting layer.

--- a/adapters/mercury-test-gate/README.md
+++ b/adapters/mercury-test-gate/README.md
@@ -11,7 +11,8 @@ When a `dev` sub-agent tries to stop, Claude Code fires the `SubagentStop` event
 3. Resolves the test command — convention file first, then auto-detect.
 4. Runs the test command with a configurable timeout.
 5. If tests fail or time out — emits `{"decision":"block","reason":"..."}` on stdout + exit 0.
-6. If tests pass — exits 0 with no output (spec-safe "no opinion").
+6. If tests pass — emits `{"hookSpecificOutput":{"hookEventName":"SubagentStop","additionalContext":"✓ Mercury test gate: `<cmd>` passed (exit 0)"}}` on stdout + exit 0, surfacing a positive signal to main (non-blocking; never combined with `decision`).
+7. If no test command resolves (fail-open) — exits 0 with no output (spec-safe "no opinion"); strict mode (`MERCURY_TEST_GATE_STRICT=1`) blocks instead.
 
 ## Setup
 

--- a/adapters/mercury-test-gate/hook.cjs
+++ b/adapters/mercury-test-gate/hook.cjs
@@ -12,15 +12,17 @@ const TIMEOUT = (() => { const n = parseInt(process.env.MERCURY_TEST_GATE_TIMEOU
 const STRICT = process.env.MERCURY_TEST_GATE_STRICT === '1';
 const TAG = '[mercury-test-gate]';
 // block: dev-only mechanical test gate — emits decision:block to prevent subagent stop.
-// passWithContext: pass path now surfaces positive signal to main via additionalContext,
+// passWithContext: pass path surfaces a fixed positive signal to main via additionalContext,
 //   so main knows tests were confirmed green (not just "no opinion from hook").
+//   Fixed text only — testCmd is intentionally NOT interpolated to avoid prompt injection
+//   and sensitive command leakage from repo-controlled config files.
 // pass: silent exit 0 for non-dev / fail-open / re-entry-exhausted paths (hook has no opinion → no noise).
 const block = (reason) => { process.stdout.write(JSON.stringify({ decision: 'block', reason }) + '\n'); process.exit(0); };
-const passWithContext = (testCmd) => {
+const passWithContext = () => {
   process.stdout.write(JSON.stringify({
     hookSpecificOutput: {
       hookEventName: 'SubagentStop',
-      additionalContext: `✓ Mercury test gate: \`${testCmd}\` passed (exit 0)`,
+      additionalContext: '✓ Mercury test gate: tests passed (exit 0)',
     },
   }) + '\n');
   process.exit(0);
@@ -72,7 +74,7 @@ async function main() {
 
   // Tests passed — clear any stale retry counters from prior blocked attempts.
   clearAttempts(path.join(cwd, '.mercury', 'state'), session_id, agent_id);
-  passWithContext(testCmd);
+  passWithContext();
 }
 
 main().catch((e) => { process.stderr.write(`${TAG} Unexpected error: ${e.message}\n`); process.exit(0); });

--- a/adapters/mercury-test-gate/hook.cjs
+++ b/adapters/mercury-test-gate/hook.cjs
@@ -14,7 +14,7 @@ const TAG = '[mercury-test-gate]';
 // block: dev-only mechanical test gate — emits decision:block to prevent subagent stop.
 // passWithContext: pass path now surfaces positive signal to main via additionalContext,
 //   so main knows tests were confirmed green (not just "no opinion from hook").
-// passQuiet: used for no-test-command fail-open (avoid noise when hook has no opinion).
+// pass: silent exit 0 for non-dev / fail-open / re-entry-exhausted paths (hook has no opinion → no noise).
 const block = (reason) => { process.stdout.write(JSON.stringify({ decision: 'block', reason }) + '\n'); process.exit(0); };
 const passWithContext = (testCmd) => {
   process.stdout.write(JSON.stringify({

--- a/adapters/mercury-test-gate/hook.cjs
+++ b/adapters/mercury-test-gate/hook.cjs
@@ -11,7 +11,20 @@ const GATED = ['dev'];
 const TIMEOUT = (() => { const n = parseInt(process.env.MERCURY_TEST_GATE_TIMEOUT_SEC, 10); return Number.isFinite(n) && n > 0 ? n : 300; })();
 const STRICT = process.env.MERCURY_TEST_GATE_STRICT === '1';
 const TAG = '[mercury-test-gate]';
+// block: dev-only mechanical test gate — emits decision:block to prevent subagent stop.
+// passWithContext: pass path now surfaces positive signal to main via additionalContext,
+//   so main knows tests were confirmed green (not just "no opinion from hook").
+// passQuiet: used for no-test-command fail-open (avoid noise when hook has no opinion).
 const block = (reason) => { process.stdout.write(JSON.stringify({ decision: 'block', reason }) + '\n'); process.exit(0); };
+const passWithContext = (testCmd) => {
+  process.stdout.write(JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: 'SubagentStop',
+      additionalContext: `✓ Mercury test gate: \`${testCmd}\` passed (exit 0)`,
+    },
+  }) + '\n');
+  process.exit(0);
+};
 const pass = () => process.exit(0);
 
 async function main() {
@@ -59,7 +72,7 @@ async function main() {
 
   // Tests passed — clear any stale retry counters from prior blocked attempts.
   clearAttempts(path.join(cwd, '.mercury', 'state'), session_id, agent_id);
-  pass();
+  passWithContext(testCmd);
 }
 
 main().catch((e) => { process.stderr.write(`${TAG} Unexpected error: ${e.message}\n`); process.exit(0); });

--- a/adapters/mercury-test-gate/package.json
+++ b/adapters/mercury-test-gate/package.json
@@ -5,7 +5,7 @@
   "type": "commonjs",
   "main": "hook.cjs",
   "scripts": {
-    "test": "node --test \"test/hook.test.cjs\""
+    "test": "node --test \"test/*.cjs\""
   },
   "engines": {
     "node": ">=18.0.0"

--- a/adapters/mercury-test-gate/package.json
+++ b/adapters/mercury-test-gate/package.json
@@ -5,7 +5,7 @@
   "type": "commonjs",
   "main": "hook.cjs",
   "scripts": {
-    "test": "node --test \"test/*.cjs\""
+    "test": "node --test test/hook.test.cjs test/resolve-command.test.cjs"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/adapters/mercury-test-gate/package.json
+++ b/adapters/mercury-test-gate/package.json
@@ -5,7 +5,7 @@
   "type": "commonjs",
   "main": "hook.cjs",
   "scripts": {
-    "test": "node --test test/"
+    "test": "node --test \"test/hook.test.cjs\""
   },
   "engines": {
     "node": ">=18.0.0"

--- a/adapters/mercury-test-gate/test/hook.test.cjs
+++ b/adapters/mercury-test-gate/test/hook.test.cjs
@@ -50,8 +50,8 @@ test('non-dev agent type exits 0 with no stdout', () => {
   assert.equal(r.stdout.trim(), '');
 });
 
-// ─── Test 2: dev agent, tests pass → no-op exit 0 ────────────────────────────
-test('dev agent, tests pass → no stdout, exit 0', () => {
+// ─── Test 2: dev agent, tests pass → additionalContext JSON, exit 0 ──────────
+test('dev agent, tests pass → additionalContext JSON, exit 0', () => {
   const isWin = process.platform === 'win32';
   const passCmd = isWin ? 'exit 0' : 'true';
   const dir = makeTmpDir({
@@ -59,7 +59,9 @@ test('dev agent, tests pass → no stdout, exit 0', () => {
   });
   const r = invokeHook({ hook_event_name: 'SubagentStop', agent_type: 'dev', session_id: 's2', agent_id: 'a2', cwd: dir });
   assert.equal(r.status, 0, `stderr: ${r.stderr}`);
-  assert.equal(r.stdout.trim(), '');
+  const parsed = JSON.parse(r.stdout.trim());
+  assert.equal(parsed.hookSpecificOutput.hookEventName, 'SubagentStop');
+  assert.ok(parsed.hookSpecificOutput.additionalContext.includes('passed'), `additionalContext: ${parsed.hookSpecificOutput.additionalContext}`);
 });
 
 // ─── Test 3: dev agent, tests fail → block decision JSON ─────────────────────
@@ -213,9 +215,62 @@ test('successful test run clears stale retry counter from prior blocks', () => {
   // Invoke with stop_hook_active=false (first-time stop attempt) + green tests
   const r = invokeHook({ hook_event_name: 'SubagentStop', agent_type: 'dev', stop_hook_active: false, session_id: sessionId, agent_id: agentId, cwd: dir });
   assert.equal(r.status, 0);
-  assert.equal(r.stdout.trim(), ''); // no block — tests pass
+  // pass path now emits additionalContext (not block) — confirm no block decision
+  const parsed = JSON.parse(r.stdout.trim());
+  assert.ok(!parsed.decision, 'should not have decision:block on green run');
+  assert.ok(parsed.hookSpecificOutput.additionalContext.includes('passed'));
 
   // The stale counter should be cleared
   const state = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
   assert.equal(state[`${sessionId}:${agentId}`], undefined, 'stale retry state should be cleared on green test run');
+});
+
+// ─── Test 11: pass-path additionalContext JSON shape ─────────────────────────
+test('pass path emits hookSpecificOutput with hookEventName=SubagentStop and additionalContext containing "passed"', () => {
+  const isWin = process.platform === 'win32';
+  const passCmd = isWin ? 'exit 0' : 'true';
+  const dir = makeTmpDir({
+    '.mercury/config/test-gate.yaml': `test_command: ${passCmd}\n`,
+  });
+  const r = invokeHook({ hook_event_name: 'SubagentStop', agent_type: 'dev', session_id: 's11', agent_id: 'a11', cwd: dir });
+  assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+  const parsed = JSON.parse(r.stdout.trim());
+  assert.ok(parsed.hookSpecificOutput, 'must have hookSpecificOutput');
+  assert.equal(parsed.hookSpecificOutput.hookEventName, 'SubagentStop');
+  assert.ok(typeof parsed.hookSpecificOutput.additionalContext === 'string', 'additionalContext must be string');
+  assert.ok(parsed.hookSpecificOutput.additionalContext.includes('passed'), `must contain "passed": ${parsed.hookSpecificOutput.additionalContext}`);
+  assert.ok(!parsed.decision, 'must not have decision field on pass path');
+});
+
+// ─── Test 12: research-stop-nudge.sh with env=1 → additionalContext ───────────
+test('research-stop-nudge.sh: MERCURY_RESEARCH_STOP_NUDGE=1 → additionalContext JSON', () => {
+  const nudgeScript = path.resolve(__dirname, '..', '..', '..', '.claude', 'hooks', 'research-stop-nudge.sh');
+  const input = JSON.stringify({ hook_event_name: 'SubagentStop', agent_type: 'research', session_id: 'rn1', agent_id: 'ra1' });
+  const result = spawnSync('bash', [nudgeScript], {
+    input,
+    env: { ...process.env, MERCURY_RESEARCH_STOP_NUDGE: '1' },
+    encoding: 'utf8',
+    timeout: 10000,
+  });
+  assert.equal(result.status, 0, `stderr: ${result.stderr}`);
+  const parsed = JSON.parse((result.stdout || '').trim());
+  assert.equal(parsed.hookSpecificOutput.hookEventName, 'SubagentStop');
+  assert.ok(typeof parsed.hookSpecificOutput.additionalContext === 'string');
+  assert.ok(parsed.hookSpecificOutput.additionalContext.length > 0);
+});
+
+// ─── Test 13: research-stop-nudge.sh without env → silent exit 0 ─────────────
+test('research-stop-nudge.sh: MERCURY_RESEARCH_STOP_NUDGE unset → silent exit 0', () => {
+  const nudgeScript = path.resolve(__dirname, '..', '..', '..', '.claude', 'hooks', 'research-stop-nudge.sh');
+  const input = JSON.stringify({ hook_event_name: 'SubagentStop', agent_type: 'research', session_id: 'rn2', agent_id: 'ra2' });
+  const envWithout = { ...process.env };
+  delete envWithout.MERCURY_RESEARCH_STOP_NUDGE;
+  const result = spawnSync('bash', [nudgeScript], {
+    input,
+    env: envWithout,
+    encoding: 'utf8',
+    timeout: 10000,
+  });
+  assert.equal(result.status, 0, `stderr: ${result.stderr}`);
+  assert.equal((result.stdout || '').trim(), '', 'should produce no stdout when env unset');
 });

--- a/adapters/mercury-test-gate/test/hook.test.cjs
+++ b/adapters/mercury-test-gate/test/hook.test.cjs
@@ -271,6 +271,29 @@ test('research-stop-nudge.sh: MERCURY_RESEARCH_STOP_NUDGE=1 → additionalContex
     assert.ok(parsed.hookSpecificOutput.additionalContext.length > 0);
   });
 
+// ─── Test 14: research-stop-nudge.sh boundary — value contains "research" string but agent_type is not "research" ───
+test('research-stop-nudge.sh: agent_type=dev with "research" in transcript value → silent (no false positive)',
+  { skip: bashAvailable ? false : 'bash unavailable' },
+  () => {
+    const nudgeScript = path.resolve(__dirname, '..', '..', '..', '.claude', 'hooks', 'research-stop-nudge.sh');
+    // agent_type is "dev"; the transcript string value contains "agent_type: research" text
+    const input = JSON.stringify({
+      hook_event_name: 'SubagentStop',
+      agent_type: 'dev',
+      session_id: 'rn-boundary',
+      agent_id: 'ra-boundary',
+      transcript: 'subagent finished; note: agent_type: research was used internally',
+    });
+    const result = spawnSync('bash', [nudgeScript], {
+      input,
+      env: { ...process.env, MERCURY_RESEARCH_STOP_NUDGE: '1' },
+      encoding: 'utf8',
+      timeout: 10000,
+    });
+    assert.equal(result.status, 0, `stderr: ${result.stderr}`);
+    assert.equal((result.stdout || '').trim(), '', 'must produce no output — dev agent_type must not match even when value contains "research"');
+  });
+
 // ─── Test 13: research-stop-nudge.sh without env → silent exit 0 ─────────────
 test('research-stop-nudge.sh: MERCURY_RESEARCH_STOP_NUDGE unset → silent exit 0',
   { skip: bashAvailable ? false : 'bash unavailable' },

--- a/adapters/mercury-test-gate/test/hook.test.cjs
+++ b/adapters/mercury-test-gate/test/hook.test.cjs
@@ -242,35 +242,49 @@ test('pass path emits hookSpecificOutput with hookEventName=SubagentStop and add
   assert.ok(!parsed.decision, 'must not have decision field on pass path');
 });
 
+// ─── bash availability probe (used by Tests 12-13) ───────────────────────────
+const bashAvailable = (() => {
+  try {
+    const probe = spawnSync('bash', ['-c', 'exit 0'], { encoding: 'utf8', timeout: 5000 });
+    return probe.status === 0;
+  } catch (_) {
+    return false;
+  }
+})();
+
 // ─── Test 12: research-stop-nudge.sh with env=1 → additionalContext ───────────
-test('research-stop-nudge.sh: MERCURY_RESEARCH_STOP_NUDGE=1 → additionalContext JSON', () => {
-  const nudgeScript = path.resolve(__dirname, '..', '..', '..', '.claude', 'hooks', 'research-stop-nudge.sh');
-  const input = JSON.stringify({ hook_event_name: 'SubagentStop', agent_type: 'research', session_id: 'rn1', agent_id: 'ra1' });
-  const result = spawnSync('bash', [nudgeScript], {
-    input,
-    env: { ...process.env, MERCURY_RESEARCH_STOP_NUDGE: '1' },
-    encoding: 'utf8',
-    timeout: 10000,
+test('research-stop-nudge.sh: MERCURY_RESEARCH_STOP_NUDGE=1 → additionalContext JSON',
+  { skip: bashAvailable ? false : 'bash unavailable' },
+  () => {
+    const nudgeScript = path.resolve(__dirname, '..', '..', '..', '.claude', 'hooks', 'research-stop-nudge.sh');
+    const input = JSON.stringify({ hook_event_name: 'SubagentStop', agent_type: 'research', session_id: 'rn1', agent_id: 'ra1' });
+    const result = spawnSync('bash', [nudgeScript], {
+      input,
+      env: { ...process.env, MERCURY_RESEARCH_STOP_NUDGE: '1' },
+      encoding: 'utf8',
+      timeout: 10000,
+    });
+    assert.equal(result.status, 0, `stderr: ${result.stderr}`);
+    const parsed = JSON.parse((result.stdout || '').trim());
+    assert.equal(parsed.hookSpecificOutput.hookEventName, 'SubagentStop');
+    assert.ok(typeof parsed.hookSpecificOutput.additionalContext === 'string');
+    assert.ok(parsed.hookSpecificOutput.additionalContext.length > 0);
   });
-  assert.equal(result.status, 0, `stderr: ${result.stderr}`);
-  const parsed = JSON.parse((result.stdout || '').trim());
-  assert.equal(parsed.hookSpecificOutput.hookEventName, 'SubagentStop');
-  assert.ok(typeof parsed.hookSpecificOutput.additionalContext === 'string');
-  assert.ok(parsed.hookSpecificOutput.additionalContext.length > 0);
-});
 
 // ─── Test 13: research-stop-nudge.sh without env → silent exit 0 ─────────────
-test('research-stop-nudge.sh: MERCURY_RESEARCH_STOP_NUDGE unset → silent exit 0', () => {
-  const nudgeScript = path.resolve(__dirname, '..', '..', '..', '.claude', 'hooks', 'research-stop-nudge.sh');
-  const input = JSON.stringify({ hook_event_name: 'SubagentStop', agent_type: 'research', session_id: 'rn2', agent_id: 'ra2' });
-  const envWithout = { ...process.env };
-  delete envWithout.MERCURY_RESEARCH_STOP_NUDGE;
-  const result = spawnSync('bash', [nudgeScript], {
-    input,
-    env: envWithout,
-    encoding: 'utf8',
-    timeout: 10000,
+test('research-stop-nudge.sh: MERCURY_RESEARCH_STOP_NUDGE unset → silent exit 0',
+  { skip: bashAvailable ? false : 'bash unavailable' },
+  () => {
+    const nudgeScript = path.resolve(__dirname, '..', '..', '..', '.claude', 'hooks', 'research-stop-nudge.sh');
+    const input = JSON.stringify({ hook_event_name: 'SubagentStop', agent_type: 'research', session_id: 'rn2', agent_id: 'ra2' });
+    const envWithout = { ...process.env };
+    delete envWithout.MERCURY_RESEARCH_STOP_NUDGE;
+    const result = spawnSync('bash', [nudgeScript], {
+      input,
+      env: envWithout,
+      encoding: 'utf8',
+      timeout: 10000,
+    });
+    assert.equal(result.status, 0, `stderr: ${result.stderr}`);
+    assert.equal((result.stdout || '').trim(), '', 'should produce no stdout when env unset');
   });
-  assert.equal(result.status, 0, `stderr: ${result.stderr}`);
-  assert.equal((result.stdout || '').trim(), '', 'should produce no stdout when env unset');
-});


### PR DESCRIPTION
Closes #484
Refs #478

## 概要

#478 harness 现代化 **P2 / S6**(精炼版,用户已定范围):SubagentStop `hookSpecificOutput.additionalContext` 强化。dev test-gate 测试通过现把**正向信号**经 additionalContext 暴露给 main(原为静默 exit 0);并文档化「为何只 gate dev」的设计判定 + 给 research 加 opt-in nudge。

## 改动

- **`adapters/mercury-test-gate/hook.cjs`**: 测试 PASS 路径 `pass()` → `passWithContext(testCmd)`,输出 `{"hookSpecificOutput":{"hookEventName":"SubagentStop","additionalContext":"✓ Mercury test gate: \`<cmd>\` passed (exit 0)"}}`。**所有 block 路径(fail/timeout/re-entry/strict)保留不变**;fail-open/non-dev/re-entry-exhausted 仍走静默 `pass()`。无任何路径同时发 `decision` + `additionalContext`。78 LOC ≤ 200(DIRECTION §8-2)。
- **`adapters/mercury-test-gate/README.md`**: 新增「为何只 gate dev(设计判定)」—— acceptance/critic/research 产出 verdict/summary 由 Main 直接消费,无外部检查可跑,`decision:block` 会阻止 Main 收 verdict 属错误行为,故不加门。
- **`.claude/hooks/research-stop-nudge.sh`**(新): research opt-in nudge,`MERCURY_RESEARCH_STOP_NUDGE=1` 启用(默认关,无噪音),始终非阻塞 exit 0,提醒 source/[UNVERIFIED] 协议。
- **`.claude/settings.json`**: SubagentStop 新增 `matcher:"research"` → research-stop-nudge.sh;原 `matcher:"dev"` 不变。
- **测试**: hook.test.cjs 更新(Test 2 断言 additionalContext)+ 新增 pass-path/nudge 测试。

## 核验(web-verified + dual-verify)

- **web-verified**(强制研究协议): SubagentStop 同时支持 `additionalContext`(non-error 续接)+ `decision:block`,matcher 按 agent_type 过滤 —— [code.claude.com/docs/en/hooks](https://code.claude.com/docs/en/hooks)。
- **dual-verify**: Claude PASS + Codex NEEDS-CHANGES → **fixed**:
  - Medium(Codex+Claude): `package.json` test script 原 `node --test "test/hook.test.cjs"` **漏跑 resolve-command.test.cjs** → 改 `node --test "test/*.cjs"`(node 原生展开 glob,跨平台;`npm test` 现 **23/23** 跑全两文件,恢复 resolveCommand 覆盖)。
  - Low(Codex): README green-path 描述 stale → 订正为 additionalContext + 拆出 fail-open。
  - Low(Claude): hook.cjs 注释 `passQuiet` 名与实际 `pass` 函数不符 → 订正。
  - hook.cjs **逻辑**两审判正确(单 JSON / 无双信号 / block 路径全保留)。
- **Final**: PASS。settings.json JSON 合法;合成 stdin 实测 dev+pass→additionalContext、dev+fail→block、research±env→nudge/静默 均通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
