### PR TITLE
feat(#514): MEMORY.md 去内联 session-history 块,改 SESSION_INDEX.md 指针 (lane-protocol Phase F.D)

### DIFF
--- a/.mercury/docs/guides/memory-index-regenerate.md
+++ b/.mercury/docs/guides/memory-index-regenerate.md
@@ -23,6 +23,7 @@ cutover.
 | **F.A (additive)** | Adds regenerate script; canonical files untouched | Issue #329 — landed |
 | **F.B (cutover)** | Splits existing rows into per-session files; replaces canonical sections with generated content via `--in-place` | Issue #330 — landed |
 | **F.C (lock-in)** | Claude Code PreToolUse + SessionEnd hooks prevent direct edits to canonical files | Issue #331 — staged in `scripts/hooks/`, deployment pending F.B 1-week soak |
+| **F.D (MEMORY.md pointer)** | `--in-place` writes a fixed pointer to `SESSION_INDEX.md` into MEMORY.md instead of per-session bullets (the inlined history overflowed the context-load window); `SESSION_INDEX.md` unchanged | Issue #514 — landed |
 
 ## Why this exists
 
@@ -209,8 +210,10 @@ What happens:
   - `<!-- END: scripts/regenerate-memory-index.sh --in-place -->`
 - Replaces SESSION_INDEX.md table body with sorted rows from per-session files
   (ascending by session number, lane=main first within tie).
-- Replaces MEMORY.md `## Project (Session History)` content with bullets
-  sorted descending (latest first), each linking to the per-session file.
+- Replaces MEMORY.md `## Project (Session History)` content with a **fixed
+  pointer** to `SESSION_INDEX.md` (Phase F.D, Issue #514 — see below), NOT
+  per-session bullets. The inlined history overflowed the context-load window;
+  `SESSION_INDEX.md` + `sessions/*.md` remain the authoritative full history.
 - Markdown table cells emit-escape `|` → `\|` so YAML scalars containing
   literal `|` survive cleanly.
 
@@ -232,6 +235,35 @@ commit/handoff to refresh canonical files from per-session sources.
 `--in-place` is mutually exclusive with `--output` and `--format diff`:
 - `--in-place + --output` → exit 2 (operators uncertain about target file)
 - `--in-place + --format diff` → exit 2 (cutover is not a diff operation)
+
+## Phase F.D — MEMORY.md history is a pointer, not bullets (Issue #514)
+
+Phase F.B wrote the full per-session history as descending bullets into **both**
+`SESSION_INDEX.md` AND MEMORY.md's `## Project (Session History)` region. At
+100+ sessions the MEMORY.md copy grew to ~64KB and **overflowed the ~24KB Claude
+Code context-load window** — the back half of MEMORY.md (curated
+User/Feedback/Reference/Project rows) was silently truncated at session start,
+defeating the index's purpose.
+
+Phase F.D drops the per-session bullets from MEMORY.md. `--in-place` now writes a
+**fixed pointer** between the MEMORY.md markers instead:
+
+```markdown
+> 完整逐-session 历史已迁出 MEMORY.md 以保持其在 Claude Code 加载窗口内可读(Issue #514, Phase F.D)。
+> 权威来源:[SESSION_INDEX.md](SESSION_INDEX.md)(本脚本 `--in-place` 维护的逐-session 表格)+ 各 `sessions/S<N>(-<lane>)?.md` 详档。
+```
+
+- **`SESSION_INDEX.md` is unchanged** — it remains the single authoritative,
+  full per-session index. Per-session `sessions/S<N>(-<lane>)?.md` bodies hold
+  the detail. **No information is lost** — the MEMORY.md bullets were always a
+  redundant projection of SESSION_INDEX.md rows / per-session frontmatter.
+- The pointer is **constant text** → `--in-place` stays byte-identical /
+  idempotent (the Phase F.B idempotency guarantee holds).
+- The `## Project (Session History)` heading + BEGIN/END markers are preserved,
+  so the F.C write-guard / validator machinery continues to operate unchanged
+  (the marker region still exists; only its content shape changed).
+- `emit_memory_history_pointer()` (replaces the former
+  `emit_memory_history_bullets()`) is the source of the pointer text.
 
 ## Phase F.C (`~/.claude/hooks/`) — staged
 
@@ -415,7 +447,7 @@ mutated. Check `.bak` file mtime against original cutover commit timestamp.
 
 ```bash
 scripts/test-regenerate-memory-index.sh           # F.A — 44 cases / 82 assertions
-scripts/test-regenerate-memory-index-in-place.sh  # F.B — 14 cases / 54 assertions
+scripts/test-regenerate-memory-index-in-place.sh  # F.B/F.D — 14 cases / 57 assertions
 scripts/test-mercury-memory-index-write-guard.sh  # F.C — 23 cases / 23 assertions
 scripts/test-mercury-memory-index-validator.sh    # F.C — 35 cases / 35 assertions
 ```

--- a/scripts/regenerate-memory-index.sh
+++ b/scripts/regenerate-memory-index.sh
@@ -11,10 +11,15 @@
 # Modes:
 #   - default (F.A additive):  writes <memory-dir>/INDEX.generated.md;
 #                              canonical MEMORY.md / SESSION_INDEX.md untouched.
-#   - --in-place (F.B cutover): rewrites canonical MEMORY.md "Project (Session
-#                              History)" subsection AND SESSION_INDEX.md table
-#                              body, idempotent via HTML-comment markers.
-#                              BREAKING per Rule 7 v0 → v0.1 promotion.
+#   - --in-place (F.B cutover): rewrites canonical SESSION_INDEX.md table body
+#                              AND MEMORY.md "Project (Session History)"
+#                              subsection, idempotent via HTML-comment markers.
+#                              BREAKING per Rule 7 v0 → v0.1 promotion. Phase F.D
+#                              (Issue #514): the MEMORY.md region is a fixed
+#                              pointer to SESSION_INDEX.md, NOT per-session
+#                              bullets — the inlined history overflowed the
+#                              ~24KB Claude Code context-load window. SESSION_INDEX.md
+#                              + per-session sessions/*.md stay authoritative.
 #
 # Source precedence (per session row, both modes):
 #   1. <memory-dir>/sessions/S<N>(-<lane>)?.md frontmatter — when present,
@@ -472,40 +477,20 @@ emit_session_index_rows_only() {
   fi
 }
 
-# emit_memory_history_bullets — emits MEMORY.md "Project (Session History)"
-# bullets in DESCENDING session order (latest first), one bullet per session.
-# Bullet form when per-session file exists: `- [<file_path>](<file_path>) — <description>`
-# Fallback when only SESSION_INDEX row exists (no per-session file yet):
-#   `- S<id>(-<lane>)? — <description>`
-# Descending order matches existing MEMORY.md convention (latest sessions
-# surface first when MEMORY.md is loaded into Claude Code session context).
-emit_memory_history_bullets() {
-  if [ -n "$SORTED" ]; then
-    printf '%s\n' "$SORTED" | awk -F'\t' '
-      function md_escape(s,    n2, parts2, i2, result2) {
-        n2 = split(s, parts2, "|")
-        result2 = parts2[1]
-        for (i2 = 2; i2 <= n2; i2++) result2 = result2 "\\|" parts2[i2]
-        return result2
-      }
-      { lines[NR] = $0; n = NR }
-      END {
-        for (i = n; i >= 1; i--) {
-          split(lines[i], f, "\t")
-          # f[1]=sid f[2]=date f[3]=theme f[4]=outcome f[5]=origin f[6]=file_path
-          fpath = (f[6] == "") ? "" : f[6]
-          # Markdown bullets render `|` literally — escape for safety even though
-          # bullet content is more permissive than table cells.
-          desc = md_escape(f[3])
-          if (fpath != "") {
-            printf "- [%s](%s) — %s\n", fpath, fpath, desc
-          } else {
-            printf "- %s — %s\n", f[1], desc
-          }
-        }
-      }
-    '
-  fi
+# emit_memory_history_pointer — emits a FIXED pointer block for the MEMORY.md
+# "Project (Session History)" marker region (Phase F.D, Issue #514). MEMORY.md
+# no longer inlines per-session bullets: the full per-session history was held
+# redundantly in MEMORY.md AND SESSION_INDEX.md, and at 100+ sessions it
+# overflowed the ~24KB Claude Code context-load window so the back half of
+# MEMORY.md was silently truncated at session start. SESSION_INDEX.md (the
+# superset table) + the per-session sessions/S<N>(-<lane>)?.md bodies remain the
+# authoritative, non-truncated home. Output is constant text (no session-derived
+# content) → byte-identical across runs, preserving --in-place idempotency.
+emit_memory_history_pointer() {
+  cat <<'POINTER_EOF'
+> 完整逐-session 历史已迁出 MEMORY.md 以保持其在 Claude Code 加载窗口内可读(Issue #514, Phase F.D)。
+> 权威来源:[SESSION_INDEX.md](SESSION_INDEX.md)(本脚本 `--in-place` 维护的逐-session 表格)+ 各 `sessions/S<N>(-<lane>)?.md` 详档。
+POINTER_EOF
 }
 
 # splice_session_index_in_place <source_file> <generated_rows_file>
@@ -631,8 +616,8 @@ splice_memory_history_in_place() {
 # ---------------------------------------------------------------------------
 if [ "$IN_PLACE" = "1" ]; then
   ROWS_TMP=$(mktemp "${TMPDIR:-/tmp}/regen-memidx.XXXXXX")    || die "mktemp failed (rows tmp)"
-  BULLETS_TMP=$(mktemp "${TMPDIR:-/tmp}/regen-memidx.XXXXXX") || die "mktemp failed (bullets tmp)"
-  trap 'rm -f "$TMPFILE" "$TMPSEEN" "$ROWS_TMP" "$BULLETS_TMP"' EXIT
+  POINTER_TMP=$(mktemp "${TMPDIR:-/tmp}/regen-memidx.XXXXXX") || die "mktemp failed (pointer tmp)"
+  trap 'rm -f "$TMPFILE" "$TMPSEEN" "$ROWS_TMP" "$POINTER_TMP"' EXIT
 
   # First-run safety: backup canonical files before mutation. Operators recover via
   # `cp <file>.pre-cutover.bak <file>` if cutover output drifts from expectation.
@@ -647,10 +632,10 @@ if [ "$IN_PLACE" = "1" ]; then
   done
 
   emit_session_index_rows_only > "$ROWS_TMP"    || die "emit session index rows failed"
-  emit_memory_history_bullets  > "$BULLETS_TMP" || die "emit memory bullets failed"
+  emit_memory_history_pointer  > "$POINTER_TMP" || die "emit memory pointer failed"
 
   splice_session_index_in_place "$SESSION_INDEX_FILE" "$ROWS_TMP"
-  splice_memory_history_in_place "$MEMORY_FILE"        "$BULLETS_TMP"
+  splice_memory_history_in_place "$MEMORY_FILE"        "$POINTER_TMP"
 
   # H1 dual-verify fix + Argus iter1 BEGIN/END symmetry fix: post-splice marker
   # verification. Three failure modes guarded:

--- a/scripts/regenerate-memory-index.sh
+++ b/scripts/regenerate-memory-index.sh
@@ -634,8 +634,8 @@ if [ "$IN_PLACE" = "1" ]; then
   emit_session_index_rows_only > "$ROWS_TMP"    || die "emit session index rows failed"
   emit_memory_history_pointer  > "$POINTER_TMP" || die "emit memory pointer failed"
 
-  splice_session_index_in_place "$SESSION_INDEX_FILE" "$ROWS_TMP"
-  splice_memory_history_in_place "$MEMORY_FILE"        "$POINTER_TMP"
+  splice_session_index_in_place "$SESSION_INDEX_FILE" "$ROWS_TMP"     || die "splice session index failed: $SESSION_INDEX_FILE"
+  splice_memory_history_in_place "$MEMORY_FILE"        "$POINTER_TMP" || die "splice memory history failed: $MEMORY_FILE"
 
   # H1 dual-verify fix + Argus iter1 BEGIN/END symmetry fix: post-splice marker
   # verification. Three failure modes guarded:

--- a/scripts/test-regenerate-memory-index-in-place.sh
+++ b/scripts/test-regenerate-memory-index-in-place.sh
@@ -314,12 +314,14 @@ write_session_file "$M12" "S1.md" "theme-1" "out-1"
 write_session_file "$M12" "S2.md" "theme-2" "out-2"
 write_session_file "$M12" "S3.md" "theme-3" "out-3"
 bash "$SCRIPT" --memory-dir "$M12" --in-place >/dev/null 2>&1
-# Count per-session bullets inside the MEMORY.md marker region — must be ZERO under F.D
-# (the full per-session history lives in SESSION_INDEX.md + sessions/*.md, not MEMORY.md)
+# Count ANY markdown bullet inside the MEMORY.md marker region — must be ZERO under F.D
+# (the region holds only the `>` pointer; full per-session history lives in
+# SESSION_INDEX.md + sessions/*.md). Per Argus #515: match any `- ` bullet form, not just
+# the `- [sessions/S...]` link form, so a regressed fallback bullet (`- S1 — ...`) is also caught.
 BULLET_COUNT=$(awk '
   /^<!-- BEGIN: scripts\/regenerate-memory-index.sh --in-place/ { in_marker = 1; next }
   /^<!-- END: scripts\/regenerate-memory-index.sh --in-place/ { in_marker = 0; next }
-  in_marker && /^- \[sessions\/S/ { c++ }
+  in_marker && /^- / { c++ }
   END { print c + 0 }
 ' "$M12/MEMORY.md")
 CASES=$((CASES + 1))

--- a/scripts/test-regenerate-memory-index-in-place.sh
+++ b/scripts/test-regenerate-memory-index-in-place.sh
@@ -206,12 +206,13 @@ assert_file_contains "first_run_session_index_end_marker"   "$M3/SESSION_INDEX.m
 assert_file_contains "first_run_session_index_new_theme"    "$M3/SESSION_INDEX.md" "new-theme"
 assert_file_NOT_contains "first_run_session_index_old_theme" "$M3/SESSION_INDEX.md" "original-theme"
 
-# --- Test 4: --in-place first run inserts markers in MEMORY.md ---
+# --- Test 4: --in-place first run inserts markers in MEMORY.md (Phase F.D #514: pointer, not bullets) ---
 assert_file_contains "first_run_memory_begin_marker" "$M3/MEMORY.md" "BEGIN: scripts/regenerate-memory-index.sh --in-place"
 assert_file_contains "first_run_memory_end_marker"   "$M3/MEMORY.md" "END: scripts/regenerate-memory-index.sh --in-place"
-# Bullet uses per-session file path
-assert_file_contains "first_run_memory_bullet"       "$M3/MEMORY.md" "[sessions/S1.md](sessions/S1.md) — new-theme"
-# Original content gone
+# Phase F.D: MEMORY.md region is a fixed pointer to SESSION_INDEX.md, NOT per-session bullets
+assert_file_contains "first_run_memory_pointer"      "$M3/MEMORY.md" "[SESSION_INDEX.md](SESSION_INDEX.md)"
+assert_file_NOT_contains "first_run_memory_no_bullet" "$M3/MEMORY.md" "[sessions/S1.md](sessions/S1.md)"
+# Original content gone (replaced by the pointer)
 assert_file_NOT_contains "first_run_memory_old_bullet" "$M3/MEMORY.md" "S1 original"
 
 # --- Test 5: --in-place preserves SESSION_INDEX header + footer + table header rows ---
@@ -273,14 +274,24 @@ else
   printf 'FAIL: subsequent_no_marker_dup — expected 1 BEGIN marker, got %d\n' "$BEGIN_COUNT" >&2
 fi
 
-# --- Test 10: bullet falls back to plain S<id> form when no per-session file ---
+# --- Test 10: no per-session file → MEMORY.md still shows only the pointer (Phase F.D);
+#     SESSION_INDEX.md table keeps the fallback row from the existing SESSION_INDEX row ---
 M10=$(mk_memdir "bullet-fallback")
 write_session_index "$M10" '| S1 | 2026-01-01 | from-index-only | from-index-out | — |'
 write_memory_md "$M10" '- placeholder'
 # No per-session file written
 bash "$SCRIPT" --memory-dir "$M10" --in-place >/dev/null 2>&1
-assert_file_contains "bullet_plain_form" "$M10/MEMORY.md" "- S1 — from-index-only"
-assert_file_NOT_contains "bullet_no_link" "$M10/MEMORY.md" "[sessions/S1.md]"
+assert_file_contains "memory_pointer_no_per_session" "$M10/MEMORY.md" "[SESSION_INDEX.md](SESSION_INDEX.md)"
+assert_file_NOT_contains "memory_no_plain_bullet" "$M10/MEMORY.md" "- S1 — from-index-only"
+# Fallback still feeds the SESSION_INDEX table (the authoritative session-history home).
+# Tighter (Codex audit): assert the row was regenerated INTO the managed marker region,
+# not merely left as pre-run fixture text sitting outside the markers.
+awk '
+  /^<!-- BEGIN: scripts\/regenerate-memory-index.sh --in-place/ { in_marker = 1; next }
+  /^<!-- END: scripts\/regenerate-memory-index.sh --in-place/   { in_marker = 0 }
+  in_marker { print }
+' "$M10/SESSION_INDEX.md" > "$M10/.index-region"
+assert_file_contains "session_index_fallback_row_in_region" "$M10/.index-region" "from-index-only"
 
 # --- Test 11: pipe escape in description and outcome cells ---
 M11=$(mk_memdir "pipe-escape")
@@ -293,7 +304,7 @@ assert_file_contains "pipe_escape_single" "$M11/SESSION_INDEX.md" 'theme with \|
 # Double pipe escaped to \|\|
 assert_file_contains "pipe_escape_double" "$M11/SESSION_INDEX.md" 'outcome with \|\| double'
 
-# --- Test 12: descending sort in MEMORY.md bullets ---
+# --- Test 12: MEMORY.md carries ONLY the pointer regardless of session count (Phase F.D #514) ---
 M12=$(mk_memdir "memory-descending")
 write_session_index "$M12" '| S1 | 2026-01-01 | t1 | o1 | — |
 | S2 | 2026-01-02 | t2 | o2 | — |
@@ -303,22 +314,22 @@ write_session_file "$M12" "S1.md" "theme-1" "out-1"
 write_session_file "$M12" "S2.md" "theme-2" "out-2"
 write_session_file "$M12" "S3.md" "theme-3" "out-3"
 bash "$SCRIPT" --memory-dir "$M12" --in-place >/dev/null 2>&1
-# Extract bullets in order, expect S3 before S2 before S1 (descending)
-ORDER=$(awk '
+# Count per-session bullets inside the MEMORY.md marker region — must be ZERO under F.D
+# (the full per-session history lives in SESSION_INDEX.md + sessions/*.md, not MEMORY.md)
+BULLET_COUNT=$(awk '
   /^<!-- BEGIN: scripts\/regenerate-memory-index.sh --in-place/ { in_marker = 1; next }
   /^<!-- END: scripts\/regenerate-memory-index.sh --in-place/ { in_marker = 0; next }
-  in_marker && /^- \[sessions\/S/ {
-    match($0, /sessions\/S[0-9]+\.md/)
-    if (RLENGTH > 0) printf "%s ", substr($0, RSTART+9, RLENGTH-12)
-  }
+  in_marker && /^- \[sessions\/S/ { c++ }
+  END { print c + 0 }
 ' "$M12/MEMORY.md")
 CASES=$((CASES + 1))
-if [ "$ORDER" = "S3 S2 S1 " ]; then
+if [ "$BULLET_COUNT" -eq 0 ]; then
   PASS=$((PASS + 1))
 else
   FAIL=$((FAIL + 1))
-  printf 'FAIL: memory_descending_order — expected "S3 S2 S1 ", got "%s"\n' "$ORDER" >&2
+  printf 'FAIL: memory_no_per_session_bullets — expected 0 bullets in marker region, got %d\n' "$BULLET_COUNT" >&2
 fi
+assert_file_contains "memory_pointer_present_multi" "$M12/MEMORY.md" "[SESSION_INDEX.md](SESSION_INDEX.md)"
 
 # --- Test 13: ascending sort in SESSION_INDEX.md table preserved ---
 ORDER=$(awk -F'|' '


### PR DESCRIPTION
Closes #514

## 问题

`MEMORY.md` 每次 session 启动加载进 Claude Code context。`regenerate-memory-index.sh --in-place`(Phase F.B)把整份 per-session 历史以倒序 bullets 写进它的 `## Project (Session History)` marker 区。100+ session 后这块 ~64KB,**超出 ~24KB context 加载窗口** → MEMORY.md 后半(curated User/Feedback/Reference 索引行)被静默截断,session 启动看不到。

## 方案(Phase F.D)

`--in-place` 改为在 MEMORY.md marker 区写**一行指向 `SESSION_INDEX.md` 的固定指针**,不再写 per-session bullets。`SESSION_INDEX.md` 全量表格 + `sessions/*.md` body **保持不变**,作为 session 历史的权威单一来源 —— **零信息丢失**(MEMORY.md 的 bullets 本就是它们的冗余投影)。

- 复用现有 splice + BEGIN/END markers + F.C write-guard/validator,改动面最小。
- 指针为常量文本 → `--in-place` 幂等性保持(byte-identical)。
- `## Project (Session History)` heading + markers 保留 → F.C 机制不受影响。

## 改动

| 文件 | 改动 |
|---|---|
| `scripts/regenerate-memory-index.sh` | `emit_memory_history_bullets()` → `emit_memory_history_pointer()`(固定 quoted-heredoc);`--in-place` 调用点切换;header 文档;tmpfile `BULLETS_TMP`→`POINTER_TMP` |
| `scripts/test-regenerate-memory-index-in-place.sh` | Test 4/10/12 改为断言指针行为(Test 10 收紧:断言 SESSION_INDEX fallback 行重生成在 marker 区**内**) |
| `.mercury/docs/guides/memory-index-regenerate.md` | phase 表加 F.D 行 + F.B cutover bullet 重写 + 新增 §Phase F.D + 测试计数 54→57 |

## 测试

| Harness | 结果 |
|---|---|
| `test-regenerate-memory-index-in-place.sh` | **14 cases / 57 assertions / 0 fail** |
| `test-regenerate-memory-index.sh` (F.A) | 44 / 82 / 0 |
| `test-mercury-memory-index-write-guard.sh` (F.C) | 23 / 23 / 0 |
| `test-mercury-memory-index-validator.sh` (F.C) | 35 / 35 / **1 fail(既有,见下)** |

`bash -n` 语法洁净;无 `emit_memory_history_bullets` 残留引用;幂等性经 reviewer 实测(连跑两次 MEMORY.md sha256 一致)。

### ⚠️ 既有失败(非本 PR 引起,out-of-scope)

validator 测试 `T6.missing-repo.no-output` 在**未改的 develop 上同样失败**,根因:真实 `~/.claude/.../sessions/S112.md` frontmatter 损坏致 `regenerate-memory-index.sh` 解析 exit 1 + T6 测试未隔离 `MERCURY_MEMORY_DIR`(回退到真实 memory 目录)。与本 PR 无关(未触碰 validator / `--format diff` / 解析路径)。可另开 follow-up Issue(测试隔离 + 真实数据修复)。

## dual-verify

- **Claude code-reviewer**:APPROVE-WITH-MINOR(0 Critical/High/Medium/Low;2 nit 均已修:文档样例反引号 + `BULLETS_TMP` 重命名)。实测验证幂等 / marker 保全 / F.A 未动 / 测试非空过。
- **Codex sync-audit**:PASS(无阻塞;test-coverage 提示「Test 10 应在 marker 区内断言」已采纳)。

## Lineage

Phase F.A #329 / F.B #330 / F.C #331(均 CLOSED)续作。Lane: side-bug。

🤖 Generated with [Claude Code](https://claude.com/claude-code)