### PR TITLE
feat(#163): NAS service-registry auto-update + drift reconciliation (BusyBox sh)

### DIFF
--- a/.mercury/docs/guides/nas-service-registry.md
+++ b/.mercury/docs/guides/nas-service-registry.md
@@ -74,10 +74,14 @@ drift). A docker-backed service that is genuinely all-down still flags.
 ## Free-form field quoting
 
 register writes free-form scalars (`subdomain`/`url`/`compose`/`purpose`/
-`repo`/`cicd`) as YAML double-quoted scalars **when** they carry a hazard
-character (`#`, a `:`-space mapping sequence, or a leading YAML indicator),
-escaping interior `"` and `\`. This keeps a `#` from being read back as an
-inline comment and stops indicator characters from changing parse structure.
+`repo`/`cicd`) as YAML double-quoted scalars **when** they carry a hazard,
+escaping interior `"` and `\`. A value is double-quoted when it contains a
+`#` (inline-comment hazard), a `: `/trailing `:` mapping sequence, **or** it
+starts with a YAML indicator character — one of `-` (block-sequence), `?`
+(complex-mapping key), `:` `#` `&` `*` `!` `|` `>` `%` `@` `` ` `` `[` `]`
+`{` `}` `,`, a quote (`"` / `'`), or a space. This keeps a `#` from being read
+back as an inline comment and stops a leading indicator from changing the parse
+structure (e.g. `- foo` parsing as a block sequence rather than a scalar).
 `reg_get_field` strips one quote layer (honoring the escapes), so values
 round-trip intact. Newlines / control characters in any flag value are rejected
 outright (they would splice extra YAML lines).

--- a/.mercury/docs/guides/nas-service-registry.md
+++ b/.mercury/docs/guides/nas-service-registry.md
@@ -1,0 +1,97 @@
+# NAS Service Registry — auto-update + reconciliation drift detection
+
+> Issue #163. Mercury-internal tooling under `scripts/` (no LOC cap). The NAS is
+> a QNAP TS-464 + Container Station running services behind a token-based
+> cloudflared tunnel. A hand-maintained `services.yaml` describes the fleet and
+> drifts over time; this suite keeps it honest from two directions.
+
+## Components
+
+| File | Role | Writes services.yaml? |
+|------|------|----------------------|
+| `scripts/lib/registry-sh.sh` | Shared BusyBox-sh helpers (read fields, comment-preserving upsert, port reserve, mkdir lock) | via upsert/reserve only |
+| `scripts/validate-registry.sh` | PULL: scan live docker, FLAG drift | **never** (read-only) |
+| `scripts/register-service.sh` | PUSH: deploy-time idempotent upsert + port reserve | yes (atomic mktemp+mv, timestamped `.bak`) |
+| `scripts/test-validate-registry.sh` / `scripts/test-register-service.sh` | Fixture-driven tests (no real NAS / no real docker) | no |
+
+## Why two scripts (AC closure rationale)
+
+- **register-service.sh satisfies the deploy-time AC**: when a service lands, the
+  deploy step pushes an accurate entry (port, derived container set) so the
+  registry is correct at write time. It cannot, however, see anything it was
+  never told about.
+- **validate-registry.sh satisfies the drift-detection AC**: it enumerates what
+  docker is *actually* running and reconciles against the registry, catching the
+  three failure modes a push structurally misses — a project deployed without
+  ever calling register (`sot-codex`), a hand-typed `containers[]` that went
+  stale (`argus` missing `argus-selfcheck-scheduler`), and an occupied host port
+  nobody reserved (`8400`).
+
+Together: push keeps the common path correct; pull is the safety net for the
+out-of-band path.
+
+## Field derivability matrix
+
+Which `services.<name>` fields can self-heal from docker vs. require a human:
+
+| Field | Source | Self-healing? |
+|-------|--------|---------------|
+| `port` | docker published host port | yes (validate flags mismatch; register writes it) |
+| `containers[]` | docker running container set per compose project | yes (register auto-derives; validate flags drift) |
+| `compose` | compose `config_files` label (comma-split for multi-file) | partially — discoverable, but a path the operator usually passes explicitly |
+| `subdomain` | — | **human-only** (no on-NAS source) |
+| `url` | — | **human-only** |
+| `purpose` | — | **human-only** |
+| `repo` | — | **human-only** |
+| `cicd` | — | **human-only** |
+
+`subdomain` / `url` route through a token-based cloudflared tunnel with no
+on-NAS ingress config to diff, so validate emits them as
+`[OUT-OF-SCOPE-UNVERIFIABLE]` and never reconciles them.
+
+## validate finding categories
+
+```
+[UNREGISTERED-PROJECT]      running compose project absent from registry
+[CONTAINER-SET-DRIFT]       registry containers[] != actual running set
+[UNRESERVED-PORT]           running host port not in reserved_ports
+[PORT-CONFLICT]             one host port claimed by >1 compose project
+[NOT-RUNNING]               registry service has zero live containers (advisory)
+[OUT-OF-SCOPE-UNVERIFIABLE] subdomain/url — tunnel has no diffable ingress
+```
+
+`[NOT-RUNNING]` deliberately means "registered but currently down" — it is NOT
+treated as "removed", so a container bouncing during a restart is not misread as
+a deletion.
+
+## BusyBox / NAS constraints (why the code looks the way it does)
+
+- `/bin/sh` is BusyBox; `/bin/bash` is a symlink to it. All scripts are pure
+  POSIX/BusyBox sh — no `[[ ]]`, arrays, `${var,,}`, process substitution, or
+  `function` keyword.
+- `python` / `python3` / `yq` / `jq` / `flock` / Entware are absent. Therefore:
+  locking is `mkdir`-based; docker output is consumed via Go-template `--format`
+  (never `--format json`, no jq); YAML is read/written with line-anchored
+  sed/awk (never a full YAML re-serialization).
+- The docker command is parameterized via `REGISTRY_DOCKER` (default is the NAS
+  `sudo env DOCKER_HOST=... <path>/docker` invocation). Tests inject a
+  fixture-printing stub, so the suite runs on any box with `sh`+`awk`+`sed`.
+- `REGISTRY_FILE` and `REGISTRY_LOCKDIR` are likewise env-parameterized.
+
+## Out of scope for this PR (deferred to user-level governance)
+
+NAS deployment, the periodic cron schedule that runs `validate-registry.sh`, and
+any historical backfill of the existing registry are **user-level governance**
+and are NOT part of this PR (which produces only the repo-side scripts). Per
+`CLAUDE.md` user-level change governance, those steps should be tracked under a
+follow-up Issue with a command log + verification checklist when performed on the
+NAS.
+
+## Running the tests
+
+```sh
+sh scripts/test-validate-registry.sh
+sh scripts/test-register-service.sh
+```
+
+Both are fixture-driven and require no NAS, no docker, and no network.

--- a/.mercury/docs/guides/nas-service-registry.md
+++ b/.mercury/docs/guides/nas-service-registry.md
@@ -37,7 +37,7 @@ Which `services.<name>` fields can self-heal from docker vs. require a human:
 | Field | Source | Self-healing? |
 |-------|--------|---------------|
 | `port` | docker published host port | yes (validate flags mismatch; register writes it) |
-| `containers[]` | docker running container set per compose project | yes (register auto-derives; validate flags drift) |
+| `containers[]` | docker running container set per compose project | yes (register auto-derives **sorted** for byte-stable output; validate flags drift) |
 | `compose` | compose `config_files` label (comma-split for multi-file) | partially — discoverable, but a path the operator usually passes explicitly |
 | `subdomain` | — | **human-only** (no on-NAS source) |
 | `url` | — | **human-only** |
@@ -63,6 +63,24 @@ on-NAS ingress config to diff, so validate emits them as
 `[NOT-RUNNING]` deliberately means "registered but currently down" — it is NOT
 treated as "removed", so a container bouncing during a restart is not misread as
 a deletion.
+
+`[NOT-RUNNING]` fires **only for docker-backed services** — those declaring a
+`containers:` list or a `compose:` file. A service with neither (e.g.
+`ssh-tunnel` = the system sshd on :22 fronted by cloudflared, not a docker
+workload) is exempt: `docker ps` can never show it, so flagging it would be
+permanent cron false-positive noise (`VALIDATE-DRIFT` forever with no real
+drift). A docker-backed service that is genuinely all-down still flags.
+
+## Free-form field quoting
+
+register writes free-form scalars (`subdomain`/`url`/`compose`/`purpose`/
+`repo`/`cicd`) as YAML double-quoted scalars **when** they carry a hazard
+character (`#`, a `:`-space mapping sequence, or a leading YAML indicator),
+escaping interior `"` and `\`. This keeps a `#` from being read back as an
+inline comment and stops indicator characters from changing parse structure.
+`reg_get_field` strips one quote layer (honoring the escapes), so values
+round-trip intact. Newlines / control characters in any flag value are rejected
+outright (they would splice extra YAML lines).
 
 ## BusyBox / NAS constraints (why the code looks the way it does)
 

--- a/scripts/lib/registry-sh.sh
+++ b/scripts/lib/registry-sh.sh
@@ -99,13 +99,37 @@ reg_get_field() {
       pat = "^    " field ":[[:space:]]*"
       if (match($0, pat)) {
         val = substr($0, RLENGTH + 1)
-        # Strip a trailing inline comment that is preceded by whitespace.
+        # Trim leading whitespace before inspecting for a quote.
+        sub(/^[[:space:]]+/, "", val)
+        if (match(val, /^"/)) {
+          # Double-quoted scalar: the value is everything up to the closing
+          # quote; a `#` INSIDE the quotes is data, not a comment. Take the
+          # substring between the first and the matching closing quote, undoing
+          # the \" and \\ escapes the writer applied.
+          rest = substr(val, 2)
+          out = ""
+          i = 1
+          n = length(rest)
+          while (i <= n) {
+            c = substr(rest, i, 1)
+            if (c == "\\" && i < n) { out = out substr(rest, i+1, 1); i += 2; continue }
+            if (c == "\"") break
+            out = out c; i++
+          }
+          print out
+          exit
+        }
+        if (match(val, /^'"'"'/)) {
+          # Single-quoted scalar: take up to the closing single quote.
+          rest = substr(val, 2)
+          q = index(rest, "'"'"'")
+          if (q > 0) print substr(rest, 1, q-1); else print rest
+          exit
+        }
+        # Plain scalar: strip a trailing inline comment preceded by whitespace,
+        # then trim trailing whitespace.
         sub(/[[:space:]]+#.*$/, "", val)
-        # Trim surrounding whitespace.
-        gsub(/^[[:space:]]+|[[:space:]]+$/, "", val)
-        # Strip matching surrounding quotes.
-        sub(/^"/, "", val); sub(/"$/, "", val)
-        sub(/^'"'"'/, "", val); sub(/'"'"'$/, "", val)
+        sub(/[[:space:]]+$/, "", val)
         print val
         exit
       }
@@ -210,9 +234,12 @@ reg_reserve_port() {
 # "<REGISTRY_FILE>.bak-<bak_suffix>" (caller supplies a local timestamp). Atomic
 # write via mktemp + mv.
 #
-# A service subtree spans from its `  <name>:` line through every following line
-# more-indented-than-2-spaces (its children) plus blank lines, up to the next
-# `  <sibling>:` line or the end of the services block.
+# A service subtree spans from its `  <name>:` line through every following
+# 4-space-or-more indented child line. The skip STOPS — and the line is
+# preserved — at the first blank line, comment line, or 2-space sibling key that
+# follows the children: those bytes logically belong to the separator before /
+# the start of the next sibling, NOT to the replaced service, so dropping them
+# would corrupt "siblings preserved byte-for-byte".
 # ---------------------------------------------------------------------------
 reg_upsert_service() {
   up_name="$1"
@@ -246,14 +273,15 @@ reg_upsert_service() {
       print; next
     }
 
-    # While skipping the old target subtree, drop its child lines (indent > 2)
-    # and blank lines, but stop at the next sibling (`  name:`).
+    # While skipping the old target subtree, drop ONLY its own child lines
+    # (indent >= 4 spaces). Stop skipping and PRESERVE the line on the first
+    # blank line, comment line, or 2-space sibling key — those bytes belong to
+    # the separator / next sibling, not to the replaced service.
     skipping {
-      if (match($0, /^  [A-Za-z0-9._-]+:/)) {
-        skipping = 0   # fall through to sibling-detection below
-      } else {
-        next           # child line or blank inside target subtree — drop
+      if (match($0, /^    /)) {
+        next           # 4-space-or-deeper child line of the target — drop
       }
+      skipping = 0     # blank / comment / sibling — fall through and keep it
     }
 
     # A 2-space-indented service key inside the block.

--- a/scripts/lib/registry-sh.sh
+++ b/scripts/lib/registry-sh.sh
@@ -89,7 +89,7 @@ reg_get_field() {
   awk -v want="$reg_name" -v field="$reg_field" '
     /^services:[[:space:]]*$/ { in_svc = 1; next }
     in_svc && /^[^[:space:]#]/ { in_svc = 0 }
-    in_svc && match($0, /^  ([A-Za-z0-9._-]+):[[:space:]]*$/) {
+    in_svc && match($0, /^  ([A-Za-z0-9._-]+):[[:space:]]*(#.*)?$/) {
       cur = $0; sub(/^  /, "", cur); sub(/:.*$/, "", cur)
       in_target = (cur == want) ? 1 : 0
       next
@@ -204,7 +204,10 @@ reg_reserve_port() {
   case "$rp_port" in
     ''|*[!0-9]*) reg_die "reg_reserve_port: port must be numeric (got '$rp_port')" ;;
   esac
-  if reg_list_reserved_ports | grep -qx -- "$rp_port"; then
+  # Symlink-redirect defense: never follow a symlinked registry file (the
+  # mktemp+mv write would otherwise replace the link target).
+  [ -L "$REGISTRY_FILE" ] && reg_die "registry file must not be a symlink: $REGISTRY_FILE"
+  if reg_list_reserved_ports | grep -qxF -- "$rp_port"; then
     return 0
   fi
   rp_tmp=$(mktemp "${TMPDIR:-/tmp}/registry-rp.XXXXXX") || reg_die "mktemp failed (reserve_port)"
@@ -245,6 +248,16 @@ reg_upsert_service() {
   up_name="$1"
   up_bak="$2"
   [ -f "$REGISTRY_FILE" ] || reg_die "reg_upsert_service: REGISTRY_FILE not found: $REGISTRY_FILE"
+  # Symlink-redirect defense: a symlinked registry file would silently redirect
+  # the mktemp+mv write (and the cp backup) to the link target.
+  [ -L "$REGISTRY_FILE" ] && reg_die "registry file must not be a symlink: $REGISTRY_FILE"
+  # Path-traversal defense on the backup suffix: up_bak flows from a
+  # caller/CI-controlled value (MERCURY_REGISTER_TIMESTAMP), so a `/` or `..`
+  # would land the backup outside the registry's directory. Restrict it to a
+  # safe filename charset. The `-` is last inside the bracket so it is literal.
+  case "$up_bak" in
+    ''|*[!A-Za-z0-9._-]*) reg_die "reg_upsert_service: unsafe backup suffix (must be [A-Za-z0-9._-]): '$up_bak'" ;;
+  esac
 
   up_block=$(mktemp "${TMPDIR:-/tmp}/registry-block.XXXXXX") || reg_die "mktemp failed (upsert block)"
   cat > "$up_block"

--- a/scripts/lib/registry-sh.sh
+++ b/scripts/lib/registry-sh.sh
@@ -1,0 +1,280 @@
+#!/bin/sh
+# scripts/lib/registry-sh.sh — shared BusyBox-sh helpers for NAS service-registry
+# tooling (Issue #163). Source this file; do not execute directly.
+#
+#   . "$(dirname "$0")/lib/registry-sh.sh"
+#
+# Pure POSIX / BusyBox sh — NO bashisms. The NAS (QNAP TS-464 + Container
+# Station) ships /bin/sh = BusyBox and /bin/bash symlinked to it. python /
+# python3 / yq / jq / flock are ABSENT. Available: BusyBox awk, sed, mkdir,
+# mktemp, cp, mv, docker. Therefore:
+#   - locking is mkdir-based (no flock)
+#   - docker output is consumed via Go-template `--format` (NEVER JSON; no jq)
+#   - YAML reads/writes are line-anchored sed/awk (NEVER a YAML re-render)
+#
+# Everything external is parameterized via env so the suite is detachable and
+# testable on a dev box with no NAS / no docker:
+#   REGISTRY_FILE     path to services.yaml
+#                     (default /share/CACHEDEV1_DATA/homes/392fyc/services.yaml)
+#   REGISTRY_DOCKER   docker command prefix; word-split on whitespace into argv.
+#                     Default is the NAS sudo+system-docker.sock invocation.
+#                     Tests point this at a stub that prints fixture output.
+#   REGISTRY_LOCKDIR  mkdir-based lock directory
+#                     (default ${TMPDIR:-/tmp}/mercury-registry.lock)
+#
+# Comment-preserving contract: services.yaml carries a header comment block and
+# inline `# argus` style comments on reserved_ports lines. reg_upsert_service /
+# reg_reserve_port do block-level / line-level splices only — surrounding bytes
+# (header, sibling services, inline comments) are preserved verbatim. There is
+# NO full-file YAML re-serialization anywhere in this library.
+
+# Defaults (only set when caller has not already exported them).
+: "${REGISTRY_FILE:=/share/CACHEDEV1_DATA/homes/392fyc/services.yaml}"
+: "${REGISTRY_DOCKER:=sudo env DOCKER_HOST=unix:///var/run/system-docker.sock /share/CACHEDEV1_DATA/.qpkg/container-station/bin/docker}"
+: "${REGISTRY_LOCKDIR:=${TMPDIR:-/tmp}/mercury-registry.lock}"
+
+reg_warn() { printf 'registry-sh WARN: %s\n' "$1" >&2; }
+reg_die()  { printf 'registry-sh: %s\n' "$1" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# reg_docker <args...>
+# Runs the parameterized docker command. REGISTRY_DOCKER is intentionally
+# word-split (unquoted) so a multi-word prefix like
+# "sudo env DOCKER_HOST=... /path/docker" expands to separate argv entries.
+# Tests inject a single-token stub script via REGISTRY_DOCKER.
+# ---------------------------------------------------------------------------
+reg_docker() {
+  # shellcheck disable=SC2086  # deliberate word-split of the command prefix
+  $REGISTRY_DOCKER "$@"
+}
+
+# ---------------------------------------------------------------------------
+# reg_list_services
+# Emits one service name per line (the keys under top-level `services:`).
+# A service key is a 2-space-indented `name:` line inside the services block;
+# nested keys (port:, subdomain:, ...) are 4-space indented and excluded.
+# Tolerates blank lines and comment lines inside the block.
+# ---------------------------------------------------------------------------
+reg_list_services() {
+  [ -f "$REGISTRY_FILE" ] || return 0
+  awk '
+    /^services:[[:space:]]*$/ { in_svc = 1; next }
+    # A new top-level key (column 0, non-space, non-comment) ends the block.
+    in_svc && /^[^[:space:]#]/ { in_svc = 0 }
+    in_svc {
+      # Service entries are exactly 2 leading spaces then `name:` (optionally
+      # followed by an inline comment). 4-space-indented child keys are excluded.
+      if (match($0, /^  [A-Za-z0-9._-]+:[[:space:]]*(#.*)?$/)) {
+        line = $0
+        sub(/^  /, "", line)
+        sub(/:.*$/, "", line)
+        print line
+      }
+    }
+  ' "$REGISTRY_FILE"
+}
+
+# ---------------------------------------------------------------------------
+# reg_get_field <name> <field>
+# Prints the scalar value of services.<name>.<field>. <field> is matched at
+# 4-space indentation inside the named service block. Strips a trailing inline
+# `# comment` and surrounding quotes/whitespace. Empty output = absent.
+# For list-valued fields (e.g. containers: [a, b]) the raw bracket text is
+# returned; callers split it (see reg_service_containers).
+# ---------------------------------------------------------------------------
+reg_get_field() {
+  reg_name="$1"
+  reg_field="$2"
+  [ -f "$REGISTRY_FILE" ] || return 0
+  awk -v want="$reg_name" -v field="$reg_field" '
+    /^services:[[:space:]]*$/ { in_svc = 1; next }
+    in_svc && /^[^[:space:]#]/ { in_svc = 0 }
+    in_svc && match($0, /^  ([A-Za-z0-9._-]+):[[:space:]]*$/) {
+      cur = $0; sub(/^  /, "", cur); sub(/:.*$/, "", cur)
+      in_target = (cur == want) ? 1 : 0
+      next
+    }
+    in_svc && in_target {
+      # field line at 4 spaces: "    field: value"
+      pat = "^    " field ":[[:space:]]*"
+      if (match($0, pat)) {
+        val = substr($0, RLENGTH + 1)
+        # Strip a trailing inline comment that is preceded by whitespace.
+        sub(/[[:space:]]+#.*$/, "", val)
+        # Trim surrounding whitespace.
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", val)
+        # Strip matching surrounding quotes.
+        sub(/^"/, "", val); sub(/"$/, "", val)
+        sub(/^'"'"'/, "", val); sub(/'"'"'$/, "", val)
+        print val
+        exit
+      }
+    }
+  ' "$REGISTRY_FILE"
+}
+
+# ---------------------------------------------------------------------------
+# reg_service_containers <name>
+# Emits the registry-declared container names for a service, one per line,
+# parsed from `containers: [a, b, c]`. Empty if the field is absent.
+# ---------------------------------------------------------------------------
+reg_service_containers() {
+  raw=$(reg_get_field "$1" containers)
+  [ -n "$raw" ] || return 0
+  printf '%s\n' "$raw" \
+    | sed 's/^\[//; s/\]$//' \
+    | tr ',' '\n' \
+    | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' \
+    | sed '/^$/d'
+}
+
+# ---------------------------------------------------------------------------
+# reg_list_reserved_ports
+# Emits one reserved port number per line from the reserved_ports list. Inline
+# `# label` comments are stripped. Tolerates `- 3000  # argus` formatting.
+# ---------------------------------------------------------------------------
+reg_list_reserved_ports() {
+  [ -f "$REGISTRY_FILE" ] || return 0
+  awk '
+    /^reserved_ports:[[:space:]]*$/ { in_rp = 1; next }
+    in_rp && /^[^[:space:]#-]/ { in_rp = 0 }
+    in_rp && match($0, /^[[:space:]]*-[[:space:]]*[0-9]+/) {
+      n = $0
+      sub(/^[[:space:]]*-[[:space:]]*/, "", n)
+      sub(/[^0-9].*$/, "", n)
+      if (n != "") print n
+    }
+  ' "$REGISTRY_FILE"
+}
+
+# ---------------------------------------------------------------------------
+# reg_lock
+# mkdir-based mutual exclusion. mkdir is atomic on POSIX filesystems: it either
+# creates the dir (we hold the lock) or fails (someone else holds it). On
+# success we install an EXIT trap so the lock is released even on abnormal exit.
+# Caller must `set -u`-safe; this uses no flock.
+# ---------------------------------------------------------------------------
+reg_lock() {
+  if mkdir "$REGISTRY_LOCKDIR" 2>/dev/null; then
+    # shellcheck disable=SC2064  # expand REGISTRY_LOCKDIR now, on trap install
+    trap "rmdir '$REGISTRY_LOCKDIR' 2>/dev/null" EXIT INT TERM
+    return 0
+  fi
+  reg_die "could not acquire lock $REGISTRY_LOCKDIR (another run in progress, or stale lock dir — rmdir it if no run is active)"
+}
+
+# reg_unlock — explicit early release (the EXIT trap also covers this).
+reg_unlock() {
+  rmdir "$REGISTRY_LOCKDIR" 2>/dev/null || true
+  trap - EXIT INT TERM
+}
+
+# ---------------------------------------------------------------------------
+# reg_reserve_port <port>
+# Appends `  - <port>` to reserved_ports if the port is not already present.
+# Idempotent. Preserves existing list formatting + inline comments (append-only;
+# never reflows the list). Atomic write via mktemp + mv.
+# ---------------------------------------------------------------------------
+reg_reserve_port() {
+  rp_port="$1"
+  case "$rp_port" in
+    ''|*[!0-9]*) reg_die "reg_reserve_port: port must be numeric (got '$rp_port')" ;;
+  esac
+  if reg_list_reserved_ports | grep -qx -- "$rp_port"; then
+    return 0
+  fi
+  rp_tmp=$(mktemp "${TMPDIR:-/tmp}/registry-rp.XXXXXX") || reg_die "mktemp failed (reserve_port)"
+  awk -v port="$rp_port" '
+    /^reserved_ports:[[:space:]]*$/ { in_rp = 1; print; next }
+    in_rp && /^[^[:space:]#-]/ {
+      # Leaving the list region without having printed our port — append before
+      # the new top-level key.
+      print "  - " port
+      in_rp = 0; printed = 1
+    }
+    { print }
+    END { if (in_rp && !printed) print "  - " port }
+  ' "$REGISTRY_FILE" > "$rp_tmp" || { rm -f "$rp_tmp"; reg_die "awk reserve_port failed"; }
+  mv -f "$rp_tmp" "$REGISTRY_FILE" || { rm -f "$rp_tmp"; reg_die "mv failed (reserve_port)"; }
+}
+
+# ---------------------------------------------------------------------------
+# reg_upsert_service <name> <bak_suffix> <<EOF ...block... EOF
+# Comment-preserving block replace. Reads the rendered service block (already
+# formatted, 2-space-indented `  <name>:` plus 4-space children) from stdin and
+# either replaces the existing services.<name>: subtree or appends it at the end
+# of the services: block. The header comment block, sibling services, and all
+# inline comments are preserved byte-for-byte.
+#
+# Backup: before mutating, copies REGISTRY_FILE to
+# "<REGISTRY_FILE>.bak-<bak_suffix>" (caller supplies a local timestamp). Atomic
+# write via mktemp + mv.
+#
+# A service subtree spans from its `  <name>:` line through every following line
+# more-indented-than-2-spaces (its children) plus blank lines, up to the next
+# `  <sibling>:` line or the end of the services block.
+# ---------------------------------------------------------------------------
+reg_upsert_service() {
+  up_name="$1"
+  up_bak="$2"
+  [ -f "$REGISTRY_FILE" ] || reg_die "reg_upsert_service: REGISTRY_FILE not found: $REGISTRY_FILE"
+
+  up_block=$(mktemp "${TMPDIR:-/tmp}/registry-block.XXXXXX") || reg_die "mktemp failed (upsert block)"
+  cat > "$up_block"
+
+  # Timestamped backup before any mutation.
+  cp "$REGISTRY_FILE" "${REGISTRY_FILE}.bak-${up_bak}" \
+    || { rm -f "$up_block"; reg_die "backup failed: ${REGISTRY_FILE}.bak-${up_bak}"; }
+
+  up_tmp=$(mktemp "${TMPDIR:-/tmp}/registry-up.XXXXXX") || { rm -f "$up_block"; reg_die "mktemp failed (upsert tmp)"; }
+
+  awk -v want="$up_name" -v blockfile="$up_block" '
+    function emit_block(   line) {
+      while ((getline line < blockfile) > 0) print line
+      close(blockfile)
+    }
+    BEGIN { in_svc = 0; skipping = 0; replaced = 0 }
+
+    # Enter services block.
+    /^services:[[:space:]]*$/ { in_svc = 1; print; next }
+
+    # A top-level key (column 0, non-space, non-comment) ends the services block.
+    # If we were still inside and never matched the target, append it here.
+    in_svc && /^[^[:space:]#]/ {
+      if (!replaced) { emit_block(); replaced = 1 }
+      in_svc = 0; skipping = 0
+      print; next
+    }
+
+    # While skipping the old target subtree, drop its child lines (indent > 2)
+    # and blank lines, but stop at the next sibling (`  name:`).
+    skipping {
+      if (match($0, /^  [A-Za-z0-9._-]+:/)) {
+        skipping = 0   # fall through to sibling-detection below
+      } else {
+        next           # child line or blank inside target subtree — drop
+      }
+    }
+
+    # A 2-space-indented service key inside the block.
+    in_svc && match($0, /^  ([A-Za-z0-9._-]+):/) {
+      cur = $0; sub(/^  /, "", cur); sub(/:.*$/, "", cur)
+      if (cur == want) {
+        emit_block(); replaced = 1
+        skipping = 1   # swallow the old subtree (this line + its children)
+        next
+      }
+    }
+
+    { print }
+
+    END {
+      # services block ran to EOF without a trailing top-level key and target
+      # was never found — append it.
+      if (in_svc && !replaced) emit_block()
+    }
+  ' "$REGISTRY_FILE" > "$up_tmp" || { rm -f "$up_block" "$up_tmp"; reg_die "awk upsert failed"; }
+
+  rm -f "$up_block"
+  mv -f "$up_tmp" "$REGISTRY_FILE" || { rm -f "$up_tmp"; reg_die "mv failed (upsert)"; }
+}

--- a/scripts/register-service.sh
+++ b/scripts/register-service.sh
@@ -1,0 +1,168 @@
+#!/bin/sh
+# scripts/register-service.sh — deploy-time push writer for the NAS service
+# registry (Issue #163). Idempotently upserts one services.<name> entry,
+# reserves its host port, and timestamp-backs-up services.yaml before writing.
+#
+# This is the PUSH half of #163: a deploy step calls this to keep the registry
+# current at the moment a service lands. validate-registry.sh is the PULL half
+# that catches anything the push missed.
+#
+# Pure BusyBox sh. No jq / yq. docker (for --containers auto-derive) is
+# parameterized via REGISTRY_DOCKER; the registry write goes through
+# lib/registry-sh.sh comment-preserving block-splice.
+#
+# Usage:
+#   scripts/register-service.sh --name NAME --port PORT [options]
+#
+#   --name NAME          (required) service key under services:
+#   --port PORT          (required) published host port
+#   --subdomain SUB      cloudflared subdomain (human-only; not derivable)
+#   --url URL            public url (human-only)
+#   --compose PATH       compose file path
+#   --containers "a,b"   comma- or space-separated container names. When omitted,
+#                        derived from running docker for this project (root fix
+#                        for stale hand-typed lists).
+#   --purpose TEXT       human description (human-only)
+#   --repo URL           source repo (human-only)
+#   --cicd TEXT          CI/CD note (human-only)
+#   --registry PATH      services.yaml path (or REGISTRY_FILE env)
+#
+# Port-collision gate: if --port is already claimed by a DIFFERENT service name
+# or appears in reserved_ports owned by another service, exit non-zero with
+# REGISTER-CONFLICT and write nothing. Re-registering the SAME name with its
+# existing port is idempotent and allowed.
+#
+# Output:
+#   success  -> exit 0, stdout "REGISTER-OK <name>"
+#   conflict -> exit 2, stdout "REGISTER-CONFLICT ..."
+
+set -u
+
+SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+. "$SELF_DIR/lib/registry-sh.sh"
+
+NAME=""; PORT=""; SUBDOMAIN=""; URL=""; COMPOSE=""; CONTAINERS=""
+PURPOSE=""; REPO=""; CICD=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --name)       shift; NAME="${1:-}"; shift ;;
+    --port)       shift; PORT="${1:-}"; shift ;;
+    --subdomain)  shift; SUBDOMAIN="${1:-}"; shift ;;
+    --url)        shift; URL="${1:-}"; shift ;;
+    --compose)    shift; COMPOSE="${1:-}"; shift ;;
+    --containers) shift; CONTAINERS="${1:-}"; shift ;;
+    --purpose)    shift; PURPOSE="${1:-}"; shift ;;
+    --repo)       shift; REPO="${1:-}"; shift ;;
+    --cicd)       shift; CICD="${1:-}"; shift ;;
+    --registry)   shift; REGISTRY_FILE="${1:-}"; shift ;;
+    -h|--help)    sed -n '2,44p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    -*)           reg_die "unknown flag: $1" ;;
+    *)            reg_die "unexpected argument: $1" ;;
+  esac
+done
+
+[ -n "$NAME" ] || reg_die "--name is required"
+[ -n "$PORT" ] || reg_die "--port is required"
+case "$PORT" in ''|*[!0-9]*) reg_die "--port must be numeric (got '$PORT')" ;; esac
+case "$NAME" in *[!A-Za-z0-9._-]*) reg_die "--name must match [A-Za-z0-9._-] (got '$NAME')" ;; esac
+[ -f "$REGISTRY_FILE" ] || reg_die "registry file not found: $REGISTRY_FILE (set --registry or REGISTRY_FILE)"
+
+# Serialize concurrent registrations.
+reg_lock
+
+# ---------------------------------------------------------------------------
+# Port-collision gate. The port belongs to NAME if NAME already declares it.
+# Reject when a DIFFERENT service declares this port, or when it's reserved but
+# our name doesn't currently own it (and isn't being (re)registered to it).
+# Same-name re-register is idempotent → allowed.
+# ---------------------------------------------------------------------------
+EXISTING_PORT=$(reg_get_field "$NAME" port)
+
+for svc in $(reg_list_services); do
+  [ "$svc" = "$NAME" ] && continue
+  other_port=$(reg_get_field "$svc" port)
+  if [ -n "$other_port" ] && [ "$other_port" = "$PORT" ]; then
+    printf 'REGISTER-CONFLICT host port %s already claimed by service "%s" (refusing to register "%s")\n' \
+      "$PORT" "$svc" "$NAME"
+    exit 2
+  fi
+done
+
+# reserved_ports collision: a reserved port not currently owned by NAME and not
+# the port NAME is already registered with. New services taking a port that is
+# reserved-but-unowned is a conflict (a non-service reservation like QNAP Web UI
+# 22443, or a leftover). Same-name idempotent re-register keeps its own port.
+if [ "$EXISTING_PORT" != "$PORT" ]; then
+  if reg_list_reserved_ports | grep -qx -- "$PORT"; then
+    # Is this reserved port owned by some OTHER service?
+    owner=""
+    for svc in $(reg_list_services); do
+      if [ "$(reg_get_field "$svc" port)" = "$PORT" ]; then owner="$svc"; break; fi
+    done
+    if [ "$owner" != "$NAME" ]; then
+      printf 'REGISTER-CONFLICT host port %s is already in reserved_ports%s (refusing to register "%s")\n' \
+        "$PORT" "$([ -n "$owner" ] && printf ' (owned by %s)' "$owner" || printf ' (reserved, no owning service)')" "$NAME"
+      exit 2
+    fi
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Derive --containers from running docker when omitted (root fix for stale
+# hand-maintained lists). Normalize comma/space separated input to a clean
+# "[a, b, c]" rendering either way.
+# ---------------------------------------------------------------------------
+if [ -z "$CONTAINERS" ]; then
+  CONTAINERS=$(reg_docker ps --format '{{.Label "com.docker.compose.project"}}|{{.Names}}' 2>/dev/null \
+    | awk -F'|' -v p="$NAME" '$1==p {print $2}' | sed '/^$/d' | paste -sd, - 2>/dev/null)
+  # paste may be absent on some BusyBox builds — fall back to tr+sed.
+  if [ -z "$CONTAINERS" ]; then
+    CONTAINERS=$(reg_docker ps --format '{{.Label "com.docker.compose.project"}}|{{.Names}}' 2>/dev/null \
+      | awk -F'|' -v p="$NAME" '$1==p {print $2}' | sed '/^$/d' | tr '\n' ',' | sed 's/,$//')
+  fi
+fi
+# Normalize separators to ", " and build a YAML flow-sequence.
+CONT_LIST=""
+if [ -n "$CONTAINERS" ]; then
+  CONT_LIST=$(printf '%s' "$CONTAINERS" | tr ',' ' ' | tr -s ' ' \
+    | sed 's/^ *//; s/ *$//' | tr ' ' '\n' | sed '/^$/d' | paste -sd, - 2>/dev/null)
+  if [ -z "$CONT_LIST" ]; then
+    CONT_LIST=$(printf '%s' "$CONTAINERS" | tr ',' ' ' | tr -s ' ' \
+      | sed 's/^ *//; s/ *$//' | tr ' ' ',')
+  fi
+  # Add space after each comma for readability: a,b -> a, b
+  CONT_LIST=$(printf '%s' "$CONT_LIST" | sed 's/,/, /g')
+fi
+
+# ---------------------------------------------------------------------------
+# Render the service block. Only emit fields that were supplied (or derived) so
+# we don't write empty keys. 2-space indent for the service key, 4-space for
+# children — matching the existing services.yaml shape.
+# ---------------------------------------------------------------------------
+BLOCK=$(mktemp "${TMPDIR:-/tmp}/registry-newblock.XXXXXX") || reg_die "mktemp failed (block)"
+{
+  printf '  %s:\n' "$NAME"
+  printf '    port: %s\n' "$PORT"
+  [ -n "$SUBDOMAIN" ] && printf '    subdomain: %s\n' "$SUBDOMAIN"
+  [ -n "$URL" ]       && printf '    url: %s\n' "$URL"
+  [ -n "$COMPOSE" ]   && printf '    compose: %s\n' "$COMPOSE"
+  [ -n "$CONT_LIST" ] && printf '    containers: [%s]\n' "$CONT_LIST"
+  [ -n "$PURPOSE" ]   && printf '    purpose: %s\n' "$PURPOSE"
+  [ -n "$REPO" ]      && printf '    repo: %s\n' "$REPO"
+  [ -n "$CICD" ]      && printf '    cicd: %s\n' "$CICD"
+} > "$BLOCK"
+
+# Timestamp for the .bak suffix — caller-local time. Fall back if date is odd.
+BAK_TS="${MERCURY_REGISTER_TIMESTAMP:-$(date +%Y%m%d-%H%M%S 2>/dev/null)}"
+[ -n "$BAK_TS" ] || BAK_TS="manual"
+
+# Comment-preserving upsert + port reservation (both atomic via lib).
+reg_upsert_service "$NAME" "$BAK_TS" < "$BLOCK"
+rm -f "$BLOCK"
+reg_reserve_port "$PORT"
+
+reg_unlock
+
+printf 'REGISTER-OK %s\n' "$NAME"
+exit 0

--- a/scripts/register-service.sh
+++ b/scripts/register-service.sh
@@ -44,18 +44,23 @@ SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 NAME=""; PORT=""; SUBDOMAIN=""; URL=""; COMPOSE=""; CONTAINERS=""
 PURPOSE=""; REPO=""; CICD=""
 
+# Value-taking flags must have a value present BEFORE we shift to consume it.
+# Without this guard, a value flag in last position (e.g. `--subdomain` with no
+# following arg) leaves $#=1; the second `shift` then runs on an empty argument
+# set and aborts under BusyBox sh. Mirror validate-registry.sh's `--registry`
+# pattern: require `[ $# -ge 2 ]` for every value flag.
 while [ $# -gt 0 ]; do
   case "$1" in
-    --name)       shift; NAME="${1:-}"; shift ;;
-    --port)       shift; PORT="${1:-}"; shift ;;
-    --subdomain)  shift; SUBDOMAIN="${1:-}"; shift ;;
-    --url)        shift; URL="${1:-}"; shift ;;
-    --compose)    shift; COMPOSE="${1:-}"; shift ;;
-    --containers) shift; CONTAINERS="${1:-}"; shift ;;
-    --purpose)    shift; PURPOSE="${1:-}"; shift ;;
-    --repo)       shift; REPO="${1:-}"; shift ;;
-    --cicd)       shift; CICD="${1:-}"; shift ;;
-    --registry)   shift; REGISTRY_FILE="${1:-}"; shift ;;
+    --name)       [ $# -ge 2 ] || reg_die "--name requires a value";       shift; NAME="$1"; shift ;;
+    --port)       [ $# -ge 2 ] || reg_die "--port requires a value";       shift; PORT="$1"; shift ;;
+    --subdomain)  [ $# -ge 2 ] || reg_die "--subdomain requires a value";  shift; SUBDOMAIN="$1"; shift ;;
+    --url)        [ $# -ge 2 ] || reg_die "--url requires a value";        shift; URL="$1"; shift ;;
+    --compose)    [ $# -ge 2 ] || reg_die "--compose requires a value";    shift; COMPOSE="$1"; shift ;;
+    --containers) [ $# -ge 2 ] || reg_die "--containers requires a value"; shift; CONTAINERS="$1"; shift ;;
+    --purpose)    [ $# -ge 2 ] || reg_die "--purpose requires a value";    shift; PURPOSE="$1"; shift ;;
+    --repo)       [ $# -ge 2 ] || reg_die "--repo requires a value";       shift; REPO="$1"; shift ;;
+    --cicd)       [ $# -ge 2 ] || reg_die "--cicd requires a value";       shift; CICD="$1"; shift ;;
+    --registry)   [ $# -ge 2 ] || reg_die "--registry requires a value";   shift; REGISTRY_FILE="$1"; shift ;;
     -h|--help)    sed -n '2,44p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
     -*)           reg_die "unknown flag: $1" ;;
     *)            reg_die "unexpected argument: $1" ;;
@@ -67,6 +72,12 @@ done
 case "$PORT" in ''|*[!0-9]*) reg_die "--port must be numeric (got '$PORT')" ;; esac
 case "$NAME" in *[!A-Za-z0-9._-]*) reg_die "--name must match [A-Za-z0-9._-] (got '$NAME')" ;; esac
 [ -f "$REGISTRY_FILE" ] || reg_die "registry file not found: $REGISTRY_FILE (set --registry or REGISTRY_FILE)"
+# Symlink-redirect defense (fail-fast, before locking): refuse to write through
+# a symlinked registry file — the lib's mktemp+mv would otherwise replace the
+# link target, a link-hijack write primitive. The lib enforces this again at the
+# actual write site; this is the early, friendly rejection.
+[ -L "$REGISTRY_FILE" ] && reg_die "registry file must not be a symlink: $REGISTRY_FILE"
+[ -w "$REGISTRY_FILE" ] || reg_die "registry file is not writable: $REGISTRY_FILE"
 
 # Reject control chars / newlines in any free-form flag value: a newline would
 # splice an extra line into the YAML structure, control chars corrupt it. Done
@@ -118,7 +129,7 @@ done
 # reserved-but-unowned is a conflict (a non-service reservation like QNAP Web UI
 # 22443, or a leftover). Same-name idempotent re-register keeps its own port.
 if [ "$EXISTING_PORT" != "$PORT" ]; then
-  if reg_list_reserved_ports | grep -qx -- "$PORT"; then
+  if reg_list_reserved_ports | grep -qxF -- "$PORT"; then
     # Is this reserved port owned by some OTHER service?
     owner=""
     for svc in $(reg_list_services); do
@@ -172,12 +183,19 @@ fi
 # docker enumeration order.
 # ---------------------------------------------------------------------------
 if [ -z "$CONTAINERS" ]; then
-  CONTAINERS=$(reg_docker ps --format '{{.Label "com.docker.compose.project"}}|{{.Names}}' 2>/dev/null \
-    | awk -F'|' -v p="$NAME" '$1==p {print $2}' | sed '/^$/d' | sort | paste -sd, - 2>/dev/null)
+  # Run `docker ps` ONCE and check its exit status. A docker failure (daemon
+  # down, permission denied) must NOT be swallowed and silently treated as
+  # "this project has no containers" — that would write an empty/incomplete
+  # containers[]. Only a SUCCESSFUL ps that returns no matching rows is a
+  # legitimate empty result (containers[] left unset, not emitted).
+  DOCKER_PS_OUT=$(reg_docker ps --format '{{.Label "com.docker.compose.project"}}|{{.Names}}') \
+    || reg_die "docker ps failed during --containers auto-derive (daemon down / permission?). Pass --containers explicitly or fix docker. (REGISTRY_DOCKER=$REGISTRY_DOCKER)"
+  DERIVED=$(printf '%s\n' "$DOCKER_PS_OUT" \
+    | awk -F'|' -v p="$NAME" '$1==p {print $2}' | sed '/^$/d' | sort)
+  CONTAINERS=$(printf '%s' "$DERIVED" | sed '/^$/d' | paste -sd, - 2>/dev/null)
   # paste may be absent on some BusyBox builds — fall back to tr+sed.
-  if [ -z "$CONTAINERS" ]; then
-    CONTAINERS=$(reg_docker ps --format '{{.Label "com.docker.compose.project"}}|{{.Names}}' 2>/dev/null \
-      | awk -F'|' -v p="$NAME" '$1==p {print $2}' | sed '/^$/d' | sort | tr '\n' ',' | sed 's/,$//')
+  if [ -z "$CONTAINERS" ] && [ -n "$DERIVED" ]; then
+    CONTAINERS=$(printf '%s\n' "$DERIVED" | sed '/^$/d' | tr '\n' ',' | sed 's/,$//')
   fi
 fi
 # Normalize separators to ", " and build a YAML flow-sequence. Sort the names so

--- a/scripts/register-service.sh
+++ b/scripts/register-service.sh
@@ -198,7 +198,7 @@ fi
 # Scalar YAML rendering. Free-form fields (subdomain/url/compose/purpose/repo/
 # cicd) can carry characters that change YAML parsing or truncate the value:
 #   - a ` #` sequence starts an inline comment (would truncate on read-back)
-#   - a leading YAML indicator (: # & * ! | > % @ ` " ' [ ] { } , and more)
+#   - a leading YAML indicator (- ? : # & * ! | > % @ ` " ' [ ] { } , and more)
 #   - an interior ": " maps-key sequence
 # When ANY risk marker is present we double-quote the value and escape interior
 # double-quotes + backslashes (YAML double-quoted scalar rules). reg_get_field
@@ -212,6 +212,7 @@ emit_field() {
   case "$ef_val" in
     *" #"*|*'#'*) ef_needs_quote=1 ;;          # inline-comment hazard
     *": "*|*":")  ef_needs_quote=1 ;;          # mapping-key hazard
+    "-"*|"?"*)    ef_needs_quote=1 ;;          # leading block-seq / complex-key indicator
     [\ \"\'\:\#\&\*\!\|\>\%\@\`\[\]\{\}\,]*) ef_needs_quote=1 ;;  # leading indicator
     *) ef_needs_quote=0 ;;
   esac

--- a/scripts/register-service.sh
+++ b/scripts/register-service.sh
@@ -68,6 +68,30 @@ case "$PORT" in ''|*[!0-9]*) reg_die "--port must be numeric (got '$PORT')" ;; e
 case "$NAME" in *[!A-Za-z0-9._-]*) reg_die "--name must match [A-Za-z0-9._-] (got '$NAME')" ;; esac
 [ -f "$REGISTRY_FILE" ] || reg_die "registry file not found: $REGISTRY_FILE (set --registry or REGISTRY_FILE)"
 
+# Reject control chars / newlines in any free-form flag value: a newline would
+# splice an extra line into the YAML structure, control chars corrupt it. Done
+# before any write. We delete only the C0 control range (0x00-0x1F) + DEL
+# (0x7F); anything left there is a control byte. UTF-8 multibyte text (e.g. the
+# "→" in the baseline cicd field) has high bytes that are NOT control chars and
+# must pass — so we match the cntrl class explicitly, NOT "everything non-print"
+# (the latter would wrongly reject multibyte UTF-8 under a byte-wise C locale).
+reg_reject_control() {
+  rc_label="$1"; rc_val="$2"
+  [ -n "$rc_val" ] || return 0
+  # Count control bytes via wc -c (NOT $(...) capture of the bytes themselves —
+  # command substitution strips trailing newlines, which would hide a trailing
+  # \n). Any control byte (incl. interior/trailing newline, tab, CR) -> reject.
+  rc_count=$(printf '%s' "$rc_val" | tr -dc '[:cntrl:]' | wc -c | tr -d ' ')
+  [ "$rc_count" = "0" ] || reg_die "$rc_label must not contain newlines or control characters"
+}
+reg_reject_control "--subdomain" "$SUBDOMAIN"
+reg_reject_control "--url" "$URL"
+reg_reject_control "--compose" "$COMPOSE"
+reg_reject_control "--containers" "$CONTAINERS"
+reg_reject_control "--purpose" "$PURPOSE"
+reg_reject_control "--repo" "$REPO"
+reg_reject_control "--cicd" "$CICD"
+
 # Serialize concurrent registrations.
 reg_lock
 
@@ -109,48 +133,113 @@ if [ "$EXISTING_PORT" != "$PORT" ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# Derive --containers from running docker when omitted (root fix for stale
-# hand-maintained lists). Normalize comma/space separated input to a clean
-# "[a, b, c]" rendering either way.
+# Merge-upsert: when NAME already exists, read its current fields so that flags
+# NOT supplied on THIS invocation retain their stored values (partial
+# re-registration must not destroy untouched fields). A brand-new service
+# renders from flags alone (absent fields are not emitted).
+#
+# We must distinguish "flag not passed" (CONTAINERS unset by the caller) from
+# "flag passed empty". A getopts-style empty string is still a pass; we treat
+# the parsed default "" as not-passed for the merge (the CLI offers no way to
+# clear a field, by design — clearing would be a destructive op out of scope).
+# ---------------------------------------------------------------------------
+SERVICE_EXISTS=0
+for _svc in $(reg_list_services); do
+  [ "$_svc" = "$NAME" ] && { SERVICE_EXISTS=1; break; }
+done
+
+if [ "$SERVICE_EXISTS" = "1" ]; then
+  [ -n "$SUBDOMAIN" ] || SUBDOMAIN=$(reg_get_field "$NAME" subdomain)
+  [ -n "$URL" ]       || URL=$(reg_get_field "$NAME" url)
+  [ -n "$COMPOSE" ]   || COMPOSE=$(reg_get_field "$NAME" compose)
+  [ -n "$PURPOSE" ]   || PURPOSE=$(reg_get_field "$NAME" purpose)
+  [ -n "$REPO" ]      || REPO=$(reg_get_field "$NAME" repo)
+  [ -n "$CICD" ]      || CICD=$(reg_get_field "$NAME" cicd)
+  # containers: keep the stored set if neither --containers nor a docker derive
+  # is wanted. We mark whether the existing value should be reused.
+  if [ -z "$CONTAINERS" ]; then
+    EXISTING_CONTAINERS=$(reg_service_containers "$NAME" | paste -sd, - 2>/dev/null)
+    [ -n "$EXISTING_CONTAINERS" ] || EXISTING_CONTAINERS=$(reg_service_containers "$NAME" | tr '\n' ',' | sed 's/,$//')
+    CONTAINERS="$EXISTING_CONTAINERS"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Derive --containers from running docker when omitted AND not retained from an
+# existing entry (root fix for stale hand-maintained lists). Normalize
+# comma/space separated input to a clean "[a, b, c]" rendering either way, with
+# the names SORTED so the same set always renders byte-identically regardless of
+# docker enumeration order.
 # ---------------------------------------------------------------------------
 if [ -z "$CONTAINERS" ]; then
   CONTAINERS=$(reg_docker ps --format '{{.Label "com.docker.compose.project"}}|{{.Names}}' 2>/dev/null \
-    | awk -F'|' -v p="$NAME" '$1==p {print $2}' | sed '/^$/d' | paste -sd, - 2>/dev/null)
+    | awk -F'|' -v p="$NAME" '$1==p {print $2}' | sed '/^$/d' | sort | paste -sd, - 2>/dev/null)
   # paste may be absent on some BusyBox builds — fall back to tr+sed.
   if [ -z "$CONTAINERS" ]; then
     CONTAINERS=$(reg_docker ps --format '{{.Label "com.docker.compose.project"}}|{{.Names}}' 2>/dev/null \
-      | awk -F'|' -v p="$NAME" '$1==p {print $2}' | sed '/^$/d' | tr '\n' ',' | sed 's/,$//')
+      | awk -F'|' -v p="$NAME" '$1==p {print $2}' | sed '/^$/d' | sort | tr '\n' ',' | sed 's/,$//')
   fi
 fi
-# Normalize separators to ", " and build a YAML flow-sequence.
+# Normalize separators to ", " and build a YAML flow-sequence. Sort the names so
+# the rendering is byte-identical for a given set (no churn on re-register).
 CONT_LIST=""
 if [ -n "$CONTAINERS" ]; then
-  CONT_LIST=$(printf '%s' "$CONTAINERS" | tr ',' ' ' | tr -s ' ' \
-    | sed 's/^ *//; s/ *$//' | tr ' ' '\n' | sed '/^$/d' | paste -sd, - 2>/dev/null)
+  CONT_SORTED=$(printf '%s' "$CONTAINERS" | tr ',' ' ' | tr -s ' ' \
+    | sed 's/^ *//; s/ *$//' | tr ' ' '\n' | sed '/^$/d' | sort)
+  CONT_LIST=$(printf '%s\n' "$CONT_SORTED" | sed '/^$/d' | paste -sd, - 2>/dev/null)
   if [ -z "$CONT_LIST" ]; then
-    CONT_LIST=$(printf '%s' "$CONTAINERS" | tr ',' ' ' | tr -s ' ' \
-      | sed 's/^ *//; s/ *$//' | tr ' ' ',')
+    CONT_LIST=$(printf '%s\n' "$CONT_SORTED" | sed '/^$/d' | tr '\n' ',' | sed 's/,$//')
   fi
   # Add space after each comma for readability: a,b -> a, b
   CONT_LIST=$(printf '%s' "$CONT_LIST" | sed 's/,/, /g')
 fi
 
 # ---------------------------------------------------------------------------
-# Render the service block. Only emit fields that were supplied (or derived) so
-# we don't write empty keys. 2-space indent for the service key, 4-space for
-# children — matching the existing services.yaml shape.
+# Scalar YAML rendering. Free-form fields (subdomain/url/compose/purpose/repo/
+# cicd) can carry characters that change YAML parsing or truncate the value:
+#   - a ` #` sequence starts an inline comment (would truncate on read-back)
+#   - a leading YAML indicator (: # & * ! | > % @ ` " ' [ ] { } , and more)
+#   - an interior ": " maps-key sequence
+# When ANY risk marker is present we double-quote the value and escape interior
+# double-quotes + backslashes (YAML double-quoted scalar rules). reg_get_field
+# strips one layer of surrounding quotes, so the value reads back intact.
+# Newlines/control chars are already rejected above, so quoting is sufficient.
+# ---------------------------------------------------------------------------
+emit_field() {
+  ef_key="$1"; ef_val="$2"
+  [ -n "$ef_val" ] || return 0
+  ef_needs_quote=0
+  case "$ef_val" in
+    *" #"*|*'#'*) ef_needs_quote=1 ;;          # inline-comment hazard
+    *": "*|*":")  ef_needs_quote=1 ;;          # mapping-key hazard
+    [\ \"\'\:\#\&\*\!\|\>\%\@\`\[\]\{\}\,]*) ef_needs_quote=1 ;;  # leading indicator
+    *) ef_needs_quote=0 ;;
+  esac
+  if [ "$ef_needs_quote" = "1" ]; then
+    # Escape \ then " for a YAML double-quoted scalar.
+    ef_esc=$(printf '%s' "$ef_val" | sed 's/\\/\\\\/g; s/"/\\"/g')
+    printf '    %s: "%s"\n' "$ef_key" "$ef_esc"
+  else
+    printf '    %s: %s\n' "$ef_key" "$ef_val"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Render the service block. Only emit fields that were supplied (or derived/
+# merged) so we don't write empty keys. 2-space indent for the service key,
+# 4-space for children — matching the existing services.yaml shape.
 # ---------------------------------------------------------------------------
 BLOCK=$(mktemp "${TMPDIR:-/tmp}/registry-newblock.XXXXXX") || reg_die "mktemp failed (block)"
 {
   printf '  %s:\n' "$NAME"
   printf '    port: %s\n' "$PORT"
-  [ -n "$SUBDOMAIN" ] && printf '    subdomain: %s\n' "$SUBDOMAIN"
-  [ -n "$URL" ]       && printf '    url: %s\n' "$URL"
-  [ -n "$COMPOSE" ]   && printf '    compose: %s\n' "$COMPOSE"
+  emit_field subdomain "$SUBDOMAIN"
+  emit_field url "$URL"
+  emit_field compose "$COMPOSE"
   [ -n "$CONT_LIST" ] && printf '    containers: [%s]\n' "$CONT_LIST"
-  [ -n "$PURPOSE" ]   && printf '    purpose: %s\n' "$PURPOSE"
-  [ -n "$REPO" ]      && printf '    repo: %s\n' "$REPO"
-  [ -n "$CICD" ]      && printf '    cicd: %s\n' "$CICD"
+  emit_field purpose "$PURPOSE"
+  emit_field repo "$REPO"
+  emit_field cicd "$CICD"
 } > "$BLOCK"
 
 # Timestamp for the .bak suffix — caller-local time. Fall back if date is odd.

--- a/scripts/test-register-service.sh
+++ b/scripts/test-register-service.sh
@@ -1,0 +1,225 @@
+#!/bin/sh
+# scripts/test-register-service.sh — fixture-driven tests for
+# scripts/register-service.sh (Issue #163). No real NAS / no real docker.
+#
+# Asserts: idempotency (byte-identical re-register), port-collision gate,
+# comment preservation (header block + reserved_ports inline comments survive),
+# and multi-file config_files / auto-derive container parsing. BusyBox-safe.
+#
+# Usage: sh scripts/test-register-service.sh [--verbose]
+# Exit: 0 all pass / 1 any fail
+
+set -u
+
+VERBOSE=0
+[ "${1:-}" = "--verbose" ] && VERBOSE=1
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || { printf 'test: must run inside a git repo\n' >&2; exit 1; }
+SCRIPT="$REPO_ROOT/scripts/register-service.sh"
+[ -f "$SCRIPT" ] || { printf 'test: %s missing\n' "$SCRIPT" >&2; exit 1; }
+
+PASS=0; FAIL=0; CASES=0
+TEST_ROOT=$(mktemp -d) || { printf 'test: mktemp -d failed\n' >&2; exit 1; }
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+write_baseline_registry() {
+  cat > "$1" <<'EOF'
+# NAS Service Registry
+# Tracks all services deployed on this NAS via Docker + Cloudflare Tunnel.
+# Update this file when adding/removing services.
+
+domain: fyc-space.uk
+tunnel: argus
+
+services:
+  argus:
+    port: 3000
+    subdomain: argus
+    url: https://argus.fyc-space.uk
+    compose: /share/homes/392fyc/argus/docker-compose.yml
+    containers: [argus, argus-tunnel]
+    purpose: PR code review agent (PR-Agent + GPT-5.3-Codex)
+    repo: https://github.com/392fyc/Argus
+    cicd: GitHub Actions → cloudflared SSH → docker compose
+
+  ssh-tunnel:
+    port: 22
+    subdomain: ssh
+    url: ssh.fyc-space.uk
+    purpose: SSH access via Cloudflare Tunnel (for CI/CD)
+
+reserved_ports:
+  - 3000  # argus
+  - 22    # ssh
+  - 22443 # QNAP Web UI (system)
+EOF
+}
+
+# docker stub for auto-derive: sot-codex has two containers (multi-file compose).
+make_docker_stub() {
+  cat > "$1" <<'EOF'
+#!/bin/sh
+cmd="$1"; shift
+[ "$cmd" = "ps" ] || exit 1
+fmt=""
+while [ $# -gt 0 ]; do case "$1" in --format) shift; fmt="$1"; shift ;; *) shift ;; esac; done
+# project|Names form (auto-derive)
+cat <<'ROWS'
+sot-codex|sot-codex-tunnel-1
+sot-codex|sot-codex-app-1
+argus|argus
+argus|argus-tunnel
+argus|argus-selfcheck-scheduler
+ROWS
+EOF
+  chmod +x "$1"
+}
+
+assert_rc() {
+  CASES=$((CASES+1))
+  if [ "$LAST_RC" = "$2" ]; then PASS=$((PASS+1)); else
+    FAIL=$((FAIL+1)); printf 'FAIL: %s (expected rc=%s got %s)\n' "$1" "$2" "$LAST_RC" >&2
+    [ -n "${LAST_OUT:-}" ] && printf '  out: %s\n' "$LAST_OUT" >&2
+  fi
+}
+assert_out_contains() {
+  CASES=$((CASES+1))
+  if printf '%s' "$LAST_OUT" | grep -qF -- "$2"; then PASS=$((PASS+1)); else
+    FAIL=$((FAIL+1)); printf 'FAIL: %s (stdout missing: %s)\n' "$1" "$2" >&2
+  fi
+}
+assert_file_contains() {
+  CASES=$((CASES+1))
+  if grep -qF -- "$2" "$3"; then PASS=$((PASS+1)); else
+    FAIL=$((FAIL+1)); printf 'FAIL: %s (file missing: %s)\n' "$1" "$2" >&2
+  fi
+}
+pass_case() { CASES=$((CASES+1)); PASS=$((PASS+1)); }
+fail_case() { CASES=$((CASES+1)); FAIL=$((FAIL+1)); printf 'FAIL: %s\n' "$1" >&2; }
+
+STUB="$TEST_ROOT/docker-stub.sh"
+make_docker_stub "$STUB"
+export MERCURY_REGISTER_TIMESTAMP="20260623-000000"
+
+reg_lockdir() { printf '%s/lock-%s' "$TEST_ROOT" "$1"; }
+
+run_register() {
+  # $1 = registry file, rest = args. Unique lockdir per call (no stale lock).
+  rf="$1"; shift
+  ld="$TEST_ROOT/lock-$$-$CASES"
+  LAST_OUT=$(REGISTRY_FILE="$rf" REGISTRY_DOCKER="$STUB" REGISTRY_LOCKDIR="$ld" \
+             sh "$SCRIPT" "$@" 2>&1) && LAST_RC=0 || LAST_RC=$?
+  rmdir "$ld" 2>/dev/null || true
+  [ "$VERBOSE" = "1" ] && printf '--- register rc=%d ---\n%s\n' "$LAST_RC" "$LAST_OUT"
+}
+
+# === Test 1: register a NEW service → REGISTER-OK, upserted, port reserved ===
+REG1="$TEST_ROOT/r1.yaml"
+write_baseline_registry "$REG1"
+run_register "$REG1" --name sot-codex --port 8400 --subdomain sot \
+  --url https://sot.fyc-space.uk --containers "sot-codex-tunnel-1,sot-codex-app-1" \
+  --purpose "SoT codex"
+assert_rc "new_service_ok" 0
+assert_out_contains "new_service_marker" "REGISTER-OK sot-codex"
+assert_file_contains "new_service_in_file" "  sot-codex:" "$REG1"
+assert_file_contains "new_service_port" "    port: 8400" "$REG1"
+assert_file_contains "new_service_containers" "containers: [sot-codex-tunnel-1, sot-codex-app-1]" "$REG1"
+# Port reserved.
+assert_file_contains "new_port_reserved" "- 8400" "$REG1"
+
+# === Test 2: header comment block preserved verbatim after upsert ===
+assert_file_contains "header_line1" "# NAS Service Registry" "$REG1"
+assert_file_contains "header_line2" "# Tracks all services deployed on this NAS via Docker + Cloudflare Tunnel." "$REG1"
+# === reserved_ports inline comments preserved verbatim ===
+assert_file_contains "reserved_inline_argus" "- 3000  # argus" "$REG1"
+assert_file_contains "reserved_inline_ssh" "- 22    # ssh" "$REG1"
+assert_file_contains "reserved_inline_qnap" "- 22443 # QNAP Web UI (system)" "$REG1"
+# === sibling service argus preserved (its containers[] untouched) ===
+assert_file_contains "sibling_argus_kept" "containers: [argus, argus-tunnel]" "$REG1"
+
+# === Test 3: idempotency — re-register same args → byte-identical services.yaml ===
+SNAP=$(cat "$REG1")
+run_register "$REG1" --name sot-codex --port 8400 --subdomain sot \
+  --url https://sot.fyc-space.uk --containers "sot-codex-tunnel-1,sot-codex-app-1" \
+  --purpose "SoT codex"
+assert_rc "idempotent_ok" 0
+if [ "$(cat "$REG1")" = "$SNAP" ]; then pass_case; else
+  fail_case "idempotent_byte_identical (re-register changed the file)"
+  if [ "$VERBOSE" = "1" ]; then
+    printf '%s\n' "$SNAP" > "$TEST_ROOT/snap.txt"
+    diff "$TEST_ROOT/snap.txt" "$REG1" >&2 || true
+  fi
+fi
+
+# === Test 4: port-collision gate — different name claims argus's port 3000 ===
+REG4="$TEST_ROOT/r4.yaml"
+write_baseline_registry "$REG4"
+BEFORE4=$(cat "$REG4")
+run_register "$REG4" --name newthing --port 3000
+assert_rc "collision_exit_nonzero" 2
+assert_out_contains "collision_marker" "REGISTER-CONFLICT"
+assert_out_contains "collision_names_argus" "argus"
+# File must be UNCHANGED on conflict (no write).
+if [ "$(cat "$REG4")" = "$BEFORE4" ]; then pass_case; else
+  fail_case "collision_no_write (file changed despite conflict)"
+fi
+
+# === Test 5: same-name re-register to its own port is NOT a conflict ===
+run_register "$REG4" --name argus --port 3000 --purpose "PR code review agent (PR-Agent + GPT-5.3-Codex)"
+assert_rc "same_name_no_conflict" 0
+assert_out_contains "same_name_ok" "REGISTER-OK argus"
+
+# === Test 6: reserved-but-unowned port (22443 QNAP) blocks a new service ===
+REG6="$TEST_ROOT/r6.yaml"
+write_baseline_registry "$REG6"
+run_register "$REG6" --name webui --port 22443
+assert_rc "reserved_unowned_conflict" 2
+assert_out_contains "reserved_unowned_marker" "REGISTER-CONFLICT"
+assert_out_contains "reserved_unowned_inreserved" "reserved_ports"
+
+# === Test 7: --containers auto-derive from docker (multi-container project) ===
+REG7="$TEST_ROOT/r7.yaml"
+write_baseline_registry "$REG7"
+run_register "$REG7" --name sot-codex --port 8400
+assert_rc "autoderive_ok" 0
+# Stub returns sot-codex-tunnel-1 + sot-codex-app-1.
+assert_file_contains "autoderive_containers" "containers: [sot-codex-tunnel-1, sot-codex-app-1]" "$REG7"
+
+# === Test 8: upsert REPLACES an existing service subtree (not duplicate) ===
+REG8="$TEST_ROOT/r8.yaml"
+write_baseline_registry "$REG8"
+# Re-register argus with a changed purpose; should replace, not append.
+run_register "$REG8" --name argus --port 3000 --purpose "CHANGED PURPOSE TEXT" \
+  --containers "argus,argus-tunnel"
+assert_rc "replace_ok" 0
+assert_file_contains "replace_new_purpose" "CHANGED PURPOSE TEXT" "$REG8"
+# Exactly one `  argus:` service key (no duplication).
+ARGUS_COUNT=$(grep -c '^  argus:' "$REG8")
+CASES=$((CASES+1))
+if [ "$ARGUS_COUNT" -eq 1 ]; then PASS=$((PASS+1)); else
+  FAIL=$((FAIL+1)); printf 'FAIL: replace_single_argus (expected 1 argus: key, got %d)\n' "$ARGUS_COUNT" >&2
+fi
+# ssh-tunnel sibling still present after replacing argus.
+assert_file_contains "replace_sibling_ssh_kept" "  ssh-tunnel:" "$REG8"
+
+# === Test 9: missing required --name / --port rejected ===
+REG9="$TEST_ROOT/r9.yaml"
+write_baseline_registry "$REG9"
+run_register "$REG9" --port 9999
+assert_rc "missing_name_err" 1
+run_register "$REG9" --name onlyname
+assert_rc "missing_port_err" 1
+
+# === Test 10: a .bak timestamped backup is created on write ===
+REG10="$TEST_ROOT/r10.yaml"
+write_baseline_registry "$REG10"
+run_register "$REG10" --name sot-codex --port 8400 --containers "sot-codex-app-1"
+assert_rc "bak_write_ok" 0
+CASES=$((CASES+1))
+if [ -f "$REG10.bak-20260623-000000" ]; then PASS=$((PASS+1)); else
+  FAIL=$((FAIL+1)); printf 'FAIL: bak_created (%s.bak-20260623-000000 missing)\n' "$REG10" >&2
+fi
+
+printf '\n=== register-service test summary ===\n'
+printf 'cases: %d  pass: %d  fail: %d\n' "$CASES" "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1

--- a/scripts/test-register-service.sh
+++ b/scripts/test-register-service.sh
@@ -123,7 +123,8 @@ assert_rc "new_service_ok" 0
 assert_out_contains "new_service_marker" "REGISTER-OK sot-codex"
 assert_file_contains "new_service_in_file" "  sot-codex:" "$REG1"
 assert_file_contains "new_service_port" "    port: 8400" "$REG1"
-assert_file_contains "new_service_containers" "containers: [sot-codex-tunnel-1, sot-codex-app-1]" "$REG1"
+# containers[] is rendered SORTED (byte-identical regardless of input order).
+assert_file_contains "new_service_containers" "containers: [sot-codex-app-1, sot-codex-tunnel-1]" "$REG1"
 # Port reserved.
 assert_file_contains "new_port_reserved" "- 8400" "$REG1"
 
@@ -182,8 +183,8 @@ REG7="$TEST_ROOT/r7.yaml"
 write_baseline_registry "$REG7"
 run_register "$REG7" --name sot-codex --port 8400
 assert_rc "autoderive_ok" 0
-# Stub returns sot-codex-tunnel-1 + sot-codex-app-1.
-assert_file_contains "autoderive_containers" "containers: [sot-codex-tunnel-1, sot-codex-app-1]" "$REG7"
+# Stub returns sot-codex-tunnel-1 + sot-codex-app-1; rendered SORTED.
+assert_file_contains "autoderive_containers" "containers: [sot-codex-app-1, sot-codex-tunnel-1]" "$REG7"
 
 # === Test 8: upsert REPLACES an existing service subtree (not duplicate) ===
 REG8="$TEST_ROOT/r8.yaml"
@@ -218,6 +219,150 @@ assert_rc "bak_write_ok" 0
 CASES=$((CASES+1))
 if [ -f "$REG10.bak-20260623-000000" ]; then PASS=$((PASS+1)); else
   FAIL=$((FAIL+1)); printf 'FAIL: bak_created (%s.bak-20260623-000000 missing)\n' "$REG10" >&2
+fi
+
+# === Test 11: merge-upsert — partial re-register must NOT drop stored fields ===
+# Register argus fully (baseline already has it), then re-register passing ONLY
+# --name + --port. subdomain/url/compose/repo/cicd must all survive.
+REG11="$TEST_ROOT/r11.yaml"
+write_baseline_registry "$REG11"
+run_register "$REG11" --name argus --port 3000
+assert_rc "merge_partial_ok" 0
+assert_file_contains "merge_keep_subdomain" "    subdomain: argus" "$REG11"
+assert_file_contains "merge_keep_url"       "    url: https://argus.fyc-space.uk" "$REG11"
+assert_file_contains "merge_keep_compose"   "    compose: /share/homes/392fyc/argus/docker-compose.yml" "$REG11"
+assert_file_contains "merge_keep_repo"      "    repo: https://github.com/392fyc/Argus" "$REG11"
+assert_file_contains "merge_keep_cicd"      "    cicd: GitHub Actions" "$REG11"
+assert_file_contains "merge_keep_containers" "containers: [argus, argus-tunnel]" "$REG11"
+# A new explicit value DOES override while the rest is retained.
+run_register "$REG11" --name argus --port 3000 --subdomain newargus
+assert_rc "merge_override_ok" 0
+assert_file_contains "merge_override_subdomain" "    subdomain: newargus" "$REG11"
+assert_file_contains "merge_override_keep_url" "    url: https://argus.fyc-space.uk" "$REG11"
+
+# === Test 12: auto-derive idempotency under shuffled docker enumeration order ===
+# Two docker stubs return the SAME container set in DIFFERENT orders. Registering
+# sot-codex (no --containers) against each must yield a byte-identical file
+# (containers[] is sorted, so order in docker output is irrelevant).
+STUB_A="$TEST_ROOT/docker-A.sh"
+STUB_B="$TEST_ROOT/docker-B.sh"
+cat > "$STUB_A" <<'EOF'
+#!/bin/sh
+cmd="$1"; shift; [ "$cmd" = "ps" ] || exit 1
+while [ $# -gt 0 ]; do case "$1" in --format) shift; shift ;; *) shift ;; esac; done
+cat <<'ROWS'
+sot-codex|sot-codex-app-1
+sot-codex|sot-codex-tunnel-1
+ROWS
+EOF
+cat > "$STUB_B" <<'EOF'
+#!/bin/sh
+cmd="$1"; shift; [ "$cmd" = "ps" ] || exit 1
+while [ $# -gt 0 ]; do case "$1" in --format) shift; shift ;; *) shift ;; esac; done
+cat <<'ROWS'
+sot-codex|sot-codex-tunnel-1
+sot-codex|sot-codex-app-1
+ROWS
+EOF
+chmod +x "$STUB_A" "$STUB_B"
+REG12A="$TEST_ROOT/r12a.yaml"; REG12B="$TEST_ROOT/r12b.yaml"
+write_baseline_registry "$REG12A"; write_baseline_registry "$REG12B"
+ld="$TEST_ROOT/lock-12a"
+LAST_OUT=$(REGISTRY_FILE="$REG12A" REGISTRY_DOCKER="$STUB_A" REGISTRY_LOCKDIR="$ld" sh "$SCRIPT" --name sot-codex --port 8400 2>&1) && LAST_RC=0 || LAST_RC=$?
+rmdir "$ld" 2>/dev/null || true
+assert_rc "shuffle_a_ok" 0
+ld="$TEST_ROOT/lock-12b"
+LAST_OUT=$(REGISTRY_FILE="$REG12B" REGISTRY_DOCKER="$STUB_B" REGISTRY_LOCKDIR="$ld" sh "$SCRIPT" --name sot-codex --port 8400 2>&1) && LAST_RC=0 || LAST_RC=$?
+rmdir "$ld" 2>/dev/null || true
+assert_rc "shuffle_b_ok" 0
+CASES=$((CASES+1))
+if [ "$(cat "$REG12A")" = "$(cat "$REG12B")" ]; then PASS=$((PASS+1)); else
+  FAIL=$((FAIL+1)); printf 'FAIL: autoderive_byte_identical (shuffled docker order changed the file)\n' >&2
+  [ "$VERBOSE" = "1" ] && diff "$REG12A" "$REG12B" >&2
+fi
+# And the sorted rendering is deterministic.
+assert_file_contains "shuffle_sorted" "containers: [sot-codex-app-1, sot-codex-tunnel-1]" "$REG12A"
+
+# === Test 13: precise sibling preservation — replacing a MIDDLE service leaves
+# the bytes before/after it (blank separators, inline comments, neighbor blocks)
+# exactly intact, not merely "still grep-able". ===
+REG13="$TEST_ROOT/r13.yaml"
+cat > "$REG13" <<'EOF'
+# NAS Service Registry
+domain: fyc-space.uk
+tunnel: argus
+
+services:
+  alpha:
+    port: 1000
+    purpose: first service
+
+  # a standalone comment that separates beta from alpha
+  beta:
+    port: 2000
+    purpose: middle service to be replaced
+
+  gamma:
+    port: 3000
+    purpose: last service
+
+reserved_ports:
+  - 1000  # alpha
+  - 2000  # beta
+  - 3000  # gamma
+EOF
+run_register "$REG13" --name beta --port 2000 --purpose "REPLACED middle"
+assert_rc "sibling_replace_ok" 0
+# alpha block byte-for-byte intact (key + child + trailing blank + the comment).
+EXPECT_ALPHA=$(printf '  alpha:\n    port: 1000\n    purpose: first service\n\n  # a standalone comment that separates beta from alpha')
+CASES=$((CASES+1))
+if printf '%s' "$(cat "$REG13")" | tr '\n' '\001' | grep -qF -- "$(printf '%s' "$EXPECT_ALPHA" | tr '\n' '\001')"; then
+  PASS=$((PASS+1))
+else
+  FAIL=$((FAIL+1)); printf 'FAIL: sibling_alpha_and_comment_exact (separator/comment before replaced service was altered)\n' >&2
+  [ "$VERBOSE" = "1" ] && cat "$REG13" >&2
+fi
+# gamma block (the service AFTER the replaced one) byte-for-byte intact, incl.
+# the blank line that separates it from beta.
+EXPECT_GAMMA=$(printf '\n  gamma:\n    port: 3000\n    purpose: last service\n')
+CASES=$((CASES+1))
+if printf '%s' "$(cat "$REG13")" | tr '\n' '\001' | grep -qF -- "$(printf '%s' "$EXPECT_GAMMA" | tr '\n' '\001')"; then
+  PASS=$((PASS+1))
+else
+  FAIL=$((FAIL+1)); printf 'FAIL: sibling_gamma_exact (separator/neighbor after replaced service was altered)\n' >&2
+  [ "$VERBOSE" = "1" ] && cat "$REG13" >&2
+fi
+assert_file_contains "sibling_beta_replaced" "    purpose: REPLACED middle" "$REG13"
+
+# === Test 14: free-form escaping — a --purpose carrying YAML-hazard chars (#)
+# must not break the file and must read back intact via the lib reader. ===
+REG14="$TEST_ROOT/r14.yaml"
+write_baseline_registry "$REG14"
+HAZ='deploy #42: needs "review" & care'
+run_register "$REG14" --name sot-codex --port 8400 --containers "sot-codex-app-1" --purpose "$HAZ"
+assert_rc "escape_ok" 0
+# The value must be double-quoted (it carries a '#').
+assert_file_contains "escape_quoted" '    purpose: "deploy #42:' "$REG14"
+# Read it back through the same lib reader the rest of the suite uses.
+READBACK=$(REGISTRY_FILE="$REG14" sh -c '. "'"$REPO_ROOT"'/scripts/lib/registry-sh.sh"; reg_get_field sot-codex purpose')
+CASES=$((CASES+1))
+if [ "$READBACK" = "$HAZ" ]; then PASS=$((PASS+1)); else
+  FAIL=$((FAIL+1)); printf 'FAIL: escape_readback (got: %s)\n' "$READBACK" >&2
+fi
+# The file must still parse cleanly: argus sibling + reserved_ports intact.
+assert_file_contains "escape_file_intact" "  argus:" "$REG14"
+assert_file_contains "escape_reserved_intact" "- 3000  # argus" "$REG14"
+
+# === Test 15: a flag value with an embedded newline is REJECTED (no write) ===
+REG15="$TEST_ROOT/r15.yaml"
+write_baseline_registry "$REG15"
+BEFORE15=$(cat "$REG15")
+NL=$(printf 'line1\nline2')
+run_register "$REG15" --name sot-codex --port 8400 --purpose "$NL"
+assert_rc "newline_rejected" 1
+CASES=$((CASES+1))
+if [ "$(cat "$REG15")" = "$BEFORE15" ]; then PASS=$((PASS+1)); else
+  FAIL=$((FAIL+1)); printf 'FAIL: newline_no_write (file changed despite rejected newline value)\n' >&2
 fi
 
 printf '\n=== register-service test summary ===\n'

--- a/scripts/test-register-service.sh
+++ b/scripts/test-register-service.sh
@@ -365,6 +365,45 @@ if [ "$(cat "$REG15")" = "$BEFORE15" ]; then PASS=$((PASS+1)); else
   FAIL=$((FAIL+1)); printf 'FAIL: newline_no_write (file changed despite rejected newline value)\n' >&2
 fi
 
+# === Test 16: leading YAML block-seq / complex-key indicator (- / ?) — a value
+# starting with '- ' or '? ' must be double-quoted (else parsed as a sequence /
+# complex mapping key), read back intact, and be idempotent on re-register. ===
+REG16="$TEST_ROOT/r16.yaml"
+write_baseline_registry "$REG16"
+DASH='- dash lead'
+run_register "$REG16" --name sot-codex --port 8400 --containers "sot-codex-app-1" --purpose "$DASH"
+assert_rc "lead_dash_ok" 0
+# (a) Rendered as a double-quoted scalar, NOT a bare block-sequence indicator.
+assert_file_contains "lead_dash_quoted" '    purpose: "- dash lead"' "$REG16"
+# (b) Reads back to the original value via the lib reader.
+RB_DASH=$(REGISTRY_FILE="$REG16" sh -c '. "'"$REPO_ROOT"'/scripts/lib/registry-sh.sh"; reg_get_field sot-codex purpose')
+CASES=$((CASES+1))
+if [ "$RB_DASH" = "$DASH" ]; then PASS=$((PASS+1)); else
+  FAIL=$((FAIL+1)); printf 'FAIL: lead_dash_readback (got: %s)\n' "$RB_DASH" >&2
+fi
+# (c) Idempotent: re-register same value → byte-identical file.
+SNAP16=$(cat "$REG16")
+run_register "$REG16" --name sot-codex --port 8400 --containers "sot-codex-app-1" --purpose "$DASH"
+assert_rc "lead_dash_idempotent_ok" 0
+CASES=$((CASES+1))
+if [ "$(cat "$REG16")" = "$SNAP16" ]; then PASS=$((PASS+1)); else
+  FAIL=$((FAIL+1)); printf 'FAIL: lead_dash_idempotent (re-register changed the file)\n' >&2
+  [ "$VERBOSE" = "1" ] && { printf '%s\n' "$SNAP16" > "$TEST_ROOT/snap16.txt"; diff "$TEST_ROOT/snap16.txt" "$REG16" >&2 || true; }
+fi
+
+# Same for a leading complex-mapping-key indicator '? '.
+REG16Q="$TEST_ROOT/r16q.yaml"
+write_baseline_registry "$REG16Q"
+QLEAD='? q lead'
+run_register "$REG16Q" --name sot-codex --port 8400 --containers "sot-codex-app-1" --purpose "$QLEAD"
+assert_rc "lead_q_ok" 0
+assert_file_contains "lead_q_quoted" '    purpose: "? q lead"' "$REG16Q"
+RB_Q=$(REGISTRY_FILE="$REG16Q" sh -c '. "'"$REPO_ROOT"'/scripts/lib/registry-sh.sh"; reg_get_field sot-codex purpose')
+CASES=$((CASES+1))
+if [ "$RB_Q" = "$QLEAD" ]; then PASS=$((PASS+1)); else
+  FAIL=$((FAIL+1)); printf 'FAIL: lead_q_readback (got: %s)\n' "$RB_Q" >&2
+fi
+
 printf '\n=== register-service test summary ===\n'
 printf 'cases: %d  pass: %d  fail: %d\n' "$CASES" "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ] && exit 0 || exit 1

--- a/scripts/test-register-service.sh
+++ b/scripts/test-register-service.sh
@@ -404,6 +404,79 @@ if [ "$RB_Q" = "$QLEAD" ]; then PASS=$((PASS+1)); else
   FAIL=$((FAIL+1)); printf 'FAIL: lead_q_readback (got: %s)\n' "$RB_Q" >&2
 fi
 
+# === Test 17 (finding 5): an unsafe MERCURY_REGISTER_TIMESTAMP backup suffix
+# containing path-traversal chars must be REJECTED before any write. ===
+REG17="$TEST_ROOT/r17.yaml"
+write_baseline_registry "$REG17"
+BEFORE17=$(cat "$REG17")
+ld="$TEST_ROOT/lock-17"
+LAST_OUT=$(REGISTRY_FILE="$REG17" REGISTRY_DOCKER="$STUB" REGISTRY_LOCKDIR="$ld" \
+           MERCURY_REGISTER_TIMESTAMP='../evil' \
+           sh "$SCRIPT" --name sot-codex --port 8400 --containers "sot-codex-app-1" 2>&1) \
+  && LAST_RC=0 || LAST_RC=$?
+rmdir "$ld" 2>/dev/null || true
+assert_rc "bak_traversal_rejected" 1
+assert_out_contains "bak_traversal_marker" "unsafe backup suffix"
+# No traversal backup must have been written anywhere outside the registry dir.
+CASES=$((CASES+1))
+if [ ! -e "$TEST_ROOT/evil" ] && [ "$(cat "$REG17")" = "$BEFORE17" ]; then PASS=$((PASS+1)); else
+  FAIL=$((FAIL+1)); printf 'FAIL: bak_traversal_no_write (traversal backup written or registry mutated)\n' >&2
+fi
+
+# === Test 18 (finding 6): a symlinked --registry target must be REJECTED (no
+# write redirected through the link). ===
+REG18_REAL="$TEST_ROOT/r18-real.yaml"
+REG18_LINK="$TEST_ROOT/r18-link.yaml"
+write_baseline_registry "$REG18_REAL"
+CASES=$((CASES+1))
+if ln -s "$REG18_REAL" "$REG18_LINK" 2>/dev/null && [ -L "$REG18_LINK" ]; then
+  PASS=$((PASS+1))
+  BEFORE18=$(cat "$REG18_REAL")
+  run_register "$REG18_LINK" --name sot-codex --port 8400 --containers "sot-codex-app-1"
+  assert_rc "symlink_rejected" 1
+  assert_out_contains "symlink_marker" "must not be a symlink"
+  CASES=$((CASES+1))
+  if [ "$(cat "$REG18_REAL")" = "$BEFORE18" ]; then PASS=$((PASS+1)); else
+    FAIL=$((FAIL+1)); printf 'FAIL: symlink_no_write (link target mutated despite rejection)\n' >&2
+  fi
+else
+  # Symlink creation unsupported (e.g. FS without symlink perms) — skip cleanly.
+  PASS=$((PASS+1)); printf 'SKIP: symlink test (ln -s unsupported here)\n' >&2
+fi
+
+# === Test 19 (finding 4): docker failure during --containers auto-derive must
+# reg_die, NOT silently write an empty containers[]. ===
+FAILSTUB="$TEST_ROOT/docker-fail.sh"
+cat > "$FAILSTUB" <<'EOF'
+#!/bin/sh
+echo "docker: Cannot connect to the Docker daemon" >&2
+exit 1
+EOF
+chmod +x "$FAILSTUB"
+REG19="$TEST_ROOT/r19.yaml"
+write_baseline_registry "$REG19"
+BEFORE19=$(cat "$REG19")
+ld="$TEST_ROOT/lock-19"
+# No --containers → triggers auto-derive → docker stub fails → must die.
+LAST_OUT=$(REGISTRY_FILE="$REG19" REGISTRY_DOCKER="$FAILSTUB" REGISTRY_LOCKDIR="$ld" \
+           sh "$SCRIPT" --name brandnew --port 8401 2>&1) && LAST_RC=0 || LAST_RC=$?
+rmdir "$ld" 2>/dev/null || true
+assert_rc "docker_fail_dies" 1
+assert_out_contains "docker_fail_marker" "docker ps failed"
+# Must NOT have written brandnew with an empty containers[].
+CASES=$((CASES+1))
+if [ "$(cat "$REG19")" = "$BEFORE19" ]; then PASS=$((PASS+1)); else
+  FAIL=$((FAIL+1)); printf 'FAIL: docker_fail_no_write (registry mutated despite docker failure)\n' >&2
+fi
+
+# === Test 20 (finding 7): a value-taking flag in LAST position with no value
+# must reg_die cleanly, NOT crash on a second shift over an empty arg set. ===
+REG20="$TEST_ROOT/r20.yaml"
+write_baseline_registry "$REG20"
+run_register "$REG20" --name sot-codex --port 8400 --subdomain
+assert_rc "trailing_flag_no_value" 1
+assert_out_contains "trailing_flag_marker" "--subdomain requires a value"
+
 printf '\n=== register-service test summary ===\n'
 printf 'cases: %d  pass: %d  fail: %d\n' "$CASES" "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ] && exit 0 || exit 1

--- a/scripts/test-validate-registry.sh
+++ b/scripts/test-validate-registry.sh
@@ -1,0 +1,208 @@
+#!/bin/sh
+# scripts/test-validate-registry.sh — fixture-driven tests for
+# scripts/validate-registry.sh (Issue #163). No real NAS / no real docker.
+#
+# REGISTRY_DOCKER is pointed at a stub that prints the GROUND-TRUTH `docker ps`
+# fixture captured from the NAS on 2026-06-23. REGISTRY_FILE points at a temp
+# copy of the GROUND-TRUTH services.yaml baseline. Run with BusyBox-compatible
+# sh (this file uses no bashisms).
+#
+# Usage: sh scripts/test-validate-registry.sh [--verbose]
+# Exit: 0 all pass / 1 any fail
+
+set -u
+
+VERBOSE=0
+[ "${1:-}" = "--verbose" ] && VERBOSE=1
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || { printf 'test: must run inside a git repo\n' >&2; exit 1; }
+SCRIPT="$REPO_ROOT/scripts/validate-registry.sh"
+[ -f "$SCRIPT" ] || { printf 'test: %s missing\n' "$SCRIPT" >&2; exit 1; }
+
+PASS=0; FAIL=0; CASES=0
+TEST_ROOT=$(mktemp -d) || { printf 'test: mktemp -d failed\n' >&2; exit 1; }
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+# --- GROUND-TRUTH services.yaml baseline (verbatim from #163 task brief) ---
+write_baseline_registry() {
+  cat > "$1" <<'EOF'
+# NAS Service Registry
+# Tracks all services deployed on this NAS via Docker + Cloudflare Tunnel.
+# Update this file when adding/removing services.
+
+domain: fyc-space.uk
+tunnel: argus
+
+services:
+  argus:
+    port: 3000
+    subdomain: argus
+    url: https://argus.fyc-space.uk
+    compose: /share/homes/392fyc/argus/docker-compose.yml
+    containers: [argus, argus-tunnel]
+    purpose: PR code review agent (PR-Agent + GPT-5.3-Codex)
+    repo: https://github.com/392fyc/Argus
+    cicd: GitHub Actions → cloudflared SSH → docker compose
+
+  ssh-tunnel:
+    port: 22
+    subdomain: ssh
+    url: ssh.fyc-space.uk
+    purpose: SSH access via Cloudflare Tunnel (for CI/CD)
+
+reserved_ports:
+  - 3000  # argus
+  - 22    # ssh
+  - 22443 # QNAP Web UI (system)
+EOF
+}
+
+# --- GROUND-TRUTH docker ps fixture stub ---
+# The stub mirrors `docker ps --format '<template>'`. Our validate script always
+# calls `ps --format '{{.Names}}|{{...}}|{{...}}|{{.Ports}}'`. The stub ignores
+# the exact template and prints the captured 4-field pipe rows. It also handles
+# the `--format '{{.Label ...project}}|{{.Names}}'` 2-field form used by the
+# register auto-derive path (not exercised here, but kept consistent).
+make_docker_stub() {
+  stub="$1"
+  cat > "$stub" <<'EOF'
+#!/bin/sh
+# Fixture docker stub. Recognizes the two --format shapes our scripts use.
+cmd="$1"; shift
+[ "$cmd" = "ps" ] || { echo "stub: unsupported docker subcommand: $cmd" >&2; exit 1; }
+fmt=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --format) shift; fmt="$1"; shift ;;
+    *) shift ;;
+  esac
+done
+case "$fmt" in
+  *Ports*)
+    # 4-field: Names|project|working_dir|Ports
+    cat <<'ROWS'
+sot-codex-tunnel-1|sot-codex|/share/CACHEDEV1_DATA/homes/392fyc/sot-codex|
+sot-codex-app-1|sot-codex|/share/CACHEDEV1_DATA/homes/392fyc/sot-codex|0.0.0.0:8400->8000/tcp
+argus-selfcheck-scheduler|argus|/share/homes/392fyc/argus|
+argus|argus|/share/homes/392fyc/argus|0.0.0.0:3000->3000/tcp
+argus-tunnel|argus|/share/homes/392fyc/argus|
+ROWS
+    ;;
+  *)
+    # 2-field project|Names (register auto-derive)
+    cat <<'ROWS'
+sot-codex|sot-codex-tunnel-1
+sot-codex|sot-codex-app-1
+argus|argus-selfcheck-scheduler
+argus|argus
+argus|argus-tunnel
+ROWS
+    ;;
+esac
+EOF
+  chmod +x "$stub"
+}
+
+# Run validate with a given registry + docker stub, capturing rc/out.
+run_validate() {
+  reg="$1"; stub="$2"
+  LAST_OUT=$(REGISTRY_FILE="$reg" REGISTRY_DOCKER="$stub" sh "$SCRIPT" 2>/dev/null) && LAST_RC=0 || LAST_RC=$?
+  [ "$VERBOSE" = "1" ] && printf '--- validate rc=%d ---\n%s\n' "$LAST_RC" "$LAST_OUT"
+}
+
+assert_rc() {
+  CASES=$((CASES+1))
+  if [ "$LAST_RC" = "$2" ]; then PASS=$((PASS+1)); else
+    FAIL=$((FAIL+1)); printf 'FAIL: %s (expected rc=%s got %s)\n' "$1" "$2" "$LAST_RC" >&2
+  fi
+}
+assert_out_contains() {
+  CASES=$((CASES+1))
+  if printf '%s' "$LAST_OUT" | grep -qF -- "$2"; then PASS=$((PASS+1)); else
+    FAIL=$((FAIL+1)); printf 'FAIL: %s (stdout missing: %s)\n' "$1" "$2" >&2
+  fi
+}
+assert_out_NOT_contains() {
+  CASES=$((CASES+1))
+  if printf '%s' "$LAST_OUT" | grep -qF -- "$2"; then
+    FAIL=$((FAIL+1)); printf 'FAIL: %s (stdout unexpectedly contains: %s)\n' "$1" "$2" >&2
+  else PASS=$((PASS+1)); fi
+}
+
+STUB="$TEST_ROOT/docker-stub.sh"
+make_docker_stub "$STUB"
+
+# === Test 1: baseline registry vs ground-truth docker → drift, 3 core findings ===
+REG1="$TEST_ROOT/services1.yaml"
+write_baseline_registry "$REG1"
+run_validate "$REG1" "$STUB"
+assert_rc "drift_exit_nonzero" 1
+assert_out_contains "drift_marker" "VALIDATE-DRIFT"
+# Core assertion 1: sot-codex project not in registry.
+assert_out_contains "unregistered_sot_codex" "[UNREGISTERED-PROJECT]"
+assert_out_contains "unregistered_sot_codex_name" "sot-codex"
+# Core assertion 2: argus containers[] missing argus-selfcheck-scheduler.
+assert_out_contains "container_set_drift" "[CONTAINER-SET-DRIFT]"
+assert_out_contains "container_set_drift_selfcheck" "argus-selfcheck-scheduler"
+# Core assertion 3: host port 8400 not reserved.
+assert_out_contains "unreserved_8400" "[UNRESERVED-PORT]"
+assert_out_contains "unreserved_8400_port" "8400"
+
+# === Test 2: argus port 3000 IS reserved → must NOT be flagged unreserved ===
+assert_out_NOT_contains "port_3000_not_flagged" "host port 3000 (project"
+
+# === Test 3: ssh-tunnel registered but not running → NOT-RUNNING, not removed ===
+# ssh-tunnel (port 22) has no container in the docker fixture.
+assert_out_contains "ssh_not_running" "[NOT-RUNNING]"
+assert_out_contains "ssh_not_running_name" "ssh-tunnel"
+# Restart-transient guard wording present (not treated as removed).
+assert_out_contains "not_running_transient_note" "restart-transient"
+
+# === Test 4: out-of-scope advisory for subdomain/url ===
+assert_out_contains "oos_advisory" "[OUT-OF-SCOPE-UNVERIFIABLE]"
+
+# === Test 5: clean registry (matches docker exactly) → VALIDATE-OK exit 0 ===
+# Build a registry that fully matches the docker fixture: argus (3 containers),
+# sot-codex (2 containers, port 8400) registered; reserved_ports includes both.
+# Drop ssh-tunnel (not running → would be NOT-RUNNING noise).
+REG5="$TEST_ROOT/services5.yaml"
+cat > "$REG5" <<'EOF'
+# NAS Service Registry
+domain: fyc-space.uk
+tunnel: argus
+
+services:
+  argus:
+    port: 3000
+    subdomain: argus
+    url: https://argus.fyc-space.uk
+    containers: [argus, argus-tunnel, argus-selfcheck-scheduler]
+    purpose: PR review
+  sot-codex:
+    port: 8400
+    subdomain: sot
+    url: https://sot.fyc-space.uk
+    containers: [sot-codex-tunnel-1, sot-codex-app-1]
+    purpose: SoT codex
+
+reserved_ports:
+  - 3000  # argus
+  - 8400  # sot-codex
+EOF
+run_validate "$REG5" "$STUB"
+assert_rc "clean_exit_zero" 0
+assert_out_contains "clean_marker" "VALIDATE-OK"
+assert_out_NOT_contains "clean_no_drift_marker" "VALIDATE-DRIFT"
+
+# === Test 6: --registry flag overrides REGISTRY_FILE selection ===
+LAST_OUT=$(REGISTRY_DOCKER="$STUB" sh "$SCRIPT" --registry "$REG5" 2>/dev/null) && LAST_RC=0 || LAST_RC=$?
+assert_rc "registry_flag" 0
+assert_out_contains "registry_flag_ok" "VALIDATE-OK"
+
+# === Test 7: missing registry file → error exit ===
+LAST_OUT=$(REGISTRY_DOCKER="$STUB" sh "$SCRIPT" --registry "$TEST_ROOT/nope.yaml" 2>/dev/null) && LAST_RC=0 || LAST_RC=$?
+assert_rc "missing_registry_err" 1
+
+printf '\n=== validate-registry test summary ===\n'
+printf 'cases: %d  pass: %d  fail: %d\n' "$CASES" "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1

--- a/scripts/test-validate-registry.sh
+++ b/scripts/test-validate-registry.sh
@@ -243,6 +243,91 @@ assert_out_contains "registry_flag_ok" "VALIDATE-OK"
 LAST_OUT=$(REGISTRY_DOCKER="$STUB" sh "$SCRIPT" --registry "$TEST_ROOT/nope.yaml" 2>/dev/null) && LAST_RC=0 || LAST_RC=$?
 assert_rc "missing_registry_err" 1
 
+# === Test 8 (finding 8): service / port membership must use FIXED-STRING match,
+# not regex. A running compose project whose name contains regex metachars (`.`)
+# must be reported UNREGISTERED when it is genuinely absent — a `grep -x` (regex)
+# could let a metachar accidentally match a different registered name. We use a
+# project name `a.c` and a registry that contains only `abc`: with regex `-x`,
+# `a.c` would match the line `abc` and the drift would be MISSED. ===
+REGEX_STUB="$TEST_ROOT/docker-regex.sh"
+cat > "$REGEX_STUB" <<'EOF'
+#!/bin/sh
+cmd="$1"; shift
+[ "$cmd" = "ps" ] || { echo "stub: unsupported: $cmd" >&2; exit 1; }
+fmt=""
+while [ $# -gt 0 ]; do case "$1" in --format) shift; fmt="$1"; shift ;; *) shift ;; esac; done
+case "$fmt" in
+  *Ports*)
+    cat <<'ROWS'
+a.c-app|a.c|/share/homes/392fyc/adotc|0.0.0.0:7100->7000/tcp
+ROWS
+    ;;
+  *)
+    cat <<'ROWS'
+a.c|a.c-app
+ROWS
+    ;;
+esac
+EOF
+chmod +x "$REGEX_STUB"
+REG8="$TEST_ROOT/services8.yaml"
+cat > "$REG8" <<'EOF'
+# NAS Service Registry
+domain: fyc-space.uk
+tunnel: argus
+
+services:
+  abc:
+    port: 7000
+    containers: [abc-app]
+    purpose: decoy whose name regex-matches a.c
+
+reserved_ports:
+  - 7000  # abc
+EOF
+run_validate "$REG8" "$REGEX_STUB"
+# Running project `a.c` is genuinely absent from the registry (only `abc` exists).
+# With fixed-string matching it MUST be flagged UNREGISTERED.
+assert_rc "regex_membership_drift" 1
+assert_out_contains "regex_membership_unregistered" "[UNREGISTERED-PROJECT]"
+assert_out_contains "regex_membership_proj_name" "'a.c'"
+
+# === Test 9 (finding 9): reg_get_field must read a service whose KEY LINE carries
+# an inline `# comment` — reg_list_services already accepts such keys, so the two
+# must agree on what a service key line is. ===
+REG9="$TEST_ROOT/services9.yaml"
+cat > "$REG9" <<'EOF'
+# NAS Service Registry
+domain: fyc-space.uk
+tunnel: argus
+
+services:
+  argus:  # inline comment on the service key line
+    port: 3000
+    subdomain: argus
+    containers: [argus, argus-tunnel]
+    purpose: PR review
+
+reserved_ports:
+  - 3000  # argus
+EOF
+GET_PORT=$(REGISTRY_FILE="$REG9" sh -c '. "'"$REPO_ROOT"'/scripts/lib/registry-sh.sh"; reg_get_field argus port')
+CASES=$((CASES+1))
+if [ "$GET_PORT" = "3000" ]; then PASS=$((PASS+1)); else
+  FAIL=$((FAIL+1)); printf 'FAIL: getfield_inline_comment_key_port (expected 3000, got "%s")\n' "$GET_PORT" >&2
+fi
+GET_SUB=$(REGISTRY_FILE="$REG9" sh -c '. "'"$REPO_ROOT"'/scripts/lib/registry-sh.sh"; reg_get_field argus subdomain')
+CASES=$((CASES+1))
+if [ "$GET_SUB" = "argus" ]; then PASS=$((PASS+1)); else
+  FAIL=$((FAIL+1)); printf 'FAIL: getfield_inline_comment_key_subdomain (expected argus, got "%s")\n' "$GET_SUB" >&2
+fi
+# And the list helper still lists it (parity check).
+LISTED=$(REGISTRY_FILE="$REG9" sh -c '. "'"$REPO_ROOT"'/scripts/lib/registry-sh.sh"; reg_list_services')
+CASES=$((CASES+1))
+if printf '%s\n' "$LISTED" | grep -qxF 'argus'; then PASS=$((PASS+1)); else
+  FAIL=$((FAIL+1)); printf 'FAIL: getfield_inline_comment_key_listed (argus not listed)\n' >&2
+fi
+
 printf '\n=== validate-registry test summary ===\n'
 printf 'cases: %d  pass: %d  fail: %d\n' "$CASES" "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ] && exit 0 || exit 1

--- a/scripts/test-validate-registry.sh
+++ b/scripts/test-validate-registry.sh
@@ -151,20 +151,18 @@ assert_out_contains "unreserved_8400_port" "8400"
 # === Test 2: argus port 3000 IS reserved → must NOT be flagged unreserved ===
 assert_out_NOT_contains "port_3000_not_flagged" "host port 3000 (project"
 
-# === Test 3: ssh-tunnel registered but not running → NOT-RUNNING, not removed ===
-# ssh-tunnel (port 22) has no container in the docker fixture.
-assert_out_contains "ssh_not_running" "[NOT-RUNNING]"
-assert_out_contains "ssh_not_running_name" "ssh-tunnel"
-# Restart-transient guard wording present (not treated as removed).
-assert_out_contains "not_running_transient_note" "restart-transient"
+# === Test 3: ssh-tunnel is a NON-docker service (no containers[]/compose) →
+# EXEMPT from NOT-RUNNING. docker ps can never show the system sshd, so flagging
+# it would be permanent cron false-positive noise. It must NOT be flagged. ===
+assert_out_NOT_contains "ssh_exempt_not_running_name" "service 'ssh-tunnel' has no running"
 
 # === Test 4: out-of-scope advisory for subdomain/url ===
 assert_out_contains "oos_advisory" "[OUT-OF-SCOPE-UNVERIFIABLE]"
 
-# === Test 5: clean registry (matches docker exactly) → VALIDATE-OK exit 0 ===
-# Build a registry that fully matches the docker fixture: argus (3 containers),
-# sot-codex (2 containers, port 8400) registered; reserved_ports includes both.
-# Drop ssh-tunnel (not running → would be NOT-RUNNING noise).
+# === Test 5: clean registry that INCLUDES the non-docker ssh-tunnel service →
+# VALIDATE-OK exit 0. This is the regression the #163 dual-verify caught: a
+# registry carrying ssh-tunnel (no containers[]/compose) with NO other real
+# drift must reconcile clean, not loop on permanent NOT-RUNNING noise. ===
 REG5="$TEST_ROOT/services5.yaml"
 cat > "$REG5" <<'EOF'
 # NAS Service Registry
@@ -184,15 +182,57 @@ services:
     url: https://sot.fyc-space.uk
     containers: [sot-codex-tunnel-1, sot-codex-app-1]
     purpose: SoT codex
+  ssh-tunnel:
+    port: 22
+    subdomain: ssh
+    url: ssh.fyc-space.uk
+    purpose: SSH access via Cloudflare Tunnel (for CI/CD)
 
 reserved_ports:
   - 3000  # argus
   - 8400  # sot-codex
+  - 22    # ssh
 EOF
 run_validate "$REG5" "$STUB"
 assert_rc "clean_exit_zero" 0
 assert_out_contains "clean_marker" "VALIDATE-OK"
 assert_out_NOT_contains "clean_no_drift_marker" "VALIDATE-DRIFT"
+# ssh-tunnel present in the clean registry must NOT be flagged NOT-RUNNING.
+assert_out_NOT_contains "clean_ssh_exempt" "[NOT-RUNNING]"
+
+# === Test 5b: a DOCKER-BACKED service that is fully down (declares containers[]
+# but none are running) DOES trigger NOT-RUNNING + exit 1 — that's real drift,
+# distinct from the ssh-tunnel exemption above. ===
+REG5B="$TEST_ROOT/services5b.yaml"
+cat > "$REG5B" <<'EOF'
+# NAS Service Registry
+domain: fyc-space.uk
+tunnel: argus
+
+services:
+  argus:
+    port: 3000
+    containers: [argus, argus-tunnel, argus-selfcheck-scheduler]
+    purpose: PR review
+  sot-codex:
+    port: 8400
+    containers: [sot-codex-tunnel-1, sot-codex-app-1]
+    purpose: SoT codex
+  ghost:
+    port: 9999
+    compose: /share/homes/392fyc/ghost/docker-compose.yml
+    containers: [ghost-app, ghost-db]
+    purpose: docker service that is fully down
+
+reserved_ports:
+  - 3000  # argus
+  - 8400  # sot-codex
+  - 9999  # ghost
+EOF
+run_validate "$REG5B" "$STUB"
+assert_rc "docker_down_exit_one" 1
+assert_out_contains "docker_down_not_running" "[NOT-RUNNING]"
+assert_out_contains "docker_down_ghost_name" "ghost"
 
 # === Test 6: --registry flag overrides REGISTRY_FILE selection ===
 LAST_OUT=$(REGISTRY_DOCKER="$STUB" sh "$SCRIPT" --registry "$REG5" 2>/dev/null) && LAST_RC=0 || LAST_RC=$?

--- a/scripts/validate-registry.sh
+++ b/scripts/validate-registry.sh
@@ -103,7 +103,7 @@ RUNNING_PORTS=$(printf '%s\n' "$DOCKER_PS" | awk -F'|' '
 # ---------------------------------------------------------------------------
 REG_SERVICES=$(reg_list_services)
 printf '%s\n' "$RUNNING_PROJECTS" | sed '/^$/d' | while IFS= read -r proj; do
-  if ! printf '%s\n' "$REG_SERVICES" | grep -qx -- "$proj"; then
+  if ! printf '%s\n' "$REG_SERVICES" | grep -qxF -- "$proj"; then
     finding "[UNREGISTERED-PROJECT] compose project '$proj' is running but absent from registry (services.<name> missing)"
   fi
 done
@@ -161,7 +161,7 @@ RESERVED=$(reg_list_reserved_ports | sort -u | sed '/^$/d')
 
 printf '%s\n' "$RUNNING_PORTS" | sed '/^$/d' | awk -F'\t' '{print $1}' | sort -u | while IFS= read -r port; do
   [ -n "$port" ] || continue
-  if ! printf '%s\n' "$RESERVED" | grep -qx -- "$port"; then
+  if ! printf '%s\n' "$RESERVED" | grep -qxF -- "$port"; then
     owner=$(printf '%s\n' "$RUNNING_PORTS" | awk -F'\t' -v p="$port" '$1==p {print $2; exit}')
     finding "[UNRESERVED-PORT] host port $port (project '$owner') is published but not in reserved_ports"
   fi

--- a/scripts/validate-registry.sh
+++ b/scripts/validate-registry.sh
@@ -119,6 +119,16 @@ printf '%s\n' "$REG_SERVICES" | sed '/^$/d' | while IFS= read -r svc; do
   declared=$(reg_service_containers "$svc" | sort -u | sed '/^$/d')
 
   if [ -z "$actual" ]; then
+    # NOT-RUNNING is only meaningful for docker-backed services: those that
+    # declare a `containers:` list or a `compose:` file in the registry. A
+    # service with NEITHER (e.g. ssh-tunnel = the system sshd on :22 fronted by
+    # cloudflared — not a docker workload) is not something docker ps can ever
+    # show, so flagging it NOT-RUNNING is permanent false-positive cron noise.
+    # Exempt it: validate manages docker-backed run-state only.
+    svc_compose=$(reg_get_field "$svc" compose)
+    if [ -z "$declared" ] && [ -z "$svc_compose" ]; then
+      continue
+    fi
     finding "[NOT-RUNNING] registry service '$svc' has no running containers (registered-but-down; restart-transient — NOT auto-treated as removed)"
     continue
   fi

--- a/scripts/validate-registry.sh
+++ b/scripts/validate-registry.sh
@@ -1,0 +1,189 @@
+#!/bin/sh
+# scripts/validate-registry.sh — read-only reconciliation / drift detector for
+# the NAS service registry (Issue #163). NEVER writes services.yaml.
+#
+# Pull model: enumerate what docker is ACTUALLY running, compare against the
+# hand-maintained services.yaml registry, and FLAG every divergence. This is
+# the half of #163 that a deploy-time push (register-service.sh) structurally
+# cannot cover — silent drift only shows up when you scan the live fleet.
+#
+# Pure BusyBox sh. No jq (docker consumed via Go-template --format). No yq
+# (services.yaml read via lib sed/awk). docker is parameterized via
+# REGISTRY_DOCKER; tests inject a fixture-printing stub.
+#
+# Usage:
+#   scripts/validate-registry.sh [--registry PATH] [--quiet]
+#
+# Env (see lib/registry-sh.sh):
+#   REGISTRY_FILE    services.yaml path  (or --registry)
+#   REGISTRY_DOCKER  docker command prefix (default = NAS sudo+system-docker)
+#
+# Output:
+#   No drift  -> exit 0, stdout "VALIDATE-OK"
+#   Any drift -> exit 1, stdout "VALIDATE-DRIFT" + one FINDING line per issue,
+#                each tagged with a category:
+#     [UNREGISTERED-PROJECT]  running compose project absent from registry
+#     [CONTAINER-SET-DRIFT]   registry containers[] != actually-running set
+#     [UNRESERVED-PORT]       running host port not in reserved_ports
+#     [PORT-CONFLICT]         same host port claimed by >1 compose project
+#     [NOT-RUNNING]           registry service has no running containers
+#                             (distinct from removed — see note below)
+#
+# Scope note: subdomain / url route through a token-based cloudflared tunnel
+# with no on-NAS ingress config to diff against, so those columns are
+# [OUT-OF-SCOPE-UNVERIFIABLE] — printed for visibility, never reconciled.
+#
+# Restart-transient guard: NOT-RUNNING flags registry services with zero live
+# containers as "registered but not running", NOT as "removed". A container
+# bouncing during a restart must not be mistaken for a deletion, so this is an
+# advisory finding, not an error of registry incorrectness.
+
+set -u
+
+SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+. "$SELF_DIR/lib/registry-sh.sh"
+
+QUIET=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --registry) shift; [ $# -gt 0 ] || reg_die "--registry needs a value"
+                REGISTRY_FILE="$1"; shift ;;
+    --quiet)    QUIET=1; shift ;;
+    -h|--help)  sed -n '2,46p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    -*)         reg_die "unknown flag: $1" ;;
+    *)          reg_die "unexpected argument: $1" ;;
+  esac
+done
+
+[ -f "$REGISTRY_FILE" ] || reg_die "registry file not found: $REGISTRY_FILE (set --registry or REGISTRY_FILE)"
+
+# ---------------------------------------------------------------------------
+# Collect live docker state.
+# Format fields, pipe-delimited (NOT JSON — no jq on NAS):
+#   Names | compose project | compose working_dir | Ports
+# config_files label may be comma-separated (multi-file compose); we capture
+# working_dir as the project anchor and config_files separately for the doc's
+# derivability matrix. Ports field holds the "0.0.0.0:HOST->CONTAINER/proto"
+# publish spec(s).
+# ---------------------------------------------------------------------------
+DOCKER_PS=$(reg_docker ps --format '{{.Names}}|{{.Label "com.docker.compose.project"}}|{{.Label "com.docker.compose.project.working_dir"}}|{{.Ports}}') \
+  || reg_die "docker ps failed (REGISTRY_DOCKER=$REGISTRY_DOCKER)"
+
+FINDINGS=$(mktemp "${TMPDIR:-/tmp}/registry-find.XXXXXX") || reg_die "mktemp failed (findings)"
+trap 'rm -f "$FINDINGS"' EXIT
+
+finding() { printf '%s\n' "$1" >> "$FINDINGS"; }
+
+# Working tables, derived from DOCKER_PS via awk/sed (no jq):
+#   RUNNING_PROJECTS  unique compose project names that have ≥1 live container
+#   RUNNING_CONTS     "project<TAB>container" for the actual running set
+#   RUNNING_PORTS     "hostport<TAB>project" for every published host port
+RUNNING_CONTS=$(printf '%s\n' "$DOCKER_PS" | awk -F'|' '
+  NF >= 2 && $2 != "" { printf "%s\t%s\n", $2, $1 }
+')
+RUNNING_PROJECTS=$(printf '%s\n' "$RUNNING_CONTS" | awk -F'\t' '{print $1}' | sort -u | sed '/^$/d')
+
+# Extract every "->HOST->CONTAINER" host port. Ports field can carry several
+# comma-separated mappings; pull each "0.0.0.0:NNNN->" host port.
+RUNNING_PORTS=$(printf '%s\n' "$DOCKER_PS" | awk -F'|' '
+  NF >= 4 && $4 != "" {
+    proj = $2
+    s = $4
+    # Walk the field finding ":<digits>->" host-port tokens.
+    while (match(s, /:[0-9]+->/)) {
+      tok = substr(s, RSTART + 1, RLENGTH - 3)   # strip leading ":" + trailing "->"
+      printf "%s\t%s\n", tok, proj
+      s = substr(s, RSTART + RLENGTH)
+    }
+  }
+')
+
+# ---------------------------------------------------------------------------
+# (a) UNREGISTERED-PROJECT: running compose project not present in registry.
+# ---------------------------------------------------------------------------
+REG_SERVICES=$(reg_list_services)
+printf '%s\n' "$RUNNING_PROJECTS" | sed '/^$/d' | while IFS= read -r proj; do
+  if ! printf '%s\n' "$REG_SERVICES" | grep -qx -- "$proj"; then
+    finding "[UNREGISTERED-PROJECT] compose project '$proj' is running but absent from registry (services.<name> missing)"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# (b) CONTAINER-SET-DRIFT: registry containers[] != actual running container
+#     set for a registered+running project.
+# (e) NOT-RUNNING: registered project with zero live containers (advisory;
+#     could be a restart transient, NOT necessarily removed).
+# ---------------------------------------------------------------------------
+printf '%s\n' "$REG_SERVICES" | sed '/^$/d' | while IFS= read -r svc; do
+  actual=$(printf '%s\n' "$RUNNING_CONTS" | awk -F'\t' -v p="$svc" '$1==p {print $2}' | sort -u | sed '/^$/d')
+  declared=$(reg_service_containers "$svc" | sort -u | sed '/^$/d')
+
+  if [ -z "$actual" ]; then
+    finding "[NOT-RUNNING] registry service '$svc' has no running containers (registered-but-down; restart-transient — NOT auto-treated as removed)"
+    continue
+  fi
+
+  # Set difference via temp files + awk (no process substitution — that's a
+  # bashism). missing = declared but not running; extra = running but not declared.
+  printf '%s\n' "$declared" > "$FINDINGS.decl"
+  printf '%s\n' "$actual"   > "$FINDINGS.run"
+  missing=$(awk 'NR==FNR{r[$0]=1; next} $0!="" && !($0 in r)' "$FINDINGS.run" "$FINDINGS.decl")
+  extra=$(awk 'NR==FNR{d[$0]=1; next} $0!="" && !($0 in d)' "$FINDINGS.decl" "$FINDINGS.run")
+  rm -f "$FINDINGS.decl" "$FINDINGS.run"
+
+  if [ -n "$declared" ] && [ -n "$missing" ]; then
+    finding "[CONTAINER-SET-DRIFT] service '$svc' registry declares containers not running: $(printf '%s' "$missing" | tr '\n' ' ')"
+  fi
+  if [ -n "$extra" ]; then
+    if [ -z "$declared" ]; then
+      finding "[CONTAINER-SET-DRIFT] service '$svc' has no containers[] in registry but runs: $(printf '%s' "$extra" | tr '\n' ' ')"
+    else
+      finding "[CONTAINER-SET-DRIFT] service '$svc' runs containers not in registry containers[]: $(printf '%s' "$extra" | tr '\n' ' ')"
+    fi
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# (c) UNRESERVED-PORT: running host port absent from reserved_ports.
+# (d) PORT-CONFLICT: same host port claimed by >1 distinct compose project.
+# ---------------------------------------------------------------------------
+RESERVED=$(reg_list_reserved_ports | sort -u | sed '/^$/d')
+
+printf '%s\n' "$RUNNING_PORTS" | sed '/^$/d' | awk -F'\t' '{print $1}' | sort -u | while IFS= read -r port; do
+  [ -n "$port" ] || continue
+  if ! printf '%s\n' "$RESERVED" | grep -qx -- "$port"; then
+    owner=$(printf '%s\n' "$RUNNING_PORTS" | awk -F'\t' -v p="$port" '$1==p {print $2; exit}')
+    finding "[UNRESERVED-PORT] host port $port (project '$owner') is published but not in reserved_ports"
+  fi
+done
+
+# Conflict: a host port mapped by more than one distinct project.
+printf '%s\n' "$RUNNING_PORTS" | sed '/^$/d' | sort -u | awk -F'\t' '
+  { count[$1]++; owners[$1] = owners[$1] " " $2 }
+  END {
+    for (p in count) if (count[p] > 1) printf "[PORT-CONFLICT]\t%s\t%s\n", p, owners[p]
+  }
+' | while IFS="$(printf '\t')" read -r tag port owners; do
+  finding "$tag host port$([ -n "$port" ] && printf ' %s' "$port") claimed by multiple projects:$owners"
+done
+
+# ---------------------------------------------------------------------------
+# Out-of-scope advisory (always printed unless --quiet): subdomain/url are not
+# reconcilable because cloudflared uses a token-based tunnel with no on-NAS
+# ingress map to diff against.
+# ---------------------------------------------------------------------------
+if [ "$QUIET" = "0" ]; then
+  printf '[OUT-OF-SCOPE-UNVERIFIABLE] subdomain/url reconciliation skipped — token-based cloudflared tunnel has no on-NAS ingress config to diff.\n'
+fi
+
+# ---------------------------------------------------------------------------
+# Report.
+# ---------------------------------------------------------------------------
+if [ -s "$FINDINGS" ]; then
+  printf 'VALIDATE-DRIFT\n'
+  sort -u "$FINDINGS"
+  exit 1
+else
+  printf 'VALIDATE-OK\n'
+  exit 0
+fi


### PR DESCRIPTION
## Issue
Refs #163

（本 PR 仅交付 repo 内脚本套件；NAS 安装 + cron + backfill 是 PR 后的**用户级变更治理**工作，#163 保持 OPEN 直到 NAS 部署完成。）

## Summary
为 #163「新服务部署自动更新 NAS 服务注册表」交付双脚本 + 共享 lib，写者/校验者分离：

- **`scripts/validate-registry.sh`（PRIMARY，只读对账）** — 用 docker `--format` template（非 JSON，NAS 无 jq）+ compose labels 采集实际运行态，diff `services.yaml`，emit 漂移报告，**永不覆写**。检测 5 类：UNREGISTERED-PROJECT / CONTAINER-SET-DRIFT / UNRESERVED-PORT / PORT-CONFLICT / NOT-RUNNING。这是唯一能检出「部署时根本没碰 registry」的静默漏注册（push 模型结构上看不见）的机制。
- **`scripts/register-service.sh`（SECONDARY，部署时推送写入）** — 满足 #163 AC 字面，merge-upsert（部分重注册保留未传字段）、port-collision gate、`docker compose` 自动派生 containers[]、timestamped backup、原子写。
- **`scripts/lib/registry-sh.sh`** — 共享 lib：comment-preserving block-splice upsert（不全文 re-render，逐字保留头部注释 + sibling + 行内注释）、mkdir-based lock（NAS 无 flock）、YAML 标量读写。
- tests（`scripts/test-*.sh`，仓库约定）+ `.mercury/docs/guides/nas-service-registry.md`（字段派生性矩阵 + AC 闭合理由）。

## 关键约束（NAS ground truth，SSH spot-check 实测确认）
纯 **BusyBox sh** — NAS QNAP `/bin/sh`=BusyBox，`python`/`yq`/`jq`/`flock` **均 ABSENT**，只有 awk/sed/mkdir/mktemp/sort/docker。所有外部依赖经 env 参数化（`REGISTRY_FILE`/`REGISTRY_DOCKER`/`REGISTRY_LOCKDIR`），可在无 NAS 的开发机用 fixture 桩测试 → detachable。

## 已确认的真实漂移（PR 后 backfill 修复）
NAS 实测 registry 与运行态 3 处漂移，validate 设计即为检出它们：sot-codex 整服务漏注册（8400→8000）、argus.containers 漏 argus-selfcheck-scheduler、端口 8400 未 reserved。

## Verification
- **dual-verify: PASS**（Claude deep-review + Codex code-audit，**3 轮迭代**）— Codex 抓 1 High（部分重注册丢字段）+ 4 Medium（YAML 结构注入、sibling 注释丢失、containers 顺序不稳、free-form 未转义），Claude 抓 ssh-tunnel 永久 NOT-RUNNING noise，全部修复闭合，终轮 0 findings。
- 测试：`sh scripts/test-validate-registry.sh` 21/21 + `sh scripts/test-register-service.sh` 66/66 PASS；`dash -n` 全部脚本无 bashism。

## Test plan
- [x] dual-verify PASS（Claude + Codex 3 轮收敛 0 findings）
- [x] 87 项 fixture 测试全 PASS（无需真 NAS）
- [x] dash -n 严格 POSIX 解析无 bashism
- [ ] Argus review APPROVED