### PR TITLE
docs(#517): migrate cherry-pick carve-out detail to guide, thin pointer in CLAUDE.md (context budget)

### DIFF
--- a/.mercury/docs/guides/cherry-pick-carve-out.md
+++ b/.mercury/docs/guides/cherry-pick-carve-out.md
@@ -1,0 +1,81 @@
+---
+title: Cherry-pick carve-out — CLI-generated scaffolding (Category A / B)
+extends: CLAUDE.md §"Cherry-pick protocol"
+issue: 517
+---
+
+# Cherry-pick carve-out: CLI-generated scaffolding
+
+> 本指南是 CLAUDE.md §"Cherry-pick protocol"(rules 1-6)的扩展细则,从 CLAUDE.md 迁出以瘦身每会话 auto-load 预算(#517 批 D)。CLAUDE.md 保留操作摘要 + 指向本文件的指针。
+
+The cherry-pick protocol in CLAUDE.md (§"Cherry-pick protocol") applies to **files lifted from a specific upstream commit** (canonical upstream path + SHA + drift monitoring). It does NOT cleanly fit two adjacent cases that produce files via CLI invocation rather than direct upstream-path import. Split into 2 sub-categories:
+
+## Category A — Pure scaffolding (one-shot project init)
+
+Generators that produce a one-time project skeleton from templated boilerplate. The templates ship with the CLI itself; no per-file upstream "source path" exists.
+
+| Generator | Invocation | Output scope |
+|---|---|---|
+| **create-tauri-app** | `pnpm create tauri-app` | Tauri 2 project skeleton (Rust workspace + JS frontend templated config) |
+| **create-vite** | `pnpm create vite` | Vite + framework skeleton (TS config + entry + index.html) |
+
+**Required for Category A**:
+
+1. **Provenance line in PR body**: PR creating the scaffold records the exact CLI invocation + version at invocation time (e.g., "Scaffold via `pnpm create tauri-app`, create-tauri-app vX.Y at 2026-MM-DD"). Use the actual version, not a placeholder. Note: `pnpm create` resolves the create-* starter package transiently and does NOT pin the generator into the produced app's `pnpm-lock.yaml` — the PR-body line is the only durable provenance record.
+2. **License compatibility check**: confirm the scaffold output's license is MIT / Apache-2.0 / similarly permissive (Tauri 2 = MIT/Apache-2.0; Vite = MIT). Record in PR body.
+3. **Customization allowed without attribution**: post-scaffold Mercury edits to the generated files do NOT require per-file `Based on` attribution.
+
+**NOT required for Category A**:
+
+- ❌ Manifest entry in `.mercury/state/upstream-manifest.json`
+- ❌ SKILL.md frontmatter `upstream_sha` field
+- ❌ Per-file `# Based on <upstream>` comment
+- ❌ Drift monitoring via `scripts/upstream-drift-check.sh`
+
+## Category B — Registry-based item import (per-item upstream lift)
+
+CLI tools that fetch named items from a versioned registry. Each `add` invocation imports a concrete registry item that has a canonical upstream identity. Closer to a per-file cherry-pick than to pure scaffolding. **Applies to ALL `shadcn add` invocations regardless of registry item type** — components, hooks, utilities, pages, fonts, themes, config files, rules, libraries, or any other resource a shadcn-compatible registry exposes (per [shadcn CLI docs](https://ui.shadcn.com/docs/cli) — `add` consumes registry items by name, URL, or local path).
+
+| Generator | Invocation | Registry default | Output scope |
+|---|---|---|---|
+| **shadcn (any registry item)** | `pnpm dlx shadcn@latest add <name-or-url-or-path>` | <https://ui.shadcn.com/r> (official shadcn registry) | Any registry-backed resource: UI components, hooks, utilities, pages, themes, fonts, config files, rules, libraries, etc. Resource arg is a registry item name (default registry), a URL (any registry), or a local path. |
+
+**Required for Category B**:
+
+1. **Provenance line in PR body** (stricter than Category A): record (a) exact CLI invocation including the item-name / URL / path arg(s), (b) shadcn CLI version at invocation time, (c) **source identifier — always**, in one of three forms depending on the arg kind:
+   - For a registry item name (default registry): `source = default registry (https://ui.shadcn.com/r)`
+   - For a URL arg (custom registry or registry item URL): `source = custom registry URL: <url>`
+   - For a local-path arg (file-system import, not registry-fetched): `source = local path: <relative-path>` (note that local-path adds bypass the registry layer entirely — the path IS the upstream identity)
+
+   The source identifier determines license + upstream identity, so the arg kind must be unambiguous on the record. (d) registry item type if non-component (e.g., `registry:hook`, `registry:font`, `registry:lib`, `registry:page`, `registry:file`). Example: "Imported via `pnpm dlx shadcn@latest add tabs`, shadcn CLI vX.Y, source = default registry (https://ui.shadcn.com/r), item type = registry:component at 2026-MM-DD".
+2. **License compatibility check**: confirm the license of the actual source you're importing from at invocation time, NOT a fixed assumption. The shadcn default registry is MIT (illustrative); custom registries may use different licenses, and local-path adds inherit the license of the source path's project. Verify per import + record the verified license in PR body.
+3. **Customization is owned by Mercury after add**: shadcn's design philosophy is "copy-paste with full ownership" — once added, the file is Mercury-owned and editable without per-file upstream-tracking attribution.
+
+**NOT required for Category B** (registry items are not pinned to upstream SHA; shadcn's contract is "you own the code"):
+
+- ❌ Manifest entry in `.mercury/state/upstream-manifest.json` (registry items are not version-pinned to a specific upstream commit; shadcn's model deliberately decouples from upstream after add)
+- ❌ Per-file `# Based on <upstream>` comment
+- ❌ Drift monitoring via `scripts/upstream-drift-check.sh`
+
+**Local-path guard — when local-path adds fall back to full cherry-pick protocol**
+
+The local-path arg form is intended for Mercury-internal registry items (e.g., a path under `mercury-gui/` or a sibling Mercury repo path). It is NOT a back door for importing arbitrary external-project files via a local checkout.
+
+A local-path add **falls back to the full cherry-pick protocol (rules 1-6)** when ANY of these conditions hold. Resolve the source path with `git rev-parse --show-toplevel` for the Mercury repo root (or `realpath` on the path arg) before applying the test — symlinks, `..` traversal, and absolute paths are all normalized this way:
+
+- The resolved path is **not** under the current Mercury repo working tree (i.e., does not have the `git rev-parse --show-toplevel` output as a prefix)
+- The resolved path is under a git submodule whose upstream points to a third-party repo (check via `git submodule status`)
+- The resolved path is under a `node_modules/`, `vendor/`, or other package-manager-staged directory whose contents originate from an external package
+- The resolved path is under a temporary checkout of an external project staged for import (e.g., a `tmp/`, `scratch/`, or any cloned third-party repo directory)
+
+When in doubt, treat the local-path source as a file-lift cherry-pick (full protocol applies). The carve-out exists to formalize "shadcn-style registry add from a versioned source" — local-path is the narrowest case and the guard above (plus the catch-all default-deny) keeps the supply-chain audit surface intact.
+
+**Tighter than Category A** — Category B's PR body line must identify (a) the specific registry-item / URL / local-path arg, (b) the source identifier in the form appropriate to the arg kind (default registry / custom registry URL / local path), and (c) the item type if non-component, because together these determine license + upstream identity.
+
+## Adding new generators to either category
+
+Extend the appropriate table via a separate PR. The PR must cite (a) generator's package source URL, (b) license, (c) whether it produces one-shot scaffolding (→ Category A) or per-item registry imports (→ Category B), (d) drift-tracking rationale. Any tool not listed should be treated as a regular cherry-pick (full protocol rules 1-6 apply) until categorized here.
+
+## Authority chain
+
+This carve-out resolves the repeat-DISAGREE-cite pattern observed during Phase 6 GUI MVP chain (PRs #421/#424/#425) where Argus / Copilot review threads flagged CLI-generated files as missing attribution. The Category A / Category B split was added in response to the audit finding that shadcn `add` is materially closer to registry-import than to pure project scaffolding, while create-tauri-app / create-vite genuinely are pure scaffolding.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ Read these docs on demand when you need the corresponding information:
 | **Dynamic Workflow 模板库 + 触发/保存/复用约定** | `.claude/workflows/README.md` |
 | 四原语选型矩阵 + budget-scaling 规则 | `.claude/agents/main.md` §编排升级 |
 | **大规模 fan-out context 护栏 + skill 迁移决策/基线** | `.mercury/docs/guides/fanout-and-skill-migration-guardrails.md` |
+| Cherry-pick carve-out 细则(CLI-scaffold: tauri/vite/shadcn) | `.mercury/docs/guides/cherry-pick-carve-out.md` |
 
 ## Ultracode 与 Dynamic Workflows
 
@@ -120,74 +121,9 @@ Drift monitoring: run `bash scripts/upstream-drift-check.sh` periodically to det
 
 ### Carve-out: CLI-generated scaffolding
 
-The cherry-pick protocol above applies to **files lifted from a specific upstream commit** (canonical upstream path + SHA + drift monitoring). It does NOT cleanly fit two adjacent cases that produce files via CLI invocation rather than direct upstream-path import. Split into 2 sub-categories:
+CLI 生成器*产出*文件(而非从 upstream commit 摘取)→ 从 cherry-pick rules 1-6 获豁免,分两类。完整表格、规则、local-path guard、authority chain 见 **[`.mercury/docs/guides/cherry-pick-carve-out.md`](.mercury/docs/guides/cherry-pick-carve-out.md)**:
 
-#### Category A — Pure scaffolding (one-shot project init)
+- **Category A — 纯脚手架**(`pnpm create tauri-app` / `pnpm create vite`):一次性项目骨架。**必需** = PR body provenance 行(精确 CLI + version)+ license check。**不需** = manifest 条目 / per-file `Based on` / drift 监控。
+- **Category B — registry-item 导入**(`pnpm dlx shadcn@latest add <name|url|path>`,任意 registry item 类型):更严的 PR body provenance,须标明 item-name/URL/local-path arg + source identifier + license + 非-component item 类型。**不需** = manifest / per-file 归属 / drift 监控。**local-path add 在 resolved path 落在 Mercury 工作树外 / submodule 下 / 包管理器暂存目录 / 外部临时 checkout 时,回退到完整 cherry-pick 协议**(存疑则 default-deny)。
 
-Generators that produce a one-time project skeleton from templated boilerplate. The templates ship with the CLI itself; no per-file upstream "source path" exists.
-
-| Generator | Invocation | Output scope |
-|---|---|---|
-| **create-tauri-app** | `pnpm create tauri-app` | Tauri 2 project skeleton (Rust workspace + JS frontend templated config) |
-| **create-vite** | `pnpm create vite` | Vite + framework skeleton (TS config + entry + index.html) |
-
-**Required for Category A**:
-
-1. **Provenance line in PR body**: PR creating the scaffold records the exact CLI invocation + version at invocation time (e.g., "Scaffold via `pnpm create tauri-app`, create-tauri-app vX.Y at 2026-MM-DD"). Use the actual version, not a placeholder. Note: `pnpm create` resolves the create-* starter package transiently and does NOT pin the generator into the produced app's `pnpm-lock.yaml` — the PR-body line is the only durable provenance record.
-2. **License compatibility check**: confirm the scaffold output's license is MIT / Apache-2.0 / similarly permissive (Tauri 2 = MIT/Apache-2.0; Vite = MIT). Record in PR body.
-3. **Customization allowed without attribution**: post-scaffold Mercury edits to the generated files do NOT require per-file `Based on` attribution.
-
-**NOT required for Category A**:
-
-- ❌ Manifest entry in `.mercury/state/upstream-manifest.json`
-- ❌ SKILL.md frontmatter `upstream_sha` field
-- ❌ Per-file `# Based on <upstream>` comment
-- ❌ Drift monitoring via `scripts/upstream-drift-check.sh`
-
-#### Category B — Registry-based item import (per-item upstream lift)
-
-CLI tools that fetch named items from a versioned registry. Each `add` invocation imports a concrete registry item that has a canonical upstream identity. Closer to a per-file cherry-pick than to pure scaffolding. **Applies to ALL `shadcn add` invocations regardless of registry item type** — components, hooks, utilities, pages, fonts, themes, config files, rules, libraries, or any other resource a shadcn-compatible registry exposes (per [shadcn CLI docs](https://ui.shadcn.com/docs/cli) — `add` consumes registry items by name, URL, or local path).
-
-| Generator | Invocation | Registry default | Output scope |
-|---|---|---|---|
-| **shadcn (any registry item)** | `pnpm dlx shadcn@latest add <name-or-url-or-path>` | <https://ui.shadcn.com/r> (official shadcn registry) | Any registry-backed resource: UI components, hooks, utilities, pages, themes, fonts, config files, rules, libraries, etc. Resource arg is a registry item name (default registry), a URL (any registry), or a local path. |
-
-**Required for Category B**:
-
-1. **Provenance line in PR body** (stricter than Category A): record (a) exact CLI invocation including the item-name / URL / path arg(s), (b) shadcn CLI version at invocation time, (c) **source identifier — always**, in one of three forms depending on the arg kind:
-   - For a registry item name (default registry): `source = default registry (https://ui.shadcn.com/r)`
-   - For a URL arg (custom registry or registry item URL): `source = custom registry URL: <url>`
-   - For a local-path arg (file-system import, not registry-fetched): `source = local path: <relative-path>` (note that local-path adds bypass the registry layer entirely — the path IS the upstream identity)
-
-   The source identifier determines license + upstream identity, so the arg kind must be unambiguous on the record. (d) registry item type if non-component (e.g., `registry:hook`, `registry:font`, `registry:lib`, `registry:page`, `registry:file`). Example: "Imported via `pnpm dlx shadcn@latest add tabs`, shadcn CLI vX.Y, source = default registry (https://ui.shadcn.com/r), item type = registry:component at 2026-MM-DD".
-2. **License compatibility check**: confirm the license of the actual source you're importing from at invocation time, NOT a fixed assumption. The shadcn default registry is MIT (illustrative); custom registries may use different licenses, and local-path adds inherit the license of the source path's project. Verify per import + record the verified license in PR body.
-3. **Customization is owned by Mercury after add**: shadcn's design philosophy is "copy-paste with full ownership" — once added, the file is Mercury-owned and editable without per-file upstream-tracking attribution.
-
-**NOT required for Category B** (registry items are not pinned to upstream SHA; shadcn's contract is "you own the code"):
-
-- ❌ Manifest entry in `.mercury/state/upstream-manifest.json` (registry items are not version-pinned to a specific upstream commit; shadcn's model deliberately decouples from upstream after add)
-- ❌ Per-file `# Based on <upstream>` comment
-- ❌ Drift monitoring via `scripts/upstream-drift-check.sh`
-
-**Local-path guard — when local-path adds fall back to full cherry-pick protocol**
-
-The local-path arg form is intended for Mercury-internal registry items (e.g., a path under `mercury-gui/` or a sibling Mercury repo path). It is NOT a back door for importing arbitrary external-project files via a local checkout.
-
-A local-path add **falls back to the full cherry-pick protocol (rules 1-6)** when ANY of these conditions hold. Resolve the source path with `git rev-parse --show-toplevel` for the Mercury repo root (or `realpath` on the path arg) before applying the test — symlinks, `..` traversal, and absolute paths are all normalized this way:
-
-- The resolved path is **not** under the current Mercury repo working tree (i.e., does not have the `git rev-parse --show-toplevel` output as a prefix)
-- The resolved path is under a git submodule whose upstream points to a third-party repo (check via `git submodule status`)
-- The resolved path is under a `node_modules/`, `vendor/`, or other package-manager-staged directory whose contents originate from an external package
-- The resolved path is under a temporary checkout of an external project staged for import (e.g., a `tmp/`, `scratch/`, or any cloned third-party repo directory)
-
-When in doubt, treat the local-path source as a file-lift cherry-pick (full protocol applies). The carve-out exists to formalize "shadcn-style registry add from a versioned source" — local-path is the narrowest case and the guard above (plus the catch-all default-deny) keeps the supply-chain audit surface intact.
-
-**Tighter than Category A** — Category B's PR body line must identify (a) the specific registry-item / URL / local-path arg, (b) the source identifier in the form appropriate to the arg kind (default registry / custom registry URL / local path), and (c) the item type if non-component, because together these determine license + upstream identity.
-
-#### Adding new generators to either category
-
-Extend the appropriate table via a separate PR. The PR must cite (a) generator's package source URL, (b) license, (c) whether it produces one-shot scaffolding (→ Category A) or per-item registry imports (→ Category B), (d) drift-tracking rationale. Any tool not listed should be treated as a regular cherry-pick (full protocol rules 1-6 apply) until categorized here.
-
-#### Authority chain
-
-This carve-out resolves the repeat-DISAGREE-cite pattern observed during Phase 6 GUI MVP chain (PRs #421/#424/#425) where Argus / Copilot review threads flagged CLI-generated files as missing attribution. The Category A / Category B split was added in response to the audit finding that shadcn `add` is materially closer to registry-import than to pure project scaffolding, while create-tauri-app / create-vite genuinely are pure scaffolding.
+reviewer 若 flag 某 CLI-scaffold 文件缺归属 → **DISAGREE-cite 该 guide**(本 carve-out 解决 Phase 6 GUI repeat-DISAGREE 模式)。未列入该 guide 的生成器 → 视作常规 cherry-pick(完整 rules 1-6),直至经 PR 扩展该 guide 归类。

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ User-level changes (anything under `~/.claude/`) are governed separately from pr
 
 Mercury's mount philosophy (DIRECTION.md §四): build the minimum in-house; mount external projects via git submodule under `modules/` with a thin `adapters/<name>/` translation layer (≤200 LOC). Phase 2-1 evaluated four candidates (GSD, Superpowers, OMC, OpenSpace) against a narrow Stop-hook acceptance criterion; all four were REJECT or DEFER on that criterion, so `modules/` is currently empty. Other value from those projects has been cherry-picked individually (see `.mercury/state/upstream-manifest.json` and `scripts/upstream-drift-check.sh`).
 
-When files from an external project are cherry-picked into Mercury, the cherry-pick protocol in [`CLAUDE.md`](CLAUDE.md) is the canonical source for the required attribution / manifest / drift discipline. Two adjacent cases (one-shot CLI scaffolding and registry-based per-item imports) have a narrower carve-out — see [CLAUDE.md §Carve-out: CLI-generated scaffolding](CLAUDE.md#carve-out-cli-generated-scaffolding) for the authoritative scope. This README does not restate the rules; consult CLAUDE.md for current details.
+When files from an external project are cherry-picked into Mercury, the cherry-pick protocol in [`CLAUDE.md`](CLAUDE.md) is the canonical source for the required attribution / manifest / drift discipline. Two adjacent cases (one-shot CLI scaffolding and registry-based per-item imports) have a narrower carve-out — CLAUDE.md keeps a summary; the authoritative full rules live in [`.mercury/docs/guides/cherry-pick-carve-out.md`](.mercury/docs/guides/cherry-pick-carve-out.md). This README does not restate the rules; consult those docs for current details.
 
 ## Example files
 

--- a/articles/001-mercury-harness-overview.md
+++ b/articles/001-mercury-harness-overview.md
@@ -410,7 +410,7 @@ Adapter 只做接口转换，不包含业务逻辑。如果需要业务逻辑，
 
 这个协议确保了三件事：溯源（知道代码从哪来）、漂移检测（知道上游是否变了）、法律合规（license gate）。
 
-**CLI scaffolding / registry-import carve-out**：[CLAUDE.md §Carve-out: CLI-generated scaffolding](../CLAUDE.md#carve-out-cli-generated-scaffolding) 是该 carve-out 的权威定义源。两个邻近场景（一次性 CLI 脚手架与 registry 单 item 导入）有更窄的处理范围；本文不复述具体规则，避免跨文档漂移——查阅 CLAUDE.md 获取当前细则。
+**CLI scaffolding / registry-import carve-out**：[`.mercury/docs/guides/cherry-pick-carve-out.md`](../.mercury/docs/guides/cherry-pick-carve-out.md) 是该 carve-out 的权威细则源（CLAUDE.md §Carve-out 留摘要指针）。两个邻近场景（一次性 CLI 脚手架与 registry 单 item 导入）有更窄的处理范围；本文不复述具体规则，避免跨文档漂移——查阅该 guide 获取当前细则。
 
 ### 实证案例：5 种挂载模式
 
@@ -529,7 +529,7 @@ Mercury 的 96 个 session（截至 S96）构成了一个清晰的演化轨迹�
 | `.claude/skills/pr-flow/SKILL.md` | PR-flow skill（Argus behavior model，escape-hatch protocol，GraphQL resolveReviewThread） |
 | `adapters/gpt-image-2/README.md` | uvx-pinned-SHA mount 案例（MIT upstream，env allowlist，drift-check policy） |
 | `adapters/gpt-image-2/invoke.py` | Slice A adapter（84 LOC，uvx 包装，env 过滤） |
-| `.mercury/state/upstream-manifest.json` | Cherry-pick 治理 manifest（全协议 cherry-pick 的 SHA + license + PR 记录；CLI scaffolding / registry-import carve-out 不在此 manifest，详见 [CLAUDE.md §Carve-out: CLI-generated scaffolding](../CLAUDE.md#carve-out-cli-generated-scaffolding)）|
+| `.mercury/state/upstream-manifest.json` | Cherry-pick 治理 manifest（全协议 cherry-pick 的 SHA + license + PR 记录；CLI scaffolding / registry-import carve-out 不在此 manifest，详见 [`.mercury/docs/guides/cherry-pick-carve-out.md`](../.mercury/docs/guides/cherry-pick-carve-out.md)）|
 | `scripts/upstream-drift-check.sh` | Drift monitoring 工具 |
 
 ### GitHub Issues / PRs（实证案例）


### PR DESCRIPTION
## 概要

#517 做减法 DEFER 批 D:CLAUDE.md(每会话 auto-load)的 `### Carve-out: CLI-generated scaffolding` 子节(Category A/B + Adding generators + Authority chain,占全文 ~35%)迁到新 guide,CLAUDE.md 留薄指针。**CLAUDE.md 21948→15395 字节(-30%)**,降每会话 context 预算。

Refs #517

## 改动
- 新 guide `.mercury/docs/guides/cherry-pick-carve-out.md`(8.3KB):carve-out 全文细则**逐字迁入**(dual-verify 确认字节级无损)。
- CLAUDE.md:`### Carve-out` 替换为薄指针(保 Category A/B required/not-required 摘要 + local-path fallback + DISAGREE-cite 指引,使 agent **无需读 guide 即可 DISAGREE-cite**)+ Navigation 表加 guide 条目。`## Cherry-pick protocol` rules 1-6 保留不动。
- retarget 3 个外部引用(README:172 + articles/001:413/532)从「CLAUDE.md §Carve-out 权威源」→ guide(迁移后 CLAUDE.md 只剩摘要)。

## dual-verify(Claude critic + Codex)
两腿确认**迁移字节级无损** + 薄指针 DISAGREE-cite 不削弱。抓到跨文档漂移(3 外引仍称 CLAUDE.md 权威源)→ retarget 修复;guide「protocol above」过时 spatial 引用 + 重复 H3 → 清理。(Codex「丢 #446 ADR」经核实是误报——carve-out Authority chain 引 #421/#424/#425[已在 guide],#446 在 CLAUDE.md MUST bullet 未碰。)

🤖 Generated with [Claude Code](https://claude.com/claude-code)