### PR TITLE
fix(#516): symlink-hijack guard for regenerate-memory-index.sh --in-place

### DIFF
--- a/scripts/regenerate-memory-index.sh
+++ b/scripts/regenerate-memory-index.sh
@@ -63,9 +63,8 @@
 #   2  invalid args / memory dir missing / SESSION_INDEX.md or MEMORY.md missing /
 #      output write failure (disk full / permission denied / parent dir missing) /
 #      --in-place + --output | --format diff combined (mutually exclusive) /
-#      --in-place canonical file (SESSION_INDEX.md or MEMORY.md) is a symlink, OR
-#      its realpath resolves outside the --memory-dir realpath (Issue #516
-#      symlink-hijack / realpath-ownership guard)
+#      --in-place canonical file (SESSION_INDEX.md or MEMORY.md) is a symlink
+#      (Issue #516 symlink-hijack guard)
 
 set -u
 
@@ -97,7 +96,7 @@ while [ $# -gt 0 ]; do
     --in-place)   IN_PLACE=1; shift ;;
     -h|--help)
       # Print full Usage + Exit-codes block (must keep this end line in sync if header grows).
-      sed -n '2,68p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      sed -n '2,67p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
       exit 0 ;;
     -*) die "unknown flag: $1" ;;
     *)  die "unexpected positional argument: $1" ;;
@@ -624,34 +623,29 @@ if [ "$IN_PLACE" = "1" ]; then
   POINTER_TMP=$(mktemp "${TMPDIR:-/tmp}/regen-memidx.XXXXXX") || die "mktemp failed (pointer tmp)"
   trap 'rm -f "$TMPFILE" "$TMPSEEN" "$ROWS_TMP" "$POINTER_TMP"' EXIT
 
-  # Realpath ownership + symlink guard (Issue #516 hardening, defense-in-depth).
-  # Runs before the backup loop (which does `cp`) and before the splice functions
-  # (which do `mv`), so a hijacked canonical path never reaches either. Mirrors the
-  # existing symlink posture already applied to sessions/ (Pass 1, `[ -L ]` skip
-  # above) and the SAFE_MEMORY_DIR frontmatter sanitization — same threat family
-  # (a canonical file replaced by a symlink, or an operator-supplied --memory-dir
-  # that resolves outside its own tree), applied to the two --in-place mutation
-  # targets. Not relying on `realpath`/`readlink -f` — neither is guaranteed on
-  # macOS/BSD without coreutils, and this script targets git-bash/Linux/macOS
-  # alike; `cd ... && pwd -P` is POSIX-portable and resolves symlinks in the
-  # directory chain.
-  MEM_DIR_REAL=$(cd "$MEMORY_DIR" && pwd -P) || die "failed to resolve realpath of memory dir: $MEMORY_DIR"
+  # Symlink guard (Issue #516 hardening, defense-in-depth). Runs before the
+  # backup loop (which does `cp`) and before the splice functions (which do
+  # `mv`), so a hijacked canonical path never reaches either. Mirrors the
+  # existing symlink posture already applied to sessions/ (Pass 1, `[ -L ]`
+  # skip above) and the SAFE_MEMORY_DIR frontmatter sanitization — same
+  # threat family (a canonical file replaced by a symlink pointing outside
+  # the memory dir), applied to the two --in-place mutation targets.
+  #
+  # A `realpath $canonical` still-under-$MEMORY_DIR prefix check was
+  # considered (per the original issue wording) but deliberately NOT
+  # implemented: SESSION_INDEX_FILE / MEMORY_FILE are always constructed as
+  # "$MEMORY_DIR/<fixed-basename>" earlier in this script, so once a
+  # canonical path has passed the `[ -L ]` check below, `dirname "$canonical"`
+  # is by construction the same directory `cd` target as `$MEMORY_DIR` itself
+  # — the prefix comparison can never fail. Adding it would be dead code that
+  # only misleads readers into believing there is a second, independent
+  # protection layer. The `[ -L ]` symlink rejection is the sole and complete
+  # protection here: it is unreachable for cp/mv to follow a link outside the
+  # tree once every symlinked canonical path is refused outright.
   for canonical in "$SESSION_INDEX_FILE" "$MEMORY_FILE"; do
-    # Primary guard: refuse outright if the canonical path itself is a symlink.
-    # This is the direct hit for the symlink-hijack scenario — cp/mv would
-    # otherwise follow the link and mutate whatever it points to.
     if [ -L "$canonical" ]; then
       die "refuse to mutate symlinked canonical file: $canonical (Issue #516 symlink-hijack guard)"
     fi
-    # Secondary guard: confirm the (non-symlink) canonical path's realpath still
-    # lives under the memory dir's realpath. Catches a --memory-dir argument
-    # that resolves outside its own tree via a symlinked ancestor directory.
-    canonical_parent_real=$(cd "$(dirname "$canonical")" && pwd -P) || die "failed to resolve realpath of parent dir for: $canonical"
-    canonical_real="$canonical_parent_real/$(basename "$canonical")"
-    case "$canonical_real" in
-      "$MEM_DIR_REAL"/*) ;;
-      *) die "refuse to mutate canonical file outside memory dir: $canonical resolves to $canonical_real (expected under $MEM_DIR_REAL) (Issue #516 realpath-ownership guard)" ;;
-    esac
   done
 
   # First-run safety: backup canonical files before mutation. Operators recover via

--- a/scripts/regenerate-memory-index.sh
+++ b/scripts/regenerate-memory-index.sh
@@ -62,7 +62,10 @@
 #      <memory-dir>/INDEX.generated.md snapshot
 #   2  invalid args / memory dir missing / SESSION_INDEX.md or MEMORY.md missing /
 #      output write failure (disk full / permission denied / parent dir missing) /
-#      --in-place + --output | --format diff combined (mutually exclusive)
+#      --in-place + --output | --format diff combined (mutually exclusive) /
+#      --in-place canonical file (SESSION_INDEX.md or MEMORY.md) is a symlink, OR
+#      its realpath resolves outside the --memory-dir realpath (Issue #516
+#      symlink-hijack / realpath-ownership guard)
 
 set -u
 
@@ -94,7 +97,7 @@ while [ $# -gt 0 ]; do
     --in-place)   IN_PLACE=1; shift ;;
     -h|--help)
       # Print full Usage + Exit-codes block (must keep this end line in sync if header grows).
-      sed -n '2,57p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      sed -n '2,68p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
       exit 0 ;;
     -*) die "unknown flag: $1" ;;
     *)  die "unexpected positional argument: $1" ;;
@@ -620,6 +623,36 @@ if [ "$IN_PLACE" = "1" ]; then
   ROWS_TMP=$(mktemp "${TMPDIR:-/tmp}/regen-memidx.XXXXXX")    || die "mktemp failed (rows tmp)"
   POINTER_TMP=$(mktemp "${TMPDIR:-/tmp}/regen-memidx.XXXXXX") || die "mktemp failed (pointer tmp)"
   trap 'rm -f "$TMPFILE" "$TMPSEEN" "$ROWS_TMP" "$POINTER_TMP"' EXIT
+
+  # Realpath ownership + symlink guard (Issue #516 hardening, defense-in-depth).
+  # Runs before the backup loop (which does `cp`) and before the splice functions
+  # (which do `mv`), so a hijacked canonical path never reaches either. Mirrors the
+  # existing symlink posture already applied to sessions/ (Pass 1, `[ -L ]` skip
+  # above) and the SAFE_MEMORY_DIR frontmatter sanitization — same threat family
+  # (a canonical file replaced by a symlink, or an operator-supplied --memory-dir
+  # that resolves outside its own tree), applied to the two --in-place mutation
+  # targets. Not relying on `realpath`/`readlink -f` — neither is guaranteed on
+  # macOS/BSD without coreutils, and this script targets git-bash/Linux/macOS
+  # alike; `cd ... && pwd -P` is POSIX-portable and resolves symlinks in the
+  # directory chain.
+  MEM_DIR_REAL=$(cd "$MEMORY_DIR" && pwd -P) || die "failed to resolve realpath of memory dir: $MEMORY_DIR"
+  for canonical in "$SESSION_INDEX_FILE" "$MEMORY_FILE"; do
+    # Primary guard: refuse outright if the canonical path itself is a symlink.
+    # This is the direct hit for the symlink-hijack scenario — cp/mv would
+    # otherwise follow the link and mutate whatever it points to.
+    if [ -L "$canonical" ]; then
+      die "refuse to mutate symlinked canonical file: $canonical (Issue #516 symlink-hijack guard)"
+    fi
+    # Secondary guard: confirm the (non-symlink) canonical path's realpath still
+    # lives under the memory dir's realpath. Catches a --memory-dir argument
+    # that resolves outside its own tree via a symlinked ancestor directory.
+    canonical_parent_real=$(cd "$(dirname "$canonical")" && pwd -P) || die "failed to resolve realpath of parent dir for: $canonical"
+    canonical_real="$canonical_parent_real/$(basename "$canonical")"
+    case "$canonical_real" in
+      "$MEM_DIR_REAL"/*) ;;
+      *) die "refuse to mutate canonical file outside memory dir: $canonical resolves to $canonical_real (expected under $MEM_DIR_REAL) (Issue #516 realpath-ownership guard)" ;;
+    esac
+  done
 
   # First-run safety: backup canonical files before mutation. Operators recover via
   # `cp <file>.pre-cutover.bak <file>` if cutover output drifts from expectation.

--- a/scripts/test-regenerate-memory-index-in-place.sh
+++ b/scripts/test-regenerate-memory-index-in-place.sh
@@ -499,6 +499,64 @@ run_case "asymmetric_markers_detected" bash "$SCRIPT" --memory-dir "$M22" --in-p
 assert_rc "asymmetric_markers_rc" 2
 assert_err_contains "asymmetric_markers_msg" "splice verification failed"
 
+# --- Test 23/24: Issue #516 — realpath ownership + symlink guard ---
+#
+# can_symlink() probes whether this environment can create symlinks at all.
+# Windows/git-bash frequently lacks the privilege (non-elevated shells, dev-mode
+# off) — `ln -s` fails silently or with a permission error. Rather than FAIL in
+# that case (which would be a false-negative on environments that simply can't
+# exercise the feature), these cases SKIP with a printed explanation and do NOT
+# count toward FAIL. Note: because SESSION_INDEX_FILE / MEMORY_FILE are always
+# derived as "$MEMORY_DIR/<fixed-basename>", the only way a canonical path can
+# resolve outside the memory dir is via a symlink — the "non-symlink but
+# out-of-tree" case cannot be constructed as a realistic fixture under this
+# script's own path-derivation logic, so the symlink cases below are the
+# complete coverage for the realpath-ownership guard added in this Issue.
+can_symlink() {
+  local probe_dir probe_target probe_link
+  probe_dir=$(mktemp -d "${TMPDIR:-/tmp}/regen-memidx-symprobe.XXXXXX") || return 1
+  probe_target="$probe_dir/target"
+  probe_link="$probe_dir/link"
+  printf 'probe' > "$probe_target"
+  if ln -s "$probe_target" "$probe_link" 2>/dev/null && [ -L "$probe_link" ]; then
+    rm -rf "$probe_dir"
+    return 0
+  fi
+  rm -rf "$probe_dir"
+  return 1
+}
+
+if can_symlink; then
+  # --- Test 23: symlinked MEMORY.md refused; out-of-tree target left untouched ---
+  M23=$(mk_memdir "symlink-hijack-memory")
+  write_session_index "$M23" '| S1 | 2026-01-01 | t | o | — |'
+  write_session_file "$M23" "S1.md" "theme1" "out1"
+  OUTSIDE23="$TEST_ROOT/symlink-hijack-memory-OUTSIDE-target.md"
+  printf 'SENTINEL: outside-tree content, must not be mutated\n' > "$OUTSIDE23"
+  rm -f "$M23/MEMORY.md"
+  ln -s "$OUTSIDE23" "$M23/MEMORY.md"
+  run_case "symlink_hijack_memory_rejected" bash "$SCRIPT" --memory-dir "$M23" --in-place
+  assert_rc "symlink_hijack_memory_rc" 2
+  assert_err_contains "symlink_hijack_memory_msg" "refuse to mutate symlinked canonical file"
+  assert_file_contains "symlink_hijack_memory_sentinel_intact" "$OUTSIDE23" "SENTINEL: outside-tree content, must not be mutated"
+  assert_file_NOT_contains "symlink_hijack_memory_not_written" "$OUTSIDE23" "BEGIN: scripts/regenerate-memory-index.sh"
+
+  # --- Test 24: symlinked SESSION_INDEX.md refused; out-of-tree target left untouched ---
+  M24=$(mk_memdir "symlink-hijack-session-index")
+  write_memory_md "$M24" '- placeholder'
+  write_session_file "$M24" "S1.md" "theme1" "out1"
+  OUTSIDE24="$TEST_ROOT/symlink-hijack-session-index-OUTSIDE-target.md"
+  printf 'SENTINEL: outside-tree content, must not be mutated\n' > "$OUTSIDE24"
+  ln -s "$OUTSIDE24" "$M24/SESSION_INDEX.md"
+  run_case "symlink_hijack_session_index_rejected" bash "$SCRIPT" --memory-dir "$M24" --in-place
+  assert_rc "symlink_hijack_session_index_rc" 2
+  assert_err_contains "symlink_hijack_session_index_msg" "refuse to mutate symlinked canonical file"
+  assert_file_contains "symlink_hijack_session_index_sentinel_intact" "$OUTSIDE24" "SENTINEL: outside-tree content, must not be mutated"
+  assert_file_NOT_contains "symlink_hijack_session_index_not_written" "$OUTSIDE24" "BEGIN: scripts/regenerate-memory-index.sh"
+else
+  printf 'SKIP: Test 23/24 (Issue #516 symlink-hijack guard) — this environment cannot create symlinks (ln -s failed; likely non-elevated Windows/git-bash without symlink privilege). Not counted as FAIL.\n' >&2
+fi
+
 # --- Final report ---
 printf '\n=== regenerate-memory-index --in-place test summary ===\n'
 printf 'cases: %d  assertions: %d  fail: %d\n' "$CASES" "$PASS" "$FAIL"

--- a/scripts/test-regenerate-memory-index-in-place.sh
+++ b/scripts/test-regenerate-memory-index-in-place.sh
@@ -499,19 +499,20 @@ run_case "asymmetric_markers_detected" bash "$SCRIPT" --memory-dir "$M22" --in-p
 assert_rc "asymmetric_markers_rc" 2
 assert_err_contains "asymmetric_markers_msg" "splice verification failed"
 
-# --- Test 23/24: Issue #516 — realpath ownership + symlink guard ---
+# --- Test 23/24: Issue #516 — symlink-hijack guard ---
 #
 # can_symlink() probes whether this environment can create symlinks at all.
 # Windows/git-bash frequently lacks the privilege (non-elevated shells, dev-mode
 # off) — `ln -s` fails silently or with a permission error. Rather than FAIL in
 # that case (which would be a false-negative on environments that simply can't
 # exercise the feature), these cases SKIP with a printed explanation and do NOT
-# count toward FAIL. Note: because SESSION_INDEX_FILE / MEMORY_FILE are always
-# derived as "$MEMORY_DIR/<fixed-basename>", the only way a canonical path can
-# resolve outside the memory dir is via a symlink — the "non-symlink but
-# out-of-tree" case cannot be constructed as a realistic fixture under this
-# script's own path-derivation logic, so the symlink cases below are the
-# complete coverage for the realpath-ownership guard added in this Issue.
+# count toward FAIL. These cases cover the symlink-hijack hard rejection — the
+# real, sole protection implemented for Issue #516. A separate realpath-prefix
+# check (canonical realpath still under --memory-dir realpath) was considered
+# per the original issue wording but removed as dead code: SESSION_INDEX_FILE /
+# MEMORY_FILE are always "$MEMORY_DIR/<fixed-basename>", so once a symlinked
+# canonical path is excluded via `[ -L ]`, that prefix comparison can never
+# fail — there is no realistic non-symlink fixture that would exercise it.
 can_symlink() {
   local probe_dir probe_target probe_link
   probe_dir=$(mktemp -d "${TMPDIR:-/tmp}/regen-memidx-symprobe.XXXXXX") || return 1


### PR DESCRIPTION
## 概要

Closes #516。给 `scripts/regenerate-memory-index.sh` 的 `--in-place` 模式加一道归属校验(defense-in-depth,side-bug 路线,来源 PR #515 Argus 发现的 pre-existing/deferred 项)。

`--in-place`(Phase F.B)在 backup(`cp`)+ splice(`mv`)改写 canonical 文件 `SESSION_INDEX.md` / `MEMORY.md` 前,原先没有校验这两个目标是否仍归属于 `$MEMORY_DIR`,也未拒绝 symlink canonical。若 canonical 被 symlink 劫持、或 `--memory-dir` 经 symlink 祖先目录解析到树外,`cp`/`mv` 可能跟随链接改到目录外文件。

## 改动

**`scripts/regenerate-memory-index.sh`**:在 `--in-place` 备份循环之前新增 symlink-hijack guard——
- 若 `SESSION_INDEX.md` / `MEMORY.md` 任一是 symlink(`[ -L ]`)→ `die`(exit 2),直接命中 symlink 劫持场景;`cp`/`mv` 否则会跟随链接写到树外。
- 与脚本既有加固姿态一致(Pass 1 对 `sessions/` 的 `[ -L ]` 跳过、`SAFE_MEMORY_DIR` frontmatter 消毒)。
- 同步更新 exit-code 文档块 + `-h/--help` 的 `sed` 范围。

**设计说明(对齐验收标准 + dual-verify)**:issue 建议里另有一条「解析后 realpath 仍在 `--memory-dir` 之内」的前缀校验。初版实现了它,但 dual-verify 的 Codex 侧正确指出它是**死代码**:`SESSION_INDEX_FILE`/`MEMORY_FILE` 恒为 `"$MEMORY_DIR/<固定 basename>"`,`dirname "$canonical"` 与 `$MEMORY_DIR` 是同一 `cd` 目标,一旦排除文件-symlink,`case` 前缀永远匹配——它无法捕获所声称的「symlinked ancestor」场景。因此移除该死代码,避免 exit-code 契约声称一个并不存在的保护。验收标准的实质意图(symlink 劫持 / 越界 canonical → 不写目录外)由 symlink 硬拒绝**完整交付**。

**`scripts/test-regenerate-memory-index-in-place.sh`**(+58):新增 Test 23/24(symlink 劫持 MEMORY.md / SESSION_INDEX.md → 断言 rc=2 + 拒绝信息 + 树外目标 sentinel 完好且未写入标记),由 `can_symlink()` 能力探测门控。

## 测试(4 个 harness)

- `test-regenerate-memory-index-in-place.sh`:0 fail(新增 Test 23/24 在本机 SKIP,见下)。
- `test-regenerate-memory-index.sh`:0 fail。
- `test-mercury-memory-index-write-guard.sh`:0 fail。
- `test-mercury-memory-index-validator.sh`:1 fail — **pre-existing 且越界**。该失败在未含本改动的 develop 上完全复现(`session_id missing in .../sessions/S112.md`,live memory dir 数据损坏),且属于 validator(另一个文件),与本改动无关,不在 #516 范围内。

**guard happy-path 已被验证不破坏正常流程**:所有既有非-symlink 的 `--in-place` 测试(12 例)现在都先经过新 guard 再继续,全部通过。

## 已知限制(诚实披露)

- **symlink Test 23/24 在作者的 Windows/git-bash 上 SKIP**(无 symlink 权限,`ln -s` 产出普通文件副本;`can_symlink()` 探测到后 SKIP 而非 FAIL)。两条 `die` 分支的逻辑由代码审查覆盖;建议在 Linux/macOS 或启用 Developer Mode 的 Windows 上跑一次以实测其 PASS(advisory,guard 逻辑本身直接)。

## 验证

- Dual-verify Claude side: PASS
- Dual-verify Codex side: PASS(首轮 NEEDS-CHANGES:Medium 死代码 realpath 块 + Low 测试注释过度声称 → commit `eded549` 修复 → 复审 0/0/0/0 PASS)
