### PR TITLE
feat(sot-workflow): talent-validate 混合验证 Workflow 底座 + SoT 工具脚本入库

### DIFF
--- a/.claude/workflows/README.md
+++ b/.claude/workflows/README.md
@@ -29,7 +29,7 @@ Dynamic Workflow 是 Claude Code 原生的「**确定性多 agent 编排**」原
 
 ## 保存与复用约定
 
-- **手写模板**(如本目录 5 个):文件名 = `meta.name`,放 `.claude/workflows/<name>.js` → 直接 `/<name>` 调用。
+- **手写模板**(本目录清单所列):文件名 = `meta.name`,放 `.claude/workflows/<name>.js` → 直接 `/<name>` 调用。
 - **从运行保存**:跑出满意的一次后 `/workflows` → 选中 → 按 `s` → Tab 切换保存位置(`.claude/workflows/` 项目级随 repo / `~/.claude/workflows/` 个人级)→ Enter。
 - **同名优先级**:项目级 > 个人级。
 - **传参**:`/<name>` 后跟参数,脚本里读全局 `args`(运行时把字符串/数组/对象**原样**传入,无需解析)。**注意**:`args` 的具体**形状是每个模板自定义的**(见各脚本顶部常量),不是每个模板都接受三种形状 —— 例如 research/plan-review/migration 接受「字符串 或 `{字段…}` 对象」,audit 接受对象;传入不符合该模板契约的形状(如给只认字符串/对象的模板传顶层数组)会落入缺参分支并打印用法提示。每个模板都对缺省/不符做了优雅降级(返回 error + hint,不抛错)。
@@ -47,12 +47,13 @@ Dynamic Workflow 是 Claude Code 原生的「**确定性多 agent 编排**」原
 | `/mercury-large-migration` | loop-until-done | 数十到数百文件机械迁移,按文件归属并行改造(每 agent 独占一文件,工作树原地编辑)+ 逐文件验证 + 循环至收敛;edits 不 commit,由 operator 合并提交 |
 | `/mercury-ecc-practice-scan` | fan-out + adversarial-verify + classify | **周期性复审** everything-claude-code(ECC)新实践:recon 扇出 → 逐条对抗式交叉核查(UNVERIFIED 标注)→ 映射到 Mercury(already-covered / worth-absorbing / not-applicable)。对齐 [#233](https://github.com/392fyc/Mercury/issues/233) ECC 审计,**只产报告不立项**。ECC-specific(非通用),见 `.mercury/docs/research/ecc-practice-scan-2026-06.md`(2026-06 首跑) |
 | `/mercury-staleness-audit` | fan-out + adversarial-verify + classify | **周期性上游依赖 staleness 审计**(Tier 2,对齐 [#508](https://github.com/392fyc/Mercury/issues/508)):discover 扫 manifest/adapter pin/plugin/lockfile → 逐项 web 核查 + 对抗式复检 → 分类(ACTIVE-RISK / ACTION-NEEDED / ACCEPTABLE-DRIFT / DORMANT-OK / NOT-STALE / UNVERIFIED)。比 `scripts/upstream-drift-check.sh`(Tier 1 机械 blob 漂移)多抓「落后幅度 / 组件失效 / 上游 archived」。**只产报告不立项**,见 `.mercury/docs/guides/upstream-drift-routine.md` |
+| `/talent-validate` | in-script deterministic + fan-out triage + adversarial duel | **SoT 天赋平衡混合验证**(对齐 roadmap §1/§9):L1 结构/枚举/tag/规则引用/史诗供给检查纯 JS 零 LLM → Haiku 语义 advisory → L2 共享 tag 组合逐对 Haiku triage(PAIR_CAP 上限,溢出 log)→ L3 Optimizer-vs-Defender 串行对抗;fail-closed(任一 stage 失败强制 verdict ≥revise)。**只读 SoT 仓**;前置起本地只读 API `scripts/sot-codex-serve.sh`;用法见 `.mercury/docs/guides/talent-validate-usage.md`。SoT-specific(非通用) |
 
 各模板的 `args` 入参见脚本顶部常量(如 `maxAngles` / `maxPractices` / `mercuryPaths` / `batchCap` / `contextPaths`)。
 
 ### 六大编排模式 ↔ 模板
 
-fan-out(`codebase-audit`/`ecc-practice-scan` 的 Recon)· adversarial-verify(`codebase-audit` 的 Verify / `adversarial-plan-review` 的 Judge / `ecc-practice-scan` 的 cross-check)· judge-panel/tournament(`adversarial-plan-review`)· generate-and-filter(`multi-source-research` 的 sweep→crosscheck)· classify-and-act(`ecc-practice-scan` 的 MapToMercury)· loop-until-done(`large-migration`)。
+fan-out(`codebase-audit`/`ecc-practice-scan` 的 Recon / `talent-validate` 的 L2 组合扫描)· adversarial-verify(`codebase-audit` 的 Verify / `adversarial-plan-review` 的 Judge / `ecc-practice-scan` 的 cross-check / `talent-validate` 的 L3 对抗)· judge-panel/tournament(`adversarial-plan-review`)· generate-and-filter(`multi-source-research` 的 sweep→crosscheck)· classify-and-act(`ecc-practice-scan` 的 MapToMercury)· loop-until-done(`large-migration`)。
 
 ---
 

--- a/.claude/workflows/talent-validate.js
+++ b/.claude/workflows/talent-validate.js
@@ -51,6 +51,24 @@ const PAIR_CAP = Math.max(1, Math.min((args && args.pairCap) || 20, 30))
 // absent/unlocked — by design — so a renamed rule would also silently disable it).
 const EPIC_SUPPLY_RULE = 'R6.6'
 const EPIC_SUPPLY_CAP = 6
+// Set refresh=true to force the Adapt agent to re-fetch everything from the API even when
+// dataDir already holds fixture files (the reuse default can silently serve a stale snapshot
+// after the design library has been edited).
+const refreshData = !!(args && (args.refresh || args.refreshData))
+
+// Operator-supplied inputs still get sanity bounds before being interpolated into agent
+// prompts: the base URL must be a plain http(s) URL without embedded credentials/whitespace
+// (deliberately NOT localhost-restricted — the design-library API is planned to move behind
+// the NAS URL once a CF service token exists, see the usage guide), and dataDir must not
+// traverse upward out of the workspace.
+if (typeof codexBaseUrl !== 'string' || !/^https?:\/\/[^\s@]+$/.test(codexBaseUrl)) {
+  log(`Blocked unsafe codex_base_url: ${codexBaseUrl}`)
+  return { talentId: talentId || (draft && draft.id) || null, verdict: 'blocked', error: 'unsafe codex_base_url (must be a plain http(s) URL without credentials)' }
+}
+if (typeof dataDir !== 'string' || dataDir.includes('..')) {
+  log('Blocked unsafe dataDir (upward traversal)')
+  return { talentId: talentId || (draft && draft.id) || null, verdict: 'blocked', error: 'unsafe dataDir (must not contain ..)' }
+}
 
 // ── Schemas ──
 const ADAPT_SCHEMA = {
@@ -137,10 +155,14 @@ const adapt = await agent(
   `You are a READ-ONLY data adapter for the SoT Codex design API. Do NOT write to any SoT repo.\n` +
   `Goal: assemble the corpus for validating talent "${candId}" (class_id="${classId}").\n\n` +
   `Step 1 — obtain data into dataDir="${dataDir}" (create it if missing):\n` +
-  `  - tags.json, rules.json, talents_${classId}.json: if present in dataDir read them, else fetch via Bash curl from ${codexBaseUrl}: GET /api/tags , GET /api/rules , GET /api/talents?class_id=${classId} and save each.\n` +
+  (refreshData
+    ? `  - REFRESH MODE: ignore any existing files in dataDir — fetch fresh tags.json, rules.json, talents_${classId}.json via Bash curl from ${codexBaseUrl} (GET /api/tags , GET /api/rules , GET /api/talents?class_id=${classId}) and overwrite them.\n`
+    : `  - tags.json, rules.json, talents_${classId}.json: if present in dataDir read them, else fetch via Bash curl from ${codexBaseUrl}: GET /api/tags , GET /api/rules , GET /api/talents?class_id=${classId} and save each.\n`) +
   (draft
     ? `  - The candidate is an INLINE DRAFT (id "${candId}" is NOT in the API — do NOT GET it, a fetch would 404). Use this JSON VERBATIM as the candidate, and WRITE exactly this JSON to dataDir/talent_${candId}.json (overwrite any 404 placeholder): ${JSON.stringify(draft)}\n`
-    : `  - candidate: GET /api/talents/${talentId} from ${codexBaseUrl} (or read dataDir/talent_${talentId}.json if present) and ensure it is saved to dataDir/talent_${talentId}.json.\n`) +
+    : (refreshData
+        ? `  - candidate: fetch fresh via GET /api/talents/${talentId} from ${codexBaseUrl} (ignore any existing dataDir copy) and save to dataDir/talent_${talentId}.json.\n`
+        : `  - candidate: GET /api/talents/${talentId} from ${codexBaseUrl} (or read dataDir/talent_${talentId}.json if present) and ensure it is saved to dataDir/talent_${talentId}.json.\n`)) +
   `Step 2 — return a LIGHT index (NOT the full peer bodies):\n` +
   `  - candidate: the full record of the talent under test (all fields).\n` +
   `  - peers: same-class talents as id/name/rarity/tags ONLY (omit effect/trigger/rules bodies — they stay in the files).\n` +
@@ -216,6 +238,10 @@ function runL1Deterministic() {
         if (isNewEpic) v.push({ level: 'error', check: 'supply-budget', message: `此候选新增史诗占位将使供给达 ${epicAfter} > ${EPIC_SUPPLY_RULE} 锁定上限 ${EPIC_SUPPLY_CAP} (该牌导致越界)` })
         else v.push({ level: 'warning', check: 'supply-budget', message: `史诗池供给 ${epicAfter} 已 > ${EPIC_SUPPLY_RULE} 上限 ${EPIC_SUPPLY_CAP} (池子既有超限,非本候选导致;需设计层腾位)` })
       }
+    } else if (candidate.rarity === '史诗') {
+      // Registry loaded but the supply rule is absent or not locked — surface the skipped
+      // check loudly instead of letting registry drift disable it in silence.
+      log(`NOTE: epic-supply check skipped — ${EPIC_SUPPLY_RULE} is absent or not 锁定 in the loaded rule registry (registry drift / renamed rule?)`)
     }
   }
   return v

--- a/.claude/workflows/talent-validate.js
+++ b/.claude/workflows/talent-validate.js
@@ -1,0 +1,354 @@
+export const meta = {
+  name: 'talent-validate',
+  description: 'Hybrid talent-balance validator for the SoT (Ship of Theseus) game design layer: deterministic structure/tag/rule checks (zero-LLM, in-script) + Haiku semantic advisory + Haiku triage of shared-tag combinations + an adversarial Optimizer-vs-Defender pass that hunts abuse sequences. Pure LLM is a known-lenient balance judge, so quantitative/structural checks are done in code and the LLM is restricted to semantics + adversarial roles.',
+  whenToUse: 'Validating a SoT talent (by id from the Codex design API, or an inline draft) before it is locked: catches illegal schema/tags, dangling rule refs, supply-budget breaches, dangerous tag-combination loops, and high-value abuse sequences. Read-only against SoT — produces a findings report; never writes to the SoT repos. Numeric power-scoring is intentionally OUT of this MVP (the Codex narrative layer has no numeric power field yet; see roadmap §1.3 / §5).',
+  phases: [
+    { title: 'Adapt', detail: 'pull candidate + peers + tag registry + rules from the Codex read-only API (or a prepared dataDir)' },
+    { title: 'Validate', detail: 'L1 deterministic (schema/enum/tag/rule-ref/supply) in-script + Haiku semantic advisory' },
+    { title: 'Combine', detail: 'L2 enumerate shared-tag peer pairs in code, Haiku-triage each interaction' },
+    { title: 'Adversarial', detail: 'L3 serial Optimizer (abuse sequence) -> Defender (refute), survivors = confirmed exploits' },
+    { title: 'Report', detail: 'consolidate L1/L2/L3 into one structured verdict' },
+  ],
+}
+
+// ── Mercury guardrails (#385 context economics; see .mercury/docs/guides/fanout-and-skill-migration-guardrails.md) ──
+// 1. LEAN DISPATCH: the Adapt agent writes the full corpus to `dataDir` as JSON files and
+//    returns only a LIGHT index (candidate fields [small], peer id/name/rarity/tags, tag keys,
+//    rule codes, rarity counts). L2/L3 agents are handed dataDir PATHS + a task and read the
+//    peer bodies themselves — the 20-peer effect/trigger text is never bulk-injected.
+// 2. FAN-OUT CAP: L2 shared-tag pairs are bounded by PAIR_CAP; anything dropped is log()'d.
+//    L3 is a fixed 2-agent serial duel. Worst-case agents ≈ 1 (Adapt) + 1 (L1 semantic) +
+//    PAIR_CAP (L2, <=30) + 2 (L3) = <=34 — far under the 800-agent self-budget / 1000 runtime cap.
+// 3. MODEL ROUTING (roadmap §1.2): Adapt = Sonnet (single corpus-assembly call, needs solid
+//    tool use); L1-semantic + L2-triage = Haiku (cheap structured calls, injected slice << 50K
+//    so we stay clear of Haiku's 200K hard cliff); L3 duel = Sonnet (strong enough for
+//    adversarial reasoning without paying for Opus on every pair).
+// 4. READ-ONLY ON SoT: Adapt only does GET against the Codex API and writes fixtures under
+//    Mercury's own tmp dir — it never mutates the SoT repos (CLAUDE.md hard constraint).
+// 5. FAIL-CLOSED: any L2/L3 agent failure (parallel null) is tracked, surfaced, and forces the
+//    verdict to at least `revise` — an incomplete adversarial pass must never read as `pass`.
+
+// ── Inputs ──
+const talentId = (args && (args.talent_id || args.talentId)) || (typeof args === 'string' ? args : null)
+const draft = (args && (args.talent_draft_json || args.draft)) || null
+if (!talentId && !draft) {
+  log('No talent specified. Pass one via args, e.g. /talent-validate { "talent_id": "ss_jianqie" } or { "talent_draft_json": {...} }')
+  return { talentId: null, verdict: 'blocked', error: 'missing talent_id or talent_draft_json' }
+}
+const classId = (args && (args.class_id || args.classId)) || (draft && draft.class_id) || 'ss'
+const codexBaseUrl = (args && (args.codex_base_url || args.codexBaseUrl)) || 'http://127.0.0.1:8000'
+// Prepared fixtures dir (skips the API round-trip when supplied). The relative default
+// resolves against the repo root (agent cwd); the Adapt agent echoes back the absolute
+// path it actually used, and that absolute path is what L2/L3 receive (corpusDir).
+const dataDir = (args && args.dataDir) || '.mercury/tmp/codex-fixtures'
+// L2 fan-out cap: how many shared-tag peer pairs get a triage agent. Clamped [1, ceiling];
+// overflow is log()'d, never silently dropped. Default 20 covers the dense ss corpus
+// (20 same-class talents share popular tags like 攻击/战棋); raise pairCap for full coverage.
+const PAIR_CAP = Math.max(1, Math.min((args && args.pairCap) || 20, 30))
+// R6.6 supply budget — HARD-COUPLED to the SoT rule registry: the code 'R6.6' and the epic
+// (史诗) cap of 6 mirror the locked rule text as of 2026-07. If SoT renumbers the rule or
+// changes the cap, update BOTH constants (the check silently disables when the code is
+// absent/unlocked — by design — so a renamed rule would also silently disable it).
+const EPIC_SUPPLY_RULE = 'R6.6'
+const EPIC_SUPPLY_CAP = 6
+
+// ── Schemas ──
+const ADAPT_SCHEMA = {
+  type: 'object',
+  required: ['candidate', 'peers', 'tagKeys', 'ruleCodes', 'rarityCounts', 'dataDir', 'candidateStoredRarity'],
+  properties: {
+    // candidate.required is the MINIMAL set needed to proceed; the FULL field spec is validated
+    // in L1 (runL1Deterministic). A draft missing damage_type/status/trigger/effect passes Adapt
+    // and is correctly flagged by L1 — that division is intentional, not a mismatch.
+    candidate: {
+      type: 'object',
+      description: 'the full record of the talent under test (all Codex fields)',
+      required: ['id', 'name', 'rarity', 'tags'],
+      properties: {
+        id: { type: 'string' }, class_id: { type: 'string' }, name: { type: 'string' },
+        damage_type: { type: 'string' }, rarity: { type: 'string' }, status: { type: 'string' },
+        trigger: { type: 'string' }, effect: { type: 'string' }, rules: { type: 'string' },
+        tags: { type: 'array', items: { type: 'string' } },
+      },
+    },
+    peers: {
+      type: 'array', description: 'same-class talents, LIGHT index only (no effect bodies)',
+      items: {
+        type: 'object', required: ['id', 'name', 'tags'],
+        properties: { id: { type: 'string' }, name: { type: 'string' }, rarity: { type: 'string' }, tags: { type: 'array', items: { type: 'string' } } },
+      },
+    },
+    tagKeys: { type: 'array', items: { type: 'object', required: ['key', 'layer'], properties: { key: { type: 'string' }, layer: { type: 'string', enum: ['mech', 'content'] } } } },
+    // status is REQUIRED: the R6.6 supply check only fires on locked rules (status=锁定), so a
+    // missing status would silently disable enforcement.
+    ruleCodes: { type: 'array', items: { type: 'object', required: ['code', 'status'], properties: { code: { type: 'string' }, status: { type: 'string' }, group: { type: 'string' } } } },
+    rarityCounts: { type: 'object', description: 'same-class talent counts by rarity over the stored library, e.g. {"史诗": 7}', additionalProperties: { type: 'number' } },
+    // The candidate's CURRENTLY STORED rarity in the library, or null if it is not in the library
+    // (inline draft, or a brand-new id). Drives correct R6.6 accounting: a candidate that is newly
+    // becoming 史诗 (storedRarity != 史诗) adds +1 to the epic pool; an already-stored epic does not.
+    candidateStoredRarity: { type: 'string', description: "candidate rarity as currently stored in the library, or '' (empty string) if not stored (inline draft or brand-new id)" },
+    dataDir: { type: 'string', description: 'absolute dir holding talent_<id>.json / talents_<class>.json / tags.json / rules.json for L2/L3 to read' },
+  },
+}
+const L1_SEMANTIC_SCHEMA = {
+  type: 'object', required: ['issues'],
+  properties: { issues: { type: 'array', items: { type: 'object', required: ['level', 'aspect', 'message'], properties: {
+    level: { type: 'string', enum: ['error', 'warning', 'note'] },
+    aspect: { type: 'string', description: 'rule-consistency | effect-trigger-coherence | scope-creep | wording' },
+    message: { type: 'string', description: 'concrete, cites the rule code / field; no praise' },
+  } } } },
+}
+const L2_TRIAGE_SCHEMA = {
+  type: 'object', required: ['interaction_type', 'risk_level', 'rationale'],
+  properties: {
+    interaction_type: { type: 'string', enum: ['loop', 'amplifier', 'neutral', 'anti-synergy'] },
+    risk_level: { type: 'string', enum: ['high', 'medium', 'low', 'none'] },
+    example_sequence: { type: 'string', description: 'concrete turn-by-turn if loop/amplifier, else empty' },
+    mitigation: { type: 'string' },
+    rationale: { type: 'string', description: 'cite the shared tag + the mechanic, not vibes' },
+  },
+}
+const L3_OPTIMIZER_SCHEMA = {
+  type: 'object', required: ['sequence', 'expected_outcome', 'win_condition_turns'],
+  properties: {
+    sequence: { type: 'array', items: { type: 'string' }, description: 'ordered turn-by-turn highest-value abuse line' },
+    expected_outcome: { type: 'string' },
+    win_condition_turns: { type: 'number', description: 'turns to reach a degenerate/winning state; lower = more dangerous' },
+    assumptions: { type: 'array', items: { type: 'string' }, description: 'engine assumptions the line depends on' },
+  },
+}
+const L3_DEFENDER_SCHEMA = {
+  type: 'object', required: ['neutralized', 'mechanism'],
+  properties: {
+    neutralized: { type: 'boolean', description: 'true if an EXISTING locked rule already stops this line' },
+    mechanism: { type: 'string', description: 'the rule code + clause that neutralizes it, or why nothing does' },
+    residual_risk: { type: 'string' },
+  },
+}
+
+// Tracks stage agents that failed (parallel null / missing result) so the verdict can fail
+// closed instead of silently reading incomplete coverage as a clean pass.
+const stageFailures = []
+
+// ── Phase 0: Adapt — Codex read-only API -> light index (lean dispatch) ──
+phase('Adapt')
+const candId = talentId || (draft && draft.id) || 'DRAFT'
+const adapt = await agent(
+  `You are a READ-ONLY data adapter for the SoT Codex design API. Do NOT write to any SoT repo.\n` +
+  `Goal: assemble the corpus for validating talent "${candId}" (class_id="${classId}").\n\n` +
+  `Step 1 — obtain data into dataDir="${dataDir}" (create it if missing):\n` +
+  `  - tags.json, rules.json, talents_${classId}.json: if present in dataDir read them, else fetch via Bash curl from ${codexBaseUrl}: GET /api/tags , GET /api/rules , GET /api/talents?class_id=${classId} and save each.\n` +
+  (draft
+    ? `  - The candidate is an INLINE DRAFT (id "${candId}" is NOT in the API — do NOT GET it, a fetch would 404). Use this JSON VERBATIM as the candidate, and WRITE exactly this JSON to dataDir/talent_${candId}.json (overwrite any 404 placeholder): ${JSON.stringify(draft)}\n`
+    : `  - candidate: GET /api/talents/${talentId} from ${codexBaseUrl} (or read dataDir/talent_${talentId}.json if present) and ensure it is saved to dataDir/talent_${talentId}.json.\n`) +
+  `Step 2 — return a LIGHT index (NOT the full peer bodies):\n` +
+  `  - candidate: the full record of the talent under test (all fields).\n` +
+  `  - peers: same-class talents as id/name/rarity/tags ONLY (omit effect/trigger/rules bodies — they stay in the files).\n` +
+  `  - tagKeys: every tag as {key, layer}. ruleCodes: every rule as {code, status, group}.\n` +
+  `  - rarityCounts: count the stored same-class talents (talents_${classId}.json) by rarity.\n` +
+  `  - candidateStoredRarity: the candidate id's rarity AS CURRENTLY STORED in talents_${classId}.json; return '' (empty string) if the id is not in that list (inline draft or brand-new id).\n` +
+  `  - dataDir: the absolute path you used.\n` +
+  `Use python or jq for robust JSON parsing (the data is UTF-8 Chinese). Keep the response to the index only.`,
+  { phase: 'Adapt', schema: ADAPT_SCHEMA, model: 'sonnet', label: `adapt:${candId}` }
+)
+if (!adapt || !adapt.candidate) {
+  log('Adapt failed — could not load candidate/corpus from Codex API or dataDir')
+  return { talentId: candId, verdict: 'blocked', error: 'adapt failed (Codex API unreachable and no usable dataDir?)' }
+}
+const candidate = adapt.candidate
+const peers = (adapt.peers || []).filter(p => p && p.id !== candidate.id)
+const tagKeySet = new Set((adapt.tagKeys || []).map(t => t.key))
+const ruleCodeSet = new Set((adapt.ruleCodes || []).map(r => r.code))
+const lockedRuleCodes = new Set((adapt.ruleCodes || []).filter(r => r.status === '锁定').map(r => r.code))
+const rarityCounts = adapt.rarityCounts || {}
+const candidateStoredRarity = adapt.candidateStoredRarity || ''
+const corpusDir = adapt.dataDir || dataDir
+log(`Adapt: candidate=${candidate.id} (${candidate.name}/${candidate.rarity}) · peers=${peers.length} · tags=${tagKeySet.size} · rules=${ruleCodeSet.size} · storedRarity=${candidateStoredRarity}`)
+// Data-completeness sanity: an empty registry would turn every tag into a false "unknown tag"
+// error and mis-judge the verdict, so the affected checks are SKIPPED — but skipped coverage
+// must never read as a clean pass (fail-closed): record it as a stage failure -> verdict >= revise.
+if (tagKeySet.size === 0) { stageFailures.push('Adapt(tag registry empty — tag-legality checks skipped)'); log('WARN: tag registry empty — L1 SKIPS tag-legality checks (fail-closed -> revise)') }
+if (ruleCodeSet.size === 0) { stageFailures.push('Adapt(rule registry empty — rule-ref/supply-budget checks skipped)'); log('WARN: rule registry empty — rule-ref / supply-budget checks disabled (fail-closed -> revise)') }
+
+// ── Phase 1: L1 deterministic (zero-LLM, in-script) ──
+phase('Validate')
+function runL1Deterministic() {
+  const v = []
+  const REQUIRED = ['id', 'class_id', 'name', 'rarity', 'damage_type', 'status', 'tags', 'trigger', 'effect']
+  for (const f of REQUIRED) {
+    const val = candidate[f]
+    const empty = val == null || (typeof val === 'string' && !val.trim()) || (Array.isArray(val) && val.length === 0)
+    if (empty) v.push({ level: 'error', check: 'schema', message: `缺失/空必填字段: ${f}` })
+  }
+  const ENUMS = {
+    rarity: ['普通', '稀有', '史诗', '传奇'],
+    damage_type: ['无', '物理', '魔法', '圣', '纯伤害', '混合'],
+    status: ['草稿', '待优化', '锁定', '废弃'],
+  }
+  for (const [f, allowed] of Object.entries(ENUMS)) {
+    if (candidate[f] != null && candidate[f] !== '' && !allowed.includes(candidate[f]))
+      v.push({ level: 'error', check: 'enum', message: `${f}="${candidate[f]}" 非法 (允许: ${allowed.join('/')})` })
+  }
+  // tag legality — only when the registry actually loaded (else every tag would false-positive).
+  if (tagKeySet.size > 0) {
+    for (const tg of (candidate.tags || [])) {
+      if (!tagKeySet.has(tg)) v.push({ level: 'error', check: 'tag', message: `未知 tag "${tg}" 不在注册表 (${tagKeySet.size} 个合法 key)` })
+    }
+  }
+  if (ruleCodeSet.size > 0) {
+    // Dangling rule references: any R<n>.<n>[letters] cited in rules/effect must exist in the
+    // registry. Boundaries prevent matching inside larger tokens (e.g. R6.66 / XR6.6); [a-z]*
+    // captures multi-letter sub-clause codes.
+    const refText = `${candidate.rules || ''} ${candidate.effect || ''}`
+    const refs = refText.match(/(?<![A-Za-z0-9_])R\d+\.\d+[a-z]*(?![A-Za-z0-9_])/g) || []
+    for (const ref of [...new Set(refs)]) {
+      if (!ruleCodeSet.has(ref)) v.push({ level: 'warning', check: 'rule-ref', message: `规则引用 ${ref} 不在规则表 (悬空引用)` })
+    }
+    // R6.6 supply budget: epic (史诗) cap is 6 per class. A candidate newly BECOMING epic
+    // (storedRarity != 史诗) adds +1 and, if that breaches the cap, this talent CAUSES the
+    // breach -> error -> reject. An already-stored epic does not change the pool; if the pool is
+    // already over cap that is a pre-existing design-layer problem, not this talent's fault -> warning.
+    if (candidate.rarity === '史诗' && lockedRuleCodes.has(EPIC_SUPPLY_RULE)) {
+      const isNewEpic = candidateStoredRarity !== '史诗'
+      let epicAfter = rarityCounts['史诗'] || 0
+      if (isNewEpic) epicAfter += 1
+      if (epicAfter > EPIC_SUPPLY_CAP) {
+        if (isNewEpic) v.push({ level: 'error', check: 'supply-budget', message: `此候选新增史诗占位将使供给达 ${epicAfter} > ${EPIC_SUPPLY_RULE} 锁定上限 ${EPIC_SUPPLY_CAP} (该牌导致越界)` })
+        else v.push({ level: 'warning', check: 'supply-budget', message: `史诗池供给 ${epicAfter} 已 > ${EPIC_SUPPLY_RULE} 上限 ${EPIC_SUPPLY_CAP} (池子既有超限,非本候选导致;需设计层腾位)` })
+      }
+    }
+  }
+  return v
+}
+const l1Deterministic = runL1Deterministic()
+log(`L1 deterministic: ${l1Deterministic.length} finding(s) — ${l1Deterministic.filter(x => x.level === 'error').length} error / ${l1Deterministic.filter(x => x.level === 'warning').length} warning`)
+
+// L1 semantic — ADVISORY ONLY (Haiku is a lenient judge; per this script's own design philosophy
+// the LLM does not drive the quantitative verdict). Results go into the report; a failure here is
+// logged but does NOT gate the verdict.
+const l1Semantic = await agent(
+  `Semantic check of ONE SoT talent (class_id="${classId}"). Do not praise. Only flag concrete issues.\n` +
+  `Candidate (verbatim): ${JSON.stringify({ id: candidate.id, name: candidate.name, rarity: candidate.rarity, damage_type: candidate.damage_type, trigger: candidate.trigger, effect: candidate.effect, rules: candidate.rules, tags: candidate.tags })}\n` +
+  `Rule registry (codes + status + group) at ${corpusDir}/rules.json — read it.\n` +
+  `Check: (1) does each rule the talent CLAIMS to follow (in its 'rules' field) actually match what the 'effect' does? ` +
+  `(2) does 'trigger' fit the tags (e.g. a 反应/reaction tag should trigger off an incoming event)? ` +
+  `(3) scope creep — does the effect quietly do more than its rarity tier warrants? Return only issues, each citing a rule code or field.`,
+  { phase: 'Validate', schema: L1_SEMANTIC_SCHEMA, model: 'haiku', effort: 'low', label: `l1-semantic:${candidate.id}` }
+)
+if (!l1Semantic) log('NOTE: L1 semantic agent failed (advisory only — verdict not affected)')
+const l1SemanticIssues = (l1Semantic && l1Semantic.issues) || []
+log(`L1 semantic (Haiku, advisory): ${l1SemanticIssues.length} issue(s)`)
+// Surface error-level advisory items loudly: they do NOT gate the verdict (by design — the LLM
+// never drives the quantitative ruling), so make sure a human sees them instead of them
+// drowning inside the report payload.
+const advisoryErrors = l1SemanticIssues.filter(i => i.level === 'error').length
+if (advisoryErrors > 0) log(`NOTE: ${advisoryErrors} error-level semantic advisory item(s) — advisory only, verdict unaffected; human review recommended`)
+
+// ── Phase 2: L2 combination scan — enumerate shared-tag pairs in code, triage in parallel ──
+phase('Combine')
+const candTags = new Set(candidate.tags || [])
+// Enumerate (not imagine) peers sharing >=1 tag with the candidate, ranked by overlap size.
+const sharedPairs = peers
+  .map(p => ({ peer: p, shared: (p.tags || []).filter(t => candTags.has(t)) }))
+  .filter(x => x.shared.length > 0)
+  .sort((a, b) => b.shared.length - a.shared.length)
+const pairsToTriage = sharedPairs.slice(0, PAIR_CAP)
+if (sharedPairs.length > pairsToTriage.length) log(`L2: ${sharedPairs.length - pairsToTriage.length} shared-tag pair(s) dropped at PAIR_CAP=${PAIR_CAP} (rerun with higher pairCap to cover them)`)
+log(`L2: ${pairsToTriage.length} shared-tag pair(s) to triage (of ${peers.length} peers)`)
+
+const l2Raw = await parallel(pairsToTriage.map(({ peer, shared }) => () =>
+  agent(
+    `Triage the interaction between two SoT talents of class "${classId}" that share tag(s) [${shared.join(', ')}].\n` +
+    `Candidate full record (verbatim): ${JSON.stringify({ id: candidate.id, name: candidate.name, rarity: candidate.rarity, trigger: candidate.trigger, effect: candidate.effect, rules: candidate.rules, tags: candidate.tags })}\n` +
+    `Peer: "${peer.name}" (${peer.id}) — read its full entry inside ${corpusDir}/talents_${classId}.json and the rules in ${corpusDir}/rules.json; do NOT assume their contents.\n` +
+    `Classify the interaction (loop / amplifier / neutral / anti-synergy) and risk (high/medium/low/none). ` +
+    `If loop or amplifier, give a concrete turn-by-turn example_sequence and a mitigation. Cite the shared tag + the actual mechanic.`,
+    { phase: 'Combine', schema: L2_TRIAGE_SCHEMA, model: 'haiku', effort: 'low', label: `l2:${candidate.id}+${peer.id}` }
+  ).then(t => t && ({ peerId: peer.id, peerName: peer.name, shared, ...t }))
+))
+const l2Ok = l2Raw.filter(Boolean)
+const l2Failed = l2Raw.length - l2Ok.length
+if (l2Failed > 0) { stageFailures.push(`L2(${l2Failed}/${l2Raw.length} triage agents failed)`); log(`WARN: ${l2Failed} L2 triage agent(s) failed — coverage incomplete`) }
+// Only loop/amplifier interactions that are actually risky (high/medium) count as flagged; a
+// benign loop (risk none/low, e.g. mutual resource with a hard cap) must NOT inflate the verdict.
+const l2Flagged = l2Ok.filter(x => (x.interaction_type === 'loop' || x.interaction_type === 'amplifier') && (x.risk_level === 'high' || x.risk_level === 'medium'))
+log(`L2: ${l2Flagged.length} risky flagged interaction(s) (loop/amplifier @ high|medium) of ${l2Ok.length} triaged`)
+
+// ── Phase 3: L3 adversarial — serial Optimizer -> Defender (Red-Teaming Game) ──
+phase('Adversarial')
+const optimizer = await agent(
+  `You are the OPTIMIZER in an adversarial balance review of SoT (a tactical RPG). Your job: break the game with this talent.\n` +
+  `Candidate talent full record (verbatim): ${JSON.stringify({ id: candidate.id, name: candidate.name, rarity: candidate.rarity, trigger: candidate.trigger, effect: candidate.effect, rules: candidate.rules, tags: candidate.tags })}\n` +
+  `The ENTIRE same-class corpus + rules live at ${corpusDir} (talents_${classId}.json, rules.json) — read them; build your line from the real corpus + the candidate above, not imagination.\n` +
+  `Construct the single HIGHEST-VALUE abuse sequence that combines this candidate with available same-class talents/skills. ` +
+  `Return the ordered turn-by-turn sequence, the expected degenerate outcome, the turn count to reach it, and the engine assumptions it depends on. Be concrete and ruthless.`,
+  { phase: 'Adversarial', schema: L3_OPTIMIZER_SCHEMA, model: 'sonnet', agentType: 'design', label: `l3-optimizer:${candidate.id}` }
+)
+let l3 = { abuseLine: null, defense: null, confirmedExploit: false, undetermined: false }
+if (!optimizer) {
+  // FAIL-CLOSED: the optimizer agent itself failed — the adversarial pass did not run at all.
+  // Do NOT conflate this with "no abuse line exists"; incomplete coverage forces >= revise.
+  stageFailures.push('L3(optimizer failed — adversarial pass incomplete)')
+  log('WARN: L3 optimizer agent failed — adversarial coverage incomplete (fail-closed -> revise)')
+} else if (!Array.isArray(optimizer.sequence) || optimizer.sequence.length === 0) {
+  // The agent ran and genuinely found no abuse line — that IS a clean adversarial signal.
+  log('L3: optimizer found no abuse line (clean adversarial pass)')
+} else {
+  const defender = await agent(
+    `You are the DEFENDER in an adversarial balance review of SoT. The Optimizer claims this abuse line:\n` +
+    `${JSON.stringify(optimizer)}\n` +
+    `Candidate under review (verbatim): ${JSON.stringify({ id: candidate.id, name: candidate.name, rarity: candidate.rarity, effect: candidate.effect, tags: candidate.tags })}\n` +
+    `Read the rules at ${corpusDir}/rules.json. Determine whether an EXISTING LOCKED rule (status=锁定) already neutralizes this line. ` +
+    `Set neutralized=true ONLY if you can cite the specific rule code + clause that stops it. If nothing existing stops it, neutralized=false and describe the residual risk — that is a CONFIRMED exploit the designer must address.`,
+    { phase: 'Adversarial', schema: L3_DEFENDER_SCHEMA, model: 'sonnet', agentType: 'critic', label: `l3-defender:${candidate.id}` }
+  )
+  if (!defender) {
+    // FAIL-CLOSED: the optimizer found a line but the defender could not rule on it. Do NOT treat
+    // an unrefuted-because-failed line as neutralized; mark it undetermined and force revise.
+    stageFailures.push('L3(defender failed — abuse line undetermined)')
+    log('WARN: L3 defender failed — abuse line UNDETERMINED, treating as unresolved risk (fail-closed)')
+    l3 = { abuseLine: optimizer, defense: null, confirmedExploit: false, undetermined: true }
+  } else {
+    // Code-side guard on the defender's claim: neutralized=true must cite a rule code that is
+    // actually in the LOCKED rule set. An uncited (or non-locked) "neutralized" is a
+    // hallucination risk and is treated as UNDETERMINED (fail-closed -> revise), never as a
+    // clean neutralization.
+    const citedCodes = ((defender.mechanism || '').match(/(?<![A-Za-z0-9_])R\d+\.\d+[a-z]*(?![A-Za-z0-9_])/g) || [])
+    const citesLockedRule = citedCodes.some(c => lockedRuleCodes.has(c))
+    if (defender.neutralized === true && !citesLockedRule) {
+      stageFailures.push('L3(defender claimed neutralized without citing a locked rule — undetermined)')
+      log('WARN: L3 defender said neutralized but cited no LOCKED rule code — treating as UNDETERMINED (fail-closed)')
+      l3 = { abuseLine: optimizer, defense: defender, confirmedExploit: false, undetermined: true }
+    } else {
+      l3 = { abuseLine: optimizer, defense: defender, confirmedExploit: defender.neutralized === false, undetermined: false }
+      log(`L3: abuse line ${l3.confirmedExploit ? 'NOT neutralized -> CONFIRMED EXPLOIT' : 'neutralized by existing locked rule'}`)
+    }
+  }
+}
+
+// ── Phase 4: Report ──
+phase('Report')
+const l1Errors = l1Deterministic.filter(x => x.level === 'error').length
+const l1Warnings = l1Deterministic.filter(x => x.level === 'warning').length
+// reject: a hard structural violation, a candidate that itself causes a supply breach, or a
+//   confirmed (refuted-and-survived) exploit.
+// revise: softer warnings, a pre-existing pool overflow, a risky tag combination, an undetermined
+//   adversarial line, OR any stage failure (incomplete coverage must not read as a clean pass).
+// pass: nothing of the above.
+let verdict
+if (l1Errors > 0 || l3.confirmedExploit) verdict = 'reject'
+else if (l1Warnings > 0 || l2Flagged.length > 0 || l3.undetermined || stageFailures.length > 0) verdict = 'revise'
+else verdict = 'pass'
+
+return {
+  talentId: candidate.id,
+  name: candidate.name,
+  rarity: candidate.rarity,
+  verdict, // pass | revise | reject | blocked
+  scope: 'MVP: structural + semantic(advisory) + combinatorial + adversarial. Numeric power-scoring NOT included (Codex narrative layer; roadmap §1.3/§5).',
+  stageFailures, // empty = full coverage; non-empty forced verdict to at least revise
+  L1: { deterministic: l1Deterministic, semantic_advisory: l1SemanticIssues },
+  L2: { triaged: l2Ok.length, failed: l2Failed, flagged: l2Flagged, droppedAtCap: Math.max(0, sharedPairs.length - pairsToTriage.length) },
+  L3: l3.abuseLine ? { confirmedExploit: l3.confirmedExploit, undetermined: l3.undetermined, abuseLine: l3.abuseLine, defense: l3.defense } : { note: 'no abuse line produced' },
+  corpusDir,
+}

--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,9 @@ CLAUDE.md
 .mercury/sessions.json
 .mercury/transcripts/
 .mercury/backups/
+# SoT-workflow runtime: gdtoolkit venv + Codex fixtures + test probes — never commit
+.mercury/tmp/
+.mercury/tools/
 .mercury/mercury.db
 .mercury/mercury.db-wal
 .mercury/mercury.db-shm

--- a/.mercury/docs/guides/talent-validate-usage.md
+++ b/.mercury/docs/guides/talent-validate-usage.md
@@ -1,0 +1,83 @@
+# talent-validate 使用指南
+
+> SoT 天赋平衡混合验证器(Mercury Dynamic Workflow)。确定性结构/tag/规则检查(纯 JS 零 LLM)+ Haiku 语义 advisory + 共享 tag 组合扫描 + 双 Sonnet 对抗(Optimizer-vs-Defender)。**只读 SoT,不改 SoT 仓**。设计/实跑验证见路线图 `.mercury/docs/research/sot-workflow-optimization-roadmap-2026-06.md` §1/§9。
+
+## 何时用
+
+设计一张新天赋、或打磨一张已录天赋时,在锁定前验证它:抓非法 schema/tag、悬空规则引用、史诗供给越界、危险 tag 组合循环、高价值滥用序列。**MVP 不含数值功率评分**(设计库 叙述层无 power 字段;待补,见路线图 §5)。
+
+## 前置:起 设计库只读 API
+
+talent-validate 需要 SoT 设计库 API 取 tag 注册表 / 规则表 / 同职业天赋。在单独终端起:
+
+```bash
+bash scripts/sot-codex-serve.sh    # http://127.0.0.1:8000, DB 隔离 Mercury tmp, 零写 SoT 仓
+```
+
+(NAS `sot.fyc-space.uk` 待 CF token,暂用本地。)
+
+## 两种调用方式
+
+### A. 验证 设计库 已录天赋 —— 传 `talent_id`
+
+```
+/talent-validate { "talent_id": "ss_jianqie", "class_id": "ss" }
+```
+
+### B. 验证新设计草稿 —— 传 `talent_draft_json`(产出新天赋主用法)
+
+不必先录 设计库,直接喂草稿 JSON:
+
+```
+/talent-validate { "talent_draft_json": {
+    "id": "ss_xxx", "class_id": "ss", "name": "天赋名",
+    "damage_type": "物理", "rarity": "史诗", "status": "草稿",
+    "trigger": "触发时机", "effect": "效果叙述",
+    "rules": "必暴遵循 R1.1。", "tags": ["处决","攻击","剑气"]
+  }, "class_id": "ss" }
+```
+
+> 也可用 Workflow 工具直接跑:`Workflow({ scriptPath: ".claude/workflows/talent-validate.js", args: {...} })`。后台跑,`/workflows` 看进度。单张约 20-22 agents / ~800K token / ~9 分钟。
+
+## 草稿字段(L1 schema 必填)
+
+`id` `class_id` `name` `damage_type` `rarity` `status` `trigger` `effect` `tags`(`rules` 强烈建议):
+
+- `rarity` ∈ 普通 / 稀有 / 史诗 / 传奇
+- `damage_type` ∈ 无 / 物理 / 魔法 / 圣 / 纯伤害 / 混合
+- `status` ∈ 草稿 / 待优化 / 锁定 / 废弃
+- `tags` 每个必须 ∈ 设计库 tag 注册表(12 个):**mech** 剑气/印记/处决/奥义/招架/反应 · **content** 区域/位移/攻击/自动/战棋/资源
+- `rules` 里引用的规则码(R1.1 等)会被核查;引用不存在的码 → 悬空 warning
+
+## verdict 解读
+
+| verdict | 含义 |
+|---|---|
+| **pass** | 无硬问题 |
+| **revise** | L1 warning(悬空引用 / 史诗池既有超限) 或 L2 危险组合(loop/amplifier@high\|medium) 或 stage 失败 |
+| **reject** | L1 error(schema/枚举/tag 非法 / **新增史诗导致供给越界**) 或 L3 确认 exploit(对抗无法被现有锁定规则中和) |
+| **blocked** | 数据/服务问题(非天赋本身);设计库 服务没起 / dataDir 缺数据 / 未传天赋 |
+
+结果分层:
+- **L1 deterministic** = 纯 JS 零 LLM,**可信**(schema/枚举/tag 合法/悬空引用/R6.6 史诗供给上限)。
+- **L1 semantic** = Haiku,**仅 advisory 不驱动 verdict**(LLM 不做定量裁决)。
+- **L2** = 与候选共享 tag 的同职业天赋组合 triage。
+- **L3** = Optimizer 构滥用序列 → Defender 用现有**锁定**规则反驳;`neutralized:false` = 确认 exploit。
+
+R6.6 史诗供给(每职业史诗 ≤6)归因区分:**已存史诗**池超限 → warning(非候选导致);**新增史诗**(草稿/库内非史诗升级)推高池越界 → error → reject(该牌导致)。
+
+## 数据新鲜度
+
+设计库 数据首次拉取后缓存在 `.mercury/tmp/codex-fixtures/`(gitignored 快照)。**在 设计库 改/加天赋后**,删该目录强制下次验证重拉最新(需服务跑着):
+
+```bash
+rm -rf .mercury/tmp/codex-fixtures    # 下次 talent-validate 自动重拉
+```
+
+或传 `args.dataDir` 指向一个新空目录强制全量重拉。
+
+## 范围与护栏
+
+- **不含数值功率评分**(待 设计库 补数值字段 + `/api/export/godot`,路线图 §5 决策点 1 已定走方案 a)。
+- 只读 SoT(GET API + 不改仓);设计库 DB 隔离 Mercury tmp。
+- #385 context 护栏:lean dispatch(传路径+任务) / fan-out cap + log / Haiku 注入 ≤50K。

--- a/.mercury/docs/guides/talent-validate-usage.md
+++ b/.mercury/docs/guides/talent-validate-usage.md
@@ -11,8 +11,10 @@
 talent-validate 需要 SoT 设计库 API 取 tag 注册表 / 规则表 / 同职业天赋。在单独终端起:
 
 ```bash
-bash scripts/sot-codex-serve.sh    # http://127.0.0.1:8000, DB 隔离 Mercury tmp, 零写 SoT 仓
+SOT_CODEX_DIR=/path/to/SoT-fyc-space bash scripts/sot-codex-serve.sh   # http://127.0.0.1:8000, DB 隔离 Mercury tmp, 零写 SoT 仓
 ```
+
+(`SOT_CODEX_DIR` 必填,指向 SoT 设计库仓库检出位置;无默认值,防止换环境时静默指错目录。)
 
 (NAS `sot.fyc-space.uk` 待 CF token,暂用本地。)
 
@@ -38,6 +40,8 @@ bash scripts/sot-codex-serve.sh    # http://127.0.0.1:8000, DB 隔离 Mercury tm
 ```
 
 > 也可用 Workflow 工具直接跑:`Workflow({ scriptPath: ".claude/workflows/talent-validate.js", args: {...} })`。后台跑,`/workflows` 看进度。单张约 20-22 agents / ~800K token / ~9 分钟。
+>
+> 复跑注意:默认复用 `.mercury/tmp/codex-fixtures/` 里的既有数据快照;若设计库在两次运行之间有更新,args 里加 `"refresh": true` 强制重新抓取 API,避免基于陈旧快照裁决。
 
 ## 草稿字段(L1 schema 必填)
 

--- a/.mercury/docs/research/sot-phase3-review-ui-plan-2026-06.md
+++ b/.mercury/docs/research/sot-phase3-review-ui-plan-2026-06.md
@@ -1,0 +1,212 @@
+# SoT 设计库 Phase 3 — 交互审阅前端实现规格（2026-06-23）
+
+> **性质**：SoT 设计库（`D:/ShipOfTheseus/SoT-fyc-space`，FastAPI+SQLModel+SQLite，部署 NAS sot.fyc-space.uk）Phase 3 实现规格。改 SoT-fyc-space 仓已授权。本文件 = 对抗式设计 Workflow（11 agent：4 研究+3 架构+1 评判+2 批判）产出 + main-loop web-verify 后的最终落地方案，dev agent 据此实现。配套权威待办在路线图 §10。
+>
+> **来源**：设计 Workflow `wf_cf1d0c3a-8a2`（冠军=草案3 UX优先，嫁接草案2稳健+草案1复用；2 批判者各判「需修订后实施」）。技术地基 main-loop web-verified（见 §6）。
+
+---
+
+## 0. 目标与约束
+
+**目标**：网页内投入天赋 → 现场异步审核 1/多张 → 对话反馈 → agent 帮改天赋（effect/rules/tags/trigger）→ 读新内容重审。
+
+**硬约束**：
+1. review 真实 ~247s → 前端**绝不同步等**（异步化）。
+2. 纯 OpenAI gpt-5.4（openai 2.43 async SDK），**不用 Claude/Anthropic**。env `OPENAI_API_KEY`。
+3. 服务端渲染 Jinja2 + HTMX 2.0.4 + Alpine（CDN），**禁 node 构建**。
+4. 单 worker uvicorn（Dockerfile CMD 无 `--workers`）—— 进程内 task + 模块级状态成立的前提。
+5. **review 绝不静默改库 Talent**（延续 Comment 独立旁注纪律）；帮改作用于会话内工作草稿，落库须显式动作。
+6. 本地无 `OPENAI_API_KEY` → 只能 mock 测编排；真实验证靠 NAS 部署 smoke。
+7. 产代码改动照走 dual-verify（跨仓库手动）+ commit master + tar 同步 NAS。
+
+---
+
+## 1. 异步传输：DB 持久 job + asyncio.create_task + HTMX 短轮询（**非 SSE，非 BackgroundTasks**）
+
+**决定性论据（web-verified §6）**：CF Tunnel 对 SSE 有 ~100s 超时 + ~100KB 缓冲 + GET 连接关闭前不流式 → SSE 对 247s 任务在 sot.fyc-space.uk **结构性失效**。FastAPI `BackgroundTasks` 是「响应后 fire-and-forget」无 job 句柄无法轮询。→ **DB job + `asyncio.create_task` + HTMX 轮询**。
+
+**机制**：
+- `POST .../sessions`（或 rerun）→ 同步内联跑 **L1**（`run_l1_deterministic`，<1s，立即填首屏）→ 建 `ReviewJob` 行（status=queued，l1_json 已写满）→ 经临界区 `asyncio.create_task(_run_l2_l3_job(...))` → 立即返回 job 卡片片段（含轮询触发器）。
+- 后台协程 `_run_l2_l3_job` 用**独立 Session**（见 §6-C1 engine 注入），分阶段写 `progress_stage`，`await run_l2_l3`（async I/O，单事件循环挂起期间可服务轮询）。
+- 轮询端点 `GET .../jobs/{job_id}/status`：queued/running→进度片段（带 `hx-trigger="every 2s"`）；done→结果片段（**不带 trigger=停轮询**）+ 亮对话面板；failed→错误卡 + 重审按钮（不带 trigger）。
+
+**停轮询（web-verified §6）**：done/failed 片段不再含 `hx-trigger` 即停（htmx 官方法一），轮询端点终态可附 `HX-Trigger`/286 兜底。
+
+---
+
+## 2. DB schema：2 表（落 `app/models.py` 末尾，随 `create_db_and_tables()` 自动建表，无 alembic）
+
+**`ReviewSession`（持久会话容器）**：
+- `id: str` PK（`uuid4().hex`）
+- `talent_id: Optional[str]` FK→talent.id，nullable index —— **软引用不级联**（删 Talent 不销毁审阅历史）
+- `class_id: str` default `"ss"`
+- `mode: str`（`"existing"`/`"draft"`）
+- `working_draft: str`（JSON 工作草稿；帮改作用于此，**绝不写 Talent**）
+- `messages: str`（JSON OpenAI 风格对话历史，默认 `"[]"`）
+- `rejected_proposals: str`（JSON list，§6-M4 否决记忆；审阅者点「拒绝此提案」append 摘要）
+- `latest_verdict: Optional[str]`
+- `status: str`（`"open"`/`"applied"`/`"archived"`）
+- `created_at`/`updated_at`（复用 models.py 既有 timezone-aware + `onupdate=_utcnow`）
+
+**`ReviewJob`（一次异步运行）**：
+- `id: str` PK（`uuid4().hex` = job_id）
+- `session_id: str` FK→reviewsession.id index
+- `candidate_snapshot: str`（JSON，派发时冻结候选副本）
+- `corpus_snapshot: str`（JSON，**派发时冻结 peers+rules**，§6-M3 防语料漂移污染 verdict 对比；后台协程用快照非实时查库）
+- `status: str` 状态机：`queued`→`running`→终态 `done`|`failed`
+- `l3_effort: str`
+- `l1_json: str`（同步内联产出，建 job 即写满）
+- `progress_stage: str`（`l1_done`/`l2_running`/`l3_optimizer`/`l3_defender`/`synthesizing`）
+- `progress_detail: str`（JSON `{l2_total,l2_done,l2_dropped,l3_phase}`）
+- `result_json: Optional[str]`（终态 = `_deep_review` 返回形状 + `corpus_dropped`）
+- `error: Optional[str]`
+- `prompt_tokens`/`completion_tokens: int` default 0（从 OpenAI usage 累加，成本监控）
+- `attempt: int` default 1
+- `created_at`/`updated_at`
+
+**隔离纪律**：working_draft/candidate_snapshot 是 Talent 字段的 JSON 副本，审阅全程读写副本，Talent 行零触碰；落库是唯一写 Talent 路径，复用现有 `talent_update`（pages.py:407）/`talent_create`（pages.py:215）。
+
+---
+
+## 3. 提速（纯 llm.py + env，与异步正交，先做）
+
+> ⚠️ 澄清：现有 ss 职业仅 ~20 天赋，corpus 不是 247s 主因（主因 = L3 xhigh reasoning + L2 pair triage）。**主延迟处理 = 异步化**（用户不同步等）+ 已在生产 .env 应用的 effort 降档（xhigh→high）+ L2 pair cap=5。corpus cap 是**无上限增长护栏**（272K cliff 防护），非主提速杠杆。
+
+- **(a) L3 corpus top-N 截断**（§6-C3 **关键修正**）：**不复用** `enumerate_shared_pairs`（它只返回共享 tag 的 peer，会结构性丢掉零 tag 交集 peer = 恰是跨机制 exploit 候选，破坏 L3）。新增独立 `_select_corpus(peers, candidate, cap)`：优先保留共享 tag peer，**cap 未用满时用零 tag 交集 peer 填充**（按稀有度/更新时间），保证跨机制候选不被剔除。cap 走 env `SOT_LLM_L3_CORPUS_CAP`（**默认 40，高于现有天赋数 → 现数据不触发截断**）。触发时 `corpus_dropped` surface「对抗仅覆盖 top-N，截断 M 张（其中 K 张零 tag 交集）」；若被丢的含零 tag peer，L3 标 `partial_coverage` 计入 stage_failures（fail-closed 抬到 revise）。
+- **(b) effort 透传**：`run_l3(..., l3_effort=None)` + `run_l2_l3(..., l3_effort=None)`，None 回退模块级 `L3_EFFORT`（默认 xhigh 不变）。前端 effort 选择器暴露 high/xhigh 两档写进 `job.l3_effort`。
+- **(c)** L2 PAIR_CAP 保持现状（生产=5），不动默认。
+- **token 粗估两路全覆盖**（§6-M3）：L2 = Σ over capped pairs `len(_slim(cand)+_slim(peer)+rules)`；L3 = `len(cand)+len(capped_corpus)+rules`；取较大/求和与 250K（env `SOT_LLM_TOKEN_WARN`）比，超则 job failed「语料过大需收窄」。不引 tiktoken，字符数/3.5 粗估（worst-case 1.35x 留余量）。
+
+---
+
+## 4. 对话：Chat Completions 自存 messages（**非 Responses API**）
+
+- **理由**：现有 `_call_json`（llm.py:101）全建在 `chat.completions.create` + 扁平 `reasoning_effort` + `response_format` json_schema，44 测 + NAS smoke 已过；切 Responses API blast radius 过大。Chat Completions 自存 messages = 真持久（单一事实源在 DB）。
+- **存哪/怎么续**：帮改对话独立 messages 流（`ReviewSession.messages`）；用户发反馈→append `{role:user}`→构造 `messages=[system(帮改专用 prompt，注入当前 working_draft + 最近 job verdict + 关键 finding 压缩摘要，**不塞 L2/L3 raw JSON** 控 token) + 历史]`→`chat.completions.create(model, messages, reasoning_effort="medium", response_format=帮改提案 schema)`→append assistant 提案→写回。L2/L3 审阅调用**不进**对话历史（结构化一次性，存 ReviewJob.result_json）。
+- **messages 滑窗 + 否决记忆**（§6-M4）：超 env `SOT_REVIEW_MAX_TURNS`（默认 20）丢最早 user/assistant 对，**保留 system + 首条结论摘要**；额外把 `rejected_proposals`（ReviewSession 字段）每轮注入 system prompt「以下提案已被审阅者否决，勿重提：<list>」—— 滑窗丢历史不丢否决记忆，token 恒定。
+
+---
+
+## 5. 帮改三段式（守 review 绝不静默改库）
+
+- **(1) 提案作用于工作草稿**：帮改 LLM 输出结构化 diff，schema = `{rationale, changes:[{field: enum[effect/rules/tags/trigger]【白名单，additionalProperties:false，非白名单 id/class_id/status 提案直接拒绝 surface 警告】, before, after, reason}], tags_add:[str], tags_remove:[str]}`。后端校验 tags_add/remove key ∈ Tag 注册表（非法拒绝该项 surface 警告不静默吞）。
+- **(2) 应用到工作草稿**（会话内不落库）：`POST .../draft/apply` 把选中 changes 合并进 `ReviewSession.working_draft`（仅副本，Talent 零触碰），支持逐字段 checkbox 部分应用，返回草稿片段（变更字段 `.field-changed` 高亮）。
+- **(3) 重审**：`POST .../rerun` 以 working_draft 为 candidate_snapshot 建新 ReviewJob（同 session 累积保留历史可对比 verdict 演进）→ 同异步流程。
+- **(4) 落库**（唯一写 Talent 路径，显式动作）：`POST .../commit` → **reject/confirmed_exploit/stage_failures 非空时二次确认门对 existing 和 draft 两条路径都生效**（§6-H3，按最近 done job 的 verdict 判，与 mode 无关，确认文案明示 exploit 摘要）→ 复用 `talent_update`（existing）/`talent_create`（draft）→ Talent 更新 + session.status=`applied` + 可选追加 Comment（author=`审阅器`，§6 草案1 嫁接：审阅结论沉淀进现有讨论流，零新表）。
+
+---
+
+## 6. 批判修正（must-fix，全部 baked-in；技术点 web-verified）
+
+### web-verified 技术地基（main-loop，2026-06-23）
+| 点 | 结论 | 来源 |
+|---|---|---|
+| HTMX 停轮询 | `every <t>` 轮询；停 = HTTP 286 或返回不含 hx-trigger 的片段 | <https://htmx.org/attributes/hx-trigger/> |
+| FastAPI 长任务 | job-id+轮询（返 202）；create_task 起后台 + task 引用集合 + semaphore | <https://fastapi.tiangolo.com/tutorial/background-tasks/> |
+| asyncio GC | 事件循环仅持弱引用，3.12 起 task 可执行中途被 GC；解法=set 持强引用+add_done_callback | <https://docs.python.org/3/library/asyncio-task.html>, cpython#91887 |
+| CF Tunnel SSE | SSE 缓冲+~100s 超时+~100KB 阈值+GET 不流式 → SSE 对 247s 失效 | cloudflared #199 / #1449 |
+| SQLite PRAGMA | WAL 持久（设一次）；busy_timeout per-connection 须 connect listener 每连接设 | <https://docs.sqlalchemy.org/en/20/dialects/sqlite.html> |
+
+### C1 [critical] 后台协程 engine 注入
+后台协程不能直接用全局磁盘 `app.db.engine`（测试注入内存 engine，会成两个库 → 异步路径单测结构性不可达 + 生产跨连接读旧态）。**修**：db.py 加 `get_engine()` 模块级函数（测试可 monkeypatch）；`_run_l2_l3_job(job_id, *, session_factory=None)` 接受 session 工厂，默认 `lambda: Session(get_engine())`。test fixture **同时** override `get_session` + monkeypatch `app.db` engine 指向同一内存 StaticPool engine。
+
+### C2 [critical] TestClient 不驱动 create_task
+同步 httpx TestClient 不持续调度 create_task 后台协程 → job 状态机测试假死 queued。**修**：`_run_l2_l3_job` 设计成可直接 `await` 的纯协程；测试用 `asyncio.run(_run_l2_l3_job(job_id, session_factory=...))` 单独测后台逻辑（状态机/result_json/异常→failed），与派发解耦；派发端点单独测（start 后断言 job=queued + l1_json 已填 + 片段含轮询触发器，不依赖后台跑完）。文档明确：真实 create_task 事件循环交互只靠 NAS smoke 验。
+
+### C3 [critical] L3 corpus 截断破坏对抗 → 见 §3(a)（独立 `_select_corpus`，不复用 enumerate_shared_pairs，零 tag peer 填充 + partial_coverage fail-closed）。
+
+### H1 [high] create_task 异常静默 + 弱引用 GC
+**修**：① `_run_l2_l3_job` 顶层 `try/except/finally`，任何异常→短事务 `job.status=failed, error=str(e)`，finally 确保非终态兜成 failed；② 模块级 `_RUNNING: set[asyncio.Task] = set()`，`create_task` 后 `_RUNNING.add(t); t.add_done_callback(_RUNNING.discard)`（asyncio 官方写法）；③ running 超时墙：轮询端点若 `status∈(queued,running)` 且 `now-updated_at > SOT_REVIEW_JOB_STALE_SECONDS`（默认 600）则渲染 failed + 停轮询（防 GC/OS kill/卡死永久转圈）。
+
+### H2 [high] 防抖 check-then-act 竞态
+SELECT-then-INSERT 在并发下双双查到无 running job 双双 create_task。**修**：临界区用进程内 `asyncio.Lock`（单 worker 有效，锁内 SELECT+INSERT 无 await，L1 同步跑完、create_task 在锁外），或对 active job 加 DB 唯一约束（`active_marker` 列）。文档绑定单 worker 前提（与 §7 多 worker 失效声明对齐）。
+
+### H3 [high] reject 二次确认门覆盖不全 → 见 §5(4)（门对 existing+draft 两路径都生效）。
+
+### H4 [high] 鉴权默认 off 公网烧钱 → **决策点见下「待用户拍板」**。无论结果，token-独立成本闸**必做**：全局并发 job 上限（env `SOT_REVIEW_MAX_CONCURRENT` 默认 2，模块级 `asyncio.Semaphore`）+ 每 session 防抖（§H2）+ 全局每日 job 硬上限（env `SOT_REVIEW_DAILY_CAP`）+ per-job token ceiling（env `SOT_REVIEW_JOB_TOKEN_CEILING` 默认 300K，累计超限中止剩余调用置 failed）。
+
+### M3 [medium] 语料快照 + token 两路 → 见 §2（corpus_snapshot 冻结）+ §3（token 两路粗估）。
+
+### M4 [medium] 滑窗丢否决记忆 → 见 §4（rejected_proposals 钉住注入）。
+
+### Medium SQLite WAL/busy_timeout
+**修**：busy_timeout 用 `sqlalchemy.event.listens_for(engine,"connect")` 每连接 `PRAGMA busy_timeout=`（不是 _build_engine 设一次）；WAL 用 connect listener 或建库后一次性设；**仅磁盘 DB 启用**（DB_PATH 是 `:memory:`/`sqlite://` 时跳过，env `SOT_SQLITE_WAL` 默认 on 内存强制 off）。`database is locked` 不复现标为 **NAS smoke-only**（StaticPool 单连接测不出文件锁），单测改断言 connect listener 确执行 PRAGMA。
+
+### 重启孤儿 job
+`main.py` startup 扫 `status IN('queued','running')` → 一律置 failed（error=「服务重启中断，请重审」），**绝不自动 requeue**（防重启风暴重复烧钱），attempt 记录。
+
+---
+
+## 7. 路由（全部网页层，新建 `app/web/review_ui.py` 便于独立可拆，main.py include_router）
+
+**注册顺序铁律**：`/talents/review/...` 静态段必须前置于 `/talents/{talent_id}` 参数路由（否则被 `talent_id="review"` 捕获，pages.py:252 同款陷阱）。
+
+- 会话：`POST /talents/{talent_id}/review/sessions`（existing）；`POST /talents/review/sessions`（draft，收 TalentValidateIn 同款字段，**须前置**）；`GET /talents/review/sessions/{sid}`（整页工作台，**须前置**）
+- 异步：`POST /talents/review/sessions/{sid}/rerun`（防抖）；`GET /talents/review/sessions/{sid}/jobs/{job_id}/status`（轮询，终态片段不带触发器）
+- 帮改：`POST .../chat`（反馈→帮改 LLM→append messages→对话流片段）；`POST .../draft/apply`（应用提案→草稿片段）；`POST .../draft`（手动编辑工作草稿回存，不落库）；`POST .../proposals/reject`（记否决，§M4）
+- 落库：`POST .../commit`（显式落库，二次确认门，existing→talent_update/draft→talent_create，session.status=applied，可选追加 Comment）
+- **保留**：现有 `POST /api/talents/{id}/review`（require_token，同步 247s）不动，作 CLI/脚本入口；异步化只发生在网页层，API 契约不破，44 测零回归。
+
+**多 worker 隐性耦合标注（必做）**：`review_ui.py` 顶部注释 + usage guide 显式标「依赖单 worker uvicorn」（进程内 task + 模块级 Semaphore/Lock/_RUNNING 在多 worker 下全失效，须换 ARQ/Redis）。
+
+---
+
+## 8. 模板（最大复用现有 HTMX 模式，暗色中文 UI，零 node）
+
+- 整页 `templates/review_session.html`（extends base.html）：顶部 job 历史 timeline（verdict 徽章演进）+ 左主区工作草稿编辑器（复用 talent_detail.html 字段表单 + tag-chip 复选，hx-post 到 draft 路由不落库）+ 内嵌 L1 即时校验（复用 `#validation-panel` + `/talents/validate` 作用于草稿）+ 中区当前 job 卡 + 右区对话面板。
+- 片段 `partials/`：
+  - `review_job_card.html`（轮询核心：queued/running→进度条 5 段灯 + l2_dropped/corpus_dropped 提示 + `hx-get .../status hx-trigger="every 2s" hx-target="this" hx-swap="outerHTML"`；done→复用 `validation_result.html` 的 verdict-{{verdict}}+vbadge 着色 + L2 flagged 列表 + L3 abuse_line/defense 折叠**不带 trigger 停轮询**；failed→错误卡+重审按钮停轮询）
+  - `review_chat_stream.html`（仿 comment_stream.html 逐条 role/content 气泡 + outerHTML swap 到 `#review-chat-stream`；assistant 含提案则嵌 diff 卡）
+  - `review_diff_card.html`（逐 change field + before（删除线红）/after（高亮绿）纯 CSS + 每项 checkbox 部分应用 + tags_add/remove 徽章 + 应用选中按钮 hx-post draft/apply + rationale）
+  - `review_draft_form.html`（草稿编辑表单，apply 后局部刷新变更字段加 `.field-changed`）
+  - `review_l2l3_result.html`（L2 flagged 对列表 + L3 abuse_line 逐回合 + defense.mechanism + confirmed_exploit/undetermined + corpus_dropped advisory）
+- `talent_detail.html` 增量一处：validation-panel 旁加「深度审阅」按钮 → `hx-post /talents/{id}/review/sessions`（复用现有「结构校验」按钮的 hx-post + hx-vals 注入 id 模式）。
+- 复用 CSS class：verdict-pass/revise/reject、vbadge、badge rarity-、status-、tag-chip、comment-list/comment、btn-*；新增少量 progress-stage 灯、diff-before/diff-after、field-changed、timeline-verdict。Alpine 仅管轮询期禁用按钮/diff 全选/commit 确认弹层（CDN 已含）。
+
+---
+
+## 9. 测试（复用 conftest 临时 DB + test_llm_review.py `_FakeClient(fn)`，本地全 mock + NAS smoke）
+
+**基建坑（§6-C2）**：现有 `_FakeCompletions.create` 强读 `kw['response_format']['json_schema']['name']` → 新增对话/帮改轮**必须带 response_format**（帮改轮用结构化提案 schema，正好满足）；effort 透传断言需扩展 fake 让 create 捕获 kw（加 `self.last_kw=kw`）；后台协程测试走 `asyncio.run` + session_factory 注入（不走 TestClient）。
+
+**新建 `tests/test_review_session.py` + `test_review_jobs.py`**（route 测走 TestClient + dependency_overrides + monkeypatch engine 内存 DB）：
+① 会话生命周期（existing/draft，working_draft 正确快照，首 job queued+l1_json 已填）；② job 状态机+防抖（已有 running job 时 rerun 拒建第二个，断言行数不增；done 后允许）；③ 异步编排（asyncio.run + mock run_l2_l3，queued→running→done，result_json 形状，stage_failures 透传 fail-closed）；④ corpus 截断（>cap peers→corpus_dropped surface，**零 tag peer 在 cap 内不被丢、cap 外触发 partial_coverage**）；⑤ effort 透传（high→断言 _call_json 收 reasoning_effort=high）；⑥ 帮改提案（chat append user+assistant，提案 JSON 解析渲染 diff，非法 tag 拒绝 surface，非白名单 field 提案被拒）；⑦ 应用提案（draft/apply 改 working_draft，`session.get(Talent,id)` 字段逐一断言不变）；⑧ messages 滑窗（超 MAX_TURNS 保留 system+首条摘要+rejected_proposals 注入）；⑨ **落库纪律【最关键】**（commit 前 Talent==原值，commit 后==working_draft；existing→update/draft→create；**existing+draft 两路径 reject/confirmed_exploit 直接 commit 都被二次确认门拦**）；⑩ 重启恢复（预置 running 孤儿 job→触发 startup→变 failed+不重跑，_FakeClient 调用=0）；⑪ 轮询片段（status queued/running 含 every2s；done/failed 不含 every2s 停轮询，grep 模板输出）；⑫ review 不写 Talent 静态断言（grep review_ui.py 除 commit 端点外无 Talent session.add+commit）；⑬ 现有 44 测 fail-closed 不回归。
+
+**NAS smoke（真实 gpt-5.4）**：① 网页开 existing 会话见切 ss_jianqie→L1 秒回 revise→轮询到 done→L3 confirmed_exploit=true（对照 Phase 2 同步版验异步未改裁决）；② 单张 high+corpus40+pair5 实测时长 + 多次轮询无 CF 524；③ 轮询不阻塞（start 后 <1s 返回 + 开第二 tab 验事件循环未阻塞）；④ 帮改一轮→提案 diff→应用→重审→verdict 变化 + **确认库内 Talent 未变**；⑤ commit 落库→Talent 更新+session applied；⑥ 重启遗弃→孤儿 job failed 不永久转圈不重烧；⑦ SQLite 并发（review 期间并发轮询+网页表单写另一天赋→无 database is locked，验 WAL+busy_timeout+短事务）。
+
+---
+
+## 10. 待用户拍板（实现前 1 个决策点）
+
+**鉴权/成本姿态（§6-H4）**：sot.fyc-space.uk 经 CF Tunnel 部署 —— LLM 触发端点（每次 ~$0.1-0.5 真金）是否默认要求 token？取决于**部署访问面**：① 已在 CF Access/私有边界（仅用户可达）→ 网页端点免 token + 成本闸即可；② 公网可达 → LLM 触发端点须默认 require token（与现有 `/api/review` 一致）防爬虫刷量烧钱。token-独立成本闸（并发≤2 + 每日上限 + 防抖 + per-job token ceiling）**无论如何都做**。
+
+**用户决策（2026-06-23）**：Q1=**默认 require token**（推荐，secure-by-default）；Q2=**站点已在 CF Access/私有边界**。→ `SOT_REVIEW_REQUIRE_TOKEN` 默认 True（纵深防御，perimeter 已挡），网页一次性「🔑 解锁」框（localStorage→hx-headers，仅注入 /review 路径），成本闸全做。
+
+---
+
+## 11. 实施完成（2026-06-24）
+
+**全部实现 + 71 pytest 全绿**（44 现有零回归 + 27 新）+ 本地 live uvicorn smoke 通过（真实 create_task 异步路径跑通）+ **NAS 部署 + 真实 gpt-5.4 端到端 smoke 全绿（2026-06-24，SoT master `619f167`）**：
+- 见切 ss_jianqie 网页发起异步深审 → 轮询 ~144s → **DONE 裁决=驳回 + L3 confirmed_exploit**（真实 gpt-5.4 经新异步端点复现 Phase 2 同步版结论，异步化未改裁决）；done 片段 0 个 hx-trigger（停轮询验证）。
+- 帮改对话一轮（真实 gpt-5.4 medium）→ 结构化提案含 effect/rules 修改；commit H3 二次确认门（latest verdict=reject+confirmed_exploit）正确拦住未写库。
+- **数据纪律 NAS 验证**：DB 查 `ss_jianqie.updated_by=None`（review 流程从未碰 Talent）+ `review_session status=applied 数=0`（无静默落库）。
+- L1 回归 = revise（R3.13c+R6.6，与 Phase 1/2 一致）；app 启动建表 + recover_orphan_jobs 无崩溃；token 门全程生效（复用现有 API_TOKEN）。
+- 部署：tar `app` 同步 NAS sot-codex/（备份 `app.backup-pre-phase3` = Phase1/2）+ `docker compose build app && up -d`，两容器（app-1 + tunnel-1）重建启动。
+
+**变更文件**（SoT 仓 `D:/ShipOfTheseus/SoT-fyc-space`，无 git remote，commit master + tar 同步 NAS）：
+- 后端：`app/web/review_ui.py`（新，核心编排+路由）、`app/validation/llm.py`（_select_corpus/effort/token估算/run_chat_turn/Budget）、`app/models.py`（ReviewSession+ReviewJob）、`app/db.py`（get_engine+PRAGMA listener）、`app/config.py`、`app/deps.py`、`app/validation/context.py`、`app/main.py`
+- 前端：`templates/review_session.html` + `partials/review_*.html`(7) + base.html/talent_detail.html/talent_new.html/app.css
+- 测试：`tests/test_review_async.py`（27 测）
+
+**dual-verify 闭环（跨仓库手动：code-reviewer + Codex MCP 并行）** —— 双路一致确认 §6 七项批判修正（C1/C2/C3/H1/H2/H3/H4）**均真实正确实现**。双路 findings 全部修复：
+- **[HIGH-A] job 终态非单调**（Codex）：`_run_l2_l3_job` 改 catch `CancelledError`(重抛)+`Exception`+`finally` 兜底；终态写 `_finalize` **单调**（仅当 status 仍 active 才落终态，不覆盖 stale 墙置的 failed）；进度写 `_update` 也跳过已终态。
+- **[HIGH-B] commit 枚举强转 500**（双路）：`_enum_or_400` 包装 cast → 400；草稿表单枚举改 `<select>`（防手输非法）。
+- **[HIGH-C] per-job token ceiling 未实装**（双路）：`llm.Budget` 类穿 `_call_json_messages`→`_call_json`/`_triage_pair`→run_l2/run_l3/run_l2_l3；从 `resp.usage` 累加；调用前超 ceiling 抛错中止；超限 job 置 failed + 持久化 `prompt_tokens`/`completion_tokens`；新 env `SOT_REVIEW_JOB_TOKEN_CEILING`（默认 300K）。
+- **[MED-D] draft 审阅前端没接通**（Codex）：`start_draft_session` 改收 Form 字段（非 JSON body）+ `talent_new.html` 加「深度审阅」按钮。
+- **[MED-E] diff 卡 `value="{{...|tojson}}"` 双引号属性破坏**（Claude）：改单引号（tojson 不转义 `"`）。
+- **[MED-F] 令牌注入限 /review 路径**（Claude）：`htmx:configRequest` 按 `path.indexOf('/review')` 过滤。
+- **[LOW-G] reject_proposal 加 token**；**[LOW-H] 对话 history 持久化前截断**（`_persist_history`）；**[LOW-I] `_build_chat_messages` 直接收 history 不 mutate ORM**（删 `_with_messages`）。
+
+**NAS 部署 runbook**（照 handoff §部署 Runbook）：tar `app` 同步 + `docker compose build app && up -d` + 真实 smoke（见切 ss_jianqie 网页审阅→轮询到 done→L3 confirmed_exploit；帮改一轮；commit 落库验 Talent 变更；并发轮询验无 database is locked）。回滚 `app.backup-pre-validate`。生产 `.env` 沿用 `SOT_LLM_L3_EFFORT=high`/`SOT_LLM_L2_PAIR_CAP=5` + 新增可选 `SOT_REVIEW_*`（默认值即安全，无需配也行）。
+
+**遗留 follow-up（非阻断，NAS smoke 验）**：① 后台协程 commit 跨 session 可见性（WAL，Open Question，NAS 并发 smoke ⑦ 验）；② LLM 输出入 HTML 属性的 XSS 边界（autoescape 默认开，NAS smoke 用含 `<script>`/`'"` 的 reply 实测）；③ `progress_detail` 字段定义但未写 L2 细粒度进度（功能缺口非 bug）；④ 派发端点 `async def` 内同步 DB 查询轻微占事件循环（poll 是 `def`/线程池不受影响，当前低流量可接受）。

--- a/.mercury/docs/research/sot-workflow-optimization-roadmap-2026-06.md
+++ b/.mercury/docs/research/sot-workflow-optimization-roadmap-2026-06.md
@@ -1,0 +1,384 @@
+# SoT 游戏开发 Workflow 优化路线图（2026-06-22）
+
+> **性质**:SoT（Ship of Theseus）游戏开发的**辅助 Workflow** 规划。非 Mercury 自身产品内容，故**不开 Mercury Issue**；待办在本文件追踪。工作区维持在 Mercury 目录。
+>
+> **硬约束(用户 2026-06-22 指令)**:
+> - 对 SoT **仅做 Workflow 优化**,**不直接干预** SoT 仓库(`D:\ShipOfTheseus\Ship_of_Theseus` / `D:\ShipOfTheseus\SoT-fyc-space`)及其名义下的产出内容。
+> - Workflow 模板宿主 = Mercury `.claude/workflows/`(随 repo 分发,可 `/<name>` 复用)。
+> - side-lane 在做 harness/Mercury 产出优化;本 lane 专注 SoT。
+> - 全程强制研究协议 web-verified;本文件事实均附来源。
+
+---
+
+## 0. SoT 现状基础设施地图(只读勘察 2026-06-22)
+
+| 资产 | 状态 | 对优化的意义 |
+|---|---|---|
+| Godot **4.6.1** 工程(`Ship_of_Theseus`) | `project.godot` features=4.6;`data/skills/*.json` 数值技能 | 引擎数据层 |
+| `addons/godot_mcp` **v2.15.0/mjs 2.16.0** | WS server + 完整命令面(scene/node/script/resource/input/screenshot/tilemap + game_bridge) | CC 可驱动编辑器/运行时(**握手有坑,见 §4**) |
+| 自研 headless 测试 | `tests/test_swordsman_resources.gd`/`_integration.gd`(`extends SceneTree`,`godot --headless --script ...`,退出 0/1)覆盖真理源(unit/damage_calculator/pathfinding)+ JSON 层 | headless 回归**已通**;`剑圣手动测试清单.md` 仍部分手动 = 摩擦 |
+| `tools/*.html` | damage-simulator / talent-tree-editor / map-designer / equipment-designer | 早于设计库;与设计库/平衡 sim **重叠**,宜演进非重复 |
+| **SoT 设计库**(`SoT-fyc-space`,FastAPI+SQLite) | 部署 NAS `sot.fyc-space.uk`(待 CF token);7 实体 + 31 API + 8 页;`/api/import` 有,**无 Godot export** | 设计**叙述**层 SoT |
+| 技能 schema 差异 | Godot=数值(`power/hit_bonus/range/area/cooldown/effects[]`);设计库 `Skill`=叙述(`effect` 散文 / `action_type` / `trigger`) | 设计库↔Godot 非 1:1,见 §5 |
+
+**核心缺口**:设计库(设计)与 Godot(引擎)**断连**;"设计库当单一事实源驱动引擎"对引擎侧未实现。
+
+---
+
+## 1. 痛点1 — 天赋设计:`talent-validate` Workflow ⭐最高优先
+
+### 1.1 诊断:为什么"agent 验证帮助小"(你的体感是对的)
+纯 LLM 是**已知的弱平衡裁判**(web-verified):
+- 系统性**宽容偏差**,非对抗框架下漏支配策略(arxiv 2512.07462 / 2601.19726)。
+- **组合穷举失败**(漏交互对,除非显式枚举)、**算术漂移**(功率和不准)。
+- LLM-only 管线无 schema 接地会产出结构非法/引擎不兼容输出(G-KMS, MDPI 2025)。
+→ 单 agent "审一下这个天赋"必然得到表扬 + 表面建议。**必须换混合结构**。
+
+### 1.2 解法:4-layer 混合管线(确定性层做量化,LLM 只做语义+对抗)
+落点 `.claude/workflows/talent-validate.js`,入参 `{talent_id}` 或 `{talent_draft_json}`;**设计库 API 当语料适配器**(像 gpt-image-2 之于 animate-frames):harness 调 设计库 API 取候选天赋 + 该职业现有天赋 + tag 注册表 + 稀有度功率上限 + 规则表,**路径+任务**传 subagent(不 bulk 注入)。
+
+| Layer | 做什么 | 谁做 | 关键 |
+|---|---|---|---|
+| **L1 结构验证**(<1s,零 LLM) | schema 校验;tag 合法性(mech/content 层一致);**确定性功率评分**(权重据现有平衡卡校准);规则冲突(SQL/JSON 查规则表) | JS 算术 + Haiku | **功率预算禁用 LLM**,纯评分函数,超稀有度上限即 flag |
+| **L2 组合扫描** | **代码**枚举与候选共享 tag 的对/三元组(非 LLM 想象)→ 每个 flagged 对喂 Haiku triage,结构化 JSON `{interaction_type:loop/amplifier/neutral/anti-synergy, risk_level, example_sequence, mitigation}` | JS 枚举 + 并行 Haiku(5-20 对,≤16 并发) | 组合爆炸由 tag 结构控制 |
+| **L3 对抗批判** | Agent A(Optimizer,得**全语料**+规则+候选)构造最高价值滥用序列 JSON `{sequence, expected_outcome, win_condition_turns}` → Agent B(Defender)指出中和它的规则 JSON `{neutralized, mechanism, residual_risk}`;`neutralized:false` → 升级为确认 exploit | 串行双 Sonnet | Red-Teaming Game(arxiv 2310.00322);~2000 token/天赋 |
+| **L4 gap-fill 构思**(按需) | 设计师在 trigger×effect 覆盖矩阵选**空格子** → 单 Sonnet 生成**1 个**语料-schema-合法候选 JSON → 立即回灌 L1-L3 | 单 Sonnet | **禁批量 20 个**(triage 负担>收益);1 个或≤3 按 gap-fit 排序 |
+| **Monte-Carlo sim** | 数值平衡(L3 只抓逻辑 exploit,定量平衡需模拟) | **Python 脚本**(harness shell 调,非 subagent) | 数值裁判;读同一份技能数据 |
+
+**减负构思三招**(web-verified):① gap-fill(查语料缺失生态位 → 约束内生成 1 个);② 设计空间矩阵(trigger×effect 覆盖图,选格子,负担从"扫全空间"降到"选一格");③ embedding 相似度过滤(text-embedding-3-small,抑制 cos>0.85 冗余)。
+
+**设计须防的失败模式**:LLM 数值漂移(所有数字从结构化字段**重算**,不信 LLM 叙述伤害);语料陈旧(扫描只与语料完整度等齐);tag 爆炸(≤60 tags,≤30 mech + ≤30 content,L1 强制归一)。
+
+### 1.3 前置依赖(决策点交用户)
+- **功率评分需数值** → 设计库 `Skill`/`Talent` 现为叙述字段,L1 评分需要数值化效果幅度。两条路(见 §5 同款):(a) 设计库补引擎数值字段;(b) 评分用一个手填的 `power_weights` 结构。**短期** L1 可先只做 schema+tag+规则冲突(不含功率评分),数值评分待 设计库补字段。
+- 设计库需暴露稳定**只读 API**(已有 31 端点;确认 GET 列表/详情够用)。
+- **Z3 可选增强**:`pip install z3-solver`(MIT)可把功率预算/tag 互斥/触发冲突编成 SAT/UNSAT + 反例(确定性可审计)。L1 的 SQL/评分够用则 Z3 是后续硬化项,非 MVP。
+
+---
+
+## 2. 痛点2 — 像素素材:`pixel-asset-pipeline` Workflow
+
+### 2.1 工具裁决(web-verified,按素材类别专精)
+**无单一工具覆盖全四类** → 三个 API 服务按强项分工 + Aseprite CLI 当统一后处理。
+
+| 素材类 | 首选 | 自动化面 | 成本 |
+|---|---|---|---|
+| 角色/单位(多帧) | **PixelLab.ai** —— `POST /v2/create-character-with-4-directions` + 骨骼动画≤16 帧 + 参考图角色一致性;**官方 MCP `pixellab-code/pixellab-mcp`**(CC 直接用无需 adapter);**Godot 明列支持** | REST 40+ 端点 + Python SDK + MCP | $0.002-0.185/call,≤512² |
+| 场景/tileset/地图 | PixelLab Wang tileset **或** Retro Diffusion **RD Tile**(Replicate,无缝纹理) | REST / Replicate | RD 新号 $0.50 免费额 |
+| 技能 VFX | **Retro Diffusion RD Animation**(Replicate;"风格一致动画像素 sprite",引擎兼容布局) | Replicate API | 按 prediction |
+| UI 图标 | **Scenario.gg** 自训 LoRA(5-100 参考图,**最强风格锁**,图标集内聚) | API-first + MCP + webhook | $10-50/月 |
+| 兜底/省钱 | gpt-image-2(**Mercury animate-frames 已包**,单帧)/ ComfyUI 本地(高量省 API 费) | 已有 skill / 本地 HTTP | $0.04-0.17/img / 本地 GPU |
+
+### 2.2 4-stage 管线(Workflow 设计)
+1. **生成**(按类别 fan-out):上表工具;角色/tileset 走 PixelLab MCP,VFX 走 RD Animation,图标走 Scenario LoRA,兜底 gpt-image-2。输入契约 = animate-frames 的 character-bible JSON(两后端共享上游契约)。
+2. **一致性+调色板门**:复用 **Mercury animate-frames 现有 dHash 一致性 + palette 量化校验**;低于阈值拒绝 + 重生成。
+3. **后处理 = Aseprite CLI**(headless 通用后处理,~$20 一次性,无 per-call 费):`aseprite -b --color-mode indexed --palette master.gpl frames/*.png --sheet out.png --sheet-type packed --sheet-pack --data out.json --split-tags` —— 一次调用搞定**调色板量化 + sprite-sheet 打包 + 帧元数据 + tag 分区**。
+4. **Godot 导入**:解析 Aseprite JSON → 生成 `.tres` SpriteFrames 资源(或 GDScript 导入助手)。**注意约束**:此步**产出物落 SoT 仓** → 按"不直接干预 SoT 仓"约束,Workflow 只产出文件到暂存区,**由用户/opencode 导入 SoT 仓**,或明确征得同意。
+
+### 2.3 Frame Ronin 定位(你的参考)
+Frame Ronin(`github.com/systemchester/FrameRonin`,开源自托管,627★)= **video/GIF → sprite-sheet 处理器**(U2Net 去背 + FFmpeg + RPGMaker 模板),**非生成式**;有 REST `/jobs` API(可自动化,无 CLI/MCP,需本地 Docker 起后端);**license 未确认(LICENSE 404,标 UNVERIFIED,采用前须核)**。
+→ **定位**:仅当用 **AI 视频生成**(Seedance/Wan2.1/Kling)产动画片段时,Frame Ronin 是"视频→精灵表"桥;若纯 gpt-image-2/PixelLab 静帧路线,**Aseprite CLI 已够,Frame Ronin 价值有限**。与 animate-frames **互补非竞争**。
+
+### 2.4 与 Mercury 现有的协同
+animate-frames 的 character-bible JSON 契约 + dHash 门 + palette 校验是地基;加 (1) PixelLab MCP 角色生成 + (2) Aseprite CLI 后处理 = 端到端管线,**无需架构重做**。PixelLab adapter 若需自写 HTTP 适配,落 `adapters/pixellab/`(≤200 LOC);但有官方 MCP 时优先 MCP 免 adapter。
+
+---
+
+## 3. `godot-test` Workflow:包装现有 headless harness 成闭环
+
+- **缺口**:dev subagent 无法自动跑+读 Godot 测试;手动测试清单摩擦。
+- **做法**:Mercury skill/workflow 跑 SoT 现有 headless 测试,带 verified 护栏:`--import --quit-after 2`(绕 race issue #77508)、`GODOT_DISABLE_LEAK_CHECKS=1`、`.godot/` 不入库、Godot 4 **不用 xvfb**(issue #43444);解析退出码/JUnit XML 回结构化 pass/fail。
+- **可选升级**:自研 SceneTree → **GUT 9.6**(对 Godot 4.6,JUnit XML + 发现)或 **GdUnit4 v6.1.3**(runtime-free 纯逻辑测试更快);或保留轻量自研只做包装。把 `剑圣手动测试清单.md` 项转自动 SceneTree 断言。
+- **gdtoolkit 门(快赢)**:`pip install "gdtoolkit==4.*"`(v4.5.0,纯 Python 无引擎)→ `gdformat`+`gdlint`+`gdparse` 提交前抓 GDScript 语法/风格错。
+- **约束**:测试 GDScript 在 SoT 仓 → Workflow 只**跑+读**(只读执行),不改 SoT 仓测试文件;新断言由用户落仓或经同意。
+
+---
+
+## 4. godot_mcp 接入 + 安全连接协议 ⚠️
+
+**握手坑(只读审计坐实)**:godot_mcp = 编辑器内 WebSocket server,bind LOCALHOST **端口 6550**,**单客户端**;新客户端**接管**(close code `4002` "Connection taken over by a newer client")**踢掉旧客户端**。SoT `.mcp.json` 已配 `godot` server(opencode + Claude 都可能用)。
+
+**当前现状(2026-06-22 检查)**:`Godot_v4.6.1-stable_win64`(PID 17240)**编辑器活动** + 多 node 进程 → **极可能 opencode 正连着 6550**。**当前 CC 在 Mercury 工作区(未加载 SoT `.mcp.json`)→ CC 此刻未连**(安全)。
+
+**安全连接协议(用户测试前必走)**:
+1. 连 godot_mcp **前**确认 6550 无其他活动 MCP client(关 opencode 的 godot 连接 / 关多余编辑器实例),否则 CC 连接会接管并**踢掉 opencode**,扰乱活动 SoT 工作。
+2. 本 session(编辑器活动)**已 defer live 连接测试** —— 符合用户"测试前先检查现状"要求。
+3. 接入方式:把 `godot` MCP server 加入**这条 CC session 的 MCP 配置**(非改 SoT 仓 `.mcp.json`),或 Workflow 内按需连;用完断开释放 6550。
+4. 版本注意:addon plugin.cfg 2.15.0 vs lazy_server.mjs 2.16.0 轻微不一致,接入时留意。
+
+### 4.1 实测记录(2026-06-25,main lane / ultracode)— live 测试全绿
+
+**接入方式**:
+- **MCP 配置**(供重启会话后用 `mcp__godot__*` 工具层):`claude mcp add godot -s local -e GODOT_PROJECT_PATH=D:/ShipOfTheseus/Ship_of_Theseus -e GODOT_MCP_PACKAGE_VERSION=2.16.0 -- node D:/ShipOfTheseus/Ship_of_Theseus/addons/godot_mcp/godot_mcp_lazy_server.mjs`。落 `~/.claude.json` **本项目私有段**(`Scope: Local config` — 不碰 SoT 仓 `.mcp.json`、不污染 git);`claude mcp get godot` 报 ✔ Connected。**改后须重启会话**才能在 session 内拿到 `mcp__godot__*` 工具(本 session 未热加载)。
+- **live 测试方式**:Node 24 内置 `WebSocket` **直连 6550**(绕 MCP stdio 桥直测 WS 命令面),本 session 即可验证、不必等会话重启。脚本 = scratchpad `godot-mcp-livetest.mjs`(纯只读命令,零 SoT 文件副作用)。
+
+**预检(安全协议第①步)**:6550 接入前**并非空闲** — PID 22984(`@satelliteoflove/godot-mcp@2.16.0` cli.js,**2026/6/21 启动**,父链 `bash→npx→cmd→node`,opencode 泄漏僵尸 MCP server)持活动连接。另有 21 个空闲 `lazy_server.mjs`(lazy connect 未占 6550,无害)。用户授权**直接接管**(close 4002 踢 22984)。
+
+**live 测试结果(9 只读命令全绿)**:
+| 命令面 | 命令 | 结果 |
+|---|---|---|
+| system | `mcp_handshake` | addon **2.15.0** / godot **4.6.1-stable (official)** / proj ShipOfTheseus / path `D:/ShipOfTheseus/Ship_of_Theseus/` |
+| project | `get_project_info` | main_scene `res://scenes/tactical/TacticalScene.tscn` |
+| scene | `get_current_scene` | 实时编辑器打开 `res://scenes/tactical/bottom_dashboard.tscn`(BottomDashboard/Control) |
+| scene | `get_scene_tree` | root=BottomDashboard/Control children=0 |
+| script | `get_current_script` | `res://scripts/tactical/tactical_scene.gd` 17KB 真实源码 |
+| node | `find_nodes`(type=Node2D) | count=0(当前 Control 树无 Node2D,命令正确执行) |
+| screenshot | `capture_editor_screenshot` | **320×233 真实 PNG**(base64 head=`iVBORw0KGgoA`=PNG magic)= 驱动编辑器渲染铁证 |
+| debug | `get_debug_output`(editor) | 编辑器日志含 "Taking over active client…Accepting replacement client" 自证 takeover 链 |
+| game_bridge | `capture_game_screenshot` | NOT_RUNNING(编辑器态未跑游戏,命令路由+运行时门控正确) |
+
+`disconnect_client` 返回 `__disconnect_after_response:true`(优雅断开协议生效)。
+
+**两点坐实**:
+1. **版本不一致**:addon plugin.cfg **2.15.0** vs server EXPECTED **2.16.0** — 握手照常工作,仅触发 console warning(`version_mismatch` 事件),不阻断命令面。
+2. **22984 是 autoReconnect 僵尸**:disconnect 后 `WS_CLOSE code=4002`(被新 client **takeover**,非 4003 server-disconnect)+ AFTER 快照 6550 被**新端口 59086** 占 → 22984 被踢后立刻重连抢回。**对直连 live 测试无影响**(被踢前 9 命令已跑完),但会**持续抢占 6550**,干扰后续重启会话用 MCP 工具层的稳定性 → 已清理。
+
+**用户裁决(2026-06-25)**:
+- ✅ **已清理 22984 僵尸链**(用户授权):kill 5 进程(cli.js 22984 + npx-cli 19472 + cmd 25656 + bash 26908/28336),6550 回归 **Listen-only 干净**(仅编辑器 17240 监听,无 Established);21 个无害空闲 `lazy_server.mjs` 未碰。后续重启会话用 MCP 工具层时 lazy_server 连 6550 不再被僵尸争抢。
+- ⏸ **MCP 工具层(`mcp__godot__*`)验证延后**:配置已就绪(local scope `claude mcp get godot` ✔),需重启会话生效;用户选"到此收尾"(底层 WS 命令面已直验,边际价值低)。
+- ⏸ **运行时 game_bridge 真截图延后**:需 `run_project` 弹游戏窗口(可见副作用);用户选"到此收尾"。
+
+---
+
+## 5. 设计库↔Godot 数据桥(中期,需用户定 schema)
+
+- **缺口**:设计库 `Skill` 叙述字段,Godot 要数值;设计库无 export → 设计不喂引擎。
+- **两条路(决策点)**:**(a)** 设计库模型补引擎数值字段(power/hit_bonus/range/area/cooldown/action_cost/timing_constraint/结构化 effects[])+ `/api/export/godot` 输出 Godot 格式 `data/skills/*.json` + **jsonschema 4.26.0**(Draft 2020-12,min/max 边界 + `additionalProperties:false`)门控 —— **利于 §1 功率评分 + §6 平衡 sim**;**(b)** 设计库存 `godot_json` blob 字段(手填引擎块 verbatim 导出,省双建模少结构)。**推荐 (a)**,数值字段正是平衡所需。
+- **约束**:此项**改 SoT 设计库仓** → 按"不直接干预 SoT 仓"约束,**本 lane 只出设计/方案,实施由用户或经明确授权**。Workflow 侧可先做"读 设计库 API → 校验 → 生成 Godot JSON 草稿到暂存区"的只读管线。
+
+---
+
+## 6. 优先级待办清单
+
+| 优先 | 待办 | 落点 | effort | 阻塞/前置 |
+|---|---|---|---|---|
+| **P0 ✅DONE** | `talent-validate.js` Workflow(L1 结构+规则冲突 + L2 组合 + L3 对抗;不含数值评分) — **2026-06-22 落地+dual-verify+实跑见切 reject,详见 §9** | `.claude/workflows/talent-validate.js` | 中 | ~~设计库只读 API~~ ✓ |
+| **P0 ✅DONE** | gdtoolkit lint 门 + `godot-test` 包装(护栏化现有 headless harness) — **2026-06-22 落地+dual-verify+6 用例回归,详见 §9.5** | `scripts/gdlint-gate.sh` + `scripts/godot-test.sh` | 小 | 无(只读跑) |
+| P1 | `pixel-asset-pipeline.js` Workflow(PixelLab MCP + Aseprite CLI + animate-frames 门) | `.claude/workflows/` + 可选 `adapters/pixellab/` | 中 | 选定工具账号(PixelLab/RD/Scenario)+ Aseprite 购置 |
+| P1 | godot_mcp 安全接入 + live 测试 | 本 session MCP 配置 | 小 | **用户确认 6550 空闲**(关 opencode 连接) |
+| **P2 ✅DONE** | 设计库数值字段扩展 + `/api/export/godot`(§5) — **2026-06-25 落地+dual-verify+NAS 部署 smoke,详见 §11** | SoT 设计库仓 `553d21a` | 中 | ~~schema (a)/(b) + 授权~~ ✓ |
+| **P2 ✅DONE(内置)** | Monte-Carlo 平衡 sim — **2026-06-25 做成设计库内置 `/api/sim` + `/sim` 网页(参数化近似模型),NAS 部署 smoke 通过,详见 §11** | SoT 设计库 `app/sim/` | 中 | ~~数值字段~~ ✓;Godot headless 防漂移冒烟仍待 |
+| P3 | gap-fill 构思:trigger×effect 覆盖矩阵 + embedding 相似度过滤(并入 talent-validate L4) | `.claude/workflows/` | 小-中 | talent-validate P0 先落 |
+
+## 7. 待用户拍板的决策点
+1. ~~**设计库 schema**:数值字段扩展 (a) vs `godot_json` blob (b)?~~ → **已决 (2026-06-22):选 (a) 补引擎数值字段 + `/api/export/godot`**(中期方向,利于功率评分+平衡 sim;改 SoT 设计库仓需授权;MVP 不阻塞)。
+2. **像素工具账号**:PixelLab(角色,有 MCP)/ Retro Diffusion(VFX)/ Scenario(图标,月费)各开哪个?Aseprite(~$20)购置?是否需要 AI 视频生成路线(才用 Frame Ronin)?
+3. **改 SoT 仓授权边界**:§5 设计库扩展 + §2.2 Godot 导入产出物 —— 哪些允许 Workflow 落仓 vs 必须用户手动?
+4. **godot_mcp 接入时机**:何时 6550 空闲可做 live 测试?
+5. ~~talent-validate **首个验证对象**?~~ → **已决+已跑通 (2026-06-22):见切 `ss_jianqie` 跑通(verdict=reject,详见 §9);其余 3 张(破釜沉舟/先之先/心眼·彻)待扩。**
+
+## 8. 来源(节选,全 web-verified)
+- **天赋验证**:Z3 SMT(MIT,`pip install z3-solver`);Imaginarium ACM 2020(dl.acm.org/doi/fullHtml/10.1145/3402942.3409605);Red-Teaming Game arxiv 2310.00322;LLM 评估宽容偏差 arxiv 2512.07462 / 2601.19726;G-KMS MDPI 2025(mdpi.com/2079-8954/14/2/175);Automatic Game Design arxiv 1908.01420。
+- **像素素材**:PixelLab API(pixellab.ai/pixellab-api)+ MCP(github.com/pixellab-code/pixellab-mcp);Retro Diffusion(replicate.com/retro-diffusion/rd-animation);Scenario(scenario.com);Aseprite CLI(aseprite.org/docs/cli);gpt-image-2(developers.openai.com/api/docs/models/gpt-image-2);Frame Ronin(github.com/systemchester/FrameRonin,license UNVERIFIED)。
+- **Godot 工具**:GUT 9.6(github.com/bitwes/Gut);GdUnit4 v6.1.3(github.com/godot-gdunit-labs/gdUnit4);gdtoolkit 4.5.0(pypi.org/project/gdtoolkit);headless gotchas issue #77508 / #43444;jsonschema 4.26.0(pypi.org/project/jsonschema)。
+- **godot_mcp 握手**:只读审计 `addons/godot_mcp/websocket_server.gd`(close code 4002 takeover)+ `.mcp.json`(port 6550)。
+
+---
+
+## 9. 进度记录:talent-validate Workflow(2026-06-22 落地)
+
+> main lane / ultracode(Workflow + agents team)。Workflow 文件 `.claude/workflows/talent-validate.js`(可 `/talent-validate` 复用)。
+
+### 9.1 已落地(P0 完成)
+- **架构(不含数值评分 MVP)**:4 层管线。
+  - **Phase0 Adapt**(agent+Bash):从 设计库只读 API(本地 `http://127.0.0.1:8000`;NAS `sot.fyc-space.uk` 待 CF token **不可达**)或 dataDir fixtures 取候选天赋+同职业天赋(轻量索引)+tag 注册表(12)+规则表(5)+rarityCounts+candidateStoredRarity;数据落 Mercury `.mercury/tmp/codex-fixtures/`(**零写 SoT 仓**)。
+  - **L1 结构验证**(脚本内**纯 JS 零 LLM**):schema 必填/枚举合法/tag∈注册表/规则引用悬空(正则带边界)/R6.6 史诗供给上限(归因区分"新增越界=error→reject"vs"池既有超限=warning→revise");+ Haiku 语义初筛(**advisory-only,不驱动 verdict**,符合"LLM 不做定量裁决")。
+  - **L2 组合扫描**:脚本 JS 枚举与候选共享 tag 的同职业天赋(PAIR_CAP=20,溢出 log)→ 并行 Haiku triage(interaction_type/risk_level);仅 loop/amplifier@high|medium 计入 flagged(防 loop+none 误报)。
+  - **L3 对抗批判**(串行双 Sonnet):Optimizer(agentType design)构滥用序列 → Defender(agentType critic)用现有**锁定**规则反驳;neutralized:false=确认 exploit。
+  - **fail-closed**:任何 L2/L3 agent 失败→stageFailures 追踪→verdict 至少 revise(覆盖不全不读作 pass)。
+- **护栏(#385)**:lean dispatch(传路径+任务,peer body 不 bulk 注入)/fan-out cap+log/Haiku 注入<<50K/只读 SoT。worst-case ≤34 agent(1 Adapt+1 L1语义+20 L2+2 L3,远低 800 自限)。
+- **dual-verify**(跨仓库手动:`oh-my-claudecode:code-reviewer` + `mcp__codex__codex`,因 dual-verify skill 假设单仓库):双审高度一致,**9 类问题已修**——① R6.6 供给归因 bug(`candidateStoredRarity` 区分新增/已存)、② L2 risk_level 门槛(loop+none 误报 revise)、③ L3 fail-open(defender 失败静默放行最危险情形)、④ stage-failure 追踪、⑤ ADAPT_SCHEMA 必填(candidateStoredRarity/ruleCodes.status)、⑥ 悬空正则边界(`[a-z]*`+lookaround)、⑦ L1 semantic advisory 化、⑧ inline draft 文件名一致、⑨ 早退返回形状带 verdict。
+
+### 9.2 实跑验证:见切 ss_jianqie(2026-06-22)
+**verdict=reject**(22 agents / 844K tokens / 522s / stageFailures=[]全覆盖)。三层各抓到真实缺陷,**完整验证路线图 §1 诊断(纯 LLM 弱裁判会漏的,混合管线抓到了)**:
+- **L1 确定性**(纯 JS,纯 LLM 必漏):① `R3.13c` 悬空规则引用(见切 rules 字段引用了规则表不存在的 R3.13c,ZOC 增伤治理无锚点);② R6.6 史诗池供给 7>6(归因正确:"池子既有超限,非见切导致;需设计层腾位")。
+- **L2 组合**(18 triaged,5 high-risk):见切 × 影缝/辻斬/先之先/明镜止水(loop high)+ 破釜沉舟(amplifier high)。**agent 真读了 dataDir 设计文档**——引用了"钉影近永久束缚"、"Fell Seal 控制链先例"、"PR #491 影缝候选删除"、"R3.12 三桶制"等真实语料(证明 lean dispatch 有效)。
+- **L3 对抗**(确认 exploit):Optimizer 构造 **见切(招架必暴)→影缝(斩击附钉影 MOV=0+不可位移)→辻斬(钉影态降级夹击:必中+产气)→明镜止水(满气保招架必成功=见切必触发)** 自锁永久控制链(win 2 回合,每环节均来自已有天赋文本,无需假设未声明机制);Defender 扫全部锁定规则(R1.1/R3.14/R3.12/R6.6)**无一能封堵**(无续接冷却/控制时长/时序禁令规则)→ neutralized=false;residual_risk 给具体修法(影缝加每场限次/续接冷却/退化一次性 debuff)。Optimizer 诚实列 8 条可证伪引擎假设(非过度自信幻觉)。
+- **判定语义**:reject ≠ 见切设计失败,而是"见切在当前语料(含影缝草稿)下触发了现有规则无法封堵的永久控制链,需设计层加门控"。这正是 talent-validate 该产出的高价值信号(**独立复现了 SoT 设计评审已知的影缝控制链争议**)。
+
+**扩跑验证:其余 3 张已审天赋(2026-06-22,3 Workflow 并行,各 20-22 agents / 760-840K tok / 全覆盖 stageFailures=[])**
+
+| 天赋 | 稀有度 | verdict | L1 确定性 | L2 flagged | L3 win | L3 exploit 核心 |
+|---|---|---|---|---|---|---|
+| 见切 ss_jianqie | 史诗 | reject | R3.13c 悬空 + R6.6 | 5 | 2 回合 | 见切→影缝→辻斬→明镜止水 永久控制链 |
+| 破釜沉舟 ss_pofu | 史诗 | reject | R6.6(已存) | 11 | 3 回合 | 影缝钉死+破釜必暴+心眼倍率+辻斬产气 自持螺旋 |
+| 先之先 ss_xianzhixian | 传奇 | reject | **空(无 R6.6)** | 8 | 4 回合 | 多敌围攻每攻击触发先制必暴"越被打越强"+背水三桶叠满 |
+| 心眼·彻 ss_xinyance | 史诗 | reject | R6.6(已存) | 13 | 3 回合 | 影缝钉影+见切必暴+辻斬产气+心眼高暴击+速度先手 |
+
+**横向验证达成**:
+- **R6.6 稀有度分支正确**:3 史诗→warning(已存归因,非候选导致);**先之先(传奇)→L1 deterministic 空**(非史诗不触发供给检查)——验证稀有度分支。
+- **悬空检测阴阳性全对**:见切 R3.13c→悬空 warning(阳性);心眼·彻 R3.14 / 破釜沉舟 R1.1→无悬空(阴性,不误报合法引用);先之先 rules 是程序注记无 R 码→正则不误匹配。
+- **L3 对抗 4/4 确认 exploit**(neutralized=false,win 2-4 回合),Defender 均扫全部锁定规则确认无法中和。
+- **L2 互引一致**:4 张互相标 high-risk(见切↔破釜沉舟↔先之先↔心眼·彻),agent 真读设计 notes(引用"高剑气进背水自强化螺旋须门控"/"影缝近永久束缚"/评审 D 阈值门控),证明 lean dispatch 有效。
+
+**核心洞察 — 影缝是剑圣职业线系统性漏洞**:3/4 的 L3 exploit 核心依赖**影缝(草稿)无冷却钉影续接**(永久 CC),先之先依赖背水剑气螺旋。4 张全 reject 的共同根因 = 影缝 + 剑气经济螺旋无门控,几乎任何产必暴/标记/产气的天赋都能接入同一控制链。**这不是管线缺陷,而是反映真实设计状态**(评审已建议砍影缝 / 落地剑气阈值门控,但均未成锁定规则)。talent-validate 独立、反复地指向同一根因 —— 正是混合管线该有的价值。
+
+**区分度后续测试建议**:移除/修复影缝(+把剑气阈值门控落成锁定规则)后重跑 4 张,看 verdict 是否分化(区分"真独立 exploit"vs"仅靠影缝接入")——可验证管线区分能力。需改 SoT 语料(不在本 lane 范围,待 SoT 设计层处理)。另:**R6.6"新增史诗→error→reject"路径**(候选 storedRarity≠史诗)这 4 张(已存史诗/传奇)未覆盖,可用合成史诗 draft 单测验证。
+
+### 9.3 用户决策(2026-06-22 拍板)
+- MVP 范围 = **不含数值功率评分版**(已落地)。
+- 设计库 schema 中期方向 = **(a) 补引擎数值字段 + `/api/export/godot`**(决策点 1;MVP 不阻塞,改 SoT 设计库仓待授权)。
+- 首验对象 = **见切先跑通**(已完成),其余 3 张待扩。
+
+### 9.4 后续待办(talent-validate 增量)
+- [ ] 扩跑其余 3 张已审天赋(破釜沉舟 `ss_pofu`/先之先 `ss_xianzhixian`/心眼·彻 `ss_xinyance`);心眼·彻作 draft 新增史诗应触发 R6.6 error→reject(验证"新增越界"归因路径,与"池既有超限"区分)。
+- [ ] **数值功率评分**(L1 增量):待 设计库补数值字段(决策点 1=a 实施后),加确定性功率预算评分(权重据现有平衡卡校准)。
+- [ ] **L4 gap-fill 构思**(§1.2/§6 P3):trigger×effect 覆盖矩阵 + embedding 相似度过滤,选空格子生成 1 个语料-schema-合法候选回灌 L1-L3。
+- [ ] Monte-Carlo 平衡 sim(Python,§6 P2)做数值平衡(L3 只抓逻辑 exploit,定量平衡需模拟)。
+- [ ] (可选硬化)把 fixtures 拉取从 Adapt agent 内联化为脚本前置;加 设计库 API 分页/规则表完整性校验(防合法引用被误报悬空);Z3 可选增强(§1.3)。
+
+### 9.5 次要任务:gdtoolkit lint 门 + godot-test 包装(2026-06-22 落地,P0 完成)
+- **落点**:`scripts/godot-test.sh` + `scripts/gdlint-gate.sh`(Mercury-internal tooling,无 LOC cap;**只读跑 SoT,不改 SoT 仓**)。
+- **gdtoolkit 4.5.0**(web-verified PyPI,纯 Python 无引擎;装 D 盘 venv `.mercury/tools/gdtoolkit-venv`,Python 3.14.3 兼容):gdlint(风格+语法)+gdformat --check(格式,不改文件)+gdparse(语法)。**实测+web 确认 gdlint/gdformat 目录递归**(无需 find 展开;gdparse 才需)。
+- **godot-test.sh**:包装 Godot 4.6.1 headless SceneTree 测试。web-verified 护栏:#88055(quit 退出码,4.6.1 实测可信但仍**退出码+stdout 双判**)、#77508(import race,`--import` 预热默认 off 避免与活动编辑器竞争)、`GODOT_DISABLE_LEAK_CHECKS=1`、#43444(Godot 4 无需 xvfb)。**三态 verdict**:pass/fail/**inconclusive**(exit 0 但无可解析总结 → 拒绝默认 pass,fail-closed)。
+- **dual-verify**(code-reviewer + Codex 跨仓库手动):核心修 **Codex HIGH false-pass**(FAILN 原只认中文 `失败`,英文失败行+exit 0 quirk 会误判 pass)→ FAILN 中英文+全角解析 + inconclusive 兜底;另修 gdformat/gdparse 缺失 fail-closed exit 2(不静默跳过门禁)、工具启动失败映射 exit 2、find 空遍历 surface、header 诚实声明(`--script` 只读性取决于被调脚本)。
+- **6 用例端到端回归全绿**:① 见切 pass/0 ② no_summary quit(0)→inconclusive/1 ③ 英文 "1 fail" quit(0)→fail/1(false-pass 修复) ④ gdlint-gate SoT FAIL/1 ⑤ clean PASS/0 ⑥ 工具缺失→exit 2。
+- **实测抓到 SoT 真实问题**(只报告,不改 SoT 仓):`test_swordsman_resources.gd` 有 4 处 mixed-tabs-and-spaces + 需格式化。
+- **用法**:`GODOT_BIN=<godot> bash scripts/godot-test.sh res://tests/test_swordsman_resources.gd <sot_project>` ; `bash scripts/gdlint-gate.sh <file_or_dir>`。
+
+### 9.6 可用性收拢(2026-06-22,用户马上投入天赋产出)
+为让 talent-validate 即用:
+- **启动脚本** `scripts/sot-codex-serve.sh`:一键起 设计库只读 API(DB 隔离 Mercury tmp,reuse 已运行实例,零写 SoT 仓)。
+- **使用指南** `.mercury/docs/guides/talent-validate-usage.md`:两种调用(talent_id / talent_draft_json)+ 草稿字段 + verdict 解读 + 数据刷新。
+- **draft 模式 bug 发现+修复**(talent_draft_json = 产出新天赋主用法):合成草稿"残月·试作"首跑暴露 bug —— Adapt 在 draft 模式误 curl 不存在的候选 id(得 404 `{detail:天赋不存在}`)写进候选文件,L2/L3 读到 404 而非草稿(L1 不受影响,用脚本变量)。**修法**:候选内容从脚本变量**内联**进 L2/L3 prompt(候选单张非 bulk,符合 #385;peer 仍读文件),Adapt draft 分支强化"不 curl 候选"。**修复后重跑确认**:L2 从"flagged 空+没分析候选"→"6+ flagged 且每个引用残月真实机制(+2 剑气/kill)",证明 L2/L3 现正确读草稿。**talent_draft_json 模式完全可用**。
+- **R6.6 新增 error 端到端确认**:残月·试作(史诗,id 不在库)→ L1 `error: 新增史诗供给达 8 > 上限 6` → reject(对照已存史诗的 warning),验证稀有度归因双分支。
+- **工作流**:① `bash scripts/sot-codex-serve.sh` 起服务 → ② 喂 talent_draft_json 草稿 → ③ 读 verdict + L1(确定性可信)/L2(组合)/L3(对抗)。
+- **待办**:talent-validate.js 的 draft 修复(4 处内联候选)**尚未 dual-verify + commit**(实证已通过重跑,静态 dual-verify 待补);产出仍在 working tree。
+
+---
+
+## 10. 方向转向:talent-validate 从 Mercury 本地 Workflow → SoT 设计库 网站内置交互式审阅(2026-06-23 用户提出)
+
+> 用户诉求:本地 CLI 调度割裂麻烦;想在 https://sot.fyc-space.uk/ 网页内投入天赋 → 现场审核 1/多张 → 对话反馈 → 改 → 重审。**这是改 SoT-fyc-space 仓**(硬约束需用户授权;用户 2026-06-23 提出=倾向授权,待明确点头)。
+
+### 10.1 可行性(web-verified 2026-06-23)
+- **Claude Agent SDK**(`claude-agent-sdk-python` / `@anthropic-ai/claude-agent-sdk`,<https://docs.claude.com/en/api/agent-sdk/overview>):Python+TS,跑任何 Node/Python runtime,自带 subagents/持久 sessions/MCP/human-in-loop。**完全能嵌 SoT 设计库 FastAPI 后端**。
+- **认证/成本(关键)**:
+  - 订阅 OAuth token(Pro/Max)**仅限 Claude Code + claude.ai;第三方应用用=违反 Anthropic 消费者 ToS**(<https://support.claude.com/en/articles/9876003>)。
+  - **但 2026-06-15 起新政**:Claude 订阅(Pro/Max/Team/Ent)有**月度 Agent SDK credit**($20-$200/计划),**覆盖第三方基于 Agent SDK 的应用**,按 API 费率计费、固定不滚存、用完另买(<https://support.claude.com/en/articles/15036540>)。→ **可合规用订阅 Agent SDK credit 供能**,额度有限;或用 Anthropic Console **API key**(按量无上限)。
+
+### 10.2 架构(高层移植路径)
+1. **L1 确定性层** → 移植成 SoT 设计库 Python 函数(FastAPI 内,纯代码零 LLM 零成本):schema/tag 合法/悬空引用/R6.6 供给。逻辑见 `talent-validate.js` `runL1Deterministic`,数据已在设计库(Talent/Tag/Rule)。**立即可做,零 API 成本**。
+2. **L2/L3 LLM 层** → Claude Agent SDK(Python)在 FastAPI 后端编排(L2 Haiku triage / L3 双 Sonnet 对抗)。用 Agent SDK credit / API key。可**精简 agent 数**降成本(本地 Workflow 22 agents 为彻底,web 版可少)。
+3. **交互前端** → 设计库加审阅页:投入天赋 → 审核 1/多张 → **Agent SDK session 持久对话**实现现场交流/反馈/迭代改/重审。
+4. **成本估算待做**:单张本地 ~800K token;web 精简版应更低;按 API 费率算月用量 vs $20-$200 credit。
+
+### 10.3 决策点(用户 2026-06-23 已全部拍板)
+1. ✅ **授权 Mercury 直接改 `SoT-fyc-space` 仓** + 完成后**重新部署到 NAS**(sot.fyc-space.uk)。
+2. ✅ **认证(双 provider fallback)**:主 = Claude 订阅自带 Agent SDK 月度 credit(沿用当前订阅),模型 `claude-opus-4-8`,effort **xhigh**;备用 = **OpenAI API key(复用 Argus 环境/配置里的 key,不在文档明文)**,模型 `gpt-5.4`,effort **xhigh**。后端实现"Claude 主→额度耗尽/失败时 fallback GPT"。
+3. ✅ **范围(分阶段)**:先 L1 纯代码移植(零 AI 成本、立即可上),再 L2/L3 Agent SDK。
+4. ✅ **谁落仓**:Mercury 直接改 `SoT-fyc-space` 仓 + NAS 重部署。
+5. ✅ **命名**:弃用"Codex"称呼(易与 OpenAI Codex 混淆)→ 全改称 **"SoT 设计库"**(指 `SoT-fyc-space` 的 FastAPI 应用,部署 sot.fyc-space.uk)。
+
+**实施注意(新 session 须 web-verify)**:Claude Agent SDK 原生用 Claude 模型;GPT-5.4 备用的集成方式(OpenAI SDK 直调 fallback,还是 Agent SDK 支持多 provider)+ `gpt-5.4`/`claude-opus-4-8` 模型 ID 可用性 + Agent SDK Python 包版本/API 签名,均须实施前 web-verify(强制研究协议)。
+
+### 10.4 注意
+- `talent-validate.js`(Mercury Workflow)仍是**原型/参考实现**,L1/L2/L3 逻辑 + 5 张实跑验证可直接复用。
+- 这是**新工程**(超当前 talent-validate MVP),建议新 session 专做(本 session context 已满)。
+- 强制研究协议:实施 Agent SDK 代码前须再 web-verify SDK API 签名/版本(本节为方向性 verify)。
+
+### 10.5 实施进度(2026-06-23 session)
+
+**Phase 1 — L1 确定性校验内置 ✅ DONE**(SoT-fyc-space `master` `54d008a`,本地仓无 remote):
+- 三层模块化:`app/validation/l1.py`(零依赖纯逻辑,忠实移植原型 `runL1Deterministic`)← `app/validation/context.py`(DB 装配)← `app/api/validation.py` + `app/web/pages.py`(HTTP/HTMX)。
+- 5 类检查:schema 必填 / rarity·damage_type·status 枚举合法 / tag∈注册表 / 悬空规则引用(正则带边界)/ R6.6 史诗供给(新增越界=error、池既有超限=warning、**跨职业迁移正确归因** —— Codex dual-verify 抓的 HIGH)。
+- 3 端点:`POST /api/talents/validate`(草稿 dry-run)、`GET /api/talents/{id}/validate`、`POST /talents/validate`(网页「结构校验」按钮 HTMX 即时反馈)。
+- **关键设计约束**:validate 输入用纯 str(非枚举类型),否则 FastAPI 422 拦截会吞掉「检测非法枚举」这个 L1 职责;web 校验路由注册早于 `{talent_id}` 参数路由。
+- **24 pytest 全绿**(纯函数 14 + API/web 端到端 10)+ live uvicorn smoke 通过。**dual-verify 闭环**:code-reviewer APPROVE(7 约束全 PASS)+ Codex 初版 HIGH(跨职业归因)→ 修复(`candidate_stored_class_id`)→ re-verify 同意合并 + 采纳 reviewer MEDIUM(枚举 drift guard test、notes 三入口统一)。
+- 测试基础设施:`requirements-dev.txt`(pytest+httpx)、`tests/conftest.py`(临时 DB,不碰 SoT 仓磁盘)。本地 `.venv` = CPython 3.14.3;Docker 部署 = python:3.12-slim,代码 3.12 兼容。
+
+**Phase 2 方向重大转向(用户 2026-06-23 拍板,推翻原 handoff 假设)**:
+- ❌ **不用 Claude / Anthropic / Agent SDK**;✅ **全用 OpenAI**(`gpt-5.4` + 纯 `openai` Python SDK)。架构从「Claude 主 + OpenAI 备双 provider」**简化为单 provider OpenAI**(无 fallback 层)。
+- **认证驱动**:web 研究(7 agent / 308K token,全 web-verified)证实 **2026-06-15 订阅 Agent SDK credit 新政已于 06-16 取消**(来源 support.claude.com/en/articles/15036540 + digitalapplied.com/blog/anthropic-claude-credit-overhaul-june-15-2026),第三方应用合规上只能用 API key;用户选定全 OpenAI。
+
+**Phase 2 — L2/L3 OpenAI 集成(✅ DONE,commit `a4e4027`,dual-verify 多轮闭环)** web-verified 事实(来源附下):
+> Phase 2 完成:`app/validation/llm.py`(L2/L3 编排)+ `context.build_review_context` + `app/api/review.py`(async 端点 + `synthesize_verdict` + `require_token` 鉴权);**44 pytest 全绿**。dual-verify:Codex(CRITICAL `_call_json` 空内容降级 / HIGH optimizer 失败不 surface / 空洞 fail-open `sequence=[""]`、空白中和 / 幻觉规则码)+ code-reviewer(HIGH `/review` 缺 `require_token`)**全修闭环**;fail-closed 加固=空内容/拒答/非法JSON/缺键/空 rationale/无锁定规则引用的中和 一律 failed/undetermined。**真实 gpt-5.4 调用未本地验证**(本地无 OPENAI_API_KEY,Codex 走 ChatGPT 登录),留 NAS 部署 smoke。**follow-up(不阻断 MVP)**:连接池跨 LLM await、同步查询阻塞事件循环、模块级 env 常量 import 固化、L3 corpus 无上限截断、L3 规则码可加状态二次核验。
+
+**🚀 NAS 部署完成(2026-06-23,真实 gpt-5.4 端到端验证成功)**:代码同步 NAS `sot-codex/`(NAS 无 git → tar over ssh)+ `OPENAI_API_KEY` 复用 argus `.secrets.toml`(写入 sot `.env`)+ docker compose rebuild(openai 2.43.0)+ restart(`sot-codex-app-1` `:8400` override,Cloudflare Tunnel → sot.fyc-space.uk;socket `/var/run/system-docker.sock`,docker compose v2.29.1-qnap2)。**真实 smoke**:L1 validate=revise(R3.13c+R6.6,与本地一致);**L2/L3 review 见切=reject + L3 confirmed_exploit=true + stage_failures=[]**——真实 gpt-5.4 独立复现原型「见切永久控制链」exploit 结论。容器内最小 gpt-5.4 调用确认 key/模型ID/reasoning_effort 扁平/response_format strict 全工作。**性能问题**:L3=high cap=5 单张 review **~247s**(接近超时);生产 `.env` 已加 `SOT_LLM_L3_EFFORT=high` / `SOT_LLM_L2_PAIR_CAP=5`。**⚠️ Phase 3 前端必须异步**(后台任务 + 轮询/SSE,不能同步等 ~4min HTTP)或进一步降 effort / 截断 L3 corpus(无上限,token 随职业天赋数膨胀)。回滚:`sot-codex/app.backup-pre-validate`(旧 app 备份)。
+- 包:`openai` 2.43.0(2026-06-17,PyPI),`AsyncOpenAI`,Python≥3.9。env `OPENAI_API_KEY`。
+- 模型:`gpt-5.4`(developers.openai.com/api/docs/models/gpt-5.4):ctx 1,050,000 / out 128K / **$2.50 input·$15 output per MTok**(缓存输入 $0.25)/ **>272K token 触发 2x 输入·1.5x 输出惩罚**。alias `gpt-5.4-2026-03-05`。
+- **reasoning effort**:Chat Completions 用**扁平字符串** `reasoning_effort="high"`(合法 none/low/medium/high/xhigh);嵌套 `reasoning={"effort":...}` 是 Responses API 写法(gapCheck 关键纠错,来源 developers.openai.com/api/docs/guides/latest-model)。
+- **结构化输出**:`response_format={"type":"json_schema","json_schema":{"name":...,"strict":True,"schema":{...,"additionalProperties":False}}}`,或 `.parse()`+Pydantic(developers.openai.com/api/docs/guides/structured-outputs)。
+- 架构(移植原型 L2/L3):L2 = 代码枚举共享 tag 对 → 并行 `gpt-5.4` triage(JSON);L3 = 串行 Optimizer→Defender(JSON)。新端点 `POST /api/talents/{id}/review`(async,L1+L2+L3);`validate` 保留 L1-only(快、零成本)。成本控制:web 版 L2 pair cap 比本地 22-agent 小(~8-10);单张 review 估 ~$0.1。
+- **key 路径决策**:代码从 env `OPENAI_API_KEY` 读(勿明文);本地无 key(Codex 走 ChatGPT 登录,Argus key 在 NAS)→ **mock 单元测试覆盖编排逻辑** + **真实 LLM smoke 放 NAS 部署阶段**(SoT 容器与 Argus 同 NAS 环境共享 key)。
+- **部署**:用户选「等 L2/L3 完成一起部署 NAS」,Phase 1 暂不单独上线。
+
+**Phase 3 — 交互审阅前端 ✅ DONE(2026-06-24,SoT master `619f167`,NAS 部署+真实 gpt-5.4 smoke 全绿)**:投入→异步审核→对话反馈→帮改→重审→显式落库全闭环。详细实现规格 + dual-verify 修复见 `sot-phase3-review-ui-plan-2026-06.md`(§6 七项对抗式批判修正 + §11 实施完成 + dual-verify 9 项修复)。
+- **异步**:DB 持久 ReviewSession/ReviewJob + `asyncio.create_task` + HTMX 短轮询(每 2s)。**不用 SSE**(web-verified:CF Tunnel 对 SSE ~100s 超时+~100KB 缓冲对 247s 任务结构性失效);**不用 BackgroundTasks**(无 job 句柄)。持久会话 = **Chat Completions 自存 messages(存 DB),不用 Responses API**(30 天 TTL + 跨重启需 fallback 全量历史,既然都得自存就直接自存)。streaming 未用(轮询替代)。
+- **对抗式设计 Workflow**(`wf_cf1d0c3a-8a2`,11 agent:4 研究+3 架构+1 评判+2 批判,冠军=草案3 UX优先嫁接草案2稳健+草案1复用) + main-loop web-verify 5 技术点(htmx 停轮询/FastAPI create_task/asyncio 弱引用 GC/CF Tunnel SSE/SQLite WAL connect listener,全附官方来源) + 跨仓库 dual-verify(code-reviewer + Codex MCP,双路确认 7 修正真实实现 + 9 项 findings 全修)。
+- **测试**:71 pytest 全绿(44 现有零回归 + 27 新) + 本地 live uvicorn smoke + **NAS 真实 gpt-5.4 端到端 smoke 全绿**(见切 ss_jianqie 异步审阅 ~144s→驳回+L3 确认 exploit 复现 Phase 2;帮改对话真实提案;commit H3 门拦住;数据纪律 Talent updated_by=None 验证;停轮询 done 片段 0 trigger)。
+- 生产 `.env` 沿用 `SOT_LLM_L3_EFFORT=high`/`SOT_LLM_L2_PAIR_CAP=5`,新 `SOT_REVIEW_*` 全安全默认(require_token 默认 ON,复用现有 API_TOKEN 作网页审阅令牌)。回滚 `sot-codex/app.backup-pre-phase3`(本次部署创建,= Phase1/2 状态)。
+- **遗留 follow-up(非阻断)**:① 后台协程跨 session 可见性随 NAS smoke 间接验(WAL+busy_timeout);② LLM 输出入 HTML 属性 XSS 边界(autoescape 默认开 + 已改单引号属性,可后续用含 `<script>` reply 专测);③ `progress_detail` L2 细粒度进度未写(功能缺口非 bug);④ 派发端点 async 内同步 DB 查询轻微占事件循环(poll 是 def/线程池不受影响,低流量可接受)。
+
+---
+
+## 11. §5 数值字段桥 + §6 P2 平衡 sim + 去 Codex 命名（2026-06-25 落地）
+
+**全部 DONE + dual-verify + NAS 部署 smoke 全绿**（SoT 设计库 master `553d21a` + 总结文档 `9e69929`）。详细产出总结（递交 SoT 组）= SoT 仓 `docs/engine-numerics-export-sim.md`。
+
+**A. 数值字段 + `/api/export/godot`**：Skill 加 `engine_json`（完整 Godot 引擎块 JSON）+ jsonschema(Draft 2020-12, web-verified 4.26) 校验门（API create/patch + 网页 + 导入/seed 全写路径）+ `/api/export/godot` 三分区 fail-closed 导出 + dry-run 校验 + 技能页编辑器。**关键设计判断**（已在总结标 SoT 组裁决）：勘察 Godot `data/skills` 发现引擎层与设计层 taxonomy 不同（英文枚举）+ 职业专属字段（剑圣 qi/mark 经济）→ §5(a) 字面"显式列"务实改为"单 engine_json 块 + jsonschema 逐字段门控"。
+
+**B. Monte-Carlo 平衡 sim**：做成设计库内置 `/api/sim/skill` `/api/sim/class` + `/sim` 网页（用户选内置非独立脚本）。参数化近似战斗模型（命中/暴击/防御/crit_damage_bonus/cooldown/effects dot/splash）→ 伤害分布/TTK/胜率 + 横向离群标记。**模型是近似非引擎复刻**（SoT KB = Obsidian `ShipOfTheseus-KB/` 有权威公式：格挡暴击互斥/pure 规则/无距离衰减/ZOC，可后续细化）。
+
+**C. 去 Codex 命名**（用户特许改 SoT KB）：「SoT Codex」→「SoT 设计库」（app/模板/README/CSS + Godot dev_doc + Mercury roadmap/talent-validate-usage）。**消歧**：保留运营标识符（codex.db/docker 网络/sot-codex 目录）+ AI 工具引用（codex-cli/Codex dual-verify/GPT-5.3-Codex）。Obsidian KB 经查无设计库义 Codex（全 AI 工具，正确保留）。
+
+**质量**：对抗式设计判断 + jsonschema 4.26 web-verified + **dual-verify 双路（code-reviewer + Codex MCP）闭环 8 修复**（splash 伤害归属 / **现有 codex.db 缺列迁移启动幂等 ALTER** / DOT chance=0 / median=0 离群抑制 / 导入校验 / PATCH null / n_runs=0 / sim.html XSS）+ **107 pytest 全绿**（71 现有零回归 + 36 新）+ **NAS smoke**（迁移补列验证 + export 三分区 + sim 真实往返 ss_zhanji win=1.0/dmg=741）。回滚：`sot-codex/db-backup-pre-engine/`（codex.db+wal+shm）+ `app.backup-pre-engine`。
+
+**遗留**：① §5(a) 偏离待 SoT 组裁决；② sim 模型可据 KB 权威公式提保真（剑气印记/格挡暴击互斥）；③ Godot headless 防漂移冒烟（§6 P2 后半）仍待；④ 数值功率评分（§9.4 / L1 增量）现已解锁（engine_json 有数值）可做。
+
+---
+
+## 12. Skill 数值层增强包：§5a 显式列 + #4 功率评分（2026-06-25 实施）
+
+> main lane / ultracode。用户裁决:§5(a)=**通用字段加显式列**;#4=**路径 X Skill 级功率评分**。两者紧耦合,统一实现为一个增强包,一次 dual-verify + 一次 NAS 部署。改 SoT 设计库仓(已授权)。
+
+### 12.1 关键勘察发现(推翻 §11 遗留 ④ 乐观假设)
+- `engine_json` 挂在 **Skill(基础技能)**,**不在 Talent(天赋卡)**。talent-validate L1 校验的是 **Talent**(candidate=talent dict,rarity/rules/effect 叙述,**无数值字段**)。
+- 原型 `talent-validate.js` 自声明 "Numeric power-scoring intentionally OUT of MVP (narrative layer has no numeric power field)"。
+- §1.2 原意"功率评分超**稀有度**上限"是 Talent 维度,但当前数值只在 Skill 层 → #4 只能先做 **Skill 级(路径 X)**;Talent 级(路径 Y)阻塞在天赋数值化(天赋多 buff/被动/skill_upgrade,难数值化),留后续。
+
+### 12.2 Part A — §5(a) 通用字段加显式列
+- **engine_json 仍单一事实源**(权威);通用标量字段镜像成 Skill `eng_*` **派生列**(便于 SQL 查询/排序/过滤 + 喂 #4 评分)。空/非法 engine_json → 列全 NULL。
+- 列清单(GODOT_SKILL_SCHEMA 通用字段拍平):`eng_damage_type/eng_power/eng_hit_bonus/eng_cooldown/eng_action_cost/eng_timing_constraint/eng_range_type/eng_range_min/eng_range_max/eng_area_type/eng_area_size/eng_effect_count`。**effects/tags 数组 + 职业专属字段(qi/mark)不拍平**(仍留 engine_json,避免 20+ nullable 列脆弱)。
+- 同步:`godot_export.derive_engine_columns(engine_json)->dict` 在每个写路径(skills.py create/patch、seed.py、import)解析填列。迁移:db.py `_ensure_columns` 幂等 ALTER 登记新列(仿 engine_json ALTER)。
+
+### 12.3 Part B — #4 Skill 级确定性功率评分
+- **`app/sim/power_score.py` = montecarlo 的确定性期望闭式版**:复用 `_def_for_type/_clamp/_num/_effects_expected_dot`(零漂移,单一战斗模型事实源),但算**期望值非 RNG 采样**(快+确定+可复现+未来可作校验门)。
+- 评分公式(对默认 Target/CombatParams):`expected_primary = base_attack×power/100 × mitig × hit_prob × (1 + crit_prob×(crit_mult−1))`;`per_use = expected_primary + expected_dot×hit_prob + expected_splash`;**`power_score = per_use/(cooldown+1)`**(每回合期望功率,体现 CD 折扣=持续输出)。
+- 端点 `/api/score/skill` + `/api/score/class`(仿 sim.py):横向按 power_score 排序 + 离群(ratio≥1.5 high/≤0.5 low,可按 action_cost 分组)。网页 `/score` 可选。
+- **vs sim 区别**:sim=蒙特卡洛随机分布(p10/p90/胜率/TTK,全面但慢+RNG);功率评分=确定性期望标量(快速横向筛+可作门)。两者复用同一战斗模型不漂移。pure 暴击固定/格挡互斥/剑气经济仍属高保真域(遗留 ②),功率评分同 sim 不纳入。
+
+### 12.4 实施进度（2026-06-25 实现+测试+dual-verify DONE，SoT 设计库 master `ec74ff1`；NAS 部署待执行）
+- **Part A（§5a 显式列）**：models.py 加 12 个 eng_* 派生列;`godot_export.derive_engine_columns`;db.py 启动迁移幂等 `ALTER ADD COLUMN` + `CREATE INDEX IF NOT EXISTS` + 回填现有行;同步覆盖**全部写路径**(API skills create/patch、网页 pages 两 form、seed/import)。
+- **Part B（#4 功率评分）**：`sim/power_score.py`(montecarlo 确定性期望闭式版,复用 `_def_for_type/_clamp/_num/_effects_expected_dot` 零漂移);`api/score.py` `/api/score/skill`+`/class` 横向离群;main 注册。
+- **测试**：**139 pytest 全绿**(107 现有零回归 + 32 新)。
+- **dual-verify（对抗式双路）**：Claude code-reviewer 3 维 Workflow(`wf_6da7924e-32f`) + Codex 跨仓库手动 → **9 findings → 8 修复闭环**(① parse_engine 非 str 守卫 ② backfill schema 非法守卫(脏库防御) ③ 升级表补建 index=True 派生列索引 **medium**(否则查询退化全表扫描,击穿"加列换性能"卖点) ④ score_skill cooldown 负值兜底 ⑤ eng_effect_count 只计 dict 项 ⑥ resolve_engine 提公开消除 score 对 sim 私有符号耦合 ⑦⑧ 注释纠正评分不读列)+ **1 DISAGREE-cite**(Codex round 精度 low,与既有 sim_class 离群模式一致,影响 <0.2%)。
+- **关键发现（已记 §12.1）**：engine_json 在 **Skill** 不在 **Talent** → #4 只能 Skill 级(路径 X);Talent 级(原 §1.2"稀有度功率预算"意图)阻塞在天赋数值化(天赋多 buff/被动/skill_upgrade),留后续。
+- **文档**：SoT 仓 `docs/engine-numerics-export-sim.md` §7(递交 SoT 组)。
+- **NAS 部署 ✅ DONE(2026-06-25)**：tar over ssh 同步 `app/` → `docker compose build app` + `up -d`(rebuild,Dockerfile COPY app 进镜像故须 rebuild 非 restart)→ 启动自动迁移 smoke **全绿**：**12 个 eng_* 列 + 3 索引**(`ix_skill_eng_damage_type/power/action_cost` —— 验证 dual-verify 索引 medium 修复在**升级库**生效)+ **回填现有技能**(`ss_zhanji` eng_power=180/damage_type=physical);`/api/score/skill` 真实往返 **power_score=66.0**(与 pytest 逐位一致);app `startup complete` 无 traceback。回滚备份:`sot-codex/db-backup-pre-engine2/`(codex.db+wal+shm) + `app.backup-pre-engine2/`。
+  - **NAS docker 调用补全(此前 KB 只记 socket+compose 版本,现补完整命令)**:QNAP Container Station docker = `/share/CACHEDEV1_DATA/.qpkg/container-station/usr/bin/docker -H unix:///var/run/system-docker.sock`;**必须 `export DOCKER_CONFIG=<可写目录>`**(否则 `.docker/config.json` permission denied 致 `docker compose` 子命令"not a docker command");392fyc 在 `administrators` 组(gid 0)可直接读写 system-docker.sock **免 sudo**。ssh 入口 `ssh.fyc-space.uk`(cloudflared access,token 需浏览器认证;**非交互 Bash 环境须 `dangerouslyDisableSandbox` 才能建隧道**)。
+
+### 12.5 SoT 组回执(2026-06-25,用户转达)— 方向调整
+1. **§2 偏离 ACCEPT**:engine_json+jsonschema 优于 20+ 显式列(引擎异质 + 职业专属,每加职业改库不可取)。**注**:本 session 已部署 = engine_json(单一事实源)+ 12 个【通用】派生列(非职业列堆叠,职业专属仍留 json) → **兼容此回执**(engine_json 为核心);12 派生列仅只读 SQL 镜像、#4 评分不依赖,**保留 vs 回退纯 engine_json 待用户定**(回退零评分影响)。
+2. **Source-of-truth = Godot repo 权威**;设计库 engine_json 作【只读镜像】、定期从 repo 回填;**暂不启用 `/api/export/godot` 回灌 Godot 仓**(避免覆盖 repo 侧 QA)。→ 数据流反转(原「设计库→导出 Godot」作废);export 端点保留但暂不回灌;需后续 **Godot `data/skills`→设计库 engine_json 回填管线**。
+3. **stale**:现有 5 张剑圣 engine_json 早于近期 QA(斩击产印记 / 拔刀溅射 50%+暴击 3.0x / 一闪 AoE),回填前视为过期;eng_* 忠实镜像故同步过期(repo 回填后自动刷新);卡片文本(斩击「转职后」/ 拔刀 ×1.5)待与现行引擎对齐。
+4. **sim=离群初筛**;剑圣精校走 KB 公式 + Godot headless(= 遗留 #2/#3)。
+5. **格挡保留方案不实装**(用户):sim/power_score 本就不含格挡,符合。
+6. **天赋暂缓**(用户):Talent 级功率评分(路径 Y)+ talent-validate L2/L3 增量,等用户设计天赋后再做。
+
+**pure 暴击固定 1.5x 数据源(用户问,已核实)**:**权威 = Godot 引擎 `scripts/core/damage_calculator.gd`**(`:54`/`:122` `enable_pure_crit` gate + `:81` 暴击固定 1.5x 不吃 crit_damage_bonus;**pure 暴击默认 disabled**,仅技能显式 `enable_pure_crit=true` 才有暴击且固定 1.5x),**2026-06-21 Godot headless 验证**(KB `swordsman-engine-verification-2026-06-21.md:48`);同步记录于 Godot `CLAUDE.md`/`AGENTS.md`/`.cursorrules` + KB `battle-calculation.md:203` + 设计库 `seed.json:536` 规则表。即 Godot repo(SoT 组②的 source-of-truth)实装事实,非臆造。正本 `rules.md`/`final-design.md` 未找到(Glob 无;引擎代码是更硬的 SoT)。**当前 sim/power_score 未实装 pure 规则**(仅列为模型边界),实装走遗留 #2 精校。
+
+**数量门槛(用户问)**:① 单技能【绝对评分】(`score_skill`/`sim_skill` 给单张 power_score/TTK)现可用,不需基准;② 【横向离群筛查】(`score_class`/`sim_class` 比中位数标 high/low)需多张同职业数值化技能(经验 ≥5-8 张才稳),当前库仅 1 张(ss_zhanji,且 stale) → 横向暂无意义。**建议下一步 = Godot `data/skills/*.json`→设计库 engine_json 回填管线**(只读 Godot repo,一次性数值化全部剑圣技能 + 用新鲜 QA 覆盖 stale + 实现②只读镜像 + 解锁横向量化)。
+
+### 12.6 SoT 设计库网页 UX/认证改进待办(2026-06-25 用户反馈,下个 session 考虑方案)
+> 性质:设计库**软件功能**改进(属 Mercury 工具层,非游戏数据内容)。本 session 仅记录不执行。
+> **核心主线 = 做网页认证用户库**(点 1/2/3 共同解):用 CF Access 登录态(`Cf-Access-Authenticated-User-Email` header)+ 用户库(当前仅「用户本人 CF 邮箱」+「Claude/agent」两个)替代手填 token / 手填 updated_by / 手选 author。
+
+1. **X-API-Token 网页输入别扭**:现状 = `base.html` 右上角 🔑 录入框,给 Phase 3 深度审阅(L2/L3 LLM)端点用(`require_review_token`,公网防 gpt-5.4 烧钱),存 localStorage 后全站 htmx 自动注入 `X-API-Token`。**改进**:网页改用 CF Access 登录态鉴权 → token 只留纯 API/agent 调用,网页不再手填。
+2. **updated_by 自动获取**:现状 = 网页手填文本框(`talent_new`/`talent_detail`),无自动;`review_ui` 写「审阅器」。**改进**:读 CF Access `Cf-Access-Authenticated-User-Email`(CF 限制当前仅用户本人唯一邮箱可登录)→ 用户网页写=登录邮箱;agent/API(带 token)=agent 标识;去掉手填框。
+3. **comment author 标签 vs 用户库**:现状 = 自由文本下拉(「我」/「Claude」,`pages.py _COMMENT_AUTHORS`)。**改进**:统一到认证用户库(同点 2 来源),不再手选标签。方案下个 session。
+4. **校验/审阅按钮位置**:现状 = 结构校验(L1)+ 深度审阅(L2/L3)按钮在「保存」旁(填表容器内)。**改进**:移到**右侧独立区**,点击跑对应 agent + **独立窗口交流**(脱离填表容器)。
+5. **Rule code/version**:`code`=规则编号(R3.14,设计规则标识符,天赋 `rules` 引用它 + L1 查悬空),**非代码**——录新规则时填编号,纯浏览可空(但 Rule 行 code 空则无法被引用)。`version` **不该用户填**,应系统管理、**仅当规则修改且实际反应到游戏代码时更新**。**改进**:version 移除手填/自动化。
+6. **Term.links 关联手填**:现状 = 术语卡片有「关联」(`Term.links`)手填。**改进**:移除手填(术语关联大量天赋/技能/规则,无尽头);改为**引用方反向对照**(天赋/技能引用术语时自动关联)。
+7. **sim 页用途 + 呼出方式**:sim(`/sim` Monte-Carlo)定位 = **技能数值横向离群初筛**(非天赋设计直接工具;需多张数值化技能才有意义,现仅 1 张)。**改进**:① 不独立页(割裂工作流),改**任意页面可呼出浮层/侧边抽屉**;② 明确用途标注(技能数值平衡工具,非天赋设计)。
+- **遗留状态更新**：§11 遗留 ①(§5a 裁决)→ 已裁决"通用字段加显式列"且落地;§11 遗留 ④(数值功率评分)→ Skill 级已做,Talent 级待天赋数值化。

--- a/scripts/gdlint-gate.sh
+++ b/scripts/gdlint-gate.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# gdlint-gate.sh — Mercury GDScript pre-commit gate via gdtoolkit (Scony/godot-gdscript-toolkit).
+#   Runs gdlint (style+syntax) + gdformat --check (formatting) + optional gdparse (pure syntax),
+#   all READ-ONLY (gdformat uses --check; nothing is rewritten).
+#
+# This is the SoT-workflow tool from roadmap §3 — Mercury hosts it; it does NOT modify the SoT
+# repos. Meant to be run by a dev subagent / CI against changed .gd files or directories.
+#
+# Tooling (web-verified + probed 2026-06-22):
+#   gdtoolkit 4.5.0 — PyPI, pure-Python, no engine. https://pypi.org/project/gdtoolkit/
+#   Exit codes: gdlint 0=clean/non-0=problems; gdformat --check 0=formatted/non-0=would-reformat
+#     (never writes); gdparse 0=syntax ok.
+#   Directory recursion: gdlint <dir> AND gdformat --check <dir> BOTH recurse into subdirectories
+#     (probed: a nested .gd with an unused-argument was reported). So directory args are passed
+#     straight through to gdlint/gdformat. gdparse does NOT take a directory, so we expand it.
+#
+# Usage:
+#   ./gdlint-gate.sh <file_or_dir> [more files/dirs...]
+# Env:
+#   GDTOOLKIT_BIN       dir holding gdlint/gdformat/gdparse (default: Mercury's bundled venv at
+#                       .mercury/tools/gdtoolkit-venv — Scripts/ on Windows, bin/ on POSIX,
+#                       auto-probed). Install: python -m venv <dir> &&
+#                       <dir>/Scripts/python -m pip install "gdtoolkit==4.*"   (Windows)
+#                       <dir>/bin/python -m pip install "gdtoolkit==4.*"       (POSIX)
+#   GDLINT_GATE_FORMAT  0 to skip the gdformat --check stage (default 1)
+#   GDLINT_GATE_PARSE   1 to also run gdparse per .gd file (default 0; gdlint already parses)
+#
+# Exit: 0 = clean; 1 = lint/format problems found; 2 = usage/environment error.
+set -uo pipefail
+
+if [[ "$#" -lt 1 ]]; then
+  echo "usage: $0 <file_or_dir> [more...]" >&2
+  exit 2
+fi
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# Default venv layout differs by platform: Windows puts entry points under Scripts/, POSIX
+# under bin/. Probe both so the default works on Git Bash AND Linux CI without overrides.
+DEFAULT_VENV="$REPO_ROOT/.mercury/tools/gdtoolkit-venv"
+if [[ -n "${GDTOOLKIT_BIN:-}" ]]; then
+  BIN="$GDTOOLKIT_BIN"
+elif [[ -d "$DEFAULT_VENV/Scripts" ]]; then
+  BIN="$DEFAULT_VENV/Scripts"
+else
+  BIN="$DEFAULT_VENV/bin"
+fi
+
+# Tools carry a .exe suffix in a Windows venv, none on POSIX — resolve either.
+resolve() {
+  if [[ -f "$BIN/$1.exe" ]]; then echo "$BIN/$1.exe"
+  elif [[ -f "$BIN/$1" ]]; then echo "$BIN/$1"
+  else echo ""; fi
+}
+GDLINT="$(resolve gdlint)"; GDFORMAT="$(resolve gdformat)"; GDPARSE="$(resolve gdparse)"
+
+# Fail closed on a requested-but-missing tool, so a gate is never SILENTLY skipped (a skipped
+# gate that still PASSes is worse than a loud environment error).
+if [[ -z "$GDLINT" ]]; then
+  echo "ERROR: gdlint not found under '$BIN'. Set GDTOOLKIT_BIN or install gdtoolkit:" >&2
+  echo "  python -m venv <dir> && <dir>/Scripts/python -m pip install \"gdtoolkit==4.*\"  (Windows)" >&2
+  echo "  python -m venv <dir> && <dir>/bin/python -m pip install \"gdtoolkit==4.*\"      (POSIX)" >&2
+  exit 2
+fi
+if [[ "${GDLINT_GATE_FORMAT:-1}" == "1" && -z "$GDFORMAT" ]]; then
+  echo "ERROR: gdformat requested (GDLINT_GATE_FORMAT=1) but not found under '$BIN'." >&2
+  echo "       Install gdtoolkit, or set GDLINT_GATE_FORMAT=0 to skip the format stage." >&2
+  exit 2
+fi
+if [[ "${GDLINT_GATE_PARSE:-0}" == "1" && -z "$GDPARSE" ]]; then
+  echo "ERROR: gdparse requested (GDLINT_GATE_PARSE=1) but not found under '$BIN'." >&2
+  echo "       Install gdtoolkit, or set GDLINT_GATE_PARSE=0 to skip the parse stage." >&2
+  exit 2
+fi
+
+problems=0
+
+for target in "$@"; do
+  if [[ ! -e "$target" ]]; then
+    echo "WARN: skip non-existent path: $target" >&2
+    problems=$((problems+1))  # fail-closed: a bad path shouldn't silently pass the gate
+    continue
+  fi
+
+  # gdlint and gdformat both recurse directories (probed) — pass the target straight through.
+  echo "== gdlint: $target =="
+  if ! "$GDLINT" "$target"; then problems=$((problems+1)); fi
+
+  if [[ "${GDLINT_GATE_FORMAT:-1}" == "1" ]]; then
+    echo "== gdformat --check: $target =="
+    if ! "$GDFORMAT" --check "$target"; then problems=$((problems+1)); fi
+  fi
+
+  if [[ "${GDLINT_GATE_PARSE:-0}" == "1" ]]; then
+    # gdparse is per-file; expand a directory to its .gd files via find.
+    if [[ -d "$target" ]]; then
+      found_any=0
+      while IFS= read -r -d '' f; do
+        found_any=1
+        "$GDPARSE" "$f" >/dev/null 2>&1 || { echo "gdparse syntax error: $f" >&2; problems=$((problems+1)); }
+      done < <(find "$target" -name '*.gd' -print0 2>/dev/null)
+      # Fail-closed: an empty traversal (no .gd, or find errored) on an explicitly requested
+      # parse stage must count as a problem, not silently read as clean.
+      if [[ "$found_any" -eq 0 ]]; then
+        echo "WARN: gdparse found no .gd under '$target' (empty dir or traversal error) — counting as a problem (fail-closed)" >&2
+        problems=$((problems+1))
+      fi
+    else
+      "$GDPARSE" "$target" >/dev/null 2>&1 || { echo "gdparse syntax error: $target" >&2; problems=$((problems+1)); }
+    fi
+  fi
+done
+
+echo "--------------------------------------"
+if [[ "$problems" -gt 0 ]]; then
+  echo "gdlint-gate: FAIL — $problems check(s) reported problems"
+  exit 1
+fi
+echo "gdlint-gate: PASS"
+exit 0

--- a/scripts/godot-test.sh
+++ b/scripts/godot-test.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# godot-test.sh — Mercury wrapper to run a Godot 4 headless SceneTree test and return a
+#   structured pass/fail/inconclusive that is robust against Godot's exit-code quirks.
+#
+# READ-ONLY INTENT on the target project, with one honest caveat: this wrapper itself only
+#   runs `--script` (+ an optional `--import` pre-warm touching the gitignored .godot/ cache)
+#   and never edits project source. HOWEVER `--script` is not *inherently* read-only — the
+#   invoked GDScript could write files. This tool is meant for SoT's existing test scripts,
+#   which are read-only; point it only at trusted test scripts. It is the SoT-workflow tool
+#   from roadmap §3 — Mercury hosts it; it does NOT modify the SoT repos.
+#
+# Web-verified guardrails (2026-06-22):
+#   - SceneTree.quit(N) exit code: probed reliable on Godot 4.6.1, but OLDER 4.x had
+#     quit(1) -> exit 0 (https://github.com/godotengine/godot/issues/88055). We therefore
+#     decide from BOTH the exit code AND a parsed stdout summary, and REFUSE to report `pass`
+#     when no summary is parseable (verdict=inconclusive) so the quirk can never become a
+#     silent false-pass.
+#   - Optional pre-import (`--headless --import --quit-after 2`) registers resources/classes
+#     and dodges the importer race (https://github.com/godotengine/godot/issues/77508).
+#     Default OFF — see GODOT_PREIMPORT. NOTE: --import writes the project's gitignored
+#     .godot/ cache (not source); off by default also avoids racing a live editor.
+#   - GODOT_DISABLE_LEAK_CHECKS=1 so the exit code reflects tests, not editor shutdown.
+#   - Godot 4 needs NO xvfb; use --headless (https://github.com/godotengine/godot/issues/43444).
+#
+# Summary-line contract (parsed for the verdict): a line containing a failure count as
+#   "<N> 失败" or "<N> fail[ed|s|ures]" (digit first; ASCII or full-width space). SoT emits
+#   "--- 结果:<P> 过 / <F> 失败 ---". If this contract drifts, the verdict degrades to
+#   `inconclusive` (never a silent pass) — keep the producing test's summary in this shape.
+#
+# Usage:
+#   GODOT_BIN=/path/to/Godot.exe ./godot-test.sh <test_script_res_path> [project_dir]
+# Env:
+#   GODOT_BIN        path to the Godot 4 executable (required if `godot` not on PATH)
+#   SOT_PROJECT      default project dir when [project_dir] arg is omitted
+#   GODOT_PREIMPORT  1 to pre-import (fresh checkout / no .godot cache). Default 0.
+#
+# Exit: 0 = all passed; 1 = failure OR inconclusive (fail-closed); 2 = usage/environment error.
+set -uo pipefail
+
+TEST_SCRIPT="${1:-}"
+PROJECT_DIR="${2:-${SOT_PROJECT:-}}"
+
+if [[ -z "$TEST_SCRIPT" || -z "$PROJECT_DIR" ]]; then
+  echo "usage: GODOT_BIN=<godot> $0 <test_script_res_path> [project_dir]" >&2
+  echo "       (or export SOT_PROJECT for the default project dir)" >&2
+  exit 2
+fi
+
+GODOT="${GODOT_BIN:-}"
+if [[ -z "$GODOT" ]]; then
+  if command -v godot >/dev/null 2>&1; then GODOT="$(command -v godot)"; else
+    echo "ERROR: Godot binary not found. Set GODOT_BIN=/path/to/Godot.exe" >&2
+    exit 2
+  fi
+fi
+if [[ ! -f "$GODOT" ]]; then
+  echo "ERROR: GODOT_BIN '$GODOT' is not a file" >&2
+  exit 2
+fi
+if [[ ! -f "$PROJECT_DIR/project.godot" ]]; then
+  echo "ERROR: '$PROJECT_DIR' is not a Godot project (no project.godot)" >&2
+  exit 2
+fi
+
+export GODOT_DISABLE_LEAK_CHECKS=1
+
+echo "== godot-test: $TEST_SCRIPT =="
+echo "   project: $PROJECT_DIR"
+echo "   godot:   $GODOT"
+
+if [[ "${GODOT_PREIMPORT:-0}" == "1" ]]; then
+  echo "   pre-import: on"
+  "$GODOT" --headless --path "$PROJECT_DIR" --import --quit-after 2 >/dev/null 2>&1 || true
+fi
+
+OUT="$("$GODOT" --headless --path "$PROJECT_DIR" --script "$TEST_SCRIPT" 2>&1)"
+CODE=$?
+
+printf '%s\n' "$OUT"
+echo "--------------------------------------"
+
+# A 126/127 exit (or failure to even launch) is an ENVIRONMENT error, not a test failure.
+if [[ "$CODE" -eq 126 || "$CODE" -eq 127 ]]; then
+  echo "ERROR: failed to launch Godot (exit $CODE) — check GODOT_BIN='$GODOT'" >&2
+  exit 2
+fi
+
+# Display anchor: prefer a real summary line, fall back to any pass/fail-ish line.
+SUMMARY="$(printf '%s\n' "$OUT" | grep -E '结果|---.*(过|失败)' | tail -1)"
+[[ -z "$SUMMARY" ]] && SUMMARY="$(printf '%s\n' "$OUT" | grep -iE 'result|[0-9]+[ 　]*(过|失败|pass|fail)' | tail -1)"
+
+# Verdict driver: parse a failure count in either language, tolerating a full-width space.
+FAILN="$(printf '%s\n' "$OUT" | grep -oiE '[0-9]+[ 　]*(失败|failed|fails|failures|fail)' | grep -oE '[0-9]+' | tail -1)"
+
+VERDICT="pass"; REASON=""
+if [[ "$CODE" -ne 0 ]]; then VERDICT="fail"; REASON="exit code $CODE"; fi
+if printf '%s\n' "$OUT" | grep -qE 'SCRIPT ERROR|Parse Error'; then
+  VERDICT="fail"; REASON="${REASON:+$REASON; }hard error in stdout (SCRIPT ERROR/Parse Error)"
+fi
+if [[ -n "${FAILN:-}" && "$FAILN" -gt 0 ]]; then
+  VERDICT="fail"; REASON="${REASON:+$REASON; }${FAILN} failure(s) reported in summary"
+fi
+# Fail-closed: exit 0 with no parseable summary/failure-count is NOT a pass — the test may
+# never have reported (e.g. early return) or the summary format drifted. Refuse to assume pass.
+if [[ "$VERDICT" == "pass" && "$CODE" -eq 0 && ( -z "$SUMMARY" || -z "${FAILN:-}" ) ]]; then
+  VERDICT="inconclusive"
+  REASON="exit 0 but no parseable pass/fail summary found — refusing to assume pass (see summary-line contract)"
+fi
+# Surface a signal disagreement (engine exit-code quirk) instead of hiding it.
+if [[ "$CODE" -eq 0 && -n "${FAILN:-}" && "$FAILN" -gt 0 ]]; then
+  REASON="$REASON [WARN: exit 0 but stdout shows ${FAILN} failures — engine exit-code quirk #88055?]"
+fi
+
+echo "godot-test verdict: $VERDICT  ${SUMMARY:+| summary: $SUMMARY}  ${REASON:+($REASON)}"
+[[ "$VERDICT" == "pass" ]] && exit 0 || exit 1

--- a/scripts/sot-codex-serve.sh
+++ b/scripts/sot-codex-serve.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# sot-codex-serve.sh — start the SoT Codex read-only API locally for talent-validate.
+#
+# Reads the SoT Codex app + seed READ-ONLY and isolates the SQLite DB to Mercury's tmp, so it
+# NEVER writes the SoT repo (CLAUDE.md hard constraint). SoT-workflow tool from roadmap §1.3/§9
+# — Mercury hosts it; the SoT repos are untouched.
+#
+# Probed working stack (2026-06-22): uvicorn 0.39.0 / CPython 3.14.3.
+#
+# Usage (run in its own terminal; it stays in the foreground serving):
+#   bash scripts/sot-codex-serve.sh
+#   # then, in another terminal / Claude session:
+#   /talent-validate { "talent_id": "ss_jianqie", "class_id": "ss" }
+#
+# Env:
+#   SOT_CODEX_DIR  SoT Codex repo (default /d/ShipOfTheseus/SoT-fyc-space — this machine's
+#                  checkout location, NOT a universal path; other environments must set it)
+#   CODEX_PORT     port (default 8000)
+#   CODEX_DB       SQLite path — kept under Mercury tmp by default (never the SoT repo)
+set -uo pipefail
+
+SOT_CODEX="${SOT_CODEX_DIR:-/d/ShipOfTheseus/SoT-fyc-space}"
+PORT="${CODEX_PORT:-8000}"
+# Repo root derived from this script's location so the default DB never hardcodes a machine path.
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DB="${CODEX_DB:-$REPO_ROOT/.mercury/tmp/codex-readonly.db}"
+
+PY="$SOT_CODEX/.venv/Scripts/python.exe"
+[[ -f "$PY" ]] || PY="$SOT_CODEX/.venv/bin/python"
+if [[ ! -f "$PY" ]]; then
+  echo "ERROR: SoT Codex venv python not found (looked for $SOT_CODEX/.venv/Scripts/python.exe and .../bin/python)" >&2
+  echo "       Set SOT_CODEX_DIR, or build the venv:" >&2
+  echo "       cd \"$SOT_CODEX\" && python -m venv .venv && .venv/Scripts/python -m pip install -r requirements.txt" >&2
+  exit 2
+fi
+if [[ ! -f "$SOT_CODEX/seed/seed.json" ]]; then
+  echo "ERROR: seed.json not found under $SOT_CODEX/seed/" >&2
+  exit 2
+fi
+
+# Reuse a live instance instead of starting a confusing second one on the same port.
+if curl -s -m 2 -o /dev/null "http://127.0.0.1:$PORT/api/tags" 2>/dev/null; then
+  echo "NOTE: port $PORT is already serving (/api/tags responded) — reusing it, not starting a second instance."
+  echo "      Stop the existing instance first if it is stale."
+  exit 0
+fi
+
+mkdir -p "$(dirname "$DB")"
+echo "Starting SoT Codex read-only API on http://127.0.0.1:$PORT"
+echo "  DB -> $DB  (SoT repo untouched)"
+echo "  Ctrl-C to stop. Leave it running while you use /talent-validate."
+exec env PYTHONPATH="$SOT_CODEX" DB_PATH="$DB" SEED_PATH="$SOT_CODEX/seed/seed.json" \
+  "$PY" -m uvicorn app.main:app --host 127.0.0.1 --port "$PORT" --app-dir "$SOT_CODEX"

--- a/scripts/sot-codex-serve.sh
+++ b/scripts/sot-codex-serve.sh
@@ -8,18 +8,23 @@
 # Probed working stack (2026-06-22): uvicorn 0.39.0 / CPython 3.14.3.
 #
 # Usage (run in its own terminal; it stays in the foreground serving):
-#   bash scripts/sot-codex-serve.sh
+#   SOT_CODEX_DIR=/path/to/SoT-fyc-space bash scripts/sot-codex-serve.sh
 #   # then, in another terminal / Claude session:
 #   /talent-validate { "talent_id": "ss_jianqie", "class_id": "ss" }
 #
 # Env:
-#   SOT_CODEX_DIR  SoT Codex repo (default /d/ShipOfTheseus/SoT-fyc-space — this machine's
-#                  checkout location, NOT a universal path; other environments must set it)
+#   SOT_CODEX_DIR  SoT Codex repo (REQUIRED — no default: repo locations are machine-specific,
+#                  and a silently wrong default is worse than a loud error)
 #   CODEX_PORT     port (default 8000)
 #   CODEX_DB       SQLite path — kept under Mercury tmp by default (never the SoT repo)
 set -uo pipefail
 
-SOT_CODEX="${SOT_CODEX_DIR:-/d/ShipOfTheseus/SoT-fyc-space}"
+SOT_CODEX="${SOT_CODEX_DIR:-}"
+if [[ -z "$SOT_CODEX" ]]; then
+  echo "ERROR: SOT_CODEX_DIR is not set. Point it at your SoT Codex repo checkout, e.g.:" >&2
+  echo "  SOT_CODEX_DIR=/path/to/SoT-fyc-space bash scripts/sot-codex-serve.sh" >&2
+  exit 2
+fi
 PORT="${CODEX_PORT:-8000}"
 # Repo root derived from this script's location so the default DB never hardcodes a machine path.
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -38,11 +43,19 @@ if [[ ! -f "$SOT_CODEX/seed/seed.json" ]]; then
   exit 2
 fi
 
-# Reuse a live instance instead of starting a confusing second one on the same port.
-if curl -s -m 2 -o /dev/null "http://127.0.0.1:$PORT/api/tags" 2>/dev/null; then
-  echo "NOTE: port $PORT is already serving (/api/tags responded) — reusing it, not starting a second instance."
-  echo "      Stop the existing instance first if it is stale."
-  exit 0
+# Reuse a live instance instead of starting a confusing second one on the same port — but only
+# when the responder actually looks like the SoT Codex API (/api/tags returns a JSON array;
+# shape probed against the live service). curl -f: an HTTP error (404/500 from an unrelated
+# service) must not read as "already serving".
+HEALTH="$(curl -fsS -m 2 "http://127.0.0.1:$PORT/api/tags" 2>/dev/null || true)"
+if [[ -n "$HEALTH" ]]; then
+  if printf '%s' "$HEALTH" | grep -qE '^\s*\['; then
+    echo "NOTE: port $PORT is already serving SoT Codex (/api/tags returned tag JSON) — reusing it."
+    echo "      Stop the existing instance first if it is stale."
+    exit 0
+  fi
+  echo "ERROR: port $PORT is occupied by a non-Codex service; refusing to reuse it." >&2
+  exit 2
 fi
 
 mkdir -p "$(dirname "$DB")"


### PR DESCRIPTION
## 概要

SoT workflow 优化 roadmap §1/§3/§9 已实跑验证的底座文件入库(此前只存在于工作树,存在丢失风险且无法被其他 session 复用):

**无关联 GitHub Issue** —— SoT 辅助 workflow,由 roadmap(`.mercury/docs/research/sot-workflow-optimization-roadmap-2026-06.md`,本 PR 一并入库)追踪;该类辅助任务不开 issue,先例 PR #529。

## 文件(9 个)

| 文件 | 内容 |
|---|---|
| `.claude/workflows/talent-validate.js` | SoT 天赋平衡混合验证 Workflow 模板:L1 纯 JS 确定性检查(schema/枚举/tag/规则引用/史诗供给)+ Haiku 语义 advisory + L2 共享 tag 组合 triage(PAIR_CAP 上限)+ L3 Optimizer-vs-Defender 对抗,全链 fail-closed;只读 SoT 仓 |
| `.claude/workflows/README.md` | 模板清单登记 `/talent-validate` + 编排模式映射;去掉会漂移的「本目录 5 个」计数 |
| `.mercury/docs/guides/talent-validate-usage.md` | 使用指南(调用方式/字段枚举/verdict 解读) |
| `.mercury/docs/research/sot-workflow-optimization-roadmap-2026-06.md` | SoT workflow 优化路线图(权威待办) |
| `.mercury/docs/research/sot-phase3-review-ui-plan-2026-06.md` | 设计库 Phase 3 交互审阅规格存档(已实施,设计 Workflow 产出) |
| `scripts/gdlint-gate.sh` | gdtoolkit 只读 lint/format 门(Windows `Scripts/` + POSIX `bin/` 双平台探测) |
| `scripts/godot-test.sh` | Godot 4 headless 测试封装(exit code + stdout 摘要双判,防静默假 pass) |
| `scripts/sot-codex-serve.sh` | 设计库只读 API 本地起服(DB 隔离到 Mercury tmp,零写 SoT 仓) |
| `.gitignore` | 忽略 `.mercury/tmp/`、`.mercury/tools/` 运行时目录 |

## 入库前修整

- `talent-validate.js` dataDir 默认值、`sot-codex-serve.sh` DB 默认路径:去掉本机绝对路径硬编码(相对路径 / 从脚本位置推导)
- 域名笔误 `sot.fyc-space.hk` → `.uk`(usage guide 1 处 + roadmap 2 处,与全仓其余引用一致)

## 验证

- Workflow JS 以运行时等价方式(AsyncFunction 作用域)语法解析通过;三个 shell 脚本 `bash -n` 通过
- **Dual-verify 两轮**:round-1 Claude 深审(1 Critical / 2 Medium / 4 Low)+ Codex 审计(2 High / 3 Medium / 1 Low),11 项发现全修——L3 optimizer 失败 fail-open→三路分支 fail-closed、Adapt 空注册表→stageFailures 强制 ≥revise、Defender「已中和」须引用锁定规则码、L1/L2 prompt 去「剑圣」硬编码改 classId 插值、R6.6 上限常量化、gdlint venv 双平台、gdparse 空遍历 fail-closed、verdict 表删 `inconclusive` 等;round-2 双侧 0 项发现
- `Dual-verify Codex side: PASS`

Generated with Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)