### PR TITLE
docs(#517): retire F.B Channel-2 pre-cutover rollback (artifacts removed) + clarify regen backup semantics

### DIFF
--- a/.mercury/docs/guides/memory-index-regenerate.md
+++ b/.mercury/docs/guides/memory-index-regenerate.md
@@ -204,7 +204,8 @@ bash scripts/regenerate-memory-index.sh --in-place
 
 What happens:
 - Auto-creates `<canonical>.pre-cutover.bak` for each canonical file (only on
-  first invocation; subsequent runs preserve the original snapshot).
+  first invocation; subsequent runs skip via `[ ! -f ]`).
+  (NOTE #517: 这是 run-time 状态的 generic pre-mutation 备份，非已退役的 F.B cutover 快照)
 - Inserts HTML-comment marker block immediately after table header / heading:
   - `<!-- BEGIN: scripts/regenerate-memory-index.sh --in-place (Issue #330 Phase F.B). Regenerated content — DO NOT edit between markers. -->`
   - `<!-- END: scripts/regenerate-memory-index.sh --in-place -->`
@@ -399,35 +400,35 @@ git push --force-with-lease origin <branch>  # if branch already pushed
 ```
 
 This reverts repo state to pre-cutover. User-memory files (NOT in git) are
-untouched — operator restores those separately if needed via Channel 2.
+untouched — (Channel 2 user-memory 回滚已 RETIRED #517——F.B `.pre-cutover.bak` 快照已删；user-memory 如需恢复改从 git 历史 / curated 记忆手动重建。)
 
 ### Channel 2: User-memory side (canonical file drift)
+
+> **⚠ RETIRED #517**: 原 `.pre-cutover.bak`（F.B cutover #330 的一次性 pre-cutover 快照）已删除——cutover 距今 2+ 月，回滚会丢 2 个月 session 历史，实务不可行。repo 侧回滚用 Channel 1（git tag `lane-protocol-v0.1-pre-cutover`）。注：`regenerate-memory-index.sh` 的 `--in-place` 仍会按需创建 `<canonical>.pre-cutover.bak`，但那是**该次运行前的 generic pre-mutation 备份（当前状态快照）**，**不是**原始 cutover 状态——勿当 cutover 回滚用。
 
 If the cutover leaves canonical `MEMORY.md` or `SESSION_INDEX.md` in unexpected
 state (e.g. stray rows, missing markers, content drift):
 
-```bash
+**历史示例 — 勿执行（`.pre-cutover.bak` 已 #517 删除；见上方 RETIRED）**:
+
+```text
 MEM_DIR="${MERCURY_MEMORY_DIR:-${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/D--Mercury-Mercury/memory}"
 cp "$MEM_DIR/SESSION_INDEX.md.pre-cutover.bak" "$MEM_DIR/SESSION_INDEX.md"
 cp "$MEM_DIR/MEMORY.md.pre-cutover.bak"        "$MEM_DIR/MEMORY.md"
 ```
 
-Backups are created automatically on first `--in-place` invocation and never
-overwritten on subsequent runs (preserves the true pre-cutover snapshot).
+注：`--in-place` 若重跑会按 `[ ! -f ]` 守卫创建 `.pre-cutover.bak`，但记录的是**该次运行前状态**（非已删的原始 cutover 快照，见上方 RETIRED 提示）。
 
 ### Channel 3: Combined (full revert)
 
+> **RETIRED #517**: 本通道的 user-memory 步骤（Channel 2）+ `INDEX.generated.md` drift 验证已退役（artifacts 已删）；仅 Channel 1（git tag）live。
+
 If both repo AND user-memory need rollback:
 
-1. Run Channel 2 first (restore canonical files from `.bak`).
-2. Run Channel 1 second (revert repo to tag).
-3. Verify regenerate works against pre-cutover state:
-   ```bash
-   bash scripts/regenerate-memory-index.sh --format diff
-   # Should report "no drift" against the original INDEX.generated.md from F.A soak
-   ```
-4. If verification fails, file new Issue with reproduction; per-session files
-   under `memory/sessions/` may need to be deleted to fully restore F.A baseline.
+1. ~~Run Channel 2 first (restore canonical files from `.bak`).~~ （Channel 2 已 RETIRED #517，跳过。）
+2. Run Channel 1 (revert repo to tag `lane-protocol-v0.1-pre-cutover`).
+3. ~~Verify regenerate works against pre-cutover state~~ **RETIRED #517**: `INDEX.generated.md`（F.A soak 快照）已删，drift 验证不可行。
+4. If repo-side verification fails after Channel 1, file new Issue with reproduction.
 
 ### Verifying rollback
 
@@ -440,8 +441,7 @@ grep -c 'BEGIN: scripts/regenerate-memory-index.sh --in-place' \
 # Expected: both report 0
 ```
 
-If the count is non-zero, Channel 2 was not invoked or the backup is itself
-mutated. Check `.bak` file mtime against original cutover commit timestamp.
+(#517: `.bak`/Channel 2 验证已退役。) Channel 1（git）回滚后，用 `git log`/`git status` 确认 repo 在 tag `lane-protocol-v0.1-pre-cutover`；canonical user-memory 文件不受 git 回滚影响。
 
 ## Tests
 

--- a/scripts/regenerate-memory-index.sh
+++ b/scripts/regenerate-memory-index.sh
@@ -499,7 +499,9 @@ POINTER_EOF
 # Atomic: writes to tmp file then mv. Operators recover via either:
 #   (a) git revert if the canonical file is in the user-memory layer's git tracking
 #   (b) cp from <memory-dir>/SESSION_INDEX.md.pre-cutover.bak (created on first
-#       --in-place run; see backup logic below)
+#       --in-place run; see backup logic below; NOTE (#517): original
+#       F.B cutover snapshot was retired/deleted — .pre-cutover.bak created by
+#       this script is a generic pre-mutation backup, not a cutover rollback)
 splice_session_index_in_place() {
   local source_file="$1"
   local rows_file="$2"
@@ -623,6 +625,9 @@ if [ "$IN_PLACE" = "1" ]; then
   # `cp <file>.pre-cutover.bak <file>` if cutover output drifts from expectation.
   # Skip backup if file already exists (subsequent runs are idempotent — backup
   # would overwrite the original pre-cutover snapshot with already-mutated content).
+  # NOTE (#517): original F.B cutover .pre-cutover.bak snapshots were
+  # retired/deleted; this block creates a generic pre-mutation backup (current state
+  # at invocation time), NOT a cutover rollback snapshot.
   for canonical in "$SESSION_INDEX_FILE" "$MEMORY_FILE"; do
     bak="${canonical}.pre-cutover.bak"
     if [ ! -f "$bak" ]; then
@@ -656,7 +661,7 @@ if [ "$IN_PLACE" = "1" ]; then
     end_count=$(grep -cF -- "$IN_PLACE_END_MARKER" "$canonical" 2>/dev/null || true)
     end_count=${end_count:-0}
     if [ "$begin_count" -ne 1 ] || [ "$end_count" -ne 1 ]; then
-      die "splice verification failed: $canonical has $begin_count BEGIN + $end_count END markers (expected 1+1). Likely missing anchor (table header / heading) OR prior partial-write state. Restore from $canonical.pre-cutover.bak before re-attempting cutover."
+      die "splice verification failed: $canonical has $begin_count BEGIN + $end_count END markers (expected 1+1). Likely missing anchor (table header / heading) OR prior partial-write state. Restore from $canonical.pre-cutover.bak (the existing generic pre-mutation backup; the original F.B cutover snapshot was retired #517) before re-attempting."
     fi
   done
 


### PR DESCRIPTION
## 概要

#517 做减法 MEM-2 收尾(用户授权「开小 PR 剥离」)。memory 的 `.pre-cutover.bak`(F.B cutover #330 一次性快照,63天旧)+ `INDEX.generated.md` 已于 #517 删除(非-git);本 PR retire 文档化的 Channel-2 user-memory 回滚通道 + 澄清 regen 脚本同名备份语义。**无脚本逻辑变更**(bash -n OK,diff 仅注释 + die-string)。

Refs #517

## 改动(2 文件,+20/-17)
- `memory-index-regenerate.md`:**#517 后只有 Channel 1(git tag `lane-protocol-v0.1-pre-cutover`)是 live 回滚**;Channel 2(user-memory `.pre-cutover.bak`)+ Channel 3 user-memory 步骤 + INDEX.generated.md drift 验证 + .bak mtime 验证全标 RETIRED #517(artifacts 已删)。澄清:脚本若重建 `.pre-cutover.bak` 是 generic pre-mutation 备份,非原 cutover 快照。
- `regenerate-memory-index.sh`:注释 + die-message 澄清(原 F.B cutover 快照已退役),**无逻辑/变量/控制流改动**。

## dual-verify(Claude critic + Codex)
critic PASS(逐行确认无逻辑变更 + git tag 实存);Codex 抓 retire 不完整(残留指向已删 artifacts 的矛盾引用 Channel 1/3 + verifying-rollback 块)→ round-2 内部一致化全清。research doc 的审计时点记录不动(point-in-time + 顶部已注执行)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)