### PR TITLE
feat(#495): listen_daemon 常驻 STT daemon + listen() 读队列 (Path 2 Slice 3)

### DIFF
--- a/scripts/voice/README.md
+++ b/scripts/voice/README.md
@@ -23,6 +23,8 @@ scripts/voice/
   stt.py        STT 层:faster-whisper 加载 + 转写 + 单句阻塞录音(复用 #465 原语)
   tts.py        TTS 层:Kokoro-FastAPI(OpenAI 兼容)客户端 + edge-tts 回退 + 播放
   state.py      双模式状态机 + 秘书结构化记录(.mercury/state/voice-mode.json)
+  voice_queue.py  per-session transcript FIFO 队列(原子入队 + O_EXCL exactly-once 出队 + watermark 时间锚定;#495 Slice 2)
+  listen_daemon.py 常驻 STT daemon(模型 A:独占 mic、转写入队;enqueue-only 半双工;#495 Slice 3)
   mcp_server.py stdio MCP server:listen / announce / set_mode / record_note / get_status
   stop_notify.py Stop-hook worker:回合末读 last_assistant_message → TTS 播报
 .claude/hooks/voice-stop-notify.sh   Stop hook 包装(opt-in,默认不注册)
@@ -104,6 +106,27 @@ worker 自守卫:仅当语音模式 active(mode ≠ idle)时才播报,非语音�
 
 ---
 
+## Path 2:常驻 STT daemon(模型 A,opt-in)
+
+默认 `listen()` 每次自开麦克风录一句(#468 行为)。Path 2 引入**常驻 STT daemon**:由**单个进程独占麦克风**、always-on 转写、把每句话写进 per-session transcript 队列(`voice_queue`);此时 `listen()` 改为**读队列**而非自开第二条音频流——消除两条 `InputStream` 抢同一设备在 Windows 上的 `PortAudio -9998`(实测)。
+
+**启动 daemon**(独立终端,用共享 venv):
+
+```bash
+# 单会话(默认 session):
+.venv-voice/Scripts/python.exe scripts/voice/listen_daemon.py
+# 多 lane:用 VOICE_QUEUE_SESSION 指定 session(daemon 与会话内 listen() 须用同一值):
+VOICE_QUEUE_SESSION=lane-x .venv-voice/Scripts/python.exe scripts/voice/listen_daemon.py
+```
+
+session **只**来自 `VOICE_QUEUE_SESSION`(与 listen() 同一解析通道,故二者永不错位)。daemon 起来后 `listen()` 自动走队列;**不起 daemon 则一切如 #468**(完全 opt-in、向后兼容)。`Ctrl+C` / `SIGTERM` 干净退出(释放设备 + 删 pidfile)。
+
+> ⚠️ **半双工 / 必须用耳机**:daemon 始终开麦,而 `announce` 的 TTS 由扬声器播放。**同房间扬声器+麦克风**会让 daemon 听到 Kokoro 自己的声音并转写成幽灵「用户说」。本实现做了**半双工门控**(持 `voice-tts.lock` 时 daemon 丢弃采集),所以**播报期间麦克风是聋的**——这意味着**不支持「打断式 barge-in」**(说话盖过 agent),真 barge-in 需要 AEC(回声消除),超出当前范围。**强烈建议用耳机**以彻底规避回授。
+>
+> ⚠️ **真 mic 验证**:daemon 的采集/转写/-9998 规避/声学回授等行为依赖真实音频硬件 + Kokoro 服务,headless 单测覆盖逻辑(队列读写、心跳/pid 自愈、半双工门控、enqueue-only 无 paste),但**端到端需在真麦克风环境验证**:① 起 daemon,说一句,确认队列出现 `utt-*.json`;② 会话内 `listen()` 返回该句;③ `announce` 播报期间说话**不**被转写入队(半双工);④ `taskkill` daemon 后 `listen()` 退回自开麦不卡死。
+
+---
+
 ## 配置(env)
 
 | 变量 | 默认 | 说明 |
@@ -125,6 +148,11 @@ worker 自守卫:仅当语音模式 active(mode ≠ idle)时才播报,非语音�
 | `VOICE_PRE_RECORD_SEC` | `0.3` | onset 前预录环形缓冲时长(秒),补回句首被 VAD 截断的清音/气口;`0`=关,有效范围 `(0, 10]`,超出/非法值告警并回退默认 0.3(永不崩 listen)。实际 maxlen=`max(ceil(秒/块时长), onset_blocks)`,保证≥onset 窗口故永不丢 onset 音;预录的静音前导不计入 `min_sec` 短句门;>0.5 有把室噪/键盘声 prepend 进首字的风险(#495) |
 | `VOICE_VAD_FACTOR` | `2.5` | 能量 VAD 阈值=噪声地板×该倍率(低增益麦克风语音仅 ~3.5× 噪声,故默认 2.5;#472) |
 | `VOICE_VAD_THRESH` | (空=自动校准) | 能量 VAD 绝对阈值覆盖(RMS,设置后跳过自动校准) |
+| `VOICE_QUEUE_SESSION` | (空=`default`) | transcript 队列 + daemon pidfile 的 session 键(多 lane 隔离;**daemon 与 listen() 端须一致**,否则各读各的队列) |
+| `VOICE_DAEMON_HEARTBEAT_SEC` | `5` | daemon 心跳(pidfile mtime)刷新基准秒;`daemon_active()` 判活的过期阈值=2× |
+| `VOICE_DAEMON_SILENCE_SEC` | `0.8` | daemon 判一句结束的尾静音秒数 |
+| `VOICE_DAEMON_MIN_SEC` | `0.4` | daemon 最短有效句长(秒),短于此丢弃 |
+| `VOICE_DAEMON_ONSET_BLOCKS` | `3` | daemon 起话所需连续浊音块数(防单次噪声尖峰开句) |
 | `VOICE_STATE_DIR` | `<repo>/.mercury/state` | 状态/笔记目录(也存跨进程播放锁) |
 | `VOICE_STOP_MAX_CHARS` | `400` | Stop hook 播报截断长度 |
 
@@ -143,3 +171,12 @@ worker 自守卫:仅当语音模式 active(mode ≠ idle)时才播报,非语音�
 - 秘书模式"快响应"可按需把 `VOICE_ZH_MODEL_SECRETARY` 降到更小模型。
 - MCP `listen` 阻塞:等待开口的 onset 窗口由 `VOICE_LISTEN_ONSET_GRACE`(默认 10s)控制,
   静默时最长阻塞 ≈ `max_seconds + onset_grace`,留意 Claude Code 工具调用超时预算。
+- **Path 2 daemon 半双工(#495 Slice 3)**:daemon 持 `voice-tts.lock` 时丢采集 → 播报期间麦克风聋,
+  **不支持 barge-in**(打断式说话);真 barge-in 需 AEC,超范围。同房间扬声器+麦克风强烈建议改耳机以防回授。
+- **Path 2 daemon 崩溃自愈**:daemon 仅在 `InputStream` 起来后写 pidfile,退出(`finally`/`atexit`/`SIGTERM`)删之,
+  每轮刷新 mtime 作心跳;`daemon_active()` 要求 **pid 活 AND 心跳新鲜**双门,故 daemon 崩溃(泄漏设备/pid 回收假活)时
+  `listen()` 退回自开麦而非卡在永不填充的队列;自开麦若撞 `-9998`(残留进程占麦)返回清晰错误而非崩工具。
+- **daemon 与 listen() 的 session 一致性**:跨 lane 共享 `.mercury/state`,队列与 pidfile 按 `VOICE_QUEUE_SESSION` 隔离;
+  daemon 启动 session 须与会话内 `listen()` 的 `VOICE_QUEUE_SESSION` 相同,否则 `listen()` 读不到 daemon 写入的队列。
+- **listen() 时间锚定**:model A 下 `listen()` 只返回**调用之后**说的话(watermark),提问前的积压由 Stop-hook drain(Slice 5)消费,
+  不会被误当成回答。

--- a/scripts/voice/README.md
+++ b/scripts/voice/README.md
@@ -153,6 +153,8 @@ session **只**来自 `VOICE_QUEUE_SESSION`(与 listen() 同一解析通道,故�
 | `VOICE_DAEMON_SILENCE_SEC` | `0.8` | daemon 判一句结束的尾静音秒数 |
 | `VOICE_DAEMON_MIN_SEC` | `0.4` | daemon 最短有效句长(秒),短于此丢弃 |
 | `VOICE_DAEMON_ONSET_BLOCKS` | `3` | daemon 起话所需连续浊音块数(防单次噪声尖峰开句) |
+| `VOICE_DAEMON_MAX_SEC` | `20` | daemon 单句最长秒数,超过即强制 finalize(防永不静音输入让缓冲无界增长) |
+| `VOICE_DAEMON_QUEUE_MAX` | `200` | daemon 音频块队列上限(块,~50ms/块);backpressure 下丢最新块而非无界增长内存 |
 | `VOICE_STATE_DIR` | `<repo>/.mercury/state` | 状态/笔记目录(也存跨进程播放锁) |
 | `VOICE_STOP_MAX_CHARS` | `400` | Stop hook 播报截断长度 |
 

--- a/scripts/voice/listen_daemon.py
+++ b/scripts/voice/listen_daemon.py
@@ -1,0 +1,399 @@
+# -*- coding: utf-8 -*-
+"""listen_daemon — always-on STT daemon that enqueues utterances (Issue #495 Path 2 Slice 3).
+
+Model A: a SINGLE daemon owns the microphone for a session and writes each finalized
+utterance to the per-session transcript queue (`voice_queue`). The MCP server's `listen()`
+then READS the queue instead of opening its own InputStream — eliminating the two-streams-
+on-one-device contention that surfaces as PortAudio -9998 on Windows (the daemon is the sole
+capturer; `listen()` never self-opens while the daemon is live). Path 2 is OPT-IN: if no
+daemon is started, `listen()` self-opens the mic exactly as in #468.
+
+§8 adversarial merge gates baked in:
+  - Enqueue-only DEDICATED path (NOT #465's `ContinuousListener`): no paste, no Enter, no
+    GRACE window. #465's `_finalize` types the transcript into the focused window + presses
+    Enter; reusing it here would inject keystrokes into whatever app has focus while the
+    agent works (§8 INTEGRATION). This daemon only transcribes + enqueues.
+  - Half-duplex: while the TTS playback lock (`voice-tts.lock`) is held by a LIVE holder, the
+    daemon DROPS capture — otherwise the open mic hears Kokoro's own output through the
+    speakers and transcribes it into phantom "user said" queue entries (§8 acoustic echo).
+    True barge-in (talking OVER the agent) needs AEC and is out of scope; this ships
+    half-duplex turn-taking (mic deaf while the agent speaks).
+  - Self-healing liveness: the pidfile is written only AFTER the InputStream starts and is
+    removed on every exit path (finally + atexit + SIGTERM/CTRL_CLOSE); its mtime is a
+    heartbeat refreshed each loop. `daemon_active()` requires BOTH a live pid AND a fresh
+    heartbeat, so a crashed daemon (leaked device / recycled pid) does NOT trap `listen()`
+    reading a queue that will never fill (§8 -9998 / pid-recycle).
+
+Reuses `stt.SttEngine` (the shared STT core: CUDA setup, transcribe, VAD calibration); the
+VAD segmentation loop here is deliberately GRACE-free + enqueue-only.
+
+Config (env):
+    VOICE_QUEUE_SESSION         session key (shared with the MCP server's listen())
+    VOICE_STATE_DIR             state dir (default <repo>/.mercury/state)
+    VOICE_ZH_MODEL / _DEVICE / _DEVICE_INDEX / _VAD_THRESH   STT (shared with #465)
+    VOICE_DAEMON_HEARTBEAT_SEC  heartbeat refresh base (default 5); staleness = 2x
+    VOICE_DAEMON_SILENCE_SEC    trailing silence to end an utterance (default 0.8)
+    VOICE_DAEMON_MIN_SEC        minimum utterance length (default 0.4)
+    VOICE_DAEMON_ONSET_BLOCKS   consecutive voiced blocks to start (default 3)
+
+Run: <repo>/.venv-voice/Scripts/python.exe scripts/voice/listen_daemon.py
+"""
+import os
+import sys
+import time
+import queue
+import signal
+import atexit
+import threading
+
+# import flat siblings (sys.path[0] == voice/); these are light. The HEAVY deps
+# (faster_whisper via stt, sounddevice, numpy) are imported lazily inside run()/_capture
+# so importing this module for daemon_active()/wait_for_utterance stays cheap for the
+# MCP server, which only needs the liveness + queue-read helpers.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import state as _state          # noqa: E402  (state-dir resolution, shared)
+import tts as _tts              # noqa: E402  (voice-tts.lock primitives for half-duplex)
+import voice_queue as _vq       # noqa: E402
+
+
+def _env_float(name, default):
+    try:
+        v = float(os.environ.get(name, "") or default)
+        return v if v > 0 else float(default)
+    except (TypeError, ValueError):
+        return float(default)
+
+
+def _env_int(name, default):
+    try:
+        v = int(os.environ.get(name, "") or default)
+        return v if v > 0 else int(default)
+    except (TypeError, ValueError):
+        return int(default)
+
+
+def _heartbeat_sec():
+    return _env_float("VOICE_DAEMON_HEARTBEAT_SEC", 5.0)
+
+
+def _stale_threshold():
+    # a daemon whose heartbeat mtime is older than 2x the refresh interval is treated as
+    # dead regardless of pid liveness (guards against a recycled pid passing _pid_alive).
+    return 2.0 * _heartbeat_sec()
+
+
+# --- liveness + queue-read helpers (LIGHT — safe for the MCP server to import) ----------
+
+def _daemon_pid_path(session=None):
+    """Per-session daemon pidfile. Keyed by the SAME resolved session as the queue dir, so
+    the daemon and the reader (listen()) always agree on which session they share."""
+    sess = _vq._resolve_session(session)
+    return _state._state_dir() / f"voice-daemon-{sess}.pid"
+
+
+def daemon_active(session=None):
+    """True iff a live daemon owns this session's mic: pidfile present AND its holder pid
+    alive AND its heartbeat (mtime) fresh. BOTH matter — a recycled pid would pass
+    _pid_alive, but a stale heartbeat reveals the real daemon is gone, so listen() must
+    fall back to self-open rather than block on a queue a dead daemon will never fill (§8).
+    """
+    p = _daemon_pid_path(session)
+    try:
+        pid = int((p.read_text(encoding="utf-8").strip() or "0"))
+    except (OSError, ValueError):
+        return False
+    if not _tts._pid_alive(pid):
+        return False
+    try:
+        return (time.time() - p.stat().st_mtime) <= _stale_threshold()
+    except OSError:
+        return False
+
+
+def _tts_playing():
+    """True iff the TTS playback lock is held by a LIVE holder (the agent is speaking).
+    Reuses tts's lock primitives so the daemon stays half-duplex without its own protocol."""
+    lp = _tts._lock_path()
+    try:
+        holder = int((lp.read_text(encoding="utf-8").strip() or "0"))
+    except (OSError, ValueError):
+        return False
+    return _tts._pid_alive(holder)
+
+
+def wait_for_utterance(max_seconds=20.0, session=None, poll_sec=0.1):
+    """Poll the queue for an utterance spoken AFTER now, up to max_seconds; '' on timeout.
+
+    Time-anchored (§8): the watermark is captured at entry, so a backlog of utterances said
+    BEFORE the agent asked is NOT returned here (that backlog is the Stop-hook drain's job).
+    This is what listen() calls in model A instead of opening its own InputStream.
+    """
+    watermark = time.time()
+    deadline = watermark + max(0.0, float(max_seconds))
+    while True:
+        text = _vq.pop_latest(watermark_ts=watermark, session=session)
+        if text:
+            return text
+        if time.time() >= deadline:
+            return ""
+        time.sleep(poll_sec)
+
+
+# --- the daemon -------------------------------------------------------------------------
+
+class EnqueueDaemon:
+    """Continuous mic capture -> energy-VAD segmentation -> transcribe -> enqueue.
+
+    A dedicated, GRACE-free, enqueue-only capture loop (no paste / Enter / focus side
+    effects). Half-duplex: capture is dropped while the TTS lock is held by a live holder.
+    """
+
+    def __init__(self, session=None):
+        self.session = session
+        self.engine = None
+        self.capture_sr = None
+        self.blocksize = None
+        self.threshold = None
+        self.q = queue.Queue()
+        self.stream = None
+        self.worker = None
+        self.running = False
+        self._sd = None
+        self._np = None
+        # cached half-duplex mute (refreshed at most ~5x/sec, off the audio callback's hot path)
+        self._muted = False
+        self._mute_check_at = 0.0
+        self.silence_sec = _env_float("VOICE_DAEMON_SILENCE_SEC", 0.8)
+        self.min_sec = _env_float("VOICE_DAEMON_MIN_SEC", 0.4)
+        self.max_sec = _env_float("VOICE_DAEMON_MAX_SEC", 20.0)
+        self.onset_blocks = _env_int("VOICE_DAEMON_ONSET_BLOCKS", 3)
+
+    def _load(self):
+        # lazy heavy imports: only the daemon process pays for faster_whisper / sounddevice
+        import numpy as np
+        import sounddevice as sd
+        import stt as _stt
+        self._np, self._sd = np, sd
+        model = os.environ.get("VOICE_ZH_MODEL", "large-v3")
+        device = os.environ.get("VOICE_ZH_DEVICE", "auto")
+        idx_raw = os.environ.get("VOICE_ZH_DEVICE_INDEX")
+        try:
+            device_index = int(idx_raw) if idx_raw not in (None, "") else None
+        except (TypeError, ValueError):
+            print(f"[voice-daemon] invalid VOICE_ZH_DEVICE_INDEX={idx_raw!r}, using default",
+                  file=sys.stderr, flush=True)
+            device_index = None
+        self.engine = _stt.SttEngine(model=model, device=device, device_index=device_index)
+        self.engine.load()
+        self.capture_sr = self.engine.capture_samplerate()
+        self.blocksize = max(256, int(0.05 * self.capture_sr))
+        self.threshold = self.engine._calibrate(
+            self.capture_sr, os.environ.get("VOICE_ZH_VAD_THRESH", "auto"))
+
+    def _maybe_muted(self):
+        now = time.monotonic()
+        if now >= self._mute_check_at:
+            self._muted = _tts_playing()
+            self._mute_check_at = now + 0.2
+        return self._muted
+
+    def _on_audio(self, indata, frames, time_info, status):
+        if status:
+            print(f"[voice-daemon] audio status: {status}", file=sys.stderr, flush=True)
+        if self._maybe_muted():
+            return  # half-duplex: drop capture while the agent's TTS is playing (§8 echo)
+        block = indata.copy().flatten()
+        rms = float(self._np.sqrt(self._np.mean(block ** 2)))
+        self.q.put((block, rms))
+
+    def _finalize(self, seg, seg_samples, onset_ts=None):
+        """Transcribe one utterance and ENQUEUE it under its capture-ONSET timestamp — no
+        paste, no Enter, no grace (§8). The onset ts (when the user STARTED speaking, NOT the
+        later transcribe-completion time) is what lets listen()'s watermark exclude speech
+        begun before the question — enqueuing under the transcribe time would mis-deliver a
+        pre-question utterance as the answer (§8 time-anchor)."""
+        if seg_samples < self.min_sec * self.capture_sr:
+            return
+        _touch_pidfile(self.session)  # refresh heartbeat BEFORE the blocking transcribe so a
+        #                               slow transcribe can't stale daemon_active() mid-utterance
+        try:
+            audio = self._np.concatenate(seg, axis=0).flatten()
+            text, _ = self.engine.transcribe(audio, self.capture_sr)
+            if text:
+                path = _vq.enqueue(text, ts=onset_ts, session=self.session)
+                print(f"[voice-daemon] enqueued {text!r} -> {path}", file=sys.stderr, flush=True)
+        except Exception as e:  # never let a bad segment kill the daemon
+            print(f"[voice-daemon] segment failed: {type(e).__name__}: {e}", file=sys.stderr, flush=True)
+        finally:
+            self._drain_queue()  # discard audio captured during the (blocking) transcribe
+
+    def _drain_queue(self):
+        try:
+            while True:
+                self.q.get_nowait()
+        except queue.Empty:
+            pass
+
+    def _run(self):
+        in_speech = False
+        seg, seg_samples, silence_run = [], 0, 0.0
+        pending, voiced_run = [], 0
+        onset_ts = 0.0  # wall-clock capture-onset of the current utterance (the queue ts)
+        block_dur = self.blocksize / self.capture_sr
+        last_hb = 0.0
+        while self.running:
+            # heartbeat: refresh the pidfile mtime so daemon_active() sees us as live
+            now = time.monotonic()
+            if now - last_hb >= _heartbeat_sec():
+                _touch_pidfile(self.session)
+                last_hb = now
+            try:
+                block, rms = self.q.get(timeout=0.1)
+            except queue.Empty:
+                continue
+            if self._maybe_muted():
+                # the agent started speaking mid-capture -> drop any partial utterance so a
+                # half-spoken-then-muted segment is never enqueued
+                in_speech, seg, seg_samples, silence_run = False, [], 0, 0.0
+                pending, voiced_run = [], 0
+                continue
+            voiced = rms > self.threshold
+            if not in_speech:
+                if voiced:
+                    if voiced_run == 0:
+                        onset_ts = time.time()  # true speech start = first voiced block (§8 anchor)
+                    voiced_run += 1
+                    pending.append(block)
+                    if voiced_run >= self.onset_blocks:
+                        in_speech = True
+                        seg, seg_samples = pending, sum(len(b) for b in pending)
+                        pending, voiced_run, silence_run = [], 0, 0.0
+                else:
+                    pending, voiced_run = [], 0
+                continue
+            seg.append(block)
+            seg_samples += len(block)
+            if voiced:
+                silence_run = 0.0
+            else:
+                silence_run += block_dur
+            # finalize on a trailing-silence gap OR a runaway-length cap — a never-silent
+            # input (room noise / a stuck mic) would otherwise grow seg unbounded (memory +
+            # an oversized transcribe that could stale the heartbeat)
+            if silence_run >= self.silence_sec or seg_samples >= self.max_sec * self.capture_sr:
+                self._finalize(seg, seg_samples, onset_ts)
+                in_speech, seg, seg_samples, silence_run = False, [], 0, 0.0
+
+    def start(self):
+        self._load()
+        self.stream = self._sd.InputStream(
+            samplerate=self.capture_sr, channels=1, dtype="float32",
+            blocksize=self.blocksize, device=self.engine.device_index, callback=self._on_audio)
+        self.stream.start()  # acquire the device FIRST
+        # pidfile is written ONLY after the device is live (and refuses a live foreign owner),
+        # so daemon_active() never reports a daemon that hasn't actually acquired the mic (§8)
+        _write_pidfile(self.session)
+        self.running = True
+        # start the consumer LAST: its heartbeat only REFRESHES an existing pidfile (never
+        # re-creates), so the worker cannot pre-create the pidfile before the device is up
+        self.worker = threading.Thread(target=self._run, daemon=True)
+        self.worker.start()
+
+    def close(self):
+        self.running = False
+        if self.stream is not None:
+            try:
+                self.stream.stop()
+                self.stream.close()  # releases the WASAPI device (verified: close frees it)
+            except Exception:
+                pass
+            finally:
+                self.stream = None
+        w = getattr(self, "worker", None)
+        if w is not None:
+            w.join(timeout=2.0)
+
+
+# --- pidfile lifecycle (module-level so signal/atexit handlers can reach it) -------------
+
+_ACTIVE_SESSION = None
+_PIDFILE_CLAIMED = False  # True once THIS process actually wrote its pidfile. NOTE: do NOT use
+#                           "_ACTIVE_SESSION is None" as the not-claimed sentinel — None is a
+#                           VALID session (env/default), so a daemon started with session=None
+#                           would otherwise never remove its pidfile on exit (Codex M).
+
+
+def _write_pidfile(session=None):
+    global _ACTIVE_SESSION, _PIDFILE_CLAIMED
+    p = _daemon_pid_path(session)
+    try:
+        existing = int((p.read_text(encoding="utf-8").strip() or "0"))
+    except (OSError, ValueError):
+        existing = 0
+    if existing and existing != os.getpid() and _tts._pid_alive(existing):
+        raise RuntimeError(f"another live voice daemon already owns this session (pid {existing})")
+    _state._atomic_write(p, str(os.getpid()))  # reuse the proven atomic write
+    _ACTIVE_SESSION = session       # set AFTER the write so a refused (live-foreign) claim, which
+    _PIDFILE_CLAIMED = True         # raises above, never marks us as the pidfile owner
+
+
+def _touch_pidfile(session=None):
+    p = _daemon_pid_path(session)
+    try:
+        os.utime(p, None)  # refresh mtime = heartbeat
+    except OSError:
+        # pidfile externally removed mid-run: re-establish it so the live daemon (which still
+        # owns the mic) stays discoverable — otherwise daemon_active() would read False forever
+        # and listen() would self-open the device the daemon still holds -> -9998 (Codex M).
+        # SAFE because start() now starts the worker only AFTER _write_pidfile (post device),
+        # so this heartbeat can never PRE-create the pidfile before the stream is up.
+        try:
+            _state._atomic_write(p, str(os.getpid()))
+        except OSError:
+            pass
+
+
+def _remove_pidfile():
+    if not _PIDFILE_CLAIMED:
+        return  # this process never wrote a pidfile -> nothing to remove
+    p = _daemon_pid_path(_ACTIVE_SESSION)
+    try:
+        # only remove OUR pidfile (don't clobber a successor daemon that re-claimed the slot)
+        if int((p.read_text(encoding="utf-8").strip() or "0")) == os.getpid():
+            p.unlink()
+    except (OSError, ValueError):
+        pass
+
+
+def main():
+    # session is resolved purely from VOICE_QUEUE_SESSION — the SAME channel the MCP server's
+    # listen() uses — so the daemon and the reader can never disagree on which queue they
+    # share. To run a daemon for a specific lane, set VOICE_QUEUE_SESSION in its environment.
+    daemon = EnqueueDaemon(session=None)
+    atexit.register(_remove_pidfile)
+
+    def _sig(_signum, _frame):
+        daemon.running = False
+    for signame in ("SIGTERM", "SIGINT", "SIGBREAK"):
+        sig = getattr(signal, signame, None)
+        if sig is not None:
+            try:
+                signal.signal(sig, _sig)
+            except (ValueError, OSError):
+                pass  # not in main thread / unsupported on this platform
+    try:
+        daemon.start()
+        print(f"[voice-daemon] listening (session={_vq._resolve_session(None)}); "
+              "Ctrl+C to stop", file=sys.stderr, flush=True)
+        while daemon.running:
+            time.sleep(0.2)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        daemon.close()
+        _remove_pidfile()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/voice/listen_daemon.py
+++ b/scripts/voice/listen_daemon.py
@@ -19,7 +19,9 @@ daemon is started, `listen()` self-opens the mic exactly as in #468.
     True barge-in (talking OVER the agent) needs AEC and is out of scope; this ships
     half-duplex turn-taking (mic deaf while the agent speaks).
   - Self-healing liveness: the pidfile is written only AFTER the InputStream starts and is
-    removed on every exit path (finally + atexit + SIGTERM/CTRL_CLOSE); its mtime is a
+    removed on exit (finally + atexit + SIGTERM/SIGINT/SIGBREAK handlers; a hard kill / console-
+    window close that bypasses atexit is self-healed on the next startup by the dead-pid steal +
+    the heartbeat-staleness check, so a leaked pidfile never traps listen() permanently); its mtime is a
     heartbeat refreshed each loop. `daemon_active()` requires BOTH a live pid AND a fresh
     heartbeat, so a crashed daemon (leaked device / recycled pid) does NOT trap `listen()`
     reading a queue that will never fill (§8 -9998 / pid-recycle).

--- a/scripts/voice/listen_daemon.py
+++ b/scripts/voice/listen_daemon.py
@@ -130,8 +130,12 @@ def wait_for_utterance(max_seconds=20.0, session=None, poll_sec=0.1):
     BEFORE the agent asked is NOT returned here (that backlog is the Stop-hook drain's job).
     This is what listen() calls in model A instead of opening its own InputStream.
     """
+    try:
+        poll_sec = max(0.01, float(poll_sec))  # clamp: a non-positive/invalid poll would busy-loop
+    except (TypeError, ValueError):              # or raise ValueError out of time.sleep (Copilot)
+        poll_sec = 0.1
     watermark = time.time()
-    deadline = watermark + max(0.0, float(max_seconds))
+    deadline = watermark + max(0.0, float(max_seconds) if isinstance(max_seconds, (int, float)) else 0.0)
     while True:
         text = _vq.pop_latest(watermark_ts=watermark, session=session)
         if text:
@@ -349,7 +353,16 @@ def _write_pidfile(session=None):
     except (OSError, ValueError):
         existing = 0
     if existing and existing != os.getpid() and _tts._pid_alive(existing):
-        raise RuntimeError(f"another live voice daemon already owns this session (pid {existing})")
+        # refuse ONLY if the holder is genuinely active (pid alive AND heartbeat fresh). A
+        # recycled pid with a STALE heartbeat is a dead daemon's leftover and is stealable —
+        # matching daemon_active()'s pid-AND-freshness liveness, so a crashed-then-pid-recycled
+        # daemon never wrongly blocks a fresh start (Copilot).
+        try:
+            fresh = (time.time() - p.stat().st_mtime) <= _stale_threshold()
+        except OSError:
+            fresh = False
+        if fresh:
+            raise RuntimeError(f"another live voice daemon already owns this session (pid {existing})")
     _state._atomic_write(p, str(os.getpid()))  # reuse the proven atomic write
     _ACTIVE_SESSION = session       # set AFTER the write so a refused (live-foreign) claim, which
     _PIDFILE_CLAIMED = True         # raises above, never marks us as the pidfile owner

--- a/scripts/voice/listen_daemon.py
+++ b/scripts/voice/listen_daemon.py
@@ -154,7 +154,12 @@ class EnqueueDaemon:
         self.capture_sr = None
         self.blocksize = None
         self.threshold = None
-        self.q = queue.Queue()
+        # bounded queue: the audio callback can NOT block, so on backpressure (e.g. a slow /
+        # hung transcribe) it drops the newest block rather than grow memory unbounded — the
+        # post-transcribe _drain_queue discards backlog anyway, so dropping under overflow is
+        # behaviourally equivalent + safe (Argus memory-risk finding).
+        self.q = queue.Queue(maxsize=_env_int("VOICE_DAEMON_QUEUE_MAX", 200))
+        self._dropped = 0
         self.stream = None
         self.worker = None
         self.running = False
@@ -204,7 +209,10 @@ class EnqueueDaemon:
             return  # half-duplex: drop capture while the agent's TTS is playing (§8 echo)
         block = indata.copy().flatten()
         rms = float(self._np.sqrt(self._np.mean(block ** 2)))
-        self.q.put((block, rms))
+        try:
+            self.q.put_nowait((block, rms))
+        except queue.Full:
+            self._dropped += 1  # backpressure: drop rather than block the audio callback
 
     def _finalize(self, seg, seg_samples, onset_ts=None):
         """Transcribe one utterance and ENQUEUE it under its capture-ONSET timestamp — no
@@ -221,7 +229,11 @@ class EnqueueDaemon:
             text, _ = self.engine.transcribe(audio, self.capture_sr)
             if text:
                 path = _vq.enqueue(text, ts=onset_ts, session=self.session)
-                print(f"[voice-daemon] enqueued {text!r} -> {path}", file=sys.stderr, flush=True)
+                # log a redacted summary (length only), NOT the transcript content — the user's
+                # speech may carry credentials / private info that must not leak to stderr logs
+                # (Argus privacy finding). The text itself lives only in the queue file.
+                print(f"[voice-daemon] enqueued utterance ({len(text)} chars) -> {path}",
+                      file=sys.stderr, flush=True)
         except Exception as e:  # never let a bad segment kill the daemon
             print(f"[voice-daemon] segment failed: {type(e).__name__}: {e}", file=sys.stderr, flush=True)
         finally:
@@ -246,6 +258,10 @@ class EnqueueDaemon:
             now = time.monotonic()
             if now - last_hb >= _heartbeat_sec():
                 _touch_pidfile(self.session)
+                if self._dropped:  # surface backpressure drops for field debugging, then reset
+                    print(f"[voice-daemon] dropped {self._dropped} block(s) under backpressure",
+                          file=sys.stderr, flush=True)
+                    self._dropped = 0
                 last_hb = now
             try:
                 block, rms = self.q.get(timeout=0.1)

--- a/scripts/voice/mcp_server.py
+++ b/scripts/voice/mcp_server.py
@@ -37,6 +37,7 @@ from mcp.server.fastmcp import FastMCP  # noqa: E402
 import stt as _stt  # noqa: E402
 import tts as _tts  # noqa: E402
 import state as _state  # noqa: E402
+import listen_daemon as _daemon  # noqa: E402  (light import; heavy deps lazy in the daemon)
 
 mcp = FastMCP("voice")
 
@@ -80,8 +81,31 @@ def listen(max_seconds: float = 20.0, silence_sec: float = 0.8) -> str:
     遇决策点/需补充信息时在工作模式下调用它，与 announce 配合实现双向交互。
     """
     mode = _state.get_mode()
-    engine = _engine_for_mode(mode)
-    text = engine.listen_once(max_seconds=max_seconds, silence_sec=silence_sec)
+    if _daemon.daemon_active():
+        # model A: a live STT daemon owns the mic -> READ the transcript queue instead of
+        # opening a second InputStream (two streams on one device contend -> PortAudio
+        # -9998). Time-anchored: only utterances spoken AFTER this call are returned, so a
+        # pre-question backlog isn't mistaken for the answer (that backlog is the Stop-hook
+        # drain's channel). silence_sec is irrelevant here — the daemon owns segmentation.
+        text = _daemon.wait_for_utterance(max_seconds=max_seconds)
+    else:
+        # no daemon -> self-open the mic, exactly as #468. Path 2 is OPT-IN: don't start the
+        # daemon and listen() behaves as before. A leaked mic device (a daemon that died
+        # without releasing its stream) surfaces here as PortAudioError -9998; surface a
+        # clear, actionable message rather than crashing the tool (§8).
+        try:
+            engine = _engine_for_mode(mode)
+            text = engine.listen_once(max_seconds=max_seconds, silence_sec=silence_sec)
+        except Exception as e:  # noqa: BLE001 — never crash listen(). Returns EARLY (before the
+            # secretary record_note below) so a capture FAILURE is never written as a note. Only
+            # a PortAudio error means the mic is contended (e.g. a leaked daemon device, §8);
+            # other errors (engine load / decode) report their real type so the message isn't a
+            # misleading "device occupied" claim.
+            print(f"[voice-mcp] listen_once failed: {type(e).__name__}: {e}", file=sys.stderr, flush=True)
+            if "PortAudio" in type(e).__name__:
+                return ("（语音捕获失败：麦克风可能被残留进程占用 [PortAudio -9998]。"
+                        "请重启 voice daemon 或确认无其他进程占用麦克风后重试。）")
+            return f"（语音捕获失败：{type(e).__name__}。请检查 STT 引擎 / 音频设备配置后重试。）"
     # in secretary mode, transcribed speech is auto-recorded as a note
     if mode == "secretary" and text:
         _state.record_note(text, kind="note")

--- a/scripts/voice/mcp_server.py
+++ b/scripts/voice/mcp_server.py
@@ -87,7 +87,13 @@ def listen(max_seconds: float = 20.0, silence_sec: float = 0.8) -> str:
         # -9998). Time-anchored: only utterances spoken AFTER this call are returned, so a
         # pre-question backlog isn't mistaken for the answer (that backlog is the Stop-hook
         # drain's channel). silence_sec is irrelevant here — the daemon owns segmentation.
-        text = _daemon.wait_for_utterance(max_seconds=max_seconds)
+        try:
+            text = _daemon.wait_for_utterance(max_seconds=max_seconds)
+        except Exception as e:  # noqa: BLE001 — the queue is a cross-process boundary; a corrupt
+            # state dir / IO error must not crash the listen() tool (parity with the self-open
+            # path's guard below) (Argus boundary finding).
+            print(f"[voice-mcp] queue read failed: {type(e).__name__}: {e}", file=sys.stderr, flush=True)
+            return f"（语音队列读取失败：{type(e).__name__}。请检查 .mercury/state 队列目录后重试。）"
     else:
         # no daemon -> self-open the mic, exactly as #468. Path 2 is OPT-IN: don't start the
         # daemon and listen() behaves as before. A leaked mic device (a daemon that died

--- a/scripts/voice/mcp_server.py
+++ b/scripts/voice/mcp_server.py
@@ -109,8 +109,10 @@ def listen(max_seconds: float = 20.0, silence_sec: float = 0.8) -> str:
             # misleading "device occupied" claim.
             print(f"[voice-mcp] listen_once failed: {type(e).__name__}: {e}", file=sys.stderr, flush=True)
             if "PortAudio" in type(e).__name__:
-                return ("（语音捕获失败：麦克风可能被残留进程占用 [PortAudio -9998]。"
-                        "请重启 voice daemon 或确认无其他进程占用麦克风后重试。）")
+                # don't hard-assert -9998 (not every PortAudioError is device-occupation); cite
+                # the real error type and offer -9998 as the LIKELY cause + an actionable next step
+                return (f"（语音捕获失败：音频设备错误 [{type(e).__name__}]，麦克风可能被残留进程占用"
+                        "（常见为 PortAudio -9998）。请重启 voice daemon 或确认无其他进程占用麦克风后重试。）")
             return f"（语音捕获失败：{type(e).__name__}。请检查 STT 引擎 / 音频设备配置后重试。）"
     # in secretary mode, transcribed speech is auto-recorded as a note
     if mode == "secretary" and text:

--- a/scripts/voice/test_listen_daemon.py
+++ b/scripts/voice/test_listen_daemon.py
@@ -1,0 +1,308 @@
+# -*- coding: utf-8 -*-
+"""Behaviour tests for the #495 Slice-3 enqueue daemon (listen_daemon.py).
+
+Headless — no microphone, no faster_whisper, no sounddevice. listen_daemon imports those
+HEAVY deps lazily (inside run()/_load), so the liveness + queue-read + finalize logic is
+unit-testable with a stubbed engine. Covers the §8 merge gates: enqueue-only (NO paste /
+keyboard side effects), daemon_active() needs a live pid AND a fresh heartbeat, half-duplex
+mute against the TTS lock, time-anchored wait_for_utterance, and pidfile self-heal.
+
+Run: <venv>/python.exe scripts/voice/test_listen_daemon.py   (also pytest-compatible)
+"""
+import os
+import sys
+import time
+import types
+import shutil
+import tempfile
+import threading
+import contextlib
+from datetime import datetime, timezone
+
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import state as _state          # noqa: E402
+import tts as _tts              # noqa: E402
+import voice_queue as _vq       # noqa: E402
+import listen_daemon as ld      # noqa: E402
+
+
+@contextlib.contextmanager
+def _temp_state():
+    prev = os.environ.get("VOICE_STATE_DIR")
+    prev_sess = os.environ.get("VOICE_QUEUE_SESSION")
+    d = tempfile.mkdtemp(prefix="ld-test-")
+    os.environ["VOICE_STATE_DIR"] = d
+    os.environ.pop("VOICE_QUEUE_SESSION", None)
+    try:
+        yield d
+    finally:
+        for key, val in (("VOICE_STATE_DIR", prev), ("VOICE_QUEUE_SESSION", prev_sess)):
+            if val is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = val
+        shutil.rmtree(d, ignore_errors=True)
+
+
+# --- §8 INTEGRATION: enqueue-only, NO paste / keyboard side effects ---------------------
+
+def test_finalize_enqueues_only():
+    with _temp_state():
+        s = "fin"
+        d = ld.EnqueueDaemon(session=s)
+        d._np = np
+        d.capture_sr = 16000
+        d.min_sec = 0.1
+        d.engine = types.SimpleNamespace(transcribe=lambda audio, sr: ("你好", 0.0))
+        d._finalize([np.zeros(8000, dtype=np.float32)], 8000)  # 0.5s > min_sec
+        assert [it["text"] for it in _vq.peek_all(session=s)] == ["你好"]
+
+
+def test_finalize_drops_too_short():
+    with _temp_state():
+        s = "short"
+        d = ld.EnqueueDaemon(session=s)
+        d._np = np
+        d.capture_sr = 16000
+        d.min_sec = 0.4
+        d.engine = types.SimpleNamespace(transcribe=lambda audio, sr: ("x", 0.0))
+        d._finalize([np.zeros(1000, dtype=np.float32)], 1000)  # ~0.06s < min_sec
+        assert _vq.is_empty(session=s)  # gated out, transcribe never reached
+
+
+def test_run_segments_on_silence_and_caps_runaway():
+    # drive the real _run VAD loop headless by feeding blocks straight into the queue (no
+    # sounddevice). Asserts a trailing-silence gap finalizes, AND a never-silent run hits the
+    # max_sec cap instead of growing seg unbounded.
+    def _run_over(blocks, max_sec):
+        with _temp_state():
+            d = ld.EnqueueDaemon(session="run")
+            d.capture_sr = 16000
+            d.blocksize = 800
+            d.threshold = 0.1
+            d.silence_sec = 0.15  # 3 blocks @50ms
+            d.min_sec = 0.0
+            d.max_sec = max_sec
+            d.onset_blocks = 2
+            d._maybe_muted = lambda: False
+            sizes = []
+            d._finalize = lambda seg, n, ts=None: sizes.append(n)
+            for b in blocks:
+                d.q.put((b, float(np.sqrt(np.mean(b ** 2)))))
+            d.running = True
+            th = threading.Thread(target=d._run, daemon=True)
+            th.start()
+            time.sleep(0.4)  # let _run drain the fed blocks + finalize
+            d.running = False
+            th.join(timeout=1.0)
+            return sizes
+
+    voi = np.full(800, 0.5, dtype=np.float32)
+    sil = np.zeros(800, dtype=np.float32)
+    # silence finalize (max_sec large so the cap never fires first): 2 onset + 2 body voiced +
+    # 3 trailing silence (silence_run reaches 0.15s on the 3rd) -> seg = 7 blocks = 5600
+    s1 = _run_over([voi] * 4 + [sil] * 3, max_sec=1.0)
+    assert s1 and s1[0] == 7 * 800, s1
+    # runaway cap (never silent): 8 continuous voiced -> cap fires exactly at max_sec*sr (4800)
+    s2 = _run_over([voi] * 8, max_sec=0.3)
+    assert s2 and s2[0] == int(0.3 * 16000), s2
+
+
+def test_finalize_enqueues_under_capture_onset_ts():
+    # §8 time-anchor: enqueue under the capture-ONSET time, NOT the transcribe-completion time,
+    # else an utterance begun BEFORE listen()'s watermark (but transcribed after) is mis-
+    # delivered as the answer. The daemon passes onset_ts; assert the stored ts reflects it.
+    with _temp_state():
+        s = "onset"
+        d = ld.EnqueueDaemon(session=s)
+        d._np = np
+        d.capture_sr = 16000
+        d.min_sec = 0.0
+        d.engine = types.SimpleNamespace(transcribe=lambda audio, sr: ("早说的", 0.0))
+        old_onset = datetime(2020, 1, 1, tzinfo=timezone.utc).timestamp()  # epoch, as the daemon passes
+        d._finalize([np.zeros(8000, dtype=np.float32)], 8000, old_onset)
+        assert [it["text"] for it in _vq.peek_all(session=s)] == ["早说的"]
+        # stored under the OLD onset -> a 2021 watermark excludes it, a 2019 watermark includes it
+        assert _vq.pop_latest(watermark_ts="2021-01-01T00:00:00Z", session=s) is None
+        assert _vq.pop_latest(watermark_ts="2019-01-01T00:00:00Z", session=s) == "早说的"
+
+
+def test_daemon_has_no_paste_side_effects():
+    # the dedicated #495 daemon must NEVER paste into the focused window or press keys —
+    # that is #465's job, and reusing it here would inject keystrokes into the active app.
+    src = open(ld.__file__, encoding="utf-8").read()
+    for forbidden in ("deliver_text", "keyboard", "press_and_release", "import keyboard"):
+        assert forbidden not in src, f"daemon must not reference {forbidden!r}"
+
+
+# --- §8 self-heal liveness: daemon_active needs live pid AND fresh heartbeat -------------
+
+def test_daemon_active_requires_live_pid_and_fresh_heartbeat():
+    with _temp_state():
+        s = "active"
+        p = ld._daemon_pid_path(s)
+        assert ld.daemon_active(s) is False                 # no pidfile
+        _state._atomic_write(p, str(os.getpid()))           # our (live) pid, fresh mtime
+        assert ld.daemon_active(s) is True
+        old = time.time() - (ld._stale_threshold() + 60)    # stale heartbeat
+        os.utime(p, (old, old))
+        assert ld.daemon_active(s) is False                 # live pid but stale -> dead
+        _state._atomic_write(p, "0")                        # pid 0 = guaranteed-dead sentinel
+        assert ld.daemon_active(s) is False                 # fresh mtime but dead pid
+
+
+def test_write_pidfile_steals_dead_then_refuses_live_foreign():
+    with _temp_state():
+        s = "owner"
+        p = ld._daemon_pid_path(s)
+        _state._atomic_write(p, "0")            # dead owner -> _write_pidfile may steal
+        ld._write_pidfile(s)
+        assert int(p.read_text(encoding="utf-8")) == os.getpid()
+        # a LIVE foreign owner must block startup (simulate via _pid_alive monkeypatch)
+        _state._atomic_write(p, "424242")
+        orig = _tts._pid_alive
+        _tts._pid_alive = lambda pid: True
+        try:
+            raised = False
+            try:
+                ld._write_pidfile(s)
+            except RuntimeError:
+                raised = True
+            assert raised, "must refuse to start when a live foreign daemon owns the session"
+        finally:
+            _tts._pid_alive = orig
+
+
+def test_main_runs_without_nameerror():
+    # the CLI entry must not crash on startup — a missing var in the startup print would
+    # NameError AFTER start() and silently exit via finally (headless tests that skip main()
+    # miss it). start()/close() are stubbed so no real audio device is touched.
+    with _temp_state():
+        orig_start, orig_close = ld.EnqueueDaemon.start, ld.EnqueueDaemon.close
+        ld.EnqueueDaemon.start = lambda self: None  # leaves running=False -> wait loop skipped
+        ld.EnqueueDaemon.close = lambda self: None
+        try:
+            assert ld.main() == 0  # must run through the startup print + finally with no NameError
+        finally:
+            ld.EnqueueDaemon.start, ld.EnqueueDaemon.close = orig_start, orig_close
+
+
+def test_write_then_remove_pidfile_with_session_none():
+    # Codex M: main() claims with session=None; _remove_pidfile MUST still remove that pidfile
+    # on shutdown. The old `_ACTIVE_SESSION is None -> early return` guard wrongly skipped it
+    # (None is a valid session), leaving a stale pidfile that could falsely read as a live
+    # daemon after pid recycling. Now gated on the _PIDFILE_CLAIMED flag instead.
+    with _temp_state():
+        ld._write_pidfile(None)
+        p = ld._daemon_pid_path(None)
+        assert p.exists()
+        ld._remove_pidfile()
+        assert not p.exists(), "shutdown must remove the pidfile even when session is None"
+
+
+def test_touch_pidfile_recreates_when_externally_removed():
+    # Codex M: if the pidfile is removed mid-run, the heartbeat re-establishes it so the live
+    # daemon (still owning the mic) stays discoverable — daemon_active() must not read False
+    # forever (which would send listen() to self-open the device the daemon holds -> -9998).
+    with _temp_state():
+        s = "reheal"
+        ld._write_pidfile(s)
+        p = ld._daemon_pid_path(s)
+        p.unlink()                       # external removal mid-run
+        ld._touch_pidfile(s)             # heartbeat re-establishes it
+        assert p.exists()
+        assert int(p.read_text(encoding="utf-8")) == os.getpid()
+
+
+def test_remove_pidfile_only_removes_own():
+    with _temp_state():
+        s = "rm"
+        ld._write_pidfile(s)
+        p = ld._daemon_pid_path(s)
+        assert p.exists()
+        ld._remove_pidfile()
+        assert not p.exists()
+        # a successor's pidfile (different pid) must NOT be clobbered by our atexit handler
+        ld._write_pidfile(s)
+        _state._atomic_write(p, "424242")  # successor re-claimed the slot
+        ld._remove_pidfile()
+        assert p.exists(), "must not remove a successor daemon's pidfile"
+
+
+# --- §8 half-duplex: drop capture while the TTS lock is held by a live holder ------------
+
+def test_tts_playing_detects_live_holder():
+    with _temp_state():
+        assert ld._tts_playing() is False
+        lp = _tts._lock_path()
+        _state._atomic_write(lp, str(os.getpid()))
+        assert ld._tts_playing() is True
+        _state._atomic_write(lp, "0")  # dead holder
+        assert ld._tts_playing() is False
+
+
+def test_maybe_muted_caches_then_reflects_lock():
+    with _temp_state():
+        d = ld.EnqueueDaemon(session="mute")
+        d._mute_check_at = 0.0
+        assert d._maybe_muted() is False
+        lp = _tts._lock_path()
+        _state._atomic_write(lp, str(os.getpid()))
+        d._mute_check_at = 0.0   # force a re-check past the cache TTL
+        assert d._maybe_muted() is True
+        lp.unlink()
+        d._mute_check_at = 0.0
+        assert d._maybe_muted() is False
+
+
+# --- §8 time-anchored listen(): wait_for_utterance ignores pre-question backlog ----------
+
+def test_wait_for_utterance_timeout_returns_empty():
+    with _temp_state():
+        t0 = time.time()
+        assert ld.wait_for_utterance(max_seconds=0.2, session="t", poll_sec=0.05) == ""
+        assert time.time() - t0 >= 0.18  # actually waited ~max_seconds
+
+
+def test_wait_for_utterance_ignores_pre_watermark_backlog():
+    with _temp_state():
+        s = "wfu_old"
+        _vq.enqueue("old", ts="2020-01-01T00:00:00Z", session=s)  # far before any watermark
+        assert ld.wait_for_utterance(max_seconds=0.2, session=s, poll_sec=0.05) == ""
+        assert [it["text"] for it in _vq.peek_all(session=s)] == ["old"]  # left for the drain
+
+
+def test_wait_for_utterance_returns_post_watermark():
+    with _temp_state():
+        s = "wfu_new"
+
+        def producer():
+            time.sleep(0.15)  # enqueue AFTER wait_for_utterance captures its watermark
+            _vq.enqueue("delayed", session=s)
+
+        threading.Thread(target=producer, daemon=True).start()
+        got = ld.wait_for_utterance(max_seconds=2.0, session=s, poll_sec=0.05)
+        assert got == "delayed", got
+
+
+def _main():
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    passed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+            passed += 1
+        except AssertionError as e:
+            print(f"FAIL {t.__name__}: {e}")
+        except Exception as e:  # noqa: BLE001
+            print(f"ERROR {t.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{passed}/{len(tests)} passed")
+    sys.exit(0 if passed == len(tests) else 1)
+
+
+if __name__ == "__main__":
+    _main()

--- a/scripts/voice/test_listen_daemon.py
+++ b/scripts/voice/test_listen_daemon.py
@@ -95,7 +95,10 @@ def test_run_segments_on_silence_and_caps_runaway():
             d.running = True
             th = threading.Thread(target=d._run, daemon=True)
             th.start()
-            time.sleep(0.4)  # let _run drain the fed blocks + finalize
+            for _ in range(60):  # poll up to ~3s for a finalize (condition-based, not a fixed sleep)
+                if sizes:
+                    break
+                time.sleep(0.05)
             d.running = False
             th.join(timeout=1.0)
             return sizes
@@ -133,7 +136,8 @@ def test_finalize_enqueues_under_capture_onset_ts():
 def test_daemon_has_no_paste_side_effects():
     # the dedicated #495 daemon must NEVER paste into the focused window or press keys —
     # that is #465's job, and reusing it here would inject keystrokes into the active app.
-    src = open(ld.__file__, encoding="utf-8").read()
+    with open(ld.__file__, encoding="utf-8") as f:  # explicit close (Windows handle/lock safety)
+        src = f.read()
     for forbidden in ("deliver_text", "keyboard", "press_and_release", "import keyboard"):
         assert forbidden not in src, f"daemon must not reference {forbidden!r}"
 

--- a/scripts/voice/test_listen_daemon.py
+++ b/scripts/voice/test_listen_daemon.py
@@ -244,6 +244,22 @@ def test_tts_playing_detects_live_holder():
         assert ld._tts_playing() is False
 
 
+def test_on_audio_drops_under_backpressure():
+    # bounded queue (Argus memory-risk): a full queue must make the audio callback DROP the
+    # newest block (never raise, never grow), so a slow/hung transcribe can't leak memory.
+    with _temp_state():
+        d = ld.EnqueueDaemon(session="bp")
+        d._np = np
+        d._muted = False
+        d._mute_check_at = float("inf")  # use the cached (False) mute state, no file IO
+        d.q = ld.queue.Queue(maxsize=2)
+        blk = np.zeros(800, dtype=np.float32)
+        for _ in range(5):
+            d._on_audio(blk, 800, None, None)  # 5 puts into a maxsize-2 queue
+        assert d.q.qsize() == 2  # capped, not grown
+        assert d._dropped == 3   # the 3 overflow blocks were dropped without raising
+
+
 def test_maybe_muted_caches_then_reflects_lock():
     with _temp_state():
         d = ld.EnqueueDaemon(session="mute")

--- a/scripts/voice/test_listen_daemon.py
+++ b/scripts/voice/test_listen_daemon.py
@@ -207,6 +207,32 @@ def test_write_then_remove_pidfile_with_session_none():
         assert not p.exists(), "shutdown must remove the pidfile even when session is None"
 
 
+def test_write_pidfile_steals_stale_heartbeat_even_if_pid_alive():
+    # Copil­ot: refuse must match daemon_active()'s liveness — a recycled pid that happens to be
+    # alive but whose heartbeat is STALE is a dead daemon's leftover and must be stealable, not
+    # wrongly block a fresh start.
+    with _temp_state():
+        s = "stale-steal"
+        p = ld._daemon_pid_path(s)
+        _state._atomic_write(p, "424242")
+        old = time.time() - (ld._stale_threshold() + 60)
+        os.utime(p, (old, old))                 # stale heartbeat
+        orig = _tts._pid_alive
+        _tts._pid_alive = lambda pid: True       # pretend the recycled pid is alive
+        try:
+            ld._write_pidfile(s)                 # stale -> stealable despite "alive" pid
+            assert int(p.read_text(encoding="utf-8")) == os.getpid()
+        finally:
+            _tts._pid_alive = orig
+
+
+def test_wait_for_utterance_clamps_bad_poll_sec():
+    # Copilot: a non-positive / invalid poll_sec must not busy-loop or raise out of time.sleep
+    with _temp_state():
+        for bad in (0, -1, "x", None):
+            assert ld.wait_for_utterance(max_seconds=0.15, session="clamp", poll_sec=bad) == ""
+
+
 def test_touch_pidfile_recreates_when_externally_removed():
     # Codex M: if the pidfile is removed mid-run, the heartbeat re-establishes it so the live
     # daemon (still owning the mic) stays discoverable — daemon_active() must not read False


### PR DESCRIPTION
## 摘要

Issue #495 Path 2 **Slice 3**:新增 `scripts/voice/listen_daemon.py`(常驻 STT daemon)+ 改 `mcp_server.py` `listen()` 读队列(模型 A)。daemon **独占麦克风**、always-on 转写、把每句话写进 per-session transcript 队列(Slice 2 的 `voice_queue`);`listen()` 在 daemon 活时**读队列**而非自开第二条音频流 —— 消除两条 `InputStream` 抢同一设备在 Windows 上的 `PortAudio -9998`。**完全 opt-in**:不起 daemon 则 `listen()` 行为与 #468 一字不差。

Refs #495 #468

## 设计依据

`.mercury/docs/research/issue-495-voice-conversation-design.md` §3.1/§3.3(模型 A)+ §8(对抗式合并门)。daemon 复用 `stt.SttEngine`(共享 STT 核心:CUDA 设置 / transcribe / VAD 校准),自写 enqueue-only 连续 VAD 捕获循环。

### 偏离设计的实现选择(有据)

设计原话「复用 #465 `ContinuousListener`」。实际改为**专用捕获路径**,因为:① `voice-zh-input.py` 文件名带连字符,无法作模块 import 子类化;② §8 评审明确要求 daemon 用 GRACE-free / AUTO_ENTER-free 的专用路径(`ContinuousListener._finalize` 会 `deliver_text` 粘贴 + 按 Enter 注入焦点窗口,且 `_busy` 门控与 #495 需求冲突)。专用路径复用 `stt.SttEngine` 转写(共享核心未重复),仅 VAD 分段循环是新写的 GRACE-free / enqueue-only 版本。

## §8 对抗式 must-fix 落地

- **enqueue-only**:daemon 绝无 `keyboard`/`deliver_text`/paste 副作用(meta-test 断言源码不含这些符号)。
- **半双工**:持 `voice-tts.lock`(活 holder)时丢采集(防麦克风听到 Kokoro 自己声音转成幽灵「用户说」)。真 barge-in 需 AEC,超范围;本切片是半双工轮流(播报期间麦聋)。
- **self-heal liveness**:pidfile 仅在 `InputStream.start()` 成功后写、退出(finally/atexit/SIGTERM)删、mtime 作心跳;`daemon_active()` 要求 **pid 活 AND 心跳新鲜**双门(防 pid 回收假活困住 `listen()`)。
- **时间锚定**:daemon 以 **capture-onset**(用户开口时刻,非转写完成时刻)入队;`listen()` 用 watermark 只返回**调用后**说的话 —— 提问前开始说的话不被误当回答。
- **fallback**:无 daemon 走 `listen_once`(向后兼容);捕获 `PortAudioError` 返回清晰中文消息(仅 PortAudio 才提「麦被占用」,其余报真实异常类型)而非崩工具。

## 测试

`scripts/voice/test_listen_daemon.py` —— **13/13 通过**(headless,无 mic/faster_whisper/sounddevice:daemon 惰性 import 重型依赖,逻辑可 stub 测)。覆盖:`_finalize` enqueue-only + capture-onset ts、无 paste 副作用 meta-test、`daemon_active` pid+心跳双门、pidfile 偷死/拒活跃外来 owner、`_remove_pidfile` 只删自己、`_tts_playing`/半双工 mute 缓存、`wait_for_utterance` 时间锚定(超时/忽略 watermark 前积压/返回 watermark 后)、真 `_run` VAD 循环(尾静音 finalize + 失控句长 cap)。回归:`test_voice_queue` 21/21、`test_stt_preroll` 12/12。

> ⚠️ **真 mic 端到端验证不在本切片范围**(headless 只验逻辑)。daemon 的采集/转写/-9998 规避/声学回授依赖真实音频硬件 + Kokoro,验证步骤见 `README.md` Path 2 段(① daemon 起 + 说话 → 队列出 `utt-*.json`;② `listen()` 返回该句;③ 播报期间说话不入队;④ taskkill daemon 后 `listen()` 退回自开麦不卡死)。

## dual-verify

- **Claude code-reviewer 侧**:深审自查出 4 项(失控句长 cap 缺失 / transcribe 心跳空窗 / session 错位 footgun / worker 未初始化),已修。
- **Codex code-audit 侧**:首轮 NEEDS-CHANGES(High×2 时间锚定未闭合 + pidfile 门窗矛盾 / Medium×2 fallback except 过宽 + secretary 副作用 / Low 测试覆盖);全部修复 + 补测试。复审:Codex 复审 4 轮收敛(findings 5→2→1→0),终轮 Critical/High/Medium/Low 全 0 PASS。两侧均 PASS → dual-verify 合并门通过。

## 约束遵守

- `scripts/voice/` 是 Mercury 内部工具,**不受 200-LOC adapter 上限**(CLAUDE.md scripts/ carve-out);非 cherry-pick(全新文件 + stt 共享核心,无 upstream)。
- 向后兼容(opt-in,无 daemon = #468);PR base develop;side-voice lane 隔离 worktree;README 更新 Path 2 daemon 文档(含 §8 半双工/耳机要求 + 真 mic 验证清单)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
