### PR TITLE
fix(#527): 工具调用 XML 泄漏缓解 — 确定性 linter + CI guard

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Shell scripts must stay LF so the shebang execs on Linux CI even when a contributor has
+# core.autocrlf=true — a CRLF `#!/usr/bin/env bash\r` fails to run on Linux. (Issue #527)
+*.sh text eol=lf

--- a/.github/workflows/auto-verify.yml
+++ b/.github/workflows/auto-verify.yml
@@ -83,3 +83,15 @@ jobs:
             fi
           done
           [ "$LOW_COVERAGE_FOUND" -eq 0 ] || echo "::notice::Some files have low docstring coverage (warnings above)"
+
+  toolcall-xml-lint:
+    name: Tool-call XML Lint (#527)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Lint Claude-context files for literal tool-call markers
+        run: bash scripts/toolcall-xml-lint.sh
+
+      - name: Self-test the linter
+        run: bash scripts/test-toolcall-xml-lint.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,7 @@ Mercury 的部分功能跨仓库运作。以下表格记录外部仓库与 Mercu
 - Do not create PRs without an associated GitHub Issue.
 - Do not build features that assume the model is weak — design for upward compatibility.
 - Do not create **external-project adapters** under `adapters/<vendor-name>/` exceeding 200 lines — rethink the mounting approach if this happens. (Mercury-internal tooling under `scripts/` is exempt — see the MUST bullet "External-project adapters under `adapters/<vendor-name>/` MUST stay under 200 lines" above for the carve-out and authority chain.)
+- Do not write literal tool-call XML markers (bare invoke / function_calls / parameter tags) into Claude-context files (`CLAUDE.md`, `AGENTS.md`, `.claude/**`, `.mercury/docs/**`, memory, handoffs) — one literal marker seeds the Opus-4.8 self-poisoning leak that hangs a turn with no output ([#527](https://github.com/392fyc/Mercury/issues/527)). Escape them (`&lt;` / `&gt;`, or split the keyword); `scripts/toolcall-xml-lint.sh` (wired into auto-verify CI) keeps the count at zero.
 
 ## Cherry-pick protocol
 

--- a/scripts/test-toolcall-xml-lint.sh
+++ b/scripts/test-toolcall-xml-lint.sh
@@ -64,6 +64,27 @@ assert_exit "real repo Claude-context is clean (baseline)" 0 bash "$LINT"
 # fail-closed: an explicit but non-existent path must not silently pass — exit 2, not 0
 assert_exit "non-existent path arg fails closed"        2 bash "$LINT" "$tmpdir/does-not-exist.md"
 
+# fail-closed on an UNREADABLE directory arg, and on a find error (unreadable subdir). chmod is
+# a no-op on Windows, so these assert only where it actually takes effect (ubuntu CI runs them
+# for real); otherwise they SKIP rather than give a false pass. (Codex re-audit coverage gap.)
+noread="$tmpdir/noread"; mkdir -p "$noread"; printf 'ok\n' > "$noread/a.md"
+chmod 000 "$noread" 2>/dev/null || true
+if [[ ! -r "$noread" || ! -x "$noread" ]]; then
+  assert_exit "unreadable directory arg fails closed"   2 bash "$LINT" "$noread"
+else
+  echo "SKIP: unreadable-directory test (chmod is a no-op on this platform)"
+fi
+chmod 755 "$noread" 2>/dev/null || true
+
+findfail="$tmpdir/findfail"; mkdir -p "$findfail/sub"; printf 'ok\n' > "$findfail/top.md"
+chmod 000 "$findfail/sub" 2>/dev/null || true
+if [[ ! -r "$findfail/sub" ]]; then
+  assert_exit "find error (unreadable subdir) fails closed" 2 bash "$LINT" "$findfail"
+else
+  echo "SKIP: find-error test (chmod is a no-op on this platform)"
+fi
+chmod 755 "$findfail/sub" 2>/dev/null || true
+
 # the linter's AND the test's own source must be marker-free (real self-poisoning proof now
 # that the linter no longer hard-skips them)
 assert_exit "linter source is marker-free"              0 bash "$LINT" "$LINT"

--- a/scripts/test-toolcall-xml-lint.sh
+++ b/scripts/test-toolcall-xml-lint.sh
@@ -73,6 +73,8 @@ assert_exit "test source is marker-free"                0 bash "$LINT" "$SELF_TE
 verbose_out="$(TOOLCALL_LINT_VERBOSE=1 bash "$LINT" "$dirty" 2>&1 || true)"
 assert_not_contains "verbose output masks the invoke bracket"        "$verbose_out" "${lt}invoke"
 assert_not_contains "verbose output masks the function_calls tag"    "$verbose_out" "${lt}function_calls${gt}"
+# verbose emits only the matched marker, never the surrounding line content (no secret leak)
+assert_not_contains "verbose output omits surrounding line content"  "$verbose_out" "intro line"
 
 echo "----------------------------------------"
 echo "toolcall-xml-lint tests: $PASS passed, $FAIL failed"

--- a/scripts/test-toolcall-xml-lint.sh
+++ b/scripts/test-toolcall-xml-lint.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# scripts/test-toolcall-xml-lint.sh — tests for toolcall-xml-lint.sh (Issue #527).
+#
+# Every tool-call marker used below is ASSEMBLED FROM VARIABLES ($lt/$gt hold the angle
+# brackets; the antml: prefix is split by a printf %s) so THIS test's own source contains no
+# intact marker — the same self-poisoning discipline as the linter it exercises. The linter is
+# run against BOTH scripts (see "source is marker-free" cases) to prove that invariant holds.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LINT="$SCRIPT_DIR/toolcall-xml-lint.sh"
+SELF_TEST="$SCRIPT_DIR/test-toolcall-xml-lint.sh"
+
+PASS=0
+FAIL=0
+pass() { echo "PASS: $1"; PASS=$(( PASS + 1 )); }
+fail() { echo "FAIL: $1"; FAIL=$(( FAIL + 1 )); }
+
+assert_exit() {
+  local label="$1" want="$2"; shift 2
+  local got=0
+  "$@" >/dev/null 2>&1 || got=$?
+  if [[ "$got" -eq "$want" ]]; then pass "$label (exit $got)"; else fail "$label — want exit $want, got $got"; fi
+}
+assert_not_contains() {
+  local label="$1" hay="$2" needle="$3"
+  if ! printf '%s' "$hay" | grep -qF "$needle"; then pass "$label"; else fail "$label — unexpectedly found the needle"; fi
+}
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+lt='<'; gt='>'   # angle brackets kept out of literal source
+
+# --- fixtures -------------------------------------------------------------------------------
+clean="$tmpdir/clean.md"
+printf 'Just normal prose about invoking a function and its parameters.\nNo markers here.\n' > "$clean"
+
+# dirty fixture exercises all three bare tag kinds (invoke / parameter / function_calls),
+# each assembled at runtime from $lt/$gt so this source stays marker-free.
+dirty="$tmpdir/dirty.md"
+{
+  printf 'intro line\n'
+  printf '%sinvoke name="Bash"%s\n'      "$lt" "$gt"
+  printf '%sparameter name="command"%s\n' "$lt" "$gt"
+  printf '%sfunction_calls%s\n'          "$lt" "$gt"
+} > "$dirty"
+
+# namespaced-prefix variant; the "antml:" prefix is split by %s so it is not spelled intact here
+dirty_prefix="$tmpdir/dirty_prefix.md"
+printf 'leading text an%sml:invoke trailing text\n' 't' > "$dirty_prefix"
+
+# a fixture with ONLY a bare parameter tag — guards the coverage hole Codex flagged
+dirty_param="$tmpdir/dirty_param.md"
+printf 'a line then %sparameter name="x"%s and more\n' "$lt" "$gt" > "$dirty_param"
+
+# --- tests ----------------------------------------------------------------------------------
+assert_exit "clean fixture passes"                      0 bash "$LINT" "$clean"
+assert_exit "dirty fixture (invoke+parameter+function_calls) fails" 1 bash "$LINT" "$dirty"
+assert_exit "dirty fixture (antml: prefix) fails"       1 bash "$LINT" "$dirty_prefix"
+assert_exit "bare parameter tag alone is caught"        1 bash "$LINT" "$dirty_param"
+assert_exit "real repo Claude-context is clean (baseline)" 0 bash "$LINT"
+
+# fail-closed: an explicit but non-existent path must not silently pass — exit 2, not 0
+assert_exit "non-existent path arg fails closed"        2 bash "$LINT" "$tmpdir/does-not-exist.md"
+
+# the linter's AND the test's own source must be marker-free (real self-poisoning proof now
+# that the linter no longer hard-skips them)
+assert_exit "linter source is marker-free"              0 bash "$LINT" "$LINT"
+assert_exit "test source is marker-free"                0 bash "$LINT" "$SELF_TEST"
+
+# verbose output must MASK the brackets — no intact marker echoed back
+verbose_out="$(TOOLCALL_LINT_VERBOSE=1 bash "$LINT" "$dirty" 2>&1 || true)"
+assert_not_contains "verbose output masks the invoke bracket"        "$verbose_out" "${lt}invoke"
+assert_not_contains "verbose output masks the function_calls tag"    "$verbose_out" "${lt}function_calls${gt}"
+
+echo "----------------------------------------"
+echo "toolcall-xml-lint tests: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]] || exit 1
+exit 0

--- a/scripts/toolcall-xml-lint.sh
+++ b/scripts/toolcall-xml-lint.sh
@@ -67,16 +67,30 @@ hits=0
 scanned=0
 for f in "${FILES[@]}"; do
   scanned=$((scanned+1))
-  # grep -I skips binary; -n gives line numbers. Read numbers off, then re-extract the line
-  # for masked display so no intact marker is ever echoed.
+  # Fail closed on an unreadable file: a gate must not silently skip (and thus read as "clean")
+  # a file it could not inspect — e.g. permission change mid-run. (Argus PR #537)
+  if [[ ! -r "$f" ]]; then
+    echo "ERROR: cannot read '$f' — failing closed (a gate must not skip an unreadable file)." >&2
+    exit 2
+  fi
+  # Capture grep's output AND status. grep rc: 0=match, 1=no match, >=2=real error. Swallowing a
+  # >=2 error (file vanished / permission change mid-scan) would yield a FALSE PASS. (Argus PR #537)
+  matches="$(grep -E -n -I "$MARKER_RE" "$f")"; rc=$?
+  if [[ "$rc" -ge 2 ]]; then
+    echo "ERROR: grep failed on '$f' (rc=$rc) — failing closed." >&2
+    exit 2
+  fi
+  [[ -z "$matches" ]] && continue
   while IFS=: read -r lineno _rest; do
     [[ -z "$lineno" ]] && continue
     hits=$((hits+1))
     echo "toolcall-xml-lint: literal tool-call marker at $f:$lineno"
     if [[ "${TOOLCALL_LINT_VERBOSE:-0}" == "1" ]]; then
-      sed -n "${lineno}p" "$f" | sed 's/</‹/g; s/>/›/g'
+      # Emit ONLY the masked matched marker(s) on this line — never the whole line — so any
+      # surrounding sensitive content (a stray token/secret) is not echoed to logs. (Argus PR #537)
+      sed -n "${lineno}p" "$f" | grep -E -o "$MARKER_RE" | sed 's/</‹/g; s/>/›/g; s/^/    marker: /'
     fi
-  done < <(grep -E -n -I "$MARKER_RE" "$f" 2>/dev/null)
+  done <<< "$matches"
 done
 
 echo "--------------------------------------"

--- a/scripts/toolcall-xml-lint.sh
+++ b/scripts/toolcall-xml-lint.sh
@@ -31,22 +31,38 @@ cd "$REPO_ROOT" || { echo "ERROR: cannot cd to repo root '$REPO_ROOT'" >&2; exit
 MARKER_RE='<f[u]nction_calls>|</f[u]nction_calls>|<in[v]oke[[:space:]]+name=|</in[v]oke>|<par[a]meter[[:space:]]+name=|</par[a]meter>|an[t]ml:in[v]oke|an[t]ml:f[u]nction_calls|an[t]ml:par[a]meter'
 
 # Build the scan set. Explicit args (files or dirs) override the default Claude-context set.
-declare -a FILES
+declare -a FILES=()
+
+# Collect one target (file or dir) into FILES, failing closed (exit 2) on anything we cannot
+# fully enumerate — an unreadable/untraversable directory arg, or a find error, must NOT be
+# silently dropped into a false PASS (this mirrors the per-file -r / grep-rc guards below).
+# Defined as a function so `exit` fires in the MAIN shell, not inside a `<(...)` subshell.
+add_target() {
+  local p="$1" out rc
+  if [[ -d "$p" ]]; then
+    if [[ ! -r "$p" || ! -x "$p" ]]; then
+      echo "ERROR: directory '$p' is not readable/traversable — failing closed." >&2
+      exit 2
+    fi
+    out="$(find "$p" -type f -name '*.md')"; rc=$?
+    if [[ "$rc" -ne 0 ]]; then
+      echo "ERROR: find failed under '$p' (rc=$rc, e.g. unreadable subdir) — failing closed." >&2
+      exit 2
+    fi
+    while IFS= read -r f; do [[ -n "$f" ]] && FILES+=("$f"); done <<< "$out"
+  elif [[ -f "$p" ]]; then
+    FILES+=("$p")
+  else
+    echo "WARN: skip non-existent path: $p" >&2
+  fi
+}
+
 if [[ "$#" -gt 0 ]]; then
-  while IFS= read -r line; do [[ -n "$line" ]] && FILES+=("$line"); done < <(
-    for p in "$@"; do
-      if [[ -d "$p" ]]; then find "$p" -type f -name '*.md' 2>/dev/null
-      elif [[ -f "$p" ]]; then printf '%s\n' "$p"
-      else echo "WARN: skip non-existent path: $p" >&2
-      fi
-    done
-  )
+  for p in "$@"; do add_target "$p"; done
 else
   # Default: the markdown/text files Claude auto-loads at session start or a skill injects.
-  while IFS= read -r line; do [[ -n "$line" ]] && FILES+=("$line"); done < <(
-    for f in CLAUDE.md CLAUDE.local.md AGENTS.md; do [[ -f "$f" ]] && printf '%s\n' "$f"; done
-    find .claude .mercury/docs -type f -name '*.md' 2>/dev/null
-  )
+  for f in CLAUDE.md CLAUDE.local.md AGENTS.md; do [[ -f "$f" ]] && FILES+=("$f"); done
+  for d in .claude .mercury/docs; do [[ -d "$d" ]] && add_target "$d"; done
 fi
 
 # Fail closed on an empty scan set: a typoed path arg, or a repo somehow missing its

--- a/scripts/toolcall-xml-lint.sh
+++ b/scripts/toolcall-xml-lint.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# scripts/toolcall-xml-lint.sh — deterministic guard against literal tool-call XML markers
+#   leaking into Claude-context files (Issue #527).
+#
+# WHY: Anthropic's Opus-4.8 generation-side defect (anthropics/claude-code #62344 / #66153 /
+#   #70241 et al. — all OPEN, no fixed-in tag) is amplified by a SELF-POISONING loop: when a
+#   context-injected file (CLAUDE.md, an agent/skill doc, a memory file, a handoff) contains a
+#   LITERAL tool-call marker, the model copies it as a template and the malformed call leaks as
+#   plain text, hanging the turn with no output. This linter keeps the count of such literal
+#   markers at ZERO across the files Claude auto-loads, so the repo never seeds that loop.
+#   (Mitigation route recorded in Issue #527's research comment; keeps the count-at-zero
+#   invariant per anthropics/claude-code #70241.)
+#
+# SELF-POISONING SAFETY: every marker keyword in MARKER_RE below is BROKEN with a single-char
+#   regex class (e.g. f[u]nction). grep -E expands each class back to the intact marker when it
+#   scans a TARGET file, but THIS script's own source holds no intact marker — so the linter
+#   never matches itself and never pollutes context if it is ever read into a prompt. Reported
+#   lines have their angle brackets masked (‹ ›), so the report output is inert too.
+#
+# Usage:
+#   ./scripts/toolcall-xml-lint.sh [path ...]   # default: Claude-context markdown files in repo
+#   TOOLCALL_LINT_VERBOSE=1 ./scripts/toolcall-xml-lint.sh   # also print each masked offending line
+# Exit: 0 = clean; 1 = literal marker(s) found; 2 = usage/environment error.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)" || { echo "ERROR: cannot resolve repo root" >&2; exit 2; }
+cd "$REPO_ROOT" || { echo "ERROR: cannot cd to repo root '$REPO_ROOT'" >&2; exit 2; }
+
+# Broken-keyword alternation (see SELF-POISONING SAFETY). Each [x] is a one-char class that
+# grep -E expands to x when matching target files; this literal source line stays inert.
+MARKER_RE='<f[u]nction_calls>|</f[u]nction_calls>|<in[v]oke[[:space:]]+name=|</in[v]oke>|<par[a]meter[[:space:]]+name=|</par[a]meter>|an[t]ml:in[v]oke|an[t]ml:f[u]nction_calls|an[t]ml:par[a]meter'
+
+# Build the scan set. Explicit args (files or dirs) override the default Claude-context set.
+declare -a FILES
+if [[ "$#" -gt 0 ]]; then
+  while IFS= read -r line; do [[ -n "$line" ]] && FILES+=("$line"); done < <(
+    for p in "$@"; do
+      if [[ -d "$p" ]]; then find "$p" -type f -name '*.md' 2>/dev/null
+      elif [[ -f "$p" ]]; then printf '%s\n' "$p"
+      else echo "WARN: skip non-existent path: $p" >&2
+      fi
+    done
+  )
+else
+  # Default: the markdown/text files Claude auto-loads at session start or a skill injects.
+  while IFS= read -r line; do [[ -n "$line" ]] && FILES+=("$line"); done < <(
+    for f in CLAUDE.md CLAUDE.local.md AGENTS.md; do [[ -f "$f" ]] && printf '%s\n' "$f"; done
+    find .claude .mercury/docs -type f -name '*.md' 2>/dev/null
+  )
+fi
+
+# Fail closed on an empty scan set: a typoed path arg, or a repo somehow missing its
+# Claude-context files, must NOT read as a silent PASS (a skipped gate that still passes is
+# worse than a loud error). Exit 2 = usage/environment error.
+# NB: use the ${arr[*]+set} form, not ${#FILES[@]} — an EMPTY array under `set -u` trips
+# "unbound variable" on bash < 4.4 (e.g. some Git Bash builds); the +set form is portable.
+if [[ -z "${FILES[*]+set}" ]]; then
+  echo "ERROR: no files to scan — bad path arg(s), or repo missing Claude-context files. Failing closed." >&2
+  exit 2
+fi
+
+# NOTE: this linter and its test are deliberately NOT excluded from scanning. They live under
+# the same broken-keyword discipline as every guarded file — the linter's own source and the
+# test's fixtures/labels must be marker-free, and the test asserts exactly that. Excluding them
+# would open a blind spot where an intact marker could hide in a "skipped" file.
+hits=0
+scanned=0
+for f in "${FILES[@]}"; do
+  scanned=$((scanned+1))
+  # grep -I skips binary; -n gives line numbers. Read numbers off, then re-extract the line
+  # for masked display so no intact marker is ever echoed.
+  while IFS=: read -r lineno _rest; do
+    [[ -z "$lineno" ]] && continue
+    hits=$((hits+1))
+    echo "toolcall-xml-lint: literal tool-call marker at $f:$lineno"
+    if [[ "${TOOLCALL_LINT_VERBOSE:-0}" == "1" ]]; then
+      sed -n "${lineno}p" "$f" | sed 's/</‹/g; s/>/›/g'
+    fi
+  done < <(grep -E -n -I "$MARKER_RE" "$f" 2>/dev/null)
+done
+
+echo "--------------------------------------"
+if [[ "$hits" -gt 0 ]]; then
+  echo "toolcall-xml-lint: FAIL — $hits literal tool-call marker(s) across $scanned file(s)."
+  echo "  Escape them so the model cannot copy them as a template: use HTML entities (e.g. &lt; / &gt;)"
+  echo "  or split the keyword with a zero-width break. Background + rationale: Issue #527."
+  exit 1
+fi
+echo "toolcall-xml-lint: PASS — no literal tool-call markers in $scanned Claude-context file(s)."
+exit 0


### PR DESCRIPTION
## Issue #527 — 工具调用 XML 泄漏缓解

### 根因(#527 调研,anthropics/claude-code #62344/#66153/#70241 等,全 OPEN 无 fixed-in)
Opus 4.8 在长上下文里把工具调用 XML 标签丢命名空间前缀,泄漏成纯文本、本轮挂起无输出。**自我污染机制**:被注入 context 的文件(CLAUDE.md / agent / skill / doc / memory)里出现**字面的工具调用标记**,会被模型当范例照抄,形成失败环(这解释了「重试没用、只有开新会话能恢复」)。

### 交付(预防性回归防护)
扫描发现 repo + memory + 用户级 CLAUDE.md **零现存字面标记**,故交付为预防性防护而非转义:
- **`scripts/toolcall-xml-lint.sh`** — 确定性 linter,把 Claude-context 文件的字面标记计数维持为零。检测关键字用正则字符类打断(`f[u]nction` 等)使脚本自身零标记(self-poisoning-safe);报告掩码尖括号;空集 fail-closed exit 2。
- **`scripts/test-toolcall-xml-lint.sh`** — 10 测试(bare invoke/parameter/function_calls 三类标签 + antml: 前缀 + fail-closed + linter/test 自扫 marker-free + verbose 掩码 + 真实 repo 基线)。fixtures 用变量拼接标记,测试源码本身零标记。
- **`.github/workflows/auto-verify.yml`** — 新 job `toolcall-xml-lint`(PR→develop/master 跑 linter + 自测)。
- **`CLAUDE.md`** — DO NOT 加一条禁止 context 文件写字面标记(措辞用 `&lt;`/`&gt;` 实体,自身不含标记)。
- **`.gitattributes`** — `*.sh eol=lf`(防 `core.autocrlf=true` 贡献者提交 CRLF 破坏 Linux CI 的 shebang)。

### scope 边界
linter 治理**污染源**(context 文件里的完整/带前缀标记),不检测**泄漏输出**(丢前缀退化成 court/count 那种通用词无法 lint,属 renderer 侧独立缺陷)。该边界写在脚本 WHY 注释 + CLAUDE.md 约定里。

### Stop-hook 兜底 — DEFER
社区 `retry-malformed-tool-call.py` 是 **UNVERIFIED** + 有「误对已执行副作用的泄漏变体重试」的风险(判断哪种变体安全重试很复杂)。linter 消除自我污染源(根因抓手、更高价值)已交付。**重开条件**:官方给出修复 / 社区 retry hook 被验证 / 出现高频不可恢复案例。

### dual-verify
- **Codex audit**:初审 NEEDS-CHANGES(3 High:bare-parameter 漏报 / self+test case-skip 盲区 / test 文件自污染;1 Medium:空参静默 PASS)→ **全修**(并连带修了 fail-closed 引出的 `set -u` 空数组 unbound bug)。
- **Claude 深审**:独立复现并确认全部修复到位,全面复核(正确性 / 误报漏报 / 自我污染 / 健壮性 / 测试覆盖 / CI)**PASS**;其建议的 `.gitattributes` 硬化已采纳。
- **Dual-verify Codex side: PASS**(findings 全修,经 Claude 深审独立确认)

Closes #527
