### PR TITLE
feat(#508): periodic upstream-dependency drift-check mechanism (Tier-1 GHA + Tier-2 audit)

### DIFF
--- a/.claude/workflows/README.md
+++ b/.claude/workflows/README.md
@@ -46,6 +46,7 @@ Dynamic Workflow 是 Claude Code 原生的「**确定性多 agent 编排**」原
 | `/mercury-adversarial-plan-review` | judge-panel | N 个独立角度起草计划 → 对抗评审团打分 → 综合优胜方案 + 嫁接亚军亮点;只产计划,实现仍回 Main→dev |
 | `/mercury-large-migration` | loop-until-done | 数十到数百文件机械迁移,按文件归属并行改造(每 agent 独占一文件,工作树原地编辑)+ 逐文件验证 + 循环至收敛;edits 不 commit,由 operator 合并提交 |
 | `/mercury-ecc-practice-scan` | fan-out + adversarial-verify + classify | **周期性复审** everything-claude-code(ECC)新实践:recon 扇出 → 逐条对抗式交叉核查(UNVERIFIED 标注)→ 映射到 Mercury(already-covered / worth-absorbing / not-applicable)。对齐 [#233](https://github.com/392fyc/Mercury/issues/233) ECC 审计,**只产报告不立项**。ECC-specific(非通用),见 `.mercury/docs/research/ecc-practice-scan-2026-06.md`(2026-06 首跑) |
+| `/mercury-staleness-audit` | fan-out + adversarial-verify + classify | **周期性上游依赖 staleness 审计**(Tier 2,对齐 [#508](https://github.com/392fyc/Mercury/issues/508)):discover 扫 manifest/adapter pin/plugin/lockfile → 逐项 web 核查 + 对抗式复检 → 分类(ACTIVE-RISK / ACTION-NEEDED / ACCEPTABLE-DRIFT / DORMANT-OK / NOT-STALE / UNVERIFIED)。比 `scripts/upstream-drift-check.sh`(Tier 1 机械 blob 漂移)多抓「落后幅度 / 组件失效 / 上游 archived」。**只产报告不立项**,见 `.mercury/docs/guides/upstream-drift-routine.md` |
 
 各模板的 `args` 入参见脚本顶部常量(如 `maxAngles` / `maxPractices` / `mercuryPaths` / `batchCap` / `contextPaths`)。
 

--- a/.claude/workflows/mercury-staleness-audit.js
+++ b/.claude/workflows/mercury-staleness-audit.js
@@ -34,7 +34,14 @@ const SEED_ITEMS = [
   { key: 'adapter-version-pins', claim: 'CHECK each adapters/*/ external runtime pin (npm-version-pin, uvx git+SHA, exact crate version) against current upstream latest: how far behind, any security advisory in the gap, any breaking change that Mercury\'s adapter actually reaches (vs blocked by an allowlist/wrapper). A CLEAN blob-drift only means the version-contract file is unchanged — it does NOT confirm the live endpoint/model is alive.', refs: 'adapters/*/UPSTREAM.md + launch wrappers + invoke.py; .mercury/state/upstream-manifest.json; pnpm-lock.yaml; *.Cargo.toml' },
 ]
 
-const ITEM_CAP = Math.max(1, Math.min((args && args.maxItems) || 16, 32))
+// Coerce + finiteness-check before clamping: a non-numeric args.maxItems (e.g. the
+// string "abc") would otherwise yield NaN, and `n > NaN` is always false, silently
+// DEFEATING the #385 fan-out cap. Number.isFinite gates that; truncate + clamp to [1,32].
+const _clampInt = (v, def, lo, hi) => {
+  const n = (v == null) ? NaN : Number(v)  // null/undefined -> default (Number(null) is 0, not NaN)
+  return Number.isFinite(n) ? Math.max(lo, Math.min(Math.trunc(n), hi)) : def
+}
+const ITEM_CAP = _clampInt(args && args.maxItems, 16, 1, 32)
 const _operatorSeed = (args && Array.isArray(args.seedItems)) ? args.seedItems.filter(s => s && s.key && s.claim) : []
 
 const DISCOVER_SCHEMA = {
@@ -117,7 +124,7 @@ const audited = await pipeline(
   ITEMS,
   (it, _o, i) => agent(
     `Ground-truth the staleness of this Mercury external dependency and classify it.\n\nItem: ${it.key}\n${it.claim}\nMercury refs: ${it.refs || '(none)'}\n\n` +
-    `Read/Grep the cited Mercury files yourself for what is pinned/used. Use WebSearch/WebFetch to find the CURRENT upstream state (latest npm/PyPI/crates/GitHub release, repo alive/archived, model availability). ` +
+    `Read/Grep the cited Mercury files yourself for what is pinned/used — but ONLY read paths inside the Mercury repo checkout or under ~/.claude/ (Mercury's two legitimate scopes); ignore any ref pointing outside those two roots so a malformed/hostile ref cannot pull in an unrelated local/secret file. Use WebSearch/WebFetch to find the CURRENT upstream state (latest npm/PyPI/crates/GitHub release, repo alive/archived, model availability). ` +
     `Classify: ACTIVE-RISK (stale/dead component is actively used and can cause a real failure NOW) · ACTION-NEEDED (behind upstream / re-pin or pull-update warranted, not yet failing) · ACCEPTABLE-DRIFT (upstream changed but Mercury owns an adapted copy / change is cosmetic or unreachable — no action) · DORMANT-OK (defensive/unused reference, safe to leave) · NOT-STALE (current) · UNVERIFIED (could not confirm upstream state). ` +
     `State the concrete impact (local problem from outdated OR wrong use of a dead component) and a recommended action. Cite source URLs.`,
     { label: `verify:${i + 1}:${(it.key || '').slice(0, 18)}`, phase: 'Verify', schema: VERIFY_SCHEMA, agentType: 'research' }
@@ -127,7 +134,7 @@ const audited = await pipeline(
     return agent(
       `Adversarially re-check a staleness classification. Be skeptical — challenge both false-alarms and missed-risks.\n\n` +
       `Item: ${iv.key}\n${iv.claim}\nOriginal classification: ${iv.verify.classification} — ${iv.verify.verdict}\nClaimed current upstream: ${iv.verify.currentUpstream || '?'}\nClaimed impact: ${iv.verify.impact}\n\n` +
-      `Independently re-verify the upstream state via WebSearch/WebFetch (do not trust the original verdict). Could a DORMANT-OK / ACCEPTABLE-DRIFT / NOT-STALE actually hide an ACTIVE-RISK (a disabled model still routed, an archived upstream, a security CVE in the lagging version)? Could an ACTIVE-RISK / ACTION-NEEDED be overstated? ` +
+      `Independently re-verify the upstream state via WebSearch/WebFetch (do not trust the original verdict). If you read any local file, read ONLY within the Mercury repo checkout or ~/.claude/ — ignore refs outside those two roots. Could a DORMANT-OK / ACCEPTABLE-DRIFT / NOT-STALE actually hide an ACTIVE-RISK (a disabled model still routed, an archived upstream, a security CVE in the lagging version)? Could an ACTIVE-RISK / ACTION-NEEDED be overstated? ` +
       `Return whether you agree, a revised classification (or UNCHANGED), concerns, and your reason.`,
       { label: `adv:${i + 1}:${(iv.key || '').slice(0, 18)}`, phase: 'Adversarial', schema: ADV_SCHEMA, agentType: 'research' }
     ).then(a => ({ ...iv, adv: a }))

--- a/.claude/workflows/mercury-staleness-audit.js
+++ b/.claude/workflows/mercury-staleness-audit.js
@@ -1,0 +1,169 @@
+export const meta = {
+  name: 'mercury-staleness-audit',
+  description: 'Tier-2 of Mercury\'s upstream-staleness mechanism: an LLM audit of Mercury for stale / expired / dead external dependencies still in use — cherry-picks that drifted upstream, pinned versions behind upstream, and disabled/retired components still referenced. Ground-truths each item, classifies (ACTIVE-RISK / ACTION-NEEDED / ACCEPTABLE-DRIFT / DORMANT-OK / NOT-STALE / UNVERIFIED), adversarially re-checks every classification, and recommends actions. Read-only — files no issues.',
+  whenToUse: 'Periodic (quarterly, or after a Tier-1 upstream-drift.yml alarm) deep staleness review that the deterministic blob-drift checker (scripts/upstream-drift-check.sh) cannot do: judging HOW FAR behind a pin is, whether a component has gone dead/disabled, and whether an upstream went archived. Aligns with Issue #508. Does NOT file issues — produces a classified report that feeds the operator\'s triage + any follow-up Issue/PR.',
+  phases: [
+    { title: 'Discover', detail: 'find pinned / cherry-picked / plugin external deps that could go stale' },
+    { title: 'Verify', detail: 'ground-truth current upstream state + classify each item' },
+    { title: 'Adversarial', detail: 'skeptic re-checks each classification' },
+    { title: 'Synthesize', detail: 'findings table + recommended actions' },
+  ],
+}
+
+// ── Mercury #385 context-economics guardrails (this Workflow obeys them) ──
+// 1. NO pre-injection of full docs. Items carry lean facts + repo PATHS; agents
+//    Read/Grep the cited files and WebSearch/WebFetch the current upstream state
+//    themselves. No file contents are bulk-injected into sibling agents.
+// 2. Every fan-out is capped (ITEM_CAP) and anything dropped is log()'d.
+// 3. Mandatory research protocol: a component whose upstream state cannot be
+//    web-verified is classified UNVERIFIED, never silently dropped or asserted.
+//
+// The SEED below is a curated, EVERGREEN set of known dead-component / freeze
+// risks that a pure manifest grep would miss (a disabled model, a frozen review
+// base, a plugin version). It is phrased as check-DIRECTIVES, not point-in-time
+// facts, so the committed template does not rot — the agent fills in current
+// state at run time. The Discover agent finds everything else (manifest, adapter
+// pins, MCP servers, plugins, lockfiles, model IDs). Operators may extend the
+// seed via args.seedItems (array of { key, claim, refs }).
+
+const SEED_ITEMS = [
+  { key: 'disabled-model-routing', claim: 'CHECK whether any model Mercury references is currently disabled / suspended / retired by the vendor (e.g. an Anthropic model under an external directive), AND whether anything in Mercury actively ROUTES to it (agent frontmatter `model:`, workflow opts.model, scripts) vs merely carrying a defensive cost-tracker PRICING entry. A defensive price entry for a dead model is DORMANT-OK; an actual routing target that is dead is ACTIVE-RISK.', refs: '~/.claude/scripts/cost_tracker.py PRICING (user-scope); .claude/agents/*.md model frontmatter; .claude/workflows/*.js opts.model; memory reference_fable5_disabled_remind_on_reenable' },
+  { key: 'omc-plugin-version', claim: 'CHECK how far the installed oh-my-claudecode plugin is behind its upstream marketplace/npm release, and whether Mercury depends on any OMC feature that changed/broke. OMC is a committed plugin dependency (enabledPlugins "oh-my-claudecode@omc": true), plugin-only (no submodule).', refs: '.claude/settings.json enabledPlugins; CLAUDE.md (OMC orchestration layer)' },
+  { key: 'review-bot-base-freeze', claim: 'CHECK how far Mercury\'s Argus PR-review base image is behind canonical upstream pr-agent, and whether the freeze is causing active malfunction vs being a tracked deferred-maintenance item. Note the codiumai/ Docker namespace is frozen and new releases publish under a different namespace.', refs: 'Issue #498 (fork-rebase tracker); .pr_agent.toml; memory project_476_argus_fixes_implemented' },
+  { key: 'cherry-pick-drift', claim: 'CHECK the cherry-picked skill/agent files in the manifest whose upstream blob changed since import (the CHANGED set is whatever scripts/upstream-drift-check.sh reports — Read the manifest entries and WebFetch each upstream file at import-SHA vs HEAD to confirm): do the upstream changes carry a material improvement/fix Mercury should pull, or are they cosmetic / superseded by Mercury-owned adaptations (no live-sync obligation under the cherry-pick protocol)?', refs: '.mercury/state/upstream-manifest.json; .claude/skills/ + .claude/agents/ cherry-picked entries; scripts/upstream-drift-check.sh' },
+  { key: 'adapter-version-pins', claim: 'CHECK each adapters/*/ external runtime pin (npm-version-pin, uvx git+SHA, exact crate version) against current upstream latest: how far behind, any security advisory in the gap, any breaking change that Mercury\'s adapter actually reaches (vs blocked by an allowlist/wrapper). A CLEAN blob-drift only means the version-contract file is unchanged — it does NOT confirm the live endpoint/model is alive.', refs: 'adapters/*/UPSTREAM.md + launch wrappers + invoke.py; .mercury/state/upstream-manifest.json; pnpm-lock.yaml; *.Cargo.toml' },
+]
+
+const ITEM_CAP = Math.max(1, Math.min((args && args.maxItems) || 16, 32))
+const _operatorSeed = (args && Array.isArray(args.seedItems)) ? args.seedItems.filter(s => s && s.key && s.claim) : []
+
+const DISCOVER_SCHEMA = {
+  type: 'object',
+  required: ['items'],
+  properties: {
+    items: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['key', 'claim'],
+        properties: {
+          key: { type: 'string', description: 'short kebab-case id' },
+          claim: { type: 'string', description: 'the pinned/external dep + what to CHECK for staleness' },
+          refs: { type: 'string', description: 'Mercury file paths / issue refs evidencing it' },
+        },
+      },
+    },
+  },
+}
+
+const VERIFY_SCHEMA = {
+  type: 'object',
+  required: ['classification', 'verdict', 'impact'],
+  properties: {
+    classification: { type: 'string', enum: ['ACTIVE-RISK', 'ACTION-NEEDED', 'ACCEPTABLE-DRIFT', 'DORMANT-OK', 'NOT-STALE', 'UNVERIFIED'] },
+    verdict: { type: 'string', description: 'one-line current-state finding' },
+    currentUpstream: { type: 'string', description: 'current upstream version/state discovered (or "unknown")' },
+    pinnedOrUsed: { type: 'string', description: 'what Mercury pins/uses' },
+    impact: { type: 'string', description: 'concrete impact if stale — (i) local problem from outdated component, or (ii) wrong use of a dead/disabled component; "none" if benign' },
+    recommendedAction: { type: 'string' },
+    sources: { type: 'array', items: { type: 'string', description: 'source URL' } },
+  },
+}
+
+const ADV_SCHEMA = {
+  type: 'object',
+  required: ['agree', 'revisedClassification', 'reason'],
+  properties: {
+    agree: { type: 'boolean', description: 'does the skeptic agree with the original classification' },
+    revisedClassification: { type: 'string', enum: ['ACTIVE-RISK', 'ACTION-NEEDED', 'ACCEPTABLE-DRIFT', 'DORMANT-OK', 'NOT-STALE', 'UNVERIFIED', 'UNCHANGED'] },
+    concerns: { type: 'array', items: { type: 'string' } },
+    reason: { type: 'string' },
+  },
+}
+
+phase('Discover')
+const seedKeys = SEED_ITEMS.concat(_operatorSeed).map(s => s.key).join(', ')
+const disc = await agent(
+  `Discover Mercury external dependencies that could go stale/expired/dead and are NOT already in this seed list: [${seedKeys}].\n\n` +
+  `Read/Grep the Mercury repo yourself. Look in: .mercury/state/upstream-manifest.json (cherry-pick ledger), adapters/*/ (package.json / pyproject pins / UPSTREAM.md / launch wrappers), .mcp.json (MCP server commands + versions), .claude/settings.json enabledPlugins, .gitmodules (git submodules if any), Cargo.toml / pnpm-lock.yaml pins, and any pinned model IDs / SHAs / npm / crate versions referenced in scripts or agent frontmatter. ` +
+  `Return only NEW items (distinct from the seed keys), each with a short key, a claim stating the pinned thing + what to CHECK for staleness, and refs. If nothing new, return an empty items array.`,
+  { label: 'discover-deps', phase: 'Discover', schema: DISCOVER_SCHEMA, agentType: 'research' }
+)
+const discovered = (disc && Array.isArray(disc.items)) ? disc.items : []
+// Dedup by key, seeds (built-in + operator) first so the cap drops the discovered
+// tail before any seed. Count seeded items POST-dedup (seededInItems) so the log
+// stays correct even when an operator seed duplicates a built-in seed key.
+const seenKeys = new Set()
+const ITEMS = []
+let seededInItems = 0
+for (const it of SEED_ITEMS.concat(_operatorSeed)) {
+  const k = (it && it.key || '').trim().toLowerCase()
+  if (!k || seenKeys.has(k)) continue
+  seenKeys.add(k); ITEMS.push(it); seededInItems++
+}
+for (const it of discovered) {
+  const k = (it && it.key || '').trim().toLowerCase()
+  if (!k || seenKeys.has(k)) continue
+  seenKeys.add(k); ITEMS.push(it)
+}
+if (ITEMS.length > ITEM_CAP) { log(`${ITEMS.length - ITEM_CAP} items dropped at ITEM_CAP=${ITEM_CAP} (rerun to cover them)`); ITEMS.length = ITEM_CAP }
+const seededShown = Math.min(seededInItems, ITEMS.length)
+log(`Auditing ${ITEMS.length} stale-dependency items (${seededShown} seeded + ${ITEMS.length - seededShown} discovered)`)
+
+phase('Verify')
+// Pipeline: each item is verified, then adversarially re-checked — no barrier, so
+// an item is re-checked as soon as its verification lands.
+const audited = await pipeline(
+  ITEMS,
+  (it, _o, i) => agent(
+    `Ground-truth the staleness of this Mercury external dependency and classify it.\n\nItem: ${it.key}\n${it.claim}\nMercury refs: ${it.refs || '(none)'}\n\n` +
+    `Read/Grep the cited Mercury files yourself for what is pinned/used. Use WebSearch/WebFetch to find the CURRENT upstream state (latest npm/PyPI/crates/GitHub release, repo alive/archived, model availability). ` +
+    `Classify: ACTIVE-RISK (stale/dead component is actively used and can cause a real failure NOW) · ACTION-NEEDED (behind upstream / re-pin or pull-update warranted, not yet failing) · ACCEPTABLE-DRIFT (upstream changed but Mercury owns an adapted copy / change is cosmetic or unreachable — no action) · DORMANT-OK (defensive/unused reference, safe to leave) · NOT-STALE (current) · UNVERIFIED (could not confirm upstream state). ` +
+    `State the concrete impact (local problem from outdated OR wrong use of a dead component) and a recommended action. Cite source URLs.`,
+    { label: `verify:${i + 1}:${(it.key || '').slice(0, 18)}`, phase: 'Verify', schema: VERIFY_SCHEMA, agentType: 'research' }
+  ).then(v => ({ ...it, verify: v })),
+  (iv, _o, i) => {
+    if (!iv || !iv.verify) return iv
+    return agent(
+      `Adversarially re-check a staleness classification. Be skeptical — challenge both false-alarms and missed-risks.\n\n` +
+      `Item: ${iv.key}\n${iv.claim}\nOriginal classification: ${iv.verify.classification} — ${iv.verify.verdict}\nClaimed current upstream: ${iv.verify.currentUpstream || '?'}\nClaimed impact: ${iv.verify.impact}\n\n` +
+      `Independently re-verify the upstream state via WebSearch/WebFetch (do not trust the original verdict). Could a DORMANT-OK / ACCEPTABLE-DRIFT / NOT-STALE actually hide an ACTIVE-RISK (a disabled model still routed, an archived upstream, a security CVE in the lagging version)? Could an ACTIVE-RISK / ACTION-NEEDED be overstated? ` +
+      `Return whether you agree, a revised classification (or UNCHANGED), concerns, and your reason.`,
+      { label: `adv:${i + 1}:${(iv.key || '').slice(0, 18)}`, phase: 'Adversarial', schema: ADV_SCHEMA, agentType: 'research' }
+    ).then(a => ({ ...iv, adv: a }))
+  }
+)
+
+phase('Synthesize')
+const A = audited.filter(Boolean)
+const finalClass = r => {
+  const orig = r.verify && r.verify.classification
+  const rev = r.adv && r.adv.revisedClassification
+  return (rev && rev !== 'UNCHANGED') ? rev : orig
+}
+const shape = r => ({
+  key: r.key,
+  classification: finalClass(r),
+  originalClassification: r.verify && r.verify.classification,
+  skepticAgreed: r.adv ? r.adv.agree : null,
+  verdict: r.verify && r.verify.verdict,
+  currentUpstream: r.verify && r.verify.currentUpstream,
+  pinnedOrUsed: r.verify && r.verify.pinnedOrUsed,
+  impact: r.verify && r.verify.impact,
+  recommendedAction: r.verify && r.verify.recommendedAction,
+  concerns: (r.adv && r.adv.concerns) || [],
+  sources: (r.verify && r.verify.sources) || [],
+})
+const all = A.map(shape)
+const bucket = c => all.filter(x => x.classification === c)
+log(`Audit: ${bucket('ACTIVE-RISK').length} ACTIVE-RISK · ${bucket('ACTION-NEEDED').length} ACTION-NEEDED · ${bucket('ACCEPTABLE-DRIFT').length} ACCEPTABLE-DRIFT · ${bucket('DORMANT-OK').length} DORMANT-OK · ${bucket('NOT-STALE').length} NOT-STALE · ${bucket('UNVERIFIED').length} UNVERIFIED`)
+return {
+  itemCount: all.length,
+  activeRisk: bucket('ACTIVE-RISK'),
+  actionNeeded: bucket('ACTION-NEEDED'),
+  acceptableDrift: bucket('ACCEPTABLE-DRIFT'),
+  dormantOk: bucket('DORMANT-OK'),
+  notStale: bucket('NOT-STALE'),
+  unverified: bucket('UNVERIFIED'),
+  note: 'Classifications where skepticAgreed=false were revised by the adversarial pass. UNVERIFIED items MUST be re-checked manually before any action (Mercury research protocol). This audit files NO issues — findings feed the operator triage + any follow-up Issue/PR (see .mercury/docs/guides/upstream-drift-routine.md).',
+}

--- a/.github/workflows/upstream-drift.yml
+++ b/.github/workflows/upstream-drift.yml
@@ -1,0 +1,133 @@
+name: upstream-drift
+
+# Monthly upstream cherry-pick / version-pin drift watch (Issue #508 — Tier 1).
+#
+# Runs the deterministic, zero-LLM checker scripts/upstream-drift-check.sh on a
+# schedule. It compares each cherry-picked / version-pinned artifact's upstream
+# blob SHA at import vs upstream HEAD (CLEAN / CHANGED / UPSTREAM_GONE / SKIP).
+# When drift is detected it find-or-creates a single tracking Issue (label
+# `upstream-drift`) and posts the report there, so drift surfaces as a standing
+# backlog item instead of silently rotting (manifest entries previously sat at
+# last_drift_check=null from import until 2026-06).
+#
+# Tier 1 (mechanical) of Mercury's upstream-staleness mechanism. Tier 2 is the
+# periodic /mercury-staleness-audit LLM workflow (dead-component + version-lag
+# judgment that blob drift cannot see). Cadence + triage protocol:
+# .mercury/docs/guides/upstream-drift-routine.md.
+#
+# This job runs READ-ONLY: it does NOT write last_drift_check back to the repo
+# (GHA must not push to develop — Mercury PR-only rule). last_drift_check is the
+# "last human-reviewed" marker, stamped by local `upstream-drift-check.sh
+# --write-back` runs committed via PR; this job is the automated alarm.
+#
+# Fully detachable (DIRECTION.md modular design): delete this file +
+# scripts/upstream-drift-check.sh and the mechanism is gone; the tracking Issue
+# and the `upstream-drift` label then become harmless orphans.
+
+on:
+  schedule:
+    # Monthly, 1st @ 09:23 UTC. cron is always UTC. The off-the-hour minute (:23,
+    # not :00) follows GitHub's guidance that on-the-hour jobs are the most
+    # delayed/dropped under load. Monthly (not weekly) because cherry-pick /
+    # pin drift moves slower than the external-intel source watch.
+    - cron: '23 9 1 * *'
+  workflow_dispatch:
+    inputs:
+      file_issue:
+        description: 'On drift, file/update the tracking Issue (false = report to run summary only)'
+        required: false
+        type: boolean
+        default: true
+
+# Minimal GITHUB_TOKEN scopes: create/edit/list/comment Issues (issues:write) +
+# checkout the script (contents:read). No PAT required.
+permissions:
+  contents: read
+  issues: write
+
+# Serialize scheduled vs manual runs so two runs never both create the tracking
+# Issue. cancel-in-progress:false → a new trigger queues behind an in-flight run.
+concurrency:
+  group: upstream-drift
+  cancel-in-progress: false
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      # gh CLI (preinstalled on ubuntu-latest) authenticates from GH_TOKEN. The
+      # drift checker itself calls `gh api` against PUBLIC upstream repos.
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+    steps:
+      - name: Checkout (drift checker + manifest must be on disk)
+        uses: actions/checkout@v4
+
+      - name: Run upstream drift check (read-only)
+        id: check
+        run: |
+          # The checker exits 0 (clean) / 1 (CHANGED) / 2 (UPSTREAM_GONE). Capture
+          # that code via PIPESTATUS without aborting the step (set +e around it).
+          set +e
+          bash scripts/upstream-drift-check.sh | tee drift-report.txt
+          rc=${PIPESTATUS[0]}
+          set -e
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+          # 1 = CHANGED, 2 = UPSTREAM_GONE → drift. Any other non-zero (3/64/127)
+          # is an error in the checker invocation itself → fail the run to surface it.
+          if [ "$rc" = "1" ] || [ "$rc" = "2" ]; then
+            echo "drift=true" >> "$GITHUB_OUTPUT"
+          elif [ "$rc" = "0" ]; then
+            echo "drift=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::upstream-drift-check.sh exited with unexpected code $rc"; exit "$rc"
+          fi
+          echo "drift check rc=$rc"
+
+      - name: Surface report to run summary
+        if: always()
+        run: |
+          {
+            echo "## Upstream drift check ($(date -u +%Y-%m-%d))"
+            echo
+            echo '```'
+            cat drift-report.txt 2>/dev/null || echo "(no report produced)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: File or update tracking Issue on drift
+        if: steps.check.outputs.drift == 'true' && (github.event_name == 'schedule' || inputs.file_issue)
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          # Idempotent label upsert keeps the module self-bootstrapping on a fresh clone.
+          gh label create upstream-drift --repo "$REPO" --color d4c5f9 \
+            --description "Upstream cherry-pick/pin drift flagged by the monthly upstream-drift watch" --force >/dev/null
+          TODAY="$(date -u +%Y-%m-%d)"
+          # Build the Issue body in a file to avoid printf/quoting injection from the report text.
+          {
+            echo "Automated upstream drift report — $TODAY ([run log]($RUN_URL))."
+            echo
+            echo "The monthly \`upstream-drift\` watch found cherry-picked / version-pinned artifacts whose upstream changed since import (CHANGED) or went away (UPSTREAM_GONE). Triage per \`.mercury/docs/guides/upstream-drift-routine.md\`: for each, decide pull-update / re-pin / accept-as-owned, then run \`bash scripts/upstream-drift-check.sh --write-back\` locally and commit the refreshed \`last_drift_check\` via PR."
+            echo
+            echo '```'
+            cat drift-report.txt
+            echo '```'
+          } > issue-body.md
+          # find-or-create a single tracking Issue: select DETERMINISTICALLY by lowest
+          # number (not gh's default ordering) and warn if more than one is open.
+          state_json="$(gh issue list --repo "$REPO" --label upstream-drift --state open --limit 100 --json number)"
+          dupes="$(printf '%s' "$state_json" | jq 'length')"
+          if [ "$dupes" -gt 1 ]; then
+            echo "::warning::multiple open upstream-drift Issues ($(printf '%s' "$state_json" | jq -c '[.[].number]')); commenting on the lowest. Close extras to keep it single-sourced."
+          fi
+          existing="$(printf '%s' "$state_json" | jq -r 'sort_by(.number) | .[0].number // empty')"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$REPO" --body-file issue-body.md
+            echo "Updated tracking Issue #$existing"
+          else
+            gh issue create --repo "$REPO" --label upstream-drift \
+              --title "🔄 Upstream drift detected ($TODAY)" --body-file issue-body.md
+          fi

--- a/.github/workflows/upstream-drift.yml
+++ b/.github/workflows/upstream-drift.yml
@@ -67,15 +67,19 @@ jobs:
       - name: Run upstream drift check (read-only)
         id: check
         run: |
-          # The checker exits 0 (clean) / 1 (CHANGED) / 2 (UPSTREAM_GONE). Capture
-          # that code via PIPESTATUS without aborting the step (set +e around it).
+          # The checker signals DRIFT only via exit 1 (CHANGED) / 2 (UPSTREAM_GONE);
+          # 0 = clean. Setup/precondition failures use distinct codes (5 = missing
+          # jq/gh or no manifest, 64 = usage, 3 = write-back — not used here since
+          # this job is read-only), so a "could not run" is NOT mistaken for drift.
+          # Capture the checker's code via PIPESTATUS (set +e so the pipe's failure
+          # does not abort the step before we read it).
           set +e
           bash scripts/upstream-drift-check.sh | tee drift-report.txt
           rc=${PIPESTATUS[0]}
           set -e
           echo "rc=$rc" >> "$GITHUB_OUTPUT"
-          # 1 = CHANGED, 2 = UPSTREAM_GONE → drift. Any other non-zero (3/64/127)
-          # is an error in the checker invocation itself → fail the run to surface it.
+          # ONLY 1/2 are drift. Any other non-zero (3/5/64/127/…) is a checker
+          # error → fail the run to surface it, never file a spurious drift Issue.
           if [ "$rc" = "1" ] || [ "$rc" = "2" ]; then
             echo "drift=true" >> "$GITHUB_OUTPUT"
           elif [ "$rc" = "0" ]; then

--- a/.mercury/docs/guides/upstream-drift-routine.md
+++ b/.mercury/docs/guides/upstream-drift-routine.md
@@ -1,0 +1,49 @@
+# Upstream dependency drift routine
+
+> 立项: Issue [#508](https://github.com/392fyc/Mercury/issues/508)(side-bug lane)。
+> 背景:`.mercury/state/upstream-manifest.json` 自导入(2026-04~05)起所有条目 `last_drift_check=null`,周期检查从未跑过;本机制把「上游依赖漂移检查」制度化,避免 ①组件过期产生局部问题 ②组件已失效却仍错误使用。
+
+Mercury 挂载/借鉴了若干外部组件(cherry-pick 的 skill/agent 文件、version-pin 的 adapter、plugin 依赖、pinned 模型 ID)。这些上游会演进、会失效。本文档定义**两层周期检查机制 + 漂移裁决流程**。
+
+## 两层机制
+
+| | Tier 1 — 机械漂移 | Tier 2 — LLM staleness 审计 |
+|---|---|---|
+| 工具 | `scripts/upstream-drift-check.sh` | `/mercury-staleness-audit`(`.claude/workflows/mercury-staleness-audit.js`)|
+| 触发 | `.github/workflows/upstream-drift.yml` 月度 cron(+ `workflow_dispatch`)| 人工周期例行(建议季度,或 Tier-1 告警后)|
+| 判定 | 确定性:比较 cherry-pick artifact 的上游 blob SHA(import vs HEAD)→ `CLEAN/CHANGED/UPSTREAM_GONE/SKIP` | LLM + 对抗验证:判「落后多少」「组件是否已失效/disabled」「上游是否 archived」「破坏性变更 Mercury 是否真触达」→ `ACTIVE-RISK/ACTION-NEEDED/ACCEPTABLE-DRIFT/DORMANT-OK/NOT-STALE/UNVERIFIED` |
+| 抓得到 | cherry-pick 文件内容漂移、上游文件被删 | 版本落后幅度、失效/禁用组件仍被引用、上游 archived、纯 transitive 依赖(blob 模型抓不到)|
+| 成本 | 零 LLM,~秒级,gh api | 一次 run 数十 agent + web,~分钟级 |
+| 产出 | 有漂移→ find-or-create 单一 tracking issue(label `upstream-drift`)贴报告 | 分类报告(不开 issue),喂给 operator 裁决 |
+
+**为什么要两层**:Tier-1 只比对 blob SHA —— 它知道「caveman SKILL.md 上游变了」,但不知道「playwright 0.0.75 落后 latest 几个版本」「Fable5 已被禁用」「某 npm 依赖已 archived」。后者需要 web + 判断,是 Tier-2 的职责。Tier-1 抓 case ①(过期),Tier-2 兼抓 case ①②(过期 + 失效误用)。
+
+## last_drift_check 语义(重要)
+
+- `last_drift_check` = **「上次人工复核日期」**,由本地 `bash scripts/upstream-drift-check.sh --write-back` 回写、经 PR 提交。它**独立于**当次 CLEAN/CHANGED 状态(状态是瞬时的,重跑即得)。
+- **GHA 只读、绝不回写**:GitHub Actions 不能 push develop(Mercury PR-only 规则)。月度 GHA 是「自动告警」(检测→开/更新 tracking issue),不动 manifest。manifest 的时间戳只在人工复核 + PR 时前进。
+- 这样分工:`upstream-drift` tracking issue = 「机器说有漂移」;`last_drift_check` = 「人看过了,日期为证」。
+
+## 漂移裁决流程(收到 CHANGED / Tier-2 ACTION-NEEDED 时)
+
+逐条三选一:
+
+1. **pull-update** —— 上游有实质改进/修复值得拉:按 cherry-pick 协议更新本地副本 + 更新 manifest `upstream_sha_at_import`,走 dual-verify + PR。
+2. **re-pin** —— version-pin adapter 落后且值得升:更新 pin(launch 包/pyproject/Cargo)+ 重新 provision + 更新 `UPSTREAM.md` + manifest SHA,走 dual-verify + PR。
+3. **accept-as-owned** —— 上游变更是 cosmetic、不可达、或 Mercury 已自有适配(cherry-pick 协议下本地副本是 Mercury-owned,无 live-sync 义务):无需改代码,仅 `--write-back` 刷新 `last_drift_check` 记录「已复核、接受现状」。
+
+裁决后跑 `bash scripts/upstream-drift-check.sh --write-back` + 提交刷新的 manifest;tracking issue 在所有 CHANGED 裁决完成后关闭。
+
+## 覆盖面与边界
+
+- manifest(因而 Tier-1)覆盖 **cherry-pick 文件 + 显式 adapter version-pin**。**纯 transitive npm/cargo 依赖**(`pnpm-lock.yaml` / `Cargo.lock` 里的间接依赖)不进 manifest —— 由 lockfile 钉版本 + Tier-2 审计(其 discover agent 会扫 lockfile/pin)兜底。
+- **用户级组件**(OMC plugin、`~/.claude/scripts/` 模型 ID 等)漂移走 [#259](https://github.com/392fyc/Mercury/issues/259) user-level governance,不在本 repo PR 流程内 —— Tier-2 会标出,由用户在其全局环境执行更新。
+- **Argus 基座**(pr-agent 冻结)漂移归 [#498](https://github.com/392fyc/Mercury/issues/498) fork-rebase 专项,本机制只负责「标出落后」,不负责升级。
+
+## 首跑基线(2026-06-24 UTC,#508)
+
+> 时间戳用 UTC(`date -u`,与月度 GHA 一致);本次回写落 `last_drift_check=2026-06-24`。
+
+- Tier-1:21 artifacts → `CLEAN=9 · CHANGED=9 · SKIP=3`。CHANGED = obra/superpowers(systematic-debugging ×2 + subagent-driven-development ×4)、JuliusBrussee/caveman ×2、microsoft/playwright-mcp。
+- Tier-2:14 items → `0 ACTIVE-RISK · 2 ACTION-NEEDED · 6 ACCEPTABLE-DRIFT · 1 DORMANT-OK · 5 NOT-STALE`。详见 #508 + side-bug user-memory。
+- 9 个 CHANGED 的裁决:superpowers 上游重构(ledger 恢复模式等)→ 单独 [#509](https://github.com/392fyc/Mercury/issues/509) 追踪 back-port(P3);caveman/agency-agents → accept-as-owned(Mercury 自有改写);playwright 0.0.76 / grammy 1.44 → 低优 re-pin(机制后续监控)。本 PR 仅回写 `last_drift_check` 建立基线,不在 PR 内 reconcile 各 CHANGED(漂移现状 = 机制监控对象)。

--- a/.mercury/state/upstream-manifest.json
+++ b/.mercury/state/upstream-manifest.json
@@ -9,7 +9,7 @@
     "import_pr": 216,
     "import_date": "2026-04-10",
     "import_rationale": "DEC-4 approved cherry-pick: root-cause debugging enforcement for Mercury quality workflow (Issue #209)",
-    "last_drift_check": null
+    "last_drift_check": "2026-06-24"
   },
   {
     "path": ".claude/skills/systematic-debugging/condition-based-waiting.md",
@@ -21,7 +21,7 @@
     "import_pr": 216,
     "import_date": "2026-04-10",
     "import_rationale": "Supporting doc for systematic-debugging skill (Issue #209)",
-    "last_drift_check": null
+    "last_drift_check": "2026-06-24"
   },
   {
     "path": ".claude/skills/systematic-debugging/condition-based-waiting-example.ts",
@@ -33,7 +33,7 @@
     "import_pr": 216,
     "import_date": "2026-04-10",
     "import_rationale": "Supporting example for systematic-debugging skill (Issue #209)",
-    "last_drift_check": null
+    "last_drift_check": "2026-06-24"
   },
   {
     "path": ".claude/skills/systematic-debugging/defense-in-depth.md",
@@ -45,7 +45,7 @@
     "import_pr": 216,
     "import_date": "2026-04-10",
     "import_rationale": "Supporting doc for systematic-debugging skill (Issue #209)",
-    "last_drift_check": null
+    "last_drift_check": "2026-06-24"
   },
   {
     "path": ".claude/skills/systematic-debugging/find-polluter.sh",
@@ -57,7 +57,7 @@
     "import_pr": 216,
     "import_date": "2026-04-10",
     "import_rationale": "Supporting script for systematic-debugging skill (Issue #209)",
-    "last_drift_check": null
+    "last_drift_check": "2026-06-24"
   },
   {
     "path": ".claude/skills/systematic-debugging/root-cause-tracing.md",
@@ -69,7 +69,7 @@
     "import_pr": 216,
     "import_date": "2026-04-10",
     "import_rationale": "Supporting doc for systematic-debugging skill (Issue #209)",
-    "last_drift_check": null
+    "last_drift_check": "2026-06-24"
   },
   {
     "path": ".claude/skills/subagent-driven-development/SKILL.md",
@@ -81,7 +81,7 @@
     "import_pr": 216,
     "import_date": "2026-04-10",
     "import_rationale": "DEC-4 approved cherry-pick: fresh-subagent-per-task execution pattern (Issue #209)",
-    "last_drift_check": null
+    "last_drift_check": "2026-06-24"
   },
   {
     "path": ".claude/skills/subagent-driven-development/code-quality-reviewer-prompt.md",
@@ -93,7 +93,7 @@
     "import_pr": 216,
     "import_date": "2026-04-10",
     "import_rationale": "Supporting prompt template for subagent-driven-development skill (Issue #209)",
-    "last_drift_check": null
+    "last_drift_check": "2026-06-24"
   },
   {
     "path": ".claude/skills/subagent-driven-development/implementer-prompt.md",
@@ -105,7 +105,7 @@
     "import_pr": 216,
     "import_date": "2026-04-10",
     "import_rationale": "Supporting prompt template for subagent-driven-development skill (Issue #209)",
-    "last_drift_check": null
+    "last_drift_check": "2026-06-24"
   },
   {
     "path": ".claude/skills/subagent-driven-development/spec-reviewer-prompt.md",
@@ -117,7 +117,7 @@
     "import_pr": 216,
     "import_date": "2026-04-10",
     "import_rationale": "Supporting prompt template for subagent-driven-development skill (Issue #209)",
-    "last_drift_check": null
+    "last_drift_check": "2026-06-24"
   },
   {
     "path": ".claude/skills/verification-before-completion/SKILL.md",
@@ -129,7 +129,7 @@
     "import_pr": 216,
     "import_date": "2026-04-10",
     "import_rationale": "DEC-4 approved cherry-pick: evidence-before-claims verification enforcement (Issue #209)",
-    "last_drift_check": null
+    "last_drift_check": "2026-06-24"
   },
   {
     "path": ".claude/skills/caveman-toggle/SKILL.md",
@@ -141,7 +141,7 @@
     "import_pr": 214,
     "import_date": "2026-04-10",
     "import_rationale": "Adapted caveman prompt text into Mercury-native persistent toggle skill (Issue #213)",
-    "last_drift_check": null
+    "last_drift_check": "2026-06-24"
   },
   {
     "path": "CLAUDE.local.md.example",
@@ -153,7 +153,7 @@
     "import_pr": 214,
     "import_date": "2026-04-10",
     "import_rationale": "Contains caveman prompt text extracted from upstream SKILL.md for use as CLAUDE.local.md injection template (Issue #213)",
-    "last_drift_check": null
+    "last_drift_check": "2026-06-24"
   },
   {
     "path": ".claude/agents/game-researcher.md",
@@ -165,7 +165,7 @@
     "import_pr": 281,
     "import_date": "2026-04-21",
     "import_rationale": "Game-dev A→B→C subagent chain stage 1 (information aggregation) for SoT production trial (Issue #281)",
-    "last_drift_check": null
+    "last_drift_check": "2026-06-24"
   },
   {
     "path": ".claude/agents/game-analyst.md",
@@ -177,7 +177,7 @@
     "import_pr": 281,
     "import_date": "2026-04-21",
     "import_rationale": "Game-dev A→B→C subagent chain stage 2 (feasibility analysis) for SoT production trial (Issue #281)",
-    "last_drift_check": null
+    "last_drift_check": "2026-06-24"
   },
   {
     "path": ".claude/agents/game-critic.md",
@@ -189,9 +189,8 @@
     "import_pr": 281,
     "import_date": "2026-04-21",
     "import_rationale": "Game-dev A→B→C subagent chain stage 3 (adversarial validation) for SoT production trial (Issue #281)",
-    "last_drift_check": null
-  }
-,
+    "last_drift_check": "2026-06-24"
+  },
   {
     "path": "adapters/mercury-channel-router/UPSTREAM.md",
     "scope": "project",
@@ -202,7 +201,7 @@
     "import_pr": 295,
     "import_date": "2026-04-25",
     "import_rationale": "Reference-only adapter inspired by Anthropic Channels reference + openclaw + node-telegram-bot-api. No code cherry-picked.",
-    "last_drift_check": null
+    "last_drift_check": "2026-06-24"
   },
   {
     "path": "adapters/mercury-channel-client/UPSTREAM.md",
@@ -214,7 +213,7 @@
     "import_pr": 295,
     "import_date": "2026-04-25",
     "import_rationale": "Reference-only adapter inspired by Anthropic Channels reference walkthrough + @modelcontextprotocol/sdk. No code cherry-picked.",
-    "last_drift_check": null
+    "last_drift_check": "2026-06-24"
   },
   {
     "path": "adapters/mercury-notify/UPSTREAM.md",
@@ -226,7 +225,7 @@
     "import_pr": 295,
     "import_date": "2026-04-25",
     "import_rationale": "Original implementation. No upstream references — thin HTTP client wrapping fetch().",
-    "last_drift_check": null
+    "last_drift_check": "2026-06-24"
   },
   {
     "path": "adapters/gpt-image-2/invoke.py",
@@ -238,7 +237,7 @@
     "import_pr": 354,
     "import_date": "2026-05-08",
     "import_rationale": "Phase 2 Slice A — wuyoscar/gpt_image_2_skill MIT mount via uvx-pinned-SHA per ADR pixel-animation-workflow §7.2.1 + S87 refinement (Issue #351). No upstream source vendored. upstream_path=pyproject.toml tracks the canonical version contract (deps, entry points) so scripts/upstream-drift-check.sh can detect upstream version bumps that affect this adapter's pinned SHA.",
-    "last_drift_check": null
+    "last_drift_check": "2026-06-24"
   },
   {
     "path": "adapters/playwright-mcp/UPSTREAM.md",
@@ -250,6 +249,6 @@
     "import_pr": 459,
     "import_date": "2026-05-26",
     "import_rationale": "Phase 2 Slice A (Issue #458, ADR issue-154-web-automation) — npm-version-pinned MCP server runtime mount (third mount mode, alongside git submodule and uvx git+SHA). Execution contract = pinned npm version @playwright/mcp@0.0.75; upstream_sha_at_import = the git tag v0.0.75 commit (audit metadata mapping the pinned npm version back to an upstream git tag, NOT the execution contract). upstream_path=package.json tracks the canonical version/deps/bin contract so scripts/upstream-drift-check.sh can detect upstream version bumps that may require re-pinning this adapter. No upstream source vendored; adapters/playwright-mcp/launch.cjs is a Mercury config-gate wrapper only.",
-    "last_drift_check": null
+    "last_drift_check": "2026-06-24"
   }
 ]

--- a/scripts/upstream-drift-check.sh
+++ b/scripts/upstream-drift-check.sh
@@ -29,7 +29,11 @@
 #   1  at least one CHANGED
 #   2  at least one UPSTREAM_GONE (most severe; takes precedence over CHANGED)
 #   3  --write-back failed (manifest left unchanged)
+#   5  prerequisite missing (jq/gh not installed) or no manifest found
 #   64 usage error (bad argument)
+# NOTE: drift is signalled ONLY by 1/2. Setup/precondition failures use 5 (not 1)
+# so a caller cannot mistake "could not run" for "CHANGED drift" — see the
+# rc-mapping in .github/workflows/upstream-drift.yml.
 #
 # Run manually:        bash scripts/upstream-drift-check.sh
 # Backfill timestamps: bash scripts/upstream-drift-check.sh --write-back
@@ -45,7 +49,7 @@ WRITE_BACK=0
 usage() {
   echo "Usage: bash scripts/upstream-drift-check.sh [--write-back]"
   echo "  --write-back  stamp last_drift_check (UTC date) on project-manifest entries after checking"
-  echo "Exit: 0 clean · 1 CHANGED present · 2 UPSTREAM_GONE present · 3 write-back failed · 64 usage error"
+  echo "Exit: 0 clean · 1 CHANGED present · 2 UPSTREAM_GONE present · 3 write-back failed · 5 prerequisite/no-manifest · 64 usage error"
 }
 for arg in "$@"; do
   case "$arg" in
@@ -62,7 +66,7 @@ USER_MANIFEST="${HOME}/.claude/upstream-manifest.json"
 for cmd in jq gh; do
   if ! command -v "$cmd" >/dev/null 2>&1; then
     echo "ERROR: $cmd is required" >&2
-    exit 1
+    exit 5  # prerequisite missing — distinct from the 1/2 drift codes
   fi
 done
 
@@ -73,7 +77,7 @@ manifest_files=()
 
 if [[ ${#manifest_files[@]} -eq 0 ]]; then
   echo "ERROR: no manifest found at project ($PROJECT_MANIFEST) or user ($USER_MANIFEST) level" >&2
-  exit 1
+  exit 5  # no manifest to check — distinct from the 1/2 drift codes
 fi
 
 # Merge all manifest arrays into one temporary file

--- a/scripts/upstream-drift-check.sh
+++ b/scripts/upstream-drift-check.sh
@@ -17,10 +17,43 @@
 # Output per artifact: CLEAN | CHANGED | UPSTREAM_GONE | SKIP
 # Summary includes per-scope counts.
 #
-# Run manually: bash scripts/upstream-drift-check.sh
-# DO NOT wire into CI or kb-lint — follow-up automation is tracked separately.
+# Flags:
+#   --write-back   After checking, stamp last_drift_check (UTC date) on every
+#                  PROJECT-manifest entry, recording that a drift review ran.
+#                  Use locally / in a PR — NOT from CI (CI must not push to
+#                  develop; the scheduled .github/workflows/upstream-drift.yml
+#                  runs read-only and files a tracking Issue instead).
+#
+# Exit codes (so a scheduler/CI can gate on drift):
+#   0  no drift (all CLEAN/SKIP)
+#   1  at least one CHANGED
+#   2  at least one UPSTREAM_GONE (most severe; takes precedence over CHANGED)
+#   3  --write-back failed (manifest left unchanged)
+#   64 usage error (bad argument)
+#
+# Run manually:        bash scripts/upstream-drift-check.sh
+# Backfill timestamps: bash scripts/upstream-drift-check.sh --write-back
+#
+# Tier 1 (mechanical/deterministic) of Mercury's upstream-staleness mechanism
+# (Issue #508). Tier 2 is the periodic /mercury-staleness-audit LLM workflow
+# (dead-component + version-lag judgment). Cadence + triage protocol:
+# .mercury/docs/guides/upstream-drift-routine.md.
 
 set -euo pipefail
+
+WRITE_BACK=0
+usage() {
+  echo "Usage: bash scripts/upstream-drift-check.sh [--write-back]"
+  echo "  --write-back  stamp last_drift_check (UTC date) on project-manifest entries after checking"
+  echo "Exit: 0 clean · 1 CHANGED present · 2 UPSTREAM_GONE present · 3 write-back failed · 64 usage error"
+}
+for arg in "$@"; do
+  case "$arg" in
+    --write-back) WRITE_BACK=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "ERROR: unknown argument '$arg'" >&2; usage >&2; exit 64 ;;
+  esac
+done
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 PROJECT_MANIFEST="$REPO_ROOT/.mercury/state/upstream-manifest.json"
@@ -45,7 +78,8 @@ fi
 
 # Merge all manifest arrays into one temporary file
 MERGED="$(mktemp)"
-trap 'rm -f "$MERGED"' EXIT
+WB_TMP=""
+trap 'rm -f "$MERGED" "${WB_TMP:-}"' EXIT
 jq -s 'add' "${manifest_files[@]}" > "$MERGED"
 
 count=$(jq 'length' "$MERGED")
@@ -139,3 +173,42 @@ done
 echo "---"
 echo "Summary: CLEAN=$clean  CHANGED=$changed  UPSTREAM_GONE=$gone  SKIP=$skipped  total=$count"
 echo "Scopes:  project=$scope_project  user=$scope_user  unknown=$scope_unknown"
+
+# --write-back: stamp last_drift_check on every PROJECT-manifest entry to record
+# that a drift review ran on this date. Only the project manifest is rewritten
+# (the user-scope manifest, if any, is left to its own owner). A single run
+# examines every project entry, so all are stamped uniformly with the run date.
+# Semantics: last_drift_check = "when last reviewed", independent of the per-run
+# CLEAN/CHANGED status (which is transient and re-derivable by re-running).
+if [[ "$WRITE_BACK" -eq 1 ]]; then
+  if [[ -f "$PROJECT_MANIFEST" ]]; then
+    run_date="$(date -u +%Y-%m-%d)"
+    # Create the rewrite temp in the manifest's OWN directory so `mv` is a
+    # same-filesystem ATOMIC rename — a temp in $TMPDIR could be on a different
+    # mount, degrading mv to a non-atomic cross-device copy that can expose a
+    # partially written manifest. Every write-back step (count, mktemp, jq, mv)
+    # is guarded to exit 3 ("write-back failed") rather than leaking jq/mv's
+    # native status — under `set -e` that status (e.g. mv→1) could otherwise be
+    # mistaken by a caller for the CHANGED (1) drift code.
+    manifest_dir="$(dirname "$PROJECT_MANIFEST")"
+    proj_count=$(jq 'length' "$PROJECT_MANIFEST") || {
+      echo "ERROR: write-back failed (cannot count manifest) — manifest unchanged" >&2; exit 3; }
+    WB_TMP="$(mktemp "$manifest_dir/.drift-wb.XXXXXX")" || {
+      echo "ERROR: write-back failed (cannot create temp in $manifest_dir) — manifest unchanged" >&2; exit 3; }
+    if jq --arg d "$run_date" 'map(.last_drift_check = $d)' "$PROJECT_MANIFEST" > "$WB_TMP" \
+       && mv "$WB_TMP" "$PROJECT_MANIFEST"; then
+      echo "write-back: stamped last_drift_check=$run_date on $proj_count project-manifest entries"
+    else
+      rm -f "$WB_TMP"
+      echo "ERROR: write-back failed (jq/mv error) — manifest left unchanged" >&2
+      exit 3
+    fi
+  else
+    echo "write-back: no project manifest at $PROJECT_MANIFEST — nothing to stamp" >&2
+  fi
+fi
+
+# Exit code reflects the most severe drift found, so a scheduler/CI can gate.
+if [[ "$gone" -gt 0 ]]; then exit 2; fi
+if [[ "$changed" -gt 0 ]]; then exit 1; fi
+exit 0


### PR DESCRIPTION
## What

Institutionalize upstream-dependency staleness checking (Issue #508). All 21 `.mercury/state/upstream-manifest.json` entries had `last_drift_check=null` from import until now — the periodic check was a never-done follow-up (the drift checker's own header said "DO NOT wire into CI — follow-up automation tracked separately"). This wires it up as a two-tier mechanism.

## Changes

**Tier 1 — mechanical/deterministic (cron-able)**
- `scripts/upstream-drift-check.sh`: add `--write-back` (atomic, same-filesystem jq stamp of `last_drift_check` onto every project-manifest entry) + exit-code semantics (`0` clean / `1` CHANGED / `2` UPSTREAM_GONE / `3` write-back-failed / `64` usage). Header updated (drop the stale "DO NOT wire into CI" note).
- `.github/workflows/upstream-drift.yml` (new): monthly cron (`23 9 1 * *`) + `workflow_dispatch`. Runs the checker **read-only**, and on drift (rc 1/2) find-or-creates a single `upstream-drift` tracking Issue with the report. Mirrors the existing `external-intel.yml` precedent (`GITHUB_TOKEN`, concurrency, fully detachable). **Never pushes to develop** — `last_drift_check` is the "last human-reviewed" marker, stamped by local `--write-back` via PR; the GHA is the automated alarm. (Default branch is develop, so the schedule fires.)

**Tier 2 — LLM judgment (periodic)**
- `.claude/workflows/mercury-staleness-audit.js` (new): reusable Dynamic Workflow template (`/mercury-staleness-audit`). Discover → Verify → Adversarial → Synthesize, classifying each external dep `ACTIVE-RISK / ACTION-NEEDED / ACCEPTABLE-DRIFT / DORMANT-OK / NOT-STALE / UNVERIFIED`. Catches what blob drift cannot: version-lag magnitude, dead/disabled components, archived upstreams. Evergreen check-directive SEED + `args.seedItems` override; #385-guardrail compliant (caps + `log()` on drops, no bulk pre-injection).
- `.claude/workflows/README.md`: register the template (+1 row).

**Routine + baseline**
- `.mercury/docs/guides/upstream-drift-routine.md` (new): two-tier mechanism, `last_drift_check` semantics, and the CHANGED-triage protocol (pull-update / re-pin / accept-as-owned).
- `.mercury/state/upstream-manifest.json`: backfill `last_drift_check` baseline (21 entries `null` → `2026-06-24` UTC; one jq comma-normalization of a malformed `}`+`,`).

## Evidence / verification

- First run baseline (this PR): Tier-1 21 artifacts → `CLEAN=9 · CHANGED=9 · SKIP=3`; Tier-2 14 items → `0 ACTIVE-RISK · 2 ACTION-NEEDED · 6 ACCEPTABLE-DRIFT · 1 DORMANT-OK · 5 NOT-STALE`. Findings feed #509 (superpowers back-port, P3) + user-level OMC v4.15.0 update note.
- Script: `bash -n` clean; exit codes 0/1/2/64 + `--write-back` validated live; atomic temp now in the manifest dir; no temp leak; manifest re-stamps idempotently + stays valid JSON.
- GHA: YAML valid (`schedule` + `workflow_dispatch`, cron `23 9 1 * *`), read-only, least-privilege (`contents:read`/`issues:write`), `--body-file` (no injection).
- JS: syntax valid (wrapped-async check; top-level await/return is intentional Workflow-DSL).
- CRLF: `core.autocrlf=true` → LF blob → GHA-safe (baseline: `intel-watch.sh`).

## dual-verify

- **Claude side: PASS** — 2 LOW self-found + fixed (write-back temp in EXIT trap; JS SEED phrasing).
- **Codex side: PASS** — round 1 found 2 Medium + 1 Low (non-atomic cross-fs `mv`; write-back failures not all exiting `3`; pre-dedup seeded/discovered count), all fixed; round 2 PASS.

## Scope / boundaries

side-bug lane, isolated from main — **does not touch NAS / argus / sot-codex**. Argus base-image freeze stays with #498; OMC plugin update is user-level (#259 governance). `scripts/` is exempt from the adapters≤200 LOC rule (CLAUDE.md carve-out).

Closes #508
