### PR TITLE
feat(#495): voice_queue.py per-session transcript 队列 (Path 2 Slice 2)

### DIFF
--- a/scripts/voice/test_voice_queue.py
+++ b/scripts/voice/test_voice_queue.py
@@ -85,7 +85,7 @@ def test_drain_takes_oldest_and_moves_to_consumed():
         assert [it["text"] for it in drained] == ["a", "b"], drained  # oldest first
         assert drained[0]["consumed"] is True  # returned dict reflects consumption
         assert [it["text"] for it in vq.peek_all(session=s)] == ["c"]  # third remains
-        # the two claimed files were os.replace'd into consumed/, not left in the queue dir
+        # the two claimed files left consumed-markers (O_EXCL) and were removed from the queue dir
         assert len(list(vq._consumed_dir(s).glob("utt-*.json"))) == 2
         assert len(list(vq._queue_dir(s).glob("utt-*.json"))) == 1
 
@@ -130,6 +130,38 @@ def test_corrupt_utt_skipped_batch_survives():
         assert (qd / "utt-99999999-0-999999.json").exists()  # left for a later pass
 
 
+def test_malformed_text_skipped():
+    # C1: an item with a ts but no usable string "text" is malformed and must be skipped —
+    # never listed/drained/counted — while a valid item alongside it is still delivered.
+    with _temp_state():
+        s = "notext"
+        vq.enqueue("ok", ts="2026-06-21T11:00:00+08:00", session=s)
+        qd = vq._queue_dir(s)
+        for nm, payload in (
+            ("utt-bad1-0-000000.json", {"ts": "2026-06-21T10:00:00+08:00", "consumed": False}),
+            ("utt-bad2-0-000000.json", {"ts": "2026-06-21T10:00:00+08:00", "text": 123}),
+            ("utt-bad3-0-000000.json", {"ts": "2026-06-21T10:00:00+08:00", "text": "   "}),
+        ):
+            (qd / nm).write_text(json.dumps(payload), encoding="utf-8")
+        assert [it["text"] for it in vq.peek_all(session=s)] == ["ok"]
+        assert [it["text"] for it in vq.drain(10, session=s)] == ["ok"]
+        assert vq.is_empty(session=s)  # the malformed orphans don't keep is_empty False
+
+
+def test_drain_coerces_max_items():
+    # A1: max_items is a boundary input (env var). A non-int / non-positive value must be a
+    # no-op (never a TypeError that aborts consumption); a float is truncated via int().
+    with _temp_state():
+        s = "coerce"
+        vq.enqueue("a", ts="2026-06-21T10:00:00+08:00", session=s)
+        vq.enqueue("b", ts="2026-06-21T11:00:00+08:00", session=s)
+        vq.enqueue("c", ts="2026-06-21T12:00:00+08:00", session=s)
+        assert vq.drain("not-an-int", session=s) == []  # bad str -> no-op, no crash
+        assert vq.drain(None, session=s) == []           # None -> no-op
+        assert vq.drain(-1, session=s) == []             # non-positive -> no-op
+        assert [it["text"] for it in vq.drain(2.9, session=s)] == ["a", "b"]  # int(2.9)=2
+
+
 def test_atomic_enqueue_leaves_no_tmp():
     with _temp_state():
         s = "atomic"
@@ -169,10 +201,16 @@ def test_session_resolution_and_injectivity():
         # distinct raw ids that sanitise to the SAME slug must NOT share a queue dir (F2:
         # per-session isolation is a safety property — a collision = cross-session leak)
         assert vq._queue_dir("a/b").name != vq._queue_dir("a:b").name
-        # an omitted session (None) -> default bucket; an explicit falsy "" -> default too,
-        # NOT silently rerouted to the env var's session (F1)
+        # an OMITTED session (None) -> shared default bucket
         assert vq._queue_dir(None).name == "default"
-        assert vq._queue_dir("").name == "default"
+        # an EXPLICIT falsy value (0 / "") is honoured as its own bucket, NEVER merged into
+        # default or another session — two distinct explicit values never collide (F1/A3)
+        assert vq._queue_dir("").name != "default"
+        assert vq._queue_dir(0).name != "default"
+        assert vq._queue_dir("").name != vq._queue_dir(0).name
+        assert vq._queue_dir("").name != vq._queue_dir(None).name
+        # length-bounded: an unbounded session id must not blow the OS filename limit (A2)
+        assert len(vq._queue_dir("x" * 5000).name) <= 61
 
 
 # --- exactly-once under concurrency (§8 test 7) ------------------------------------
@@ -189,7 +227,7 @@ def test_concurrent_drain_consumes_each_once():
         barrier = threading.Barrier(n)
 
         def worker():
-            barrier.wait()  # release all threads together to maximise os.replace contention
+            barrier.wait()  # release all threads together to maximise O_EXCL claim contention
             got = vq.drain(100, session=s)
             with lock:
                 results.extend(it["text"] for it in got)

--- a/scripts/voice/test_voice_queue.py
+++ b/scripts/voice/test_voice_queue.py
@@ -1,0 +1,296 @@
+# -*- coding: utf-8 -*-
+"""Behaviour tests for the #495 Slice-2 transcript queue (voice_queue.py).
+
+Pure file IO — no microphone, no native deps. Each test runs against a throwaway
+VOICE_STATE_DIR so the queue lives entirely under a temp dir. Covers the §8 adversarial
+merge gates: atomic enqueue, pinned `utt-*.json` glob (half-write safe), per-file parse
+resilience, per-session isolation, exactly-once concurrent drain, and watermark-anchored
+pop_latest.
+
+Run: <venv>/python.exe scripts/voice/test_voice_queue.py   (also pytest-compatible)
+"""
+import os
+import sys
+import json
+import shutil
+import tempfile
+import threading
+import contextlib
+from pathlib import Path
+from datetime import datetime
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import voice_queue as vq  # noqa: E402
+
+
+@contextlib.contextmanager
+def _temp_state():
+    """Point VOICE_STATE_DIR at a fresh temp dir for the duration of one test."""
+    prev = os.environ.get("VOICE_STATE_DIR")
+    prev_sess = os.environ.get("VOICE_QUEUE_SESSION")
+    d = tempfile.mkdtemp(prefix="vq-test-")
+    os.environ["VOICE_STATE_DIR"] = d
+    os.environ.pop("VOICE_QUEUE_SESSION", None)  # tests pass session explicitly
+    try:
+        yield d
+    finally:
+        for key, val in (("VOICE_STATE_DIR", prev), ("VOICE_QUEUE_SESSION", prev_sess)):
+            if val is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = val
+        shutil.rmtree(d, ignore_errors=True)
+
+
+# --- core round-trip ---------------------------------------------------------------
+
+def test_enqueue_peek_roundtrip():
+    with _temp_state():
+        s = "round"
+        assert vq.enqueue("一", session=s)
+        assert vq.enqueue("二", session=s)
+        items = vq.peek_all(session=s)
+        assert [it["text"] for it in items] == ["一", "二"], items
+        assert all(it["consumed"] is False for it in items)  # peek does not consume
+        assert not vq.is_empty(session=s)
+
+
+def test_enqueue_empty_returns_none():
+    with _temp_state():
+        s = "empty-text"
+        assert vq.enqueue("", session=s) is None
+        assert vq.enqueue("   ", session=s) is None
+        assert vq.enqueue(None, session=s) is None
+        assert vq.is_empty(session=s)
+
+
+def test_drain_empty_and_pop_empty():
+    with _temp_state():
+        assert vq.drain(5, session="none") == []
+        assert vq.pop_latest(session="none") is None
+        assert vq.is_empty(session="none")
+        assert vq.drain(0, session="none") == []  # non-positive max -> no-op
+
+
+# --- drain FIFO + consumed/ archive ------------------------------------------------
+
+def test_drain_takes_oldest_and_moves_to_consumed():
+    with _temp_state():
+        s = "fifo"
+        vq.enqueue("a", ts="2026-06-21T10:00:00+08:00", session=s)
+        vq.enqueue("b", ts="2026-06-21T11:00:00+08:00", session=s)
+        vq.enqueue("c", ts="2026-06-21T12:00:00+08:00", session=s)
+        drained = vq.drain(2, session=s)
+        assert [it["text"] for it in drained] == ["a", "b"], drained  # oldest first
+        assert drained[0]["consumed"] is True  # returned dict reflects consumption
+        assert [it["text"] for it in vq.peek_all(session=s)] == ["c"]  # third remains
+        # the two claimed files were os.replace'd into consumed/, not left in the queue dir
+        assert len(list(vq._consumed_dir(s).glob("utt-*.json"))) == 2
+        assert len(list(vq._queue_dir(s).glob("utt-*.json"))) == 1
+
+
+def test_is_empty_lifecycle():
+    with _temp_state():
+        s = "lifecycle"
+        assert vq.is_empty(session=s)
+        vq.enqueue("x", session=s)
+        assert not vq.is_empty(session=s)
+        vq.drain(10, session=s)
+        assert vq.is_empty(session=s)
+
+
+# --- half-write / corruption safety (§8 merge gates) -------------------------------
+
+def test_halfwrite_tmp_excluded_by_glob():
+    with _temp_state():
+        s = "tmp-safe"
+        vq.enqueue("real", session=s)
+        qd = vq._queue_dir(s)
+        # a half-written enqueue temp (the .tmp-*.json os.replace target) must be invisible
+        (qd / ".tmp-inflight.json").write_text('{"ts": "2026', encoding="utf-8")
+        assert [it["text"] for it in vq.peek_all(session=s)] == ["real"]
+        drained = vq.drain(10, session=s)
+        assert [it["text"] for it in drained] == ["real"]  # no exception, tmp untouched
+        assert (qd / ".tmp-inflight.json").exists()  # pinned glob never read/moved it
+
+
+def test_corrupt_utt_skipped_batch_survives():
+    with _temp_state():
+        s = "corrupt"
+        vq.enqueue("ok1", ts="2026-06-21T10:00:00+08:00", session=s)
+        vq.enqueue("ok2", ts="2026-06-21T11:00:00+08:00", session=s)
+        qd = vq._queue_dir(s)
+        # a truncated file that DOES match utt-*.json: a single bad file must be skipped
+        # per-file, never aborting the whole batch (would silently drop ok1+ok2 otherwise)
+        (qd / "utt-99999999-0-999999.json").write_text('{"ts": "2026-06-21T13:00', encoding="utf-8")
+        assert sorted(it["text"] for it in vq.peek_all(session=s)) == ["ok1", "ok2"]
+        drained = vq.drain(10, session=s)
+        assert sorted(it["text"] for it in drained) == ["ok1", "ok2"]  # batch survived
+        assert (qd / "utt-99999999-0-999999.json").exists()  # left for a later pass
+
+
+def test_atomic_enqueue_leaves_no_tmp():
+    with _temp_state():
+        s = "atomic"
+        vq.enqueue("done", session=s)
+        qd = vq._queue_dir(s)
+        assert list(qd.glob(".tmp-*.json")) == []  # os.replace consumed the temp
+        assert len(list(qd.glob("utt-*.json"))) == 1
+
+
+# --- per-session scoping (§8: concurrent lanes share .mercury/state) ---------------
+
+def test_per_session_isolation():
+    with _temp_state():
+        vq.enqueue("forA", session="A")
+        vq.enqueue("forB", session="B")
+        assert [it["text"] for it in vq.peek_all(session="A")] == ["forA"]
+        assert [it["text"] for it in vq.peek_all(session="B")] == ["forB"]
+        vq.drain(10, session="A")  # draining A must not touch B
+        assert vq.is_empty(session="A")
+        assert not vq.is_empty(session="B")
+
+
+def test_session_sanitization_no_traversal():
+    with _temp_state() as d:
+        root = (Path(d) / "voice-queue").resolve()
+        qd = vq._queue_dir("../../etc").resolve()
+        assert str(qd).startswith(str(root) + os.sep), (qd, root)  # confined under voice-queue
+        assert qd.name == "etc"  # separators stripped, single component
+        assert vq._queue_dir("..").name == "default"  # pure-dots -> shared default bucket
+
+
+# --- exactly-once under concurrency (§8 test 7) ------------------------------------
+
+def test_concurrent_drain_consumes_each_once():
+    with _temp_state():
+        s = "race"
+        texts = [f"u{i}" for i in range(8)]
+        for i, t in enumerate(texts):
+            vq.enqueue(t, ts=f"2026-06-21T10:00:{i:02d}+08:00", session=s)
+        results = []
+        lock = threading.Lock()
+        n = 4
+        barrier = threading.Barrier(n)
+
+        def worker():
+            barrier.wait()  # release all threads together to maximise os.replace contention
+            got = vq.drain(100, session=s)
+            with lock:
+                results.extend(it["text"] for it in got)
+
+        threads = [threading.Thread(target=worker) for _ in range(n)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        # exactly-once: every utterance consumed once, none twice, none dropped
+        assert sorted(results) == sorted(texts), results
+        assert len(results) == len(texts)
+        assert vq.is_empty(session=s)
+
+
+def test_retained_marker_blocks_reconsume_and_no_ghost():
+    with _temp_state():
+        s = "marker"
+        p = vq.enqueue("a", session=s)  # enqueue returns the utt file path
+        assert [it["text"] for it in vq.drain(10, session=s)] == ["a"]  # consumed -> marker kept
+        # stale-snapshot replay / crash-mid-claim: the same utt file is present while its
+        # consumed-marker still exists. It must be treated as already-consumed — not
+        # re-listed, not re-consumed, and NOT a permanent ghost that distorts is_empty /
+        # peek_all (the marker is the single source of truth for consumed-ness) (F2).
+        Path(p).write_text(
+            json.dumps({"ts": "2026-06-21T10:00:00+08:00", "text": "a", "consumed": False}),
+            encoding="utf-8")
+        assert vq.drain(10, session=s) == []      # claim refused, not re-consumed
+        assert vq.peek_all(session=s) == []        # ghost not surfaced
+        assert vq.is_empty(session=s) is True      # is_empty not distorted
+
+
+def test_archive_write_failure_does_not_abort_drain():
+    # F1: a best-effort archive write that raises mid-claim must NOT abort the batch; the
+    # claim (marker) is the exactly-once token, so the item is still consumed exactly once.
+    with _temp_state():
+        s = "writefail"
+        vq.enqueue("a", ts="2026-06-21T10:00:00+08:00", session=s)
+        vq.enqueue("b", ts="2026-06-21T11:00:00+08:00", session=s)
+        orig_write = vq.os.write
+        vq.os.write = lambda fd, data: (_ for _ in ()).throw(OSError("disk full (injected)"))
+        try:
+            drained = vq.drain(10, session=s)  # must NOT raise despite os.write failing
+        finally:
+            vq.os.write = orig_write
+        assert sorted(it["text"] for it in drained) == ["a", "b"], drained
+        assert vq.is_empty(session=s)  # sources still removed -> consumed exactly once
+
+
+# --- watermark-anchored pop_latest (§8: no pre-question speech) --------------------
+
+def test_pop_latest_watermark_iso():
+    with _temp_state():
+        s = "wm"
+        vq.enqueue("old", ts="2026-06-21T10:00:00+08:00", session=s)
+        vq.enqueue("mid", ts="2026-06-21T12:00:00+08:00", session=s)
+        vq.enqueue("new", ts="2026-06-21T14:00:00+08:00", session=s)
+        wm = "2026-06-21T11:00:00+08:00"  # between old and mid
+        assert vq.pop_latest(watermark_ts=wm, session=s) == "new"   # newest after wm
+        assert vq.pop_latest(watermark_ts=wm, session=s) == "mid"   # next newest after wm
+        assert vq.pop_latest(watermark_ts=wm, session=s) is None    # old is before wm
+        # the pre-watermark utterance is never returned by a watermarked pop
+        assert [it["text"] for it in vq.peek_all(session=s)] == ["old"]
+
+
+def test_pop_latest_watermark_epoch_float():
+    with _temp_state():
+        s = "wm-epoch"
+        vq.enqueue("e_old", ts="2026-06-21T10:00:00+08:00", session=s)
+        vq.enqueue("e_new", ts="2026-06-21T14:00:00+08:00", session=s)
+        # §3.3 listen() may pass time.time() (epoch float) as the anchor
+        epoch_wm = datetime.fromisoformat("2026-06-21T12:00:00+08:00").timestamp()
+        assert vq.pop_latest(watermark_ts=epoch_wm, session=s) == "e_new"
+        assert vq.pop_latest(watermark_ts=epoch_wm, session=s) is None  # e_old before wm
+
+
+def test_pop_latest_bad_watermark_fails_closed():
+    # F3: a watermark that was REQUESTED but is unparseable must fail closed (return None),
+    # not silently degrade to no-anchor and risk returning pre-question speech. The queue
+    # must be left intact so a later well-formed anchor can still consume it.
+    with _temp_state():
+        s = "bad-wm"
+        vq.enqueue("hi", ts="2026-06-21T10:00:00+08:00", session=s)
+        for bad in ("not-a-date", "", True, [], {}):
+            assert vq.pop_latest(watermark_ts=bad, session=s) is None, bad
+        assert [it["text"] for it in vq.peek_all(session=s)] == ["hi"]  # nothing consumed
+        # a valid anchor still works afterwards
+        assert vq.pop_latest(watermark_ts="2026-06-21T09:00:00+08:00", session=s) == "hi"
+
+
+def test_pop_latest_no_watermark_returns_newest():
+    with _temp_state():
+        s = "no-wm"
+        vq.enqueue("p1", ts="2026-06-21T10:00:00+08:00", session=s)
+        vq.enqueue("p2", ts="2026-06-21T11:00:00+08:00", session=s)
+        assert vq.pop_latest(session=s) == "p2"  # latest
+        assert vq.pop_latest(session=s) == "p1"
+        assert vq.pop_latest(session=s) is None
+
+
+def _main():
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    passed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+            passed += 1
+        except AssertionError as e:
+            print(f"FAIL {t.__name__}: {e}")
+        except Exception as e:  # noqa: BLE001
+            print(f"ERROR {t.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{passed}/{len(tests)} passed")
+    sys.exit(0 if passed == len(tests) else 1)
+
+
+if __name__ == "__main__":
+    _main()

--- a/scripts/voice/test_voice_queue.py
+++ b/scripts/voice/test_voice_queue.py
@@ -318,6 +318,20 @@ def test_pop_latest_bad_watermark_fails_closed():
         assert vq.pop_latest(watermark_ts="2026-06-21T09:00:00+08:00", session=s) == "hi"
 
 
+def test_parse_ts_accepts_z_suffix():
+    # CP: ISO8601 with a UTC "Z" suffix must parse for BOTH the enqueue ts and the watermark
+    # anchor — never fail-closed on a valid timestamp (Z is normalised to +00:00).
+    with _temp_state():
+        s = "zsuffix"
+        vq.enqueue("zulu", ts="2026-06-21T10:00:00Z", session=s)
+        assert [it["text"] for it in vq.peek_all(session=s)] == ["zulu"]  # Z ts parsed + listed
+        # a Z-suffixed watermark BEFORE the utterance -> returned (not fail-closed)
+        assert vq.pop_latest(watermark_ts="2026-06-21T09:00:00Z", session=s) == "zulu"
+        # a Z-suffixed watermark AFTER the next utterance excludes it (comparison still works)
+        vq.enqueue("later", ts="2026-06-21T12:00:00Z", session=s)
+        assert vq.pop_latest(watermark_ts="2026-06-21T13:00:00Z", session=s) is None
+
+
 def test_pop_latest_no_watermark_returns_newest():
     with _temp_state():
         s = "no-wm"

--- a/scripts/voice/test_voice_queue.py
+++ b/scripts/voice/test_voice_queue.py
@@ -155,10 +155,24 @@ def test_per_session_isolation():
 def test_session_sanitization_no_traversal():
     with _temp_state() as d:
         root = (Path(d) / "voice-queue").resolve()
-        qd = vq._queue_dir("../../etc").resolve()
-        assert str(qd).startswith(str(root) + os.sep), (qd, root)  # confined under voice-queue
-        assert qd.name == "etc"  # separators stripped, single component
-        assert vq._queue_dir("..").name == "default"  # pure-dots -> shared default bucket
+        for raw in ("../../etc", "..", "a/../../b", "/abs/path"):
+            qd = vq._queue_dir(raw).resolve()
+            assert str(qd).startswith(str(root) + os.sep), (raw, qd, root)  # confined under root
+            assert os.sep not in qd.name and "/" not in qd.name, (raw, qd.name)  # one component
+        assert vq._queue_dir("../../etc").name.startswith("etc-")  # sanitised slug + hash suffix
+
+
+def test_session_resolution_and_injectivity():
+    with _temp_state():
+        # an already-safe id (UUID-like) maps to itself, verbatim and readable
+        assert vq._queue_dir("5e193a21-c931-4b46").name == "5e193a21-c931-4b46"
+        # distinct raw ids that sanitise to the SAME slug must NOT share a queue dir (F2:
+        # per-session isolation is a safety property — a collision = cross-session leak)
+        assert vq._queue_dir("a/b").name != vq._queue_dir("a:b").name
+        # an omitted session (None) -> default bucket; an explicit falsy "" -> default too,
+        # NOT silently rerouted to the env var's session (F1)
+        assert vq._queue_dir(None).name == "default"
+        assert vq._queue_dir("").name == "default"
 
 
 # --- exactly-once under concurrency (§8 test 7) ------------------------------------

--- a/scripts/voice/voice_queue.py
+++ b/scripts/voice/voice_queue.py
@@ -40,6 +40,7 @@ import os
 import re
 import sys
 import json
+import hashlib
 import itertools
 from pathlib import Path
 from datetime import datetime, timezone
@@ -60,22 +61,32 @@ _MIN_DT = datetime.min.replace(tzinfo=timezone.utc)
 
 
 def _safe_session(raw):
-    """Confine a (semi-trusted) session id to a single safe path component.
+    """Map a (semi-trusted) session id to a safe, collision-free single path component.
 
-    The id may arrive from a Stop-hook stdin payload or an env var, so it could contain
-    path separators or `..`. Replace anything outside [A-Za-z0-9._-] with `_` and strip
-    leading/trailing dots/underscores, so `../../etc` -> `etc` and `..` -> `default` —
-    no traversal out of the voice-queue dir is possible.
+    The id may arrive from a Stop-hook stdin payload or an env var, so two goals:
+      - traversal containment: replace anything outside [A-Za-z0-9._-] with `_` and strip
+        leading/trailing dots/underscores, so `../../etc` cannot escape the voice-queue dir.
+      - injective mapping: the sanitiser is lossy (distinct raw ids can fold to one slug),
+        and per-session isolation is a SAFETY property (§8 — a shared dir is cross-session
+        contamination), so a short hash of the RAW id is appended whenever sanitisation
+        changed anything. An already-safe id (e.g. a UUID session id) maps to itself
+        verbatim, keeping dir names readable; only mangled inputs grow the hash suffix.
     """
-    s = _SESSION_SANITIZE.sub("_", str(raw)).strip("._")
-    return s or "default"
+    raw = str(raw)
+    slug = _SESSION_SANITIZE.sub("_", raw).strip("._")
+    if slug == raw and slug:
+        return slug  # already a safe, non-empty single component (e.g. a UUID) — verbatim
+    digest = hashlib.sha1(raw.encode("utf-8", "replace")).hexdigest()[:12]
+    return f"{slug}-{digest}" if slug else f"s-{digest}"
 
 
 def _resolve_session(session=None):
-    if session:
-        return _safe_session(session)
-    env = os.environ.get("VOICE_QUEUE_SESSION")
-    return _safe_session(env) if env else "default"
+    # Only an OMITTED session (None) falls back to env/default. An explicitly-passed value —
+    # even a falsy one like "" — is honoured rather than silently rerouted to the env var's
+    # session, so a caller can never accidentally cross into another session's queue (F1).
+    if session is None:
+        session = os.environ.get("VOICE_QUEUE_SESSION")
+    return _safe_session(session) if session else "default"
 
 
 def _queue_dir(session=None):

--- a/scripts/voice/voice_queue.py
+++ b/scripts/voice/voice_queue.py
@@ -42,7 +42,6 @@ import sys
 import json
 import hashlib
 import itertools
-from pathlib import Path
 from datetime import datetime, timezone
 
 # this file is scripts/voice/voice_queue.py — import flat siblings (sys.path[0] == voice/),
@@ -53,7 +52,11 @@ import state as _state  # noqa: E402  (reuse _atomic_write + _state_dir — desi
 # per-process monotonic counter: disambiguates two enqueues that land in the same clock
 # tick. Windows datetime.now() can be coarse (~1ms), so a microsecond stamp alone is NOT
 # collision-free; the zero-padded seq makes the filename unique AND preserves insertion
-# order as a same-ts tiebreak when sorting lexicographically.
+# order as a same-ts tiebreak when sorting lexicographically. This gives strict FIFO within
+# ONE producer process — model A runs a SINGLE daemon per session as the sole producer, so
+# cross-process global FIFO is out of scope; were multiple producer processes ever to share
+# a session, same-microsecond items would order by filename (an accepted boundary, not a
+# regression) (Argus FIFO-boundary finding).
 _SEQ = itertools.count()
 _SESSION_SANITIZE = re.compile(r"[^A-Za-z0-9._-]")
 # aware sentinel so entries with an unparseable ts still sort (as oldest) without raising
@@ -99,7 +102,8 @@ def _queue_dir(session=None):
 
 
 def _consumed_dir_path(session=None):
-    """The consumed/ archive path WITHOUT creating it (safe for read-only listing checks)."""
+    """Return the consumed/ archive path. Does NOT create consumed/ itself, so the read-only
+    listing marker-check has no side effect (the parent queue dir is ensured by _queue_dir)."""
     return _queue_dir(session) / "consumed"
 
 
@@ -131,8 +135,11 @@ def _parse_ts(value):
             return datetime.fromtimestamp(value, tz=timezone.utc)
         except (OverflowError, OSError, ValueError):
             return None
+    s = str(value).strip()
+    if s[-1:] in ("Z", "z"):
+        s = s[:-1] + "+00:00"  # normalise UTC 'Z' suffix (fromisoformat rejects it pre-3.11)
     try:
-        dt = datetime.fromisoformat(str(value))
+        dt = datetime.fromisoformat(s)
     except (ValueError, TypeError):
         return None
     return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
@@ -241,7 +248,13 @@ def _claim(path, session=None):
     # here and abort the rest of the batch.
     try:
         try:
-            os.write(fd, path.read_bytes())  # archive the consumed payload (best-effort)
+            data = path.read_bytes()  # archive the consumed payload (best-effort)
+            off = 0  # os.write may write fewer bytes than requested -> loop until all written
+            while off < len(data):
+                written = os.write(fd, data[off:])
+                if not written:
+                    break  # defensive: don't spin if the fd refuses further progress
+                off += written
         except OSError:
             pass
     finally:

--- a/scripts/voice/voice_queue.py
+++ b/scripts/voice/voice_queue.py
@@ -61,32 +61,35 @@ _MIN_DT = datetime.min.replace(tzinfo=timezone.utc)
 
 
 def _safe_session(raw):
-    """Map a (semi-trusted) session id to a safe, collision-free single path component.
+    """Map a (semi-trusted) session id to a safe, bounded, collision-free path component.
 
-    The id may arrive from a Stop-hook stdin payload or an env var, so two goals:
-      - traversal containment: replace anything outside [A-Za-z0-9._-] with `_` and strip
-        leading/trailing dots/underscores, so `../../etc` cannot escape the voice-queue dir.
-      - injective mapping: the sanitiser is lossy (distinct raw ids can fold to one slug),
-        and per-session isolation is a SAFETY property (§8 — a shared dir is cross-session
-        contamination), so a short hash of the RAW id is appended whenever sanitisation
-        changed anything. An already-safe id (e.g. a UUID session id) maps to itself
-        verbatim, keeping dir names readable; only mangled inputs grow the hash suffix.
+    The id may arrive from a Stop-hook stdin payload or an env var. Three properties:
+      - traversal containment: chars outside [A-Za-z0-9._-] -> `_`, leading/trailing
+        dots/underscores stripped, so `../../etc` cannot escape the voice-queue dir.
+      - bounded length: the readable slug is capped at 48 chars — an unbounded id would
+        otherwise blow the OS filename-length limit on mkdir/open into a controllable DoS
+        (Argus security finding).
+      - injective mapping: sanitising/capping is lossy, and per-session isolation is a
+        SAFETY property (§8 — a shared dir is cross-session contamination), so a short hash
+        of the RAW id is appended whenever anything changed. An already-safe, short id
+        (e.g. a UUID) maps to itself verbatim, keeping dir names readable.
     """
     raw = str(raw)
-    slug = _SESSION_SANITIZE.sub("_", raw).strip("._")
+    slug = _SESSION_SANITIZE.sub("_", raw).strip("._")[:48].strip("._")
     if slug == raw and slug:
-        return slug  # already a safe, non-empty single component (e.g. a UUID) — verbatim
+        return slug  # already a safe, short single component (e.g. a UUID) — verbatim
     digest = hashlib.sha1(raw.encode("utf-8", "replace")).hexdigest()[:12]
     return f"{slug}-{digest}" if slug else f"s-{digest}"
 
 
 def _resolve_session(session=None):
-    # Only an OMITTED session (None) falls back to env/default. An explicitly-passed value —
-    # even a falsy one like "" — is honoured rather than silently rerouted to the env var's
-    # session, so a caller can never accidentally cross into another session's queue (F1).
-    if session is None:
-        session = os.environ.get("VOICE_QUEUE_SESSION")
-    return _safe_session(session) if session else "default"
+    # Only an OMITTED session (None) falls back to env/default. ANY explicitly-passed value
+    # — even a falsy one like "" / 0 — goes through _safe_session, so two distinct explicit
+    # sessions can never be silently merged into one queue dir (cross-session safety; F1).
+    if session is not None:
+        return _safe_session(session)
+    env = os.environ.get("VOICE_QUEUE_SESSION")
+    return _safe_session(env) if env else "default"
 
 
 def _queue_dir(session=None):
@@ -165,8 +168,11 @@ def _list_entries(session=None):
             data = json.loads(p.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError, ValueError):
             continue  # partial / corrupt / vanished -> leave for a later pass, skip this one
-        if not isinstance(data, dict) or "ts" not in data:
+        if not isinstance(data, dict):
             continue
+        text = data.get("text")
+        if "ts" not in data or not isinstance(text, str) or not text.strip():
+            continue  # malformed: missing ts or no usable string text -> skip, never list (C1)
         entries.append((p, data, _parse_ts(data.get("ts"))))
     # primary: ts (aware); secondary: filename (zero-padded seq) so same-ts items keep
     # insertion order. Unparseable ts sorts oldest via the aware _MIN_DT sentinel.
@@ -253,10 +259,17 @@ def _claim(path, session=None):
 def drain(max_items, session=None):
     """Consume up to `max_items` oldest utterances; return the claimed dicts, oldest first.
 
-    Each item is atomically moved to consumed/; an item lost to a concurrent consumer is
-    skipped (never double-consumed, never aborting the batch).
+    Each item is claimed via an exclusive consumed-marker (O_CREAT|O_EXCL) then best-effort
+    removed from the live queue — NOT an os.replace move; an item lost to a concurrent
+    consumer is skipped (never double-consumed, never aborting the batch). `max_items` is a
+    boundary input (e.g. an env var), so it is coerced to int and a non-int / non-positive
+    value is a no-op rather than a TypeError that would abort consumption.
     """
-    if not max_items or max_items <= 0:
+    try:
+        max_items = int(max_items)
+    except (TypeError, ValueError):
+        return []
+    if max_items <= 0:
         return []
     claimed = []
     for p, data, _ in _list_entries(session):

--- a/scripts/voice/voice_queue.py
+++ b/scripts/voice/voice_queue.py
@@ -1,0 +1,279 @@
+# -*- coding: utf-8 -*-
+"""voice_queue — per-session transcript FIFO with atomic enqueue + exactly-once drain.
+
+Issue #495 Path 2 Slice 2. The always-on STT daemon (Slice 3) writes each finalized
+utterance here; the Stop-hook drain (Slice 5) and `listen()` (model A) read from here.
+Design: `.mercury/docs/research/issue-495-voice-conversation-design.md` §3.2 (format/API)
++ §8 (the adversarial-review merge gates this module bakes in).
+
+Why a NEW module and not `state.record_note`: record_note is an append-only markdown
+note (no consume cursor, no atomic dequeue). #495 needs a FIFO with a consume pointer.
+This reuses state's proven atomic-write + state-dir primitives (design §3.2).
+
+Why NOT named `queue.py`: `scripts/voice/` is on `sys.path[0]`, so a `queue.py` here
+would shadow the stdlib `queue` that `stt.py` imports (design R10).
+
+Hardening baked in from the §8 adversarial review (each is a merge gate, not optional):
+  - Atomic enqueue: write a `.tmp-*.json` temp + `os.replace`, so a concurrent reader
+    NEVER sees a half-written file (reuses `state._atomic_write`).
+  - Pinned glob `utt-*.json`: the in-flight `.tmp-*.json` temp and the `consumed/`
+    archive subdir are excluded by name — a half-write can't be read as a queue item.
+  - Per-file resilience: a single corrupt / partial / vanished file is SKIPPED, never
+    aborting the whole batch (a batch-level abort would silently drop every utterance).
+  - Per-session scoping: Mercury runs concurrent lanes sharing `.mercury/state`, so the
+    queue dir is keyed by session — session A's drain can't race session B's items.
+  - Exactly-once dequeue: claim via an O_CREAT|O_EXCL exclusive create of the consumed
+    marker (the atomic claim token). NOTE — this deviates from the design's §3.2 prose
+    ("os.replace == I own it"): os.replace / os.rename are NOT exactly-once on Windows
+    under concurrency (empirically, several concurrent movers of one source all
+    "succeed" → double-consume; O_EXCL create yields exactly one winner of N racers on
+    local NTFS). A lost claim (FileExistsError/OSError) skips that item and keeps
+    draining — never double-consumes, never aborts the batch.
+  - Time-anchored `pop_latest(watermark_ts)`: returns only utterances with ts strictly
+    after the watermark, so `listen()` never returns speech said BEFORE the question.
+
+Config (env):
+    VOICE_STATE_DIR       state dir (default <repo>/.mercury/state); shared with state.py
+    VOICE_QUEUE_SESSION   default session key when none is passed explicitly
+"""
+import os
+import re
+import sys
+import json
+import itertools
+from pathlib import Path
+from datetime import datetime, timezone
+
+# this file is scripts/voice/voice_queue.py — import flat siblings (sys.path[0] == voice/),
+# matching mcp_server.py's convention so `import state` resolves however we're loaded.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import state as _state  # noqa: E402  (reuse _atomic_write + _state_dir — design §3.2)
+
+# per-process monotonic counter: disambiguates two enqueues that land in the same clock
+# tick. Windows datetime.now() can be coarse (~1ms), so a microsecond stamp alone is NOT
+# collision-free; the zero-padded seq makes the filename unique AND preserves insertion
+# order as a same-ts tiebreak when sorting lexicographically.
+_SEQ = itertools.count()
+_SESSION_SANITIZE = re.compile(r"[^A-Za-z0-9._-]")
+# aware sentinel so entries with an unparseable ts still sort (as oldest) without raising
+_MIN_DT = datetime.min.replace(tzinfo=timezone.utc)
+
+
+def _safe_session(raw):
+    """Confine a (semi-trusted) session id to a single safe path component.
+
+    The id may arrive from a Stop-hook stdin payload or an env var, so it could contain
+    path separators or `..`. Replace anything outside [A-Za-z0-9._-] with `_` and strip
+    leading/trailing dots/underscores, so `../../etc` -> `etc` and `..` -> `default` —
+    no traversal out of the voice-queue dir is possible.
+    """
+    s = _SESSION_SANITIZE.sub("_", str(raw)).strip("._")
+    return s or "default"
+
+
+def _resolve_session(session=None):
+    if session:
+        return _safe_session(session)
+    env = os.environ.get("VOICE_QUEUE_SESSION")
+    return _safe_session(env) if env else "default"
+
+
+def _queue_dir(session=None):
+    d = _state._state_dir() / "voice-queue" / _resolve_session(session)
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _consumed_dir_path(session=None):
+    """The consumed/ archive path WITHOUT creating it (safe for read-only listing checks)."""
+    return _queue_dir(session) / "consumed"
+
+
+def _consumed_dir(session=None):
+    d = _consumed_dir_path(session)
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _now_iso():
+    """Current local time as a microsecond-precision ISO8601 string (capture anchor)."""
+    return datetime.now(timezone.utc).astimezone().isoformat()
+
+
+def _parse_ts(value):
+    """Normalise an ISO8601 string / epoch float / datetime to an aware datetime, else None.
+
+    Used for ordering and watermark comparison. Comparing aware datetimes is correct across
+    timezone offsets — lexicographic string compare is NOT, so we always parse first.
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if isinstance(value, bool):  # bool is an int subclass — reject before the number branch
+        return None
+    if isinstance(value, (int, float)):
+        try:
+            return datetime.fromtimestamp(value, tz=timezone.utc)
+        except (OverflowError, OSError, ValueError):
+            return None
+    try:
+        dt = datetime.fromisoformat(str(value))
+    except (ValueError, TypeError):
+        return None
+    return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+
+
+def _to_iso(ts):
+    """Normalise a caller-supplied ts (capture-onset time) to ISO8601, else use now()."""
+    dt = _parse_ts(ts)
+    return dt.isoformat() if dt is not None else _now_iso()
+
+
+def _list_entries(session=None):
+    """Return [(path, data, ts_dt)] of unconsumed utterances, oldest first.
+
+    Pinned to `utt-*.json` (excludes the `.tmp-*.json` enqueue temp and the `consumed/`
+    archive subdir, which `Path.glob` does not recurse into). Each file is parsed
+    independently: a corrupt / half-written / mid-read-vanished file is skipped, NEVER
+    aborting the listing (§8 — a batch-level abort would drop every queued utterance).
+
+    An utterance whose consumed-marker already exists is treated as ALREADY consumed and
+    skipped — the marker is the single source of truth for consumed-ness. So a crash (or
+    os.remove failure) between claiming and removing the source leaves a harmless orphan
+    file on disk, NOT a permanently-stuck ghost that distorts peek_all/is_empty (F2).
+    """
+    entries = []
+    cdir = _consumed_dir_path(session)
+    for p in _queue_dir(session).glob("utt-*.json"):
+        if not p.is_file():
+            continue
+        if (cdir / p.name).exists():
+            continue  # consumed-marker present -> already claimed; never re-list (F2)
+        try:
+            data = json.loads(p.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError, ValueError):
+            continue  # partial / corrupt / vanished -> leave for a later pass, skip this one
+        if not isinstance(data, dict) or "ts" not in data:
+            continue
+        entries.append((p, data, _parse_ts(data.get("ts"))))
+    # primary: ts (aware); secondary: filename (zero-padded seq) so same-ts items keep
+    # insertion order. Unparseable ts sorts oldest via the aware _MIN_DT sentinel.
+    entries.sort(key=lambda it: (it[2] or _MIN_DT, it[0].name))
+    return entries
+
+
+def enqueue(text, ts=None, session=None):
+    """Atomically append one utterance; return its file path, or None for empty text.
+
+    `ts` is the capture-onset time (ISO8601 / epoch / datetime); defaults to now(). The
+    write is atomic (`.tmp-*.json` temp + os.replace) so a concurrent drain never reads a
+    half-written file. The filename carries pid + a monotonic seq, so two enqueues in the
+    same clock tick never os.replace-clobber each other.
+    """
+    text = (text or "").strip()
+    if not text:
+        return None
+    qdir = _queue_dir(session)
+    payload = json.dumps({"ts": _to_iso(ts), "text": text, "consumed": False}, ensure_ascii=False)
+    stamp = datetime.now().strftime("%Y%m%d-%H%M%S-%f")
+    name = f"utt-{stamp}-{os.getpid()}-{next(_SEQ):06d}.json"
+    path = qdir / name
+    _state._atomic_write(path, payload)  # mkstemp(.tmp-*.json) + os.replace — shared primitive
+    return str(path)
+
+
+def peek_all(session=None):
+    """List unconsumed utterances (dicts), oldest first. Does NOT consume."""
+    return [data for _, data, _ in _list_entries(session)]
+
+
+def is_empty(session=None):
+    """True when no (parseable) unconsumed utterance remains — the drain hook's load guard."""
+    return not _list_entries(session)
+
+
+def _claim(path, session=None):
+    """Atomically claim one utterance; True iff THIS caller won it (exactly-once).
+
+    The claim token is an O_CREAT|O_EXCL exclusive create of the consumed-marker — a real
+    atomic test-and-set on local NTFS (verified: exactly one winner of N concurrent
+    racers). os.replace/os.rename are NOT exactly-once on Windows under concurrency, so
+    they are deliberately NOT used here. The winner archives the payload into the marker
+    and removes the source from the live queue. A lost claim (FileExistsError) or any
+    OSError returns False so the caller skips this item and keeps draining — never
+    double-consumes, never aborts the batch.
+
+    The marker is RETAINED, never deleted: it is the token a consumer holding a stale
+    pre-removal snapshot hits (FileExistsError) to correctly skip an already-claimed item.
+    Deleting it would reopen a double-consume window. Filenames are per-process unique
+    (microsecond + pid + monotonic seq), so a retained marker can never false-reject a
+    future utterance. consumed/ growth is bounded per session; pruning is a session-scoped
+    janitor concern (out of Slice-2 scope).
+    """
+    dest = _consumed_dir(session) / path.name
+    try:
+        # O_BINARY (Windows-only; 0 elsewhere) keeps the archived payload byte-exact
+        fd = os.open(str(dest), os.O_CREAT | os.O_EXCL | os.O_WRONLY | getattr(os, "O_BINARY", 0))
+    except FileExistsError:
+        return False  # another consumer already claimed this exact utterance -> skip
+    except OSError:
+        return False  # vanished dir / perms -> treat as a lost claim, never abort the batch
+    # We won the claim: the marker's existence is the exactly-once token. Everything below
+    # is best-effort — archiving the payload / removing the source must never raise out of
+    # here and abort the rest of the batch.
+    try:
+        try:
+            os.write(fd, path.read_bytes())  # archive the consumed payload (best-effort)
+        except OSError:
+            pass
+    finally:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        try:
+            os.remove(str(path))  # drop from the live queue (best-effort; marker is truth)
+        except OSError:
+            pass
+    return True
+
+
+def drain(max_items, session=None):
+    """Consume up to `max_items` oldest utterances; return the claimed dicts, oldest first.
+
+    Each item is atomically moved to consumed/; an item lost to a concurrent consumer is
+    skipped (never double-consumed, never aborting the batch).
+    """
+    if not max_items or max_items <= 0:
+        return []
+    claimed = []
+    for p, data, _ in _list_entries(session):
+        if len(claimed) >= max_items:
+            break
+        if _claim(p, session):
+            data["consumed"] = True  # in-memory only: reflect that THIS call consumed it
+            claimed.append(data)
+    return claimed
+
+
+def pop_latest(watermark_ts=None, session=None):
+    """Consume + return the text of the most-recent utterance strictly after `watermark_ts`.
+
+    `watermark_ts` (ISO8601 / epoch float / datetime) anchors listen() to its question:
+    utterances enqueued at or before it are NOT returned, so listen() never picks up speech
+    the user said before being asked. None -> no anchor (returns the latest overall).
+    A watermark that was REQUESTED but is unparseable fails CLOSED (returns None) rather
+    than silently degrading to no-anchor — never risk returning pre-question speech (F3).
+    Returns None when nothing qualifies. A lost race falls through to the next-newest.
+    """
+    entries = _list_entries(session)
+    if watermark_ts is not None:
+        wm = _parse_ts(watermark_ts)
+        if wm is None:
+            return None  # anchor requested but uninterpretable -> fail closed (gate #6)
+        entries = [it for it in entries if it[2] is not None and it[2] > wm]
+    for p, data, _ in reversed(entries):  # newest first
+        if _claim(p, session):
+            return data.get("text")
+    return None


### PR DESCRIPTION
## 摘要

Issue #495 Path 2 **Slice 2**:新增 `scripts/voice/voice_queue.py` —— per-session transcript FIFO 队列模块,为后续 Slice 3(常驻 STT daemon 写入)/ Slice 5(Stop-hook drain)/ 模型 A 的 `listen()`(读队列)铺路。纯文件 IO,无 mic 依赖,opt-in(不起 daemon 即今天的 #468 行为)。

Refs #495 #468

## 设计依据

`.mercury/docs/research/issue-495-voice-conversation-design.md` §3.2(队列格式/API)+ §8(3-lens 对抗式评审,合并门)。复用 `state.py` 的 `_atomic_write` + `_state_dir`(§3.2 指定),不命名 `queue.py`(避免遮蔽 stt.py 的 stdlib `import queue`,R10)。

## §8 对抗式 must-fix 落地(每条都是硬合并门)

- **原子入队**:`enqueue` 经 `state._atomic_write`(mkstemp `.tmp-*.json` + `os.replace`),读者绝不见半写文件。
- **glob 钉死 `utt-*.json`**:排除 `.tmp-*.json` 临时文件 + `consumed/` 子目录(非递归 glob)。
- **per-file 解析韧性**:单个损坏/半写/读时消失文件被跳过,绝不 abort 整批。
- **per-session 作用域**:队列目录按 session 隔离(`VOICE_QUEUE_SESSION` env 或参数);`_safe_session` 阻断 `../` 路径遍历(session id 来自半信任的 stdin/env)。
- **exactly-once 出队**:见下「关键实现偏离」。
- **watermark 时间锚定**:`pop_latest(watermark_ts)` 只返回 `ts` 严格大于 watermark 的 utterance(防 `listen()` 返回提问前的话);ts 解析为 aware datetime 比较(非字符串字典序),支持 ISO8601 串 + epoch float;非法 watermark **fail-closed**。

## 关键实现偏离设计:exactly-once 不用 os.replace

设计 §3.2/§439 假设「`os.replace` rename 成功 == 我独占」。**实测推翻**(Windows 11 / py3.14,本 PR 用最小复现验证):
- `os.replace` 同源并发移动 → **多个线程都成功**(`MOVEFILE_REPLACE_EXISTING` + 源句柄竞争),非 exactly-once。
- `os.rename`(无 REPLACE)唯一目标 → 仍 2 winner。
- **`os.open(O_CREAT|O_EXCL)` → N 并发恰好 1 winner** ✓(NTFS 原子 test-and-set)。

故 `_claim` 改用 O_EXCL 排他创建 `consumed/<name>` marker 作为 claim token;marker **保留不删**(它是 stale-snapshot 消费者撞 `FileExistsError` 正确跳过的凭据,删了会重开 double-consume 窗口)。`_list_entries` 把「marker 已存在」的 utt 视为已消费跳过 → 崩溃只留无害 orphan,不产生永久 ghost。

> 设计研究文档按 side-voice lane Rule 4 未改;此偏离在 `voice_queue.py` 模块/函数 docstring 内显式记录,供设计文档后续更新参考。

## 测试

`scripts/voice/test_voice_queue.py` —— **17/17 通过**(共享 venv `.venv-voice` / py3.14,纯文件 IO 无 mic,headless,pytest 兼容)。覆盖:enqueue↔peek 往返、drain FIFO + consumed/ 归档、**并发 drain exactly-once(线程 + Barrier,5 次稳定)**、半写 `.tmp` glob 排除、损坏 `utt-*.json` 批级存活、per-session 隔离、`_safe_session` 路径遍历防护、watermark(ISO + epoch float)、**fail-closed 非法 watermark**、**marker 保留防重复消费 + 无 ghost 失真**、**注入 os.write OSError 不中止批**。

## dual-verify

- **Claude code-reviewer 侧**:深审 → 自查出 3 项(`_now_iso` 死代码 / `os.write` 非完全 best-effort / marker 保留正确性),已修。
- **Codex code-audit 侧**:首轮 NEEDS-CHANGES(Critical 1 / High 2 / Medium 1)——os.write/os.close 冒泡中止批、ghost entry、fail-open watermark、测试覆盖缺口;全部修复 + 新增 3 测试。复审:Codex 复审 PASS(Critical/High/Medium/Low 全 0;确认 C1/H2/H3/M4 全闭合,无新回归)。两侧均 PASS → dual-verify 合并门通过。

## 约束遵守

- `scripts/voice/` 是 Mercury 内部工具,**不受 200-LOC adapter 上限**(CLAUDE.md scripts/ carve-out);非 cherry-pick(全新文件,无 upstream)。
- 模块独立可分离(仅依赖同包 `state.py`);PR base develop;side-voice lane 隔离 worktree。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
