### PR TITLE
chore(#517): sunset gh-project-flow + tombstone AgentKB + re-eval #384 ADR (mem0 retired)

### DIFF
--- a/.claude/skills/dev-pipeline/PHILOSOPHY.md
+++ b/.claude/skills/dev-pipeline/PHILOSOPHY.md
@@ -51,7 +51,7 @@ Three is not magic. Two is too few (one mistake, one fix, no slack). Four is too
 
 ## What it IS
 
-A 220-line markdown file that says: when a coding task is well-scoped and you want a second opinion, run it through this loop. Copy the file into any GitHub-based repository that has `.claude/agents/dev.md` and `.claude/agents/acceptance.md` defined, strip the Mercury-specific `/gh-project-flow` line out of Phase 6, and you are done.
+A 220-line markdown file that says: when a coding task is well-scoped and you want a second opinion, run it through this loop. Copy the file into any GitHub-based repository that has `.claude/agents/dev.md` and `.claude/agents/acceptance.md` defined, and you are done — Phase 6 already hands off via a portable `Closes #N` (no Mercury-specific `/gh-project-flow` step to strip).
 
 The methodology is the asset. The skill file is the artifact.
 

--- a/.claude/skills/dev-pipeline/SKILL.md
+++ b/.claude/skills/dev-pipeline/SKILL.md
@@ -278,7 +278,7 @@ Phase 6 is reached **only on `pass`**. Cleanup for non-pass terminal exits is ha
 On pass:
 1. Confirm commit is pushed (`git status`)
 2. If user requested PR: invoke `/pr-flow`
-3. Mark related GitHub Project item Done (via `/gh-project-flow` if Mercury self-dev) or via `Closes #N` in PR (general case)
+3. Mark the related GitHub Issue done — if a PR was created, its `Closes #N` auto-closes the issue on merge; otherwise close/update the issue manually.
 4. Summarize in Chinese for the user
 5. After PR merge is confirmed, run the **Phase 5 Cleanup block** as the final action (see Phase 5 above — the retry + `rm -rf` fallback logic is the SoT and is not duplicated here).
 
@@ -304,10 +304,6 @@ This skill is designed to be portable to any repository that uses GitHub + Claud
 - The target repo uses **GitHub Issues + GitHub PRs** (the protocol references `Closes #N`, `gh pr create`, and Mercury's `/pr-flow` skill — all GitHub-specific). Non-GitHub repos would need protocol adaptation.
 - The repo has a sane verifyCommands story (tests, lint, build commands that exit non-zero on failure)
 - The user is on a feature branch (not main, develop, or master)
-
-The `/gh-project-flow` reference in Phase 6 is **Mercury-specific** and should be removed or replaced when porting elsewhere — it is mentioned only because Mercury self-development uses Project #3 for task tracking.
-
-To use it elsewhere, copy this skill directory plus the two agent files, then strip the `/gh-project-flow` line from Phase 6. No other Mercury dependency.
 
 ## Known Limitations
 

--- a/.mercury/docs/guides/fanout-and-skill-migration-guardrails.md
+++ b/.mercury/docs/guides/fanout-and-skill-migration-guardrails.md
@@ -123,11 +123,12 @@ fan-out 前**逐条**过,任一不满足即调整方案(降规模 / 换 model �
 
 > 防侵蚀的可核对基线:下列稳定 skill **不得**被删除/掏空改投模板,除非对应 PR 通过 §4.3 decision gate。
 
-### 5.1 当前稳定 Mercury 自有 skill(`.claude/skills/`,NL 形态,**12 个**)
+### 5.1 当前稳定 Mercury 自有 skill(`.claude/skills/`,NL 形态,**11 个**)
 
-`animate-frames` · `autoresearch` · `caveman-toggle` · `dev-pipeline` · `dual-verify` · `gh-project-flow` · `handoff` · `pr-flow` · `subagent-driven-development` · `systematic-debugging` · `verification-before-completion` · `web-research`
+`animate-frames` · `autoresearch` · `caveman-toggle` · `dev-pipeline` · `dual-verify` · `handoff` · `pr-flow` · `subagent-driven-development` · `systematic-debugging` · `verification-before-completion` · `web-research`
 
 > 基线快照 2026-06-28(#517):kb-lint 硬依赖 unset 的 $AGENTKB_DIR 已归档至 archive/skills/,NL-skill 13→12。
+> 基线快照 2026-06-28(#517):gh-project-flow(BOOTSTRAP-ONLY,Project#3 废弃)归档至 archive/skills/,NL-skill 12→11。
 
 ### 5.2 当前 Workflow 模板(`.claude/workflows/`,**4 个**,P0 #479 新建,非从 skill 迁来)
 
@@ -135,9 +136,9 @@ fan-out 前**逐条**过,任一不满足即调整方案(降规模 / 换 model �
 
 ### 5.3 侵蚀检测规则(回归基线 invariant)
 
-1. **NL-skill 计数下限 = 12**:`.claude/skills/` 的**子目录数**(只数目录,不数散落文件)**不得低于 12**,除非某次下降由一个通过 §4.3 decision gate 的 PR 显式解释。核对命令(只数目录 → 误放的非目录文件不会掩盖被删 skill;给两种环境形态):
-   - PowerShell(Windows 主环境):`(Get-ChildItem .claude/skills -Directory).Count` ≥ 12
-   - bash / git-bash:`ls -d .claude/skills/*/ | wc -l` ≥ 12(`*/` glob 只匹配目录)
+1. **NL-skill 计数下限 = 11**:`.claude/skills/` 的**子目录数**(只数目录,不数散落文件)**不得低于 11**,除非某次下降由一个通过 §4.3 decision gate 的 PR 显式解释。核对命令(只数目录 → 误放的非目录文件不会掩盖被删 skill;给两种环境形态):
+   - PowerShell(Windows 主环境):`(Get-ChildItem .claude/skills -Directory).Count` ≥ 11
+   - bash / git-bash:`ls -d .claude/skills/*/ | wc -l` ≥ 11(`*/` glob 只匹配目录)
 2. **迁移留痕**:任何把 `.claude/skills/<name>/` 改写为 `.claude/workflows/<name>.js`(或为模板掏空一个 NL-skill)的 PR,必须:(a) PR body 答完 §4.3 五问;(b) 保留原 NL-skill ≥1 release 周期;(c) 走 dual-verify;(d) 在本表 §5.1/§5.2 记录迁移(基线随之更新)。
 3. **模板不夺触发词**:新增 Workflow 模板的 `meta.name` / 触发词不得遮蔽既有 skill 触发词(`dual-verify`/`pr-flow`/`autoresearch` 等),避免用户调用被静默改路由。
 4. **基线更新**:每次新增/迁移/删除 skill 或模板,**同一 PR** 内更新本节快照 + 日期,使本基线始终反映 ground truth。

--- a/.mercury/docs/research/cma-memory-vs-mem0-2026-05.md
+++ b/.mercury/docs/research/cma-memory-vs-mem0-2026-05.md
@@ -1,10 +1,21 @@
 # CMA Memory + `/responses/compact` vs Mercury mem0 — ADR
 
-> 状态: **生效中** | 制定日期: 2026-05-16 | 决策者: 392fyc (main lane S102) | Closes: [Issue #384](https://github.com/392fyc/Mercury/issues/384)
+> 状态: **已取代 (SUPERSEDED) — re-eval 2026-06-28** | 原制定: 2026-05-16 (主 lane S102) | 取代依据: mem0 已 #518 退役 (见下方 §Re-eval 2026-06-28) | Closes: [Issue #384](https://github.com/392fyc/Mercury/issues/384)
 > Parent context: [Issue #381 tech intel sweep](https://github.com/392fyc/Mercury/issues/381) + `~/.claude/projects/D--Mercury-Mercury/memory/research/tech-intel-sweep-2026-05-12.md` (user-level memory file, 不在 Mercury repo)
 > Predecessor: PR #258 (`scripts/mem0_hooks.py` 引入, Mercury #252 **Phase A** 2026-04-17 — adapter prototype; Phase B hook 接线后续 user-level 落地 per CLAUDE.md #259 governance pattern)
 >
 > **路径约定**: 本 ADR 涉及的用户级路径形式 `~/.claude/...` 等价于 `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/...`, 二者可任选一种书写, env 形式在多账户 / CI 下更可移植 — 沿用 CLAUDE.md §"Related Repositories" 约定。
+
+---
+
+## Re-eval 2026-06-28 — Verdict (a) SUPERSEDED
+
+**mem0 已于 [#518](https://github.com/392fyc/Mercury/issues/518) 完全退役**(#517 瘦身审计实测空仓:Qdrant 0 行 / `history.db` 0 行,自 2026-04-18 从未写入;根因 `OPENAI_API_KEY` unset → 静默 no-op;`recall()` 零调用方)。原 Verdict (a)「mem0 + Qdrant 保持 canonical memory layer」的**前提(mem0 在用且有召回价值)已被空仓证据证伪**,故 verdict (a) 失效。
+
+- **触发机制**:原 4 个 monitor 条件(CMA non-runtime access / dreaming GA / mem0 维护成本飙升 / Mercury pivot CMA)**无一 fire**——退役由一个**未预见的新增条件**(空仓 + 从未使用)+ 用户裁定驱动,非原 ADR 预设路径。
+- **当前长期记忆 = 文件式**(无向量语义召回层):auto-memory `MEMORY.md` + `SESSION_INDEX.md` + handoff KB(Mercury_KB)+ daily-log flush。
+- **落地**:user-level runtime(#518)+ repo Phase A 原型(#521)+ CLAUDE.md(#519)+ DIRECTION.md 模块2(#520)全退役。
+- 下方原 ADR 正文**保留作历史**(2026-05-16 决策时点快照)。
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ Mercury 的部分功能跨仓库运作。以下表格记录外部仓库与 Mercu
 |------|----------|---------|------|
 | **Memory layer (user-level)** | `~/.claude/hooks/` + `~/.claude/scripts/` | flush + session-start/end hooks + cost tracker (#361) | 运行时独立于任何 git 仓库；cost-tracker per-session jsonl 在 `~/.claude/scripts/cost-tracker/`（mem0 层已于 #518 退役） |
 | **claude-handoff** | 插件仓库 <https://github.com/392fyc/claude-handoff> | Session handoff / 续接 + `session_chain` SQLite | 作为本地插件挂载在 `~/.claude/settings.json` marketplace |
-| **AgentKB (archival-pending)** | `$AGENTKB_DIR` | 旧 Memory 层（Karpathy-style KB），Mercury #252 后被 mem0 取代 | 待归档；salvage 审计见 `.mercury/docs/research/agentkb-fork-salvage-audit-2026-04-17.md` |
+| **AgentKB** *(retired)* | `$AGENTKB_DIR`（本机 unset） | 旧 Memory 层（Karpathy-style KB），#252 被 mem0 取代；mem0 自身已 #518 退役 → 当前长期记忆=文件式 | **已退役**（运行时 de-ref 完成、AGENTKB_DIR unset、kb-lint 已归档、mem0_migrate 已删）；salvage 审计见 `.mercury/docs/research/agentkb-fork-salvage-audit-2026-04-17.md` |
 | **Mercury_KB** | Obsidian vault（路径见 `.handoff-config` 的 `kb_dir`） | 项目专属 KB；现为 handoff 文档落点（#475，经 `.handoff-config` kb_dir 接线） | **active** — 经直接文件系统访问（非 obsidian MCP）；旧「已归档」表述 stale，#517 审计对齐 |
 
 **跨仓库开发注意事项：**

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ On session start, Claude Code auto-discovers every agent under `.claude/agents/`
 
 The skills under `.claude/skills/` and sub-agents under `.claude/agents/` are **detachable** — each directory is self-contained and can be copied into another Claude Code project. Skill frontmatter lists the trigger phrases in English and Chinese. Treat the directory contents as the authoritative list; the snapshot below is current as of this writing and intentionally not a pinned count.
 
-Skills (12 at time of writing):
+Skills (11 at time of writing):
 
 | Skill | Purpose |
 |-------|---------|
@@ -115,7 +115,6 @@ Skills (12 at time of writing):
 | `systematic-debugging` | Root-cause-first debugging workflow |
 | `subagent-driven-development` | Execute a plan via fresh sub-agent per task, two-stage review |
 | `verification-before-completion` | Hard evidence-before-claims checkpoint before "done" |
-| `gh-project-flow` | GitHub Project task pull/update for Mercury's own development |
 | `animate-frames` | Pixel-frame animation pipeline (sprite sequences) via the `gpt-image-2` adapter |
 | `caveman-toggle` | Persistent concise-output mode |
 

--- a/archive/skills/gh-project-flow/SKILL.md
+++ b/archive/skills/gh-project-flow/SKILL.md
@@ -6,6 +6,8 @@ user-invocable: true
 allowed-tools: Bash, Read, Grep, Write, Edit
 ---
 
+> **ARCHIVED 2026-06-28 (#517)**: BOOTSTRAP-ONLY skill(自声明 Phase 3 退役)。Project #3 看板事实废弃(最大 issue ~#248 vs repo #521+),Mercury 现走 issue-first(Closes #N)。随 #517 做减法归档;如需恢复看板自动化可从此还原。
+
 # gh-project-flow — Bootstrap Task Management for Mercury Self-Dev
 
 > **BOOTSTRAP-ONLY**. This skill drives Mercury's *own* development task board (GitHub Project #3, owner `392fyc`). It is not a general-purpose project tracker. Mercury's vision for general dev is Memory Layer + Dev Pipeline, which arrive in Phase 3. When that ships, this skill is deprecated.


### PR DESCRIPTION
## 概要

#517 做减法 DEFER 批 C(用户授权全部依次执行)。3 个 harness/文档清理。

Refs #517 #518

## 改动
1. **archive `gh-project-flow` skill** — BOOTSTRAP-ONLY 自声明 + Project #3 看板事实废弃(open 但最大 issue ~#248 vs repo #521,Mercury 现 issue-first)→ `git mv` archive/skills/ + ARCHIVED 横幅 + 从 README/guardrails 移除(skill 计数 12→11)+ 去 dev-pipeline(核心 skill)的 `/gh-project-flow` 引用(SKILL.md Phase 6 + PHILOSOPHY.md)。**Project #3 看板本身归用户,未触碰。**
2. **AgentKB 墓碑化**(CLAUDE.md L58)— AgentKB 被 #252 mem0 取代,mem0 自身已 #518 退役 → 标 retired(运行时 de-ref 完成、AGENTKB_DIR unset)。L66/L80 的 AGENTKB grep 校验保留。
3. **#384 ADR re-eval** — mem0 退役 → `cma-memory-vs-mem0-2026-05.md` 状态改 SUPERSEDED + 插 Re-eval 2026-06-28 section(verdict (a) 前提失效;原 4 monitor 无一 fire,空仓为未预见新增条件)。原 ADR 正文保留作历史。

## dual-verify(Claude critic + Codex)
两腿抓 4 处:① PHILOSOPHY.md 漏改过时 strip 指令(in-scope miss)② Phase 6 step 3 no-PR 路径逻辑 gap ③ Detachability 冗余中文行 ④ CLAUDE.md「kb-lint 已删」精度(实为归档)→ 全修。计数一致(实测 .claude/skills/=11)、无悬挂 path 引用、scope 干净(未碰 DIRECTION/EXECUTION-PLAN)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)