### PR TITLE
feat(#495): Stop-hook 队列 drain — 回合末重注入 daemon 入队语音 (Path 2 Slice 5)

### DIFF
--- a/.claude/hooks/voice-queue-drain.sh
+++ b/.claude/hooks/voice-queue-drain.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# voice-queue-drain — Stop hook: re-inject voice the user spoke DURING the turn (Issue #495 Slice 5).
+#
+# Opt-in: NOT registered in .claude/settings.json by default (would spawn a Python process every
+# turn for the whole team + require .venv-voice). Enable it yourself by appending a Stop matcher
+# entry alongside stop-guard.sh / voice-stop-notify.sh — see scripts/voice/README.md §Path 2.
+# The worker self-guards: it no-ops unless a voice mode is active AND the transcript queue is
+# non-empty, so even if registered it is silent for non-voice sessions.
+#
+# Reads the Stop-hook JSON on stdin and pipes it to the voice venv's queue_drain.py. The worker
+# may emit a top-level {"decision":"block","reason":...} to continue the turn with the queued
+# speech in context. `"$PY" ... || true` preserves that stdout (only the exit code is swallowed),
+# so the block decision reaches Claude Code even if Python exits non-zero. Always exits 0 — a
+# queue hiccup must never block Claude Code.
+set -euo pipefail
+
+PROJ="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+PY="$PROJ/.venv-voice/Scripts/python.exe"          # native Windows venv
+[ -x "$PY" ] || PY="$PROJ/.venv-voice/bin/python"  # posix venv fallback
+
+# voice venv not installed -> nothing to do
+if [ ! -x "$PY" ]; then
+  cat >/dev/null 2>&1 || true   # drain stdin
+  exit 0
+fi
+
+"$PY" "$PROJ/scripts/voice/queue_drain.py" || true
+exit 0

--- a/.claude/hooks/voice-queue-drain.sh
+++ b/.claude/hooks/voice-queue-drain.sh
@@ -15,8 +15,13 @@
 set -euo pipefail
 
 PROJ="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
-PY="$PROJ/.venv-voice/Scripts/python.exe"          # native Windows venv
-[ -x "$PY" ] || PY="$PROJ/.venv-voice/bin/python"  # posix venv fallback
+# VOICE_QUEUE_DRAIN_PYTHON overrides the interpreter for non-default deploy layouts; else fall
+# back to the documented shared venv (.venv-voice) on native Windows / posix.
+PY="${VOICE_QUEUE_DRAIN_PYTHON:-}"
+if [ -z "$PY" ]; then
+  PY="$PROJ/.venv-voice/Scripts/python.exe"          # native Windows venv
+  [ -x "$PY" ] || PY="$PROJ/.venv-voice/bin/python"  # posix venv fallback
+fi
 
 # voice venv not installed -> nothing to do
 if [ ! -x "$PY" ]; then

--- a/scripts/voice/README.md
+++ b/scripts/voice/README.md
@@ -184,6 +184,7 @@ session **只**来自 `VOICE_QUEUE_SESSION`(与 listen() 同一解析通道,故�
 | `VOICE_QUEUE_MAX_CONTINUATIONS` | `3` | drain 连续自动续接(block)上限,防室噪/回授导致无限 spin;到顶则把队列项留到下个用户回合 |
 | `VOICE_QUEUE_CONT_WINDOW` | `120` | 续接计数链的新鲜窗口(秒);超过此空闲间隔的旧计数链视为陈旧并重置(仿 auto-handoff mtime 守卫,跨会话/空闲自愈) |
 | `VOICE_QUEUE_DRAIN_MAX_CHARS` | `1000` | drain 重注入 reason 的转写文本字符上限(超出截断);防长转写撑大 Stop-hook 输出/上下文 |
+| `VOICE_QUEUE_DRAIN_PYTHON` | (空=`.venv-voice`) | `voice-queue-drain.sh` 解释器覆盖;非默认部署目录(不用 .venv-voice)时指定 Python 绝对路径 |
 | `VOICE_DAEMON_HEARTBEAT_SEC` | `5` | daemon 心跳(pidfile mtime)刷新基准秒;`daemon_active()` 判活的过期阈值=2× |
 | `VOICE_DAEMON_SILENCE_SEC` | `0.8` | daemon 判一句结束的尾静音秒数 |
 | `VOICE_DAEMON_MIN_SEC` | `0.4` | daemon 最短有效句长(秒),短于此丢弃 |

--- a/scripts/voice/README.md
+++ b/scripts/voice/README.md
@@ -27,7 +27,9 @@ scripts/voice/
   listen_daemon.py 常驻 STT daemon(模型 A:独占 mic、转写入队;enqueue-only 半双工;#495 Slice 3)
   mcp_server.py stdio MCP server:listen / announce / set_mode / record_note / get_status
   stop_notify.py Stop-hook worker:回合末读 last_assistant_message → TTS 播报
+  queue_drain.py Stop-hook worker:回合末 drain transcript 队列 → {decision:block} 重注入(#495 Slice 5)
 .claude/hooks/voice-stop-notify.sh   Stop hook 包装(opt-in,默认不注册)
+.claude/hooks/voice-queue-drain.sh   Stop hook 包装:队列 drain(opt-in,默认不注册;#495 Slice 5)
 .claude/commands/secretary.md|work.md  /secretary、/work 模式切换 slash command
 ```
 
@@ -127,6 +129,33 @@ session **只**来自 `VOICE_QUEUE_SESSION`(与 listen() 同一解析通道,故�
 >
 > ⚠️ **真 mic 验证**:daemon 的采集/转写/-9998 规避/声学回授等行为依赖真实音频硬件 + Kokoro 服务,headless 单测覆盖逻辑(队列读写、心跳/pid 自愈、半双工门控、enqueue-only 无 paste),但**端到端需在真麦克风环境验证**:① 起 daemon,说一句,确认队列出现 `utt-*.json`;② 会话内 `listen()` 返回该句;③ `announce` 播报期间说话**不**被转写入队(半双工);④ `taskkill` daemon 后 `listen()` 退回自开麦不卡死。
 
+### Stop-hook 队列 drain(#495 Slice 5,opt-in)
+
+`announce`+`listen` 是回合内主动拉取;daemon 在 agent **干活期间**捕获的话进了 transcript 队列,需要在**回合边界**把它们重注入会话,否则「干活期间说的话」会丢。`queue_drain.py`(经 `voice-queue-drain.sh` 包装)是这个回合末 worker:drain 队列 → 输出 `{"decision":"block","reason":<转写>}` exit 0,让 Claude Code 带着这些话续这一回合。
+
+**默认不注册**(避免给全团队每回合 spawn 进程)。要启用,往现有 `hooks.Stop[0].hooks` 数组**追加**一条(与 `stop-guard.sh` / `voice-stop-notify.sh` 并列,**不要替换整个 Stop**):
+
+```json
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          { "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/stop-guard.sh\"", "timeout": 10 },
+          { "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/voice-queue-drain.sh\"", "timeout": 15 }
+        ]
+      }
+    ]
+  }
+}
+```
+
+(只新增 `voice-queue-drain.sh` 那一行;`stop-guard.sh` 原样保留。drain 排在 `stop-guard.sh` / `auto-handoff-stop.sh` 之后 —— 它们用 `decision:block` 时优先,可接受:下个干净 stop 再 drain。)
+
+> ⚠️ **与 `voice-stop-notify.sh` 二选一/合并**:两者都在 Stop 触发会让用户既听到队列重注入又听到上条回复播报(且共享播放锁串行)。建议**只注册其一**,或后续合并为单一 Stop worker(§设计 §8 minor)。
+>
+> **§8 续接回合聋区防护(loop-guard)**:drain **不**只靠 `stop_hook_active` 单守卫(那会漏掉「续接回合期间」说的话)。它自持 per-session 续接计数器(仿 `auto-handoff-stop.sh` 的 RETRY marker),即使 `stop_hook_active=true` 也会对**新的**非空队列再 block,但用 `VOICE_QUEUE_MAX_CONTINUATIONS`(默认 3)封顶连续续接 —— 防室噪/麦听到 Kokoro 自己声音导致无限 spin。**到顶后停止 block 并把队列项留到下个用户回合(绝不丢弃)** + stderr 提示。新用户回合(`stop_hook_active` falsy)重置计数链。worker **纯文本**(无同步 TTS,防慢 synth 撑爆 hook timeout)。
+
 ---
 
 ## 配置(env)
@@ -150,7 +179,10 @@ session **只**来自 `VOICE_QUEUE_SESSION`(与 listen() 同一解析通道,故�
 | `VOICE_PRE_RECORD_SEC` | `0.3` | onset 前预录环形缓冲时长(秒),补回句首被 VAD 截断的清音/气口;`0`=关,有效范围 `(0, 10]`,超出/非法值告警并回退默认 0.3(永不崩 listen)。实际 maxlen=`max(ceil(秒/块时长), onset_blocks)`,保证≥onset 窗口故永不丢 onset 音;预录的静音前导不计入 `min_sec` 短句门;>0.5 有把室噪/键盘声 prepend 进首字的风险(#495) |
 | `VOICE_VAD_FACTOR` | `2.5` | 能量 VAD 阈值=噪声地板×该倍率(低增益麦克风语音仅 ~3.5× 噪声,故默认 2.5;#472) |
 | `VOICE_VAD_THRESH` | (空=自动校准) | 能量 VAD 绝对阈值覆盖(RMS,设置后跳过自动校准) |
-| `VOICE_QUEUE_SESSION` | (空=`default`) | transcript 队列 + daemon pidfile 的 session 键(多 lane 隔离;**daemon 与 listen() 端须一致**,否则各读各的队列) |
+| `VOICE_QUEUE_SESSION` | (空=`default`) | transcript 队列 + daemon pidfile 的 session 键(多 lane 隔离;**daemon / listen() / queue-drain 三端须一致**,否则各读各的队列。queue-drain 端:env 未设时退回 Stop-hook stdin 的 session_id) |
+| `VOICE_QUEUE_MAX_ITEMS` | `5` | Stop-hook drain 单次重注入的最多 utterance 数(配合 hook timeout 预算) |
+| `VOICE_QUEUE_MAX_CONTINUATIONS` | `3` | drain 连续自动续接(block)上限,防室噪/回授导致无限 spin;到顶则把队列项留到下个用户回合 |
+| `VOICE_QUEUE_CONT_WINDOW` | `120` | 续接计数链的新鲜窗口(秒);超过此空闲间隔的旧计数链视为陈旧并重置(仿 auto-handoff mtime 守卫,跨会话/空闲自愈) |
 | `VOICE_DAEMON_HEARTBEAT_SEC` | `5` | daemon 心跳(pidfile mtime)刷新基准秒;`daemon_active()` 判活的过期阈值=2× |
 | `VOICE_DAEMON_SILENCE_SEC` | `0.8` | daemon 判一句结束的尾静音秒数 |
 | `VOICE_DAEMON_MIN_SEC` | `0.4` | daemon 最短有效句长(秒),短于此丢弃 |
@@ -180,7 +212,11 @@ session **只**来自 `VOICE_QUEUE_SESSION`(与 listen() 同一解析通道,故�
 - **Path 2 daemon 半双工(默认,#495 Slice 3)**:daemon 持 `voice-tts.lock` 时丢采集 → 播报期间麦克风聋(安全轮流对讲)。
 - **opt-in barge-in(#495 Slice 4,默认关)**:`VOICE_BARGEIN=1` 后 daemon 播报期间不静音,onset 即写 generation-绑定
   停播信号(`voice-tts.stop`)让 `announce` 提前停;**仅耳机/AEC 环境可靠**(扬声器会假打断 + 回授幽灵句),
-  真扬声器 barge-in 需 AEC 超范围。可中断播放用 elapsed-time 边界而非 `sd.get_stream()`(§8:后者可能轮询错流)。
+  真扬声器 barge-in 需 AEC 超范围。可中断播放用后台 drain 线程 + 全程 poll(无不可中断尾窗),不用 `sd.get_stream()`(§8:后者可能轮询错流)。
+- **Stop-hook 队列 drain(#495 Slice 5,opt-in,默认不注册)**:回合末把 daemon 在干活期间入队的话重注入会话。loop-guard
+  自持续接计数器 + `VOICE_QUEUE_MAX_CONTINUATIONS` 封顶(不只靠 `stop_hook_active`),到顶把队列项留到下个用户回合不丢弃;
+  纯文本无同步 TTS(防撑爆 hook timeout)。**注册进 settings.json 是用户级治理变更,须手动按上方片段添加**(本切片不自动改 settings.json)。
+  与 `voice-stop-notify.sh` 建议二选一(否则双声)。
 - **Path 2 daemon 崩溃自愈**:daemon 仅在 `InputStream` 起来后写 pidfile,退出(`finally`/`atexit`/`SIGTERM`)删之,
   每轮刷新 mtime 作心跳;`daemon_active()` 要求 **pid 活 AND 心跳新鲜**双门,故 daemon 崩溃(泄漏设备/pid 回收假活)时
   `listen()` 退回自开麦而非卡在永不填充的队列;自开麦若撞 `-9998`(残留进程占麦)返回清晰错误而非崩工具。

--- a/scripts/voice/README.md
+++ b/scripts/voice/README.md
@@ -183,6 +183,7 @@ session **只**来自 `VOICE_QUEUE_SESSION`(与 listen() 同一解析通道,故�
 | `VOICE_QUEUE_MAX_ITEMS` | `5` | Stop-hook drain 单次重注入的最多 utterance 数(配合 hook timeout 预算) |
 | `VOICE_QUEUE_MAX_CONTINUATIONS` | `3` | drain 连续自动续接(block)上限,防室噪/回授导致无限 spin;到顶则把队列项留到下个用户回合 |
 | `VOICE_QUEUE_CONT_WINDOW` | `120` | 续接计数链的新鲜窗口(秒);超过此空闲间隔的旧计数链视为陈旧并重置(仿 auto-handoff mtime 守卫,跨会话/空闲自愈) |
+| `VOICE_QUEUE_DRAIN_MAX_CHARS` | `1000` | drain 重注入 reason 的转写文本字符上限(超出截断);防长转写撑大 Stop-hook 输出/上下文 |
 | `VOICE_DAEMON_HEARTBEAT_SEC` | `5` | daemon 心跳(pidfile mtime)刷新基准秒;`daemon_active()` 判活的过期阈值=2× |
 | `VOICE_DAEMON_SILENCE_SEC` | `0.8` | daemon 判一句结束的尾静音秒数 |
 | `VOICE_DAEMON_MIN_SEC` | `0.4` | daemon 最短有效句长(秒),短于此丢弃 |

--- a/scripts/voice/queue_drain.py
+++ b/scripts/voice/queue_drain.py
@@ -103,13 +103,6 @@ def main():
 
     session = _resolve_session(payload)
     try:
-        # benign TOCTOU: a daemon enqueue landing AFTER this is_empty() check is simply delivered
-        # on the NEXT Stop, not lost — drain() below is the atomic per-session consume (its
-        # `not items` branch also covers the reverse race), so the early-return only widens a
-        # one-turn defer window, never drops speech.
-        if _vq.is_empty(session):
-            _reset_count(session)  # clean turn: nothing was said -> reset the continuation chain
-            return 0
         cap = _env_int("VOICE_QUEUE_MAX_CONTINUATIONS", 3)
         # Carry the continuation count forward ONLY if this is a continuation of OUR OWN chain:
         # the harness says we're mid-continuation (stop_hook_active) AND our marker is fresh
@@ -121,22 +114,25 @@ def main():
         count = _read_count(session) if in_own_chain else 0
         if count >= cap:
             # too many consecutive auto-continuations (likely room noise / echo loop). STOP
-            # blocking; LEAVE the items queued (do NOT drain/consume) so a later user turn still
-            # delivers them — never silently drop the user's speech (§8).
-            pending = len(_vq.peek_all(session))
-            _reset_count(session)
-            print(f"[voice-queue-drain] continuation cap ({cap}) reached — {pending} utterance(s) "
-                  "deferred to the next user-initiated turn", file=sys.stderr, flush=True)
+            # blocking; do NOT drain/consume so the items stay queued — a fresh user turn (or a
+            # chain gone stale past the window) resets the count above and delivers them later;
+            # never silently drop the user's speech (§8).
+            print(f"[voice-queue-drain] continuation cap ({cap}) reached — deferring queued "
+                  "speech to the next user-initiated turn", file=sys.stderr, flush=True)
             return 0
+        # ONE parse of the queue on the common path: drain() is the atomic per-session consume,
+        # and its empty result IS the "nothing queued" guard — no separate is_empty() directory
+        # walk (this runs in a timeout-bounded Stop hook) (Copilot).
         items = _vq.drain(_env_int("VOICE_QUEUE_MAX_ITEMS", 5), session)
         if not items:
-            _reset_count(session)  # raced empty between is_empty and drain
+            _reset_count(session)  # nothing was queued -> clean turn, reset the continuation chain
             return 0
         _write_count(session, count + 1)
-        transcript = "\n".join(f"- {it.get('text', '')}" for it in items)
+        # per-item type guard: a single malformed entry must NOT raise out and drop the WHOLE
+        # already-drained batch (voice_queue only enqueues dicts, but defend the boundary) (Argus).
+        transcript = "\n".join(f"- {it.get('text', '')}" for it in items if isinstance(it, dict))
         # bound the injected text: max_items caps the COUNT, but an individual transcription can
-        # be long — cap total chars so the Stop-hook block output can't bloat the context / strain
-        # the hook (Argus). Truncated content is still in the queue's consumed/ archive.
+        # be long — cap total chars so the Stop-hook block output can't bloat the context (Argus).
         cap_chars = _env_int("VOICE_QUEUE_DRAIN_MAX_CHARS", 1000)
         if len(transcript) > cap_chars:
             transcript = transcript[:cap_chars] + "……（其余略）"

--- a/scripts/voice/queue_drain.py
+++ b/scripts/voice/queue_drain.py
@@ -1,0 +1,148 @@
+# -*- coding: utf-8 -*-
+"""queue_drain — Stop-hook worker: re-inject voice spoken DURING the turn (#495 Slice 5).
+
+At a turn boundary, drain the per-session transcript queue (what the user said via the
+always-on daemon while the agent was working) and emit `{"decision":"block","reason":...}`
+exit 0 — the verified form (auto-handoff-stop.sh:129, stop-guard.sh) that makes Claude Code
+continue the turn with that speech in context, closing the "things said during the previous
+turn are lost" gap.
+
+§8 loop-correctness (the hard merge gate): relying on `stop_hook_active` ALONE to break the
+block loop would strand any utterance spoken DURING the continuation turn (it is guarded out
+and may never be delivered in work-mode). So this worker OWNS its own continuation counter
+(mirroring auto-handoff-stop.sh's RETRY marker, which deliberately AVOIDS stop_hook_active):
+it re-blocks on a NEW non-empty queue even when stop_hook_active is true, but caps consecutive
+auto-continuations (VOICE_QUEUE_MAX_CONTINUATIONS, default 3) so room noise / the agent's own
+TTS picked up by the mic cannot spin forever. At the cap it STOPS blocking and LEAVES the items
+queued (NOT consumed) for the next user-initiated turn, logging a deferral nudge.
+
+Self-guards (all exit 0 — a hook must never crash the turn): venv handled by the wrapper;
+mode == idle -> no-op; empty queue -> no-op; any error -> no-op.
+
+Text-only: NO synchronous TTS here — a slow Kokoro synth could blow the hook timeout (§8);
+the block reason is plain text Claude reads. `reason` is json.dumps-serialised (Chinese /
+quotes / backslashes safe), never string-concatenated into JSON.
+
+Invoked by .claude/hooks/voice-queue-drain.sh (opt-in; NOT registered by default — see
+scripts/voice/README.md for the settings.json Stop-matcher snippet).
+"""
+import os
+import sys
+import json
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import state as _state          # noqa: E402
+import voice_queue as _vq       # noqa: E402
+
+
+def _env_int(name, default):
+    try:
+        v = int(os.environ.get(name, "") or default)
+        return v if v > 0 else int(default)
+    except (TypeError, ValueError):
+        return int(default)
+
+
+def _resolve_session(payload):
+    """env VOICE_QUEUE_SESSION (shared with the daemon) wins; else the Stop-hook's session_id
+    from stdin (the per-session key §8 prescribes); else None -> the default bucket."""
+    return os.environ.get("VOICE_QUEUE_SESSION") or payload.get("session_id") or None
+
+
+def _cont_path(session):
+    # keyed by the SAME resolved session as the queue dir, so the counter tracks the right queue
+    return _state._state_dir() / f"voice-queue-cont-{_vq._resolve_session(session)}"
+
+
+def _read_count(session):
+    try:
+        return int((_cont_path(session).read_text(encoding="utf-8").strip() or "0"))
+    except (OSError, ValueError):
+        return 0
+
+
+def _write_count(session, n):
+    try:
+        _state._atomic_write(_cont_path(session), str(int(n)))
+    except OSError:
+        pass
+
+
+def _reset_count(session):
+    try:
+        _cont_path(session).unlink()
+    except OSError:
+        pass
+
+
+def _counter_fresh(session, window):
+    """True iff the continuation counter file exists AND is fresh (mtime within `window`). A
+    chain older than the window (the agent went idle, or a prior session left it) is stale and
+    must NOT be inherited — mirrors auto-handoff-stop.sh's mtime-staleness disarm (line 54).
+    This is the OWN marker: the loop guard does not rely on stop_hook_active alone (§8)."""
+    try:
+        return (time.time() - _cont_path(session).stat().st_mtime) <= window
+    except OSError:
+        return False
+
+
+def main():
+    raw = sys.stdin.read()
+    try:
+        payload = json.loads(raw) if raw.strip() else {}
+    except json.JSONDecodeError:
+        return 0
+    if not isinstance(payload, dict):
+        return 0
+    try:
+        if _state.get_mode() == "idle":
+            return 0  # voice interaction not active — no-op
+    except Exception:  # noqa: BLE001 — a hook must never crash the turn
+        return 0
+
+    session = _resolve_session(payload)
+    try:
+        # benign TOCTOU: a daemon enqueue landing AFTER this is_empty() check is simply delivered
+        # on the NEXT Stop, not lost — drain() below is the atomic per-session consume (its
+        # `not items` branch also covers the reverse race), so the early-return only widens a
+        # one-turn defer window, never drops speech.
+        if _vq.is_empty(session):
+            _reset_count(session)  # clean turn: nothing was said -> reset the continuation chain
+            return 0
+        cap = _env_int("VOICE_QUEUE_MAX_CONTINUATIONS", 3)
+        # Carry the continuation count forward ONLY if this is a continuation of OUR OWN chain:
+        # the harness says we're mid-continuation (stop_hook_active) AND our marker is fresh
+        # (mtime within the window). A fresh user turn (stop_hook_active falsy), a stale/idle
+        # chain, or a continuation another hook caused (our marker absent/old) all reset to 0,
+        # so the loop guard never depends on stop_hook_active alone (§8 / Codex).
+        window = _env_int("VOICE_QUEUE_CONT_WINDOW", 120)
+        in_own_chain = bool(payload.get("stop_hook_active")) and _counter_fresh(session, window)
+        count = _read_count(session) if in_own_chain else 0
+        if count >= cap:
+            # too many consecutive auto-continuations (likely room noise / echo loop). STOP
+            # blocking; LEAVE the items queued (do NOT drain/consume) so a later user turn still
+            # delivers them — never silently drop the user's speech (§8).
+            pending = len(_vq.peek_all(session))
+            _reset_count(session)
+            print(f"[voice-queue-drain] continuation cap ({cap}) reached — {pending} utterance(s) "
+                  "deferred to the next user-initiated turn", file=sys.stderr, flush=True)
+            return 0
+        items = _vq.drain(_env_int("VOICE_QUEUE_MAX_ITEMS", 5), session)
+        if not items:
+            _reset_count(session)  # raced empty between is_empty and drain
+            return 0
+        _write_count(session, count + 1)
+        transcript = "\n".join(f"- {it.get('text', '')}" for it in items)
+        reason = ("用户在你上一回合执行期间通过语音补充了以下内容（按时间顺序），"
+                  "请在继续前纳入考虑：\n" + transcript)
+        print(json.dumps({"decision": "block", "reason": reason}, ensure_ascii=False))
+        return 0
+    except Exception as e:  # noqa: BLE001 — a hook must never crash the turn
+        print(f"[voice-queue-drain] error (ignored): {type(e).__name__}: {e}",
+              file=sys.stderr, flush=True)
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/voice/queue_drain.py
+++ b/scripts/voice/queue_drain.py
@@ -134,6 +134,12 @@ def main():
             return 0
         _write_count(session, count + 1)
         transcript = "\n".join(f"- {it.get('text', '')}" for it in items)
+        # bound the injected text: max_items caps the COUNT, but an individual transcription can
+        # be long — cap total chars so the Stop-hook block output can't bloat the context / strain
+        # the hook (Argus). Truncated content is still in the queue's consumed/ archive.
+        cap_chars = _env_int("VOICE_QUEUE_DRAIN_MAX_CHARS", 1000)
+        if len(transcript) > cap_chars:
+            transcript = transcript[:cap_chars] + "……（其余略）"
         reason = ("用户在你上一回合执行期间通过语音补充了以下内容（按时间顺序），"
                   "请在继续前纳入考虑：\n" + transcript)
         print(json.dumps({"decision": "block", "reason": reason}, ensure_ascii=False))

--- a/scripts/voice/test_queue_drain.py
+++ b/scripts/voice/test_queue_drain.py
@@ -26,12 +26,12 @@ import queue_drain as qd        # noqa: E402
 
 @contextlib.contextmanager
 def _temp_state():
-    saved = {k: os.environ.get(k) for k in (
-        "VOICE_STATE_DIR", "VOICE_QUEUE_SESSION",
-        "VOICE_QUEUE_MAX_CONTINUATIONS", "VOICE_QUEUE_MAX_ITEMS")}
+    keys = ("VOICE_STATE_DIR", "VOICE_QUEUE_SESSION", "VOICE_QUEUE_MAX_CONTINUATIONS",
+            "VOICE_QUEUE_MAX_ITEMS", "VOICE_QUEUE_CONT_WINDOW", "VOICE_QUEUE_DRAIN_MAX_CHARS")
+    saved = {k: os.environ.get(k) for k in keys}
     d = tempfile.mkdtemp(prefix="qd-test-")
     os.environ["VOICE_STATE_DIR"] = d
-    for k in ("VOICE_QUEUE_SESSION", "VOICE_QUEUE_MAX_CONTINUATIONS", "VOICE_QUEUE_MAX_ITEMS"):
+    for k in keys[1:]:
         os.environ.pop(k, None)
     try:
         yield d
@@ -132,6 +132,19 @@ def test_fresh_user_turn_resets_continuation_chain():
         rc, out = _run({"stop_hook_active": False, "session_id": s})  # fresh turn -> count reset
         assert _block_reason(out)["decision"] == "block"
         assert "b" in _block_reason(out)["reason"]
+
+
+def test_reason_length_is_capped():
+    # Argus: max_items caps the COUNT but not chars — a long transcription must not bloat the
+    # block output. The assembled transcript is truncated at VOICE_QUEUE_DRAIN_MAX_CHARS.
+    with _temp_state():
+        os.environ["VOICE_QUEUE_DRAIN_MAX_CHARS"] = "50"
+        s = "longcap"
+        _vq.enqueue("x" * 300, session=s)
+        rc, out = _run({"stop_hook_active": False, "session_id": s})
+        reason = _block_reason(out)["reason"]
+        assert "（其余略）" in reason            # truncation marker present
+        assert reason.count("x") <= 60           # bounded near the 50-char cap, not 300
 
 
 def test_bad_stdin_json_exits_zero_no_block():

--- a/scripts/voice/test_queue_drain.py
+++ b/scripts/voice/test_queue_drain.py
@@ -1,0 +1,179 @@
+# -*- coding: utf-8 -*-
+"""Behaviour tests for the #495 Slice-5 Stop-hook queue drain (queue_drain.py).
+
+Headless — drives queue_drain.main() with a stubbed stdin (the Stop-hook JSON) and captures
+stdout (the {"decision":"block",...} injection). Covers the §8 loop-correctness merge gate:
+drain+block on a non-empty queue, the OWN continuation counter + cap (so a daemon that keeps
+enqueueing can't spin forever), cap-reached DEFERS items (never drops them), a fresh
+user-initiated turn resets the chain, and the no-op guards (idle / empty).
+
+Run: <venv>/python.exe scripts/voice/test_queue_drain.py   (also pytest-compatible)
+"""
+import io
+import os
+import sys
+import json
+import shutil
+import tempfile
+import contextlib
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import state as _state          # noqa: E402
+import voice_queue as _vq       # noqa: E402
+import queue_drain as qd        # noqa: E402
+
+
+@contextlib.contextmanager
+def _temp_state():
+    saved = {k: os.environ.get(k) for k in (
+        "VOICE_STATE_DIR", "VOICE_QUEUE_SESSION",
+        "VOICE_QUEUE_MAX_CONTINUATIONS", "VOICE_QUEUE_MAX_ITEMS")}
+    d = tempfile.mkdtemp(prefix="qd-test-")
+    os.environ["VOICE_STATE_DIR"] = d
+    for k in ("VOICE_QUEUE_SESSION", "VOICE_QUEUE_MAX_CONTINUATIONS", "VOICE_QUEUE_MAX_ITEMS"):
+        os.environ.pop(k, None)
+    try:
+        yield d
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        shutil.rmtree(d, ignore_errors=True)
+
+
+def _run(stdin_obj, mode="work"):
+    """Set the voice mode, feed stdin JSON to queue_drain.main(), return (rc, stdout)."""
+    _state.set_mode(mode)
+    out = io.StringIO()
+    old = sys.stdin
+    sys.stdin = io.StringIO(json.dumps(stdin_obj))
+    try:
+        with contextlib.redirect_stdout(out):
+            rc = qd.main()
+    finally:
+        sys.stdin = old
+    return rc, out.getvalue()
+
+
+def _block_reason(stdout):
+    return json.loads(stdout.strip())  # raises if not valid JSON
+
+
+# --- no-op guards -----------------------------------------------------------------------
+
+def test_empty_queue_no_block():
+    with _temp_state():
+        rc, out = _run({"stop_hook_active": False, "session_id": "e"})
+        assert rc == 0 and out.strip() == ""  # nothing queued -> no block
+
+
+def test_idle_mode_no_block():
+    with _temp_state():
+        _vq.enqueue("hi", session="i")
+        rc, out = _run({"stop_hook_active": False, "session_id": "i"}, mode="idle")
+        assert rc == 0 and out.strip() == ""  # idle -> no-op even with a non-empty queue
+
+
+# --- drain + block ----------------------------------------------------------------------
+
+def test_drains_and_blocks_with_transcript():
+    with _temp_state():
+        s = "drain"
+        _vq.enqueue("跑一下测试", ts="2026-06-21T10:00:00+08:00", session=s)
+        _vq.enqueue("顺便看看日志", ts="2026-06-21T10:00:01+08:00", session=s)
+        rc, out = _run({"stop_hook_active": False, "session_id": s})
+        assert rc == 0
+        obj = _block_reason(out)
+        assert obj["decision"] == "block"
+        assert "跑一下测试" in obj["reason"] and "顺便看看日志" in obj["reason"]
+        assert _vq.is_empty(s)  # both consumed
+
+
+def test_reason_is_valid_json_with_quotes_and_chinese():
+    with _temp_state():
+        s = "json"
+        _vq.enqueue('他说"立刻部署"，对吧\\反斜杠', session=s)
+        rc, out = _run({"stop_hook_active": False, "session_id": s})
+        obj = _block_reason(out)  # must parse — reason is json.dumps-serialised, never concatenated
+        assert '他说"立刻部署"' in obj["reason"]
+
+
+# --- §8 continuation counter + cap ------------------------------------------------------
+
+def test_continuation_cap_defers_without_dropping():
+    with _temp_state():
+        os.environ["VOICE_QUEUE_MAX_CONTINUATIONS"] = "2"
+        s = "cap"
+        _vq.enqueue("a", ts="2026-06-21T10:00:00+08:00", session=s)
+        _, out = _run({"stop_hook_active": False, "session_id": s})   # turn 0 -> count 1
+        assert _block_reason(out)["decision"] == "block"
+        _vq.enqueue("b", ts="2026-06-21T10:00:01+08:00", session=s)
+        _, out = _run({"stop_hook_active": True, "session_id": s})    # turn 1 -> count 2
+        assert _block_reason(out)["decision"] == "block"
+        _vq.enqueue("c", ts="2026-06-21T10:00:02+08:00", session=s)
+        rc, out = _run({"stop_hook_active": True, "session_id": s})   # count 2 >= cap 2 -> stop
+        assert rc == 0 and out.strip() == ""                          # no block
+        assert [it["text"] for it in _vq.peek_all(s)] == ["c"]        # 'c' DEFERRED, not dropped
+
+
+def test_fresh_user_turn_resets_continuation_chain():
+    with _temp_state():
+        os.environ["VOICE_QUEUE_MAX_CONTINUATIONS"] = "1"
+        s = "reset"
+        _vq.enqueue("a", session=s)
+        _, out = _run({"stop_hook_active": False, "session_id": s})  # turn 0 -> count 1
+        assert _block_reason(out)["decision"] == "block"
+        # a continuation now would hit the cap (count 1 >= 1) and defer; but a FRESH user turn
+        # (stop_hook_active false) resets the chain -> drains + blocks again
+        _vq.enqueue("b", session=s)
+        rc, out = _run({"stop_hook_active": False, "session_id": s})  # fresh turn -> count reset
+        assert _block_reason(out)["decision"] == "block"
+        assert "b" in _block_reason(out)["reason"]
+
+
+def test_bad_stdin_json_exits_zero_no_block():
+    with _temp_state():
+        _vq.enqueue("hi", session="bad")  # queue non-empty, but stdin is garbage
+        _state.set_mode("work")
+        out = io.StringIO()
+        old = sys.stdin
+        sys.stdin = io.StringIO("{not valid json")
+        try:
+            with contextlib.redirect_stdout(out):
+                rc = qd.main()
+        finally:
+            sys.stdin = old
+        assert rc == 0 and out.getvalue().strip() == ""  # malformed payload -> no-op, never crashes
+
+
+def test_env_session_overrides_stdin_session_id():
+    with _temp_state():
+        os.environ["VOICE_QUEUE_SESSION"] = "env-sess"
+        _vq.enqueue("from-env-session", session="env-sess")  # only the ENV session has an item
+        # stdin carries a DIFFERENT session_id; env must win (drain reads env-sess, finds the item)
+        rc, out = _run({"stop_hook_active": False, "session_id": "stdin-sess"})
+        assert _block_reason(out)["decision"] == "block"
+        assert "from-env-session" in _block_reason(out)["reason"]
+
+
+def _main():
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    passed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+            passed += 1
+        except AssertionError as e:
+            print(f"FAIL {t.__name__}: {e}")
+        except Exception as e:  # noqa: BLE001
+            print(f"ERROR {t.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{passed}/{len(tests)} passed")
+    sys.exit(0 if passed == len(tests) else 1)
+
+
+if __name__ == "__main__":
+    _main()


### PR DESCRIPTION
## 摘要

Issue #495 Path 2 **Slice 5**(最后一片):**Stop-hook 队列 drain** —— 回合末把 daemon 在 agent **干活期间**捕获入队的语音重注入会话,闭合「干活期间说的话会丢」的聋区。新增 `scripts/voice/queue_drain.py`(worker)+ `.claude/hooks/voice-queue-drain.sh`(wrapper)+ 测试。

Refs #495 #468

## 范围(用户裁定)

注册进 `settings.json` Stop 数组是**用户级治理变更**(CLAUDE.md 要求开 Issue + 备份 + 用户参与)。故本 PR **交付代码 + 测试 + README 手动注册片段,不自动改 settings.json**。hook 默认不注册(opt-in)。

## 实现要点

- **机制**:回合末 `voice_queue.drain(max_items, session)` → `print(json.dumps({"decision":"block","reason":<转写>}))` exit 0 —— 验证过的形式(`auto-handoff-stop.sh:129` / `stop-guard.sh`)让 Claude 续回合带上这些话。`reason` 用 `json.dumps`(中文/引号/反斜杠安全),绝不拼接。
- **§8 loop-correctness(硬合并门)**:**不**只靠 `stop_hook_active` 单守卫(会 strand 续接回合期间说的话)。worker 自持 **per-session 续接计数器**(仿 `auto-handoff-stop.sh` RETRY marker,刻意避开 stop_hook_active):`stop_hook_active=true` 也对**新**非空队列再 block,但 `VOICE_QUEUE_MAX_CONTINUATIONS`(默认 3)封顶防室噪/回授无限 spin。**cap 检查在 drain 之前** → 到顶时 STOP block 且把队列项**留着不 consume**(绝不丢用户的话),留给下个用户回合;新用户回合(`stop_hook_active` falsy)重置计数链。
- **per-session + exactly-once**:drain 复用 Slice 2 的 O_EXCL exactly-once;session = env `VOICE_QUEUE_SESSION` 或 Stop-hook stdin `session_id`(§8 per-session 键)。
- **安全**:全 exit 0 自守卫(mode==idle / 空队列 / 坏 stdin JSON / 任何异常);**纯文本无同步 TTS**(慢 Kokoro synth 不会撑爆 hook timeout,§8);wrapper `"$PY" ... || true` 透传 stdout(block JSON 到达 Claude)+ 总 exit 0;venv 缺失则 no-op。

## 测试

`test_queue_drain.py` —— **6/6**(headless:stub stdin JSON + 捕获 stdout)。覆盖:空队列/idle no-op、drain+block(reason 含转写)、reason 合法 JSON(含中文/引号/反斜杠)、**续接 cap 后 defer 不丢弃**、**fresh 用户回合重置计数链**。真进程冒烟:venv python 跑 queue_drain 读真 stdin → 输出合法 block JSON。回归:voice_queue 21/21 + stt_preroll 12/12。

> ⚠️ **真 Stop-hook 集成验证待用户**(headless 只验逻辑)。需在真实 voice 会话注册 hook 后验:① daemon 干活期间入队的话回合末重注入;② 续接 cap 后队列不丢;③ 与 `voice-stop-notify.sh` 二选一避免双声。

## dual-verify

- Claude code-reviewer 自审通过(cap 在 drain 前防丢 / 计数器重置时机 / json.dumps / 全异常 exit 0)。
- Codex code-audit:Codex 首轮 NEEDS-CHANGES(High loop-guard own-marker + Medium TOCTOU + Low 测试)→ 全修 → 复审全 0 PASS。两侧均 PASS。

## 约束

- `scripts/voice/` 内部工具不受 200-LOC;非 cherry-pick。
- **不改 settings.json**(用户级治理,README 给手动 Stop-matcher 片段);hook opt-in 默认不注册;PR base develop;side-voice lane 隔离 worktree。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
