### PR TITLE
docs(#509): back-port superpowers subagent-driven-development 上游改进

### DIFF
--- a/.claude/skills/subagent-driven-development/SKILL.md
+++ b/.claude/skills/subagent-driven-development/SKILL.md
@@ -5,19 +5,37 @@ description: >-
   (spec compliance then code quality). Use when implementing a multi-task plan
   within the current session using isolated subagents.
 user-invocable: true
-allowed-tools: Read, Glob, Grep, Agent
+# Controller-side tool contract: Read/Glob/Grep to locate plan + ledger, Agent to
+# dispatch implementer/reviewer subagents, TodoWrite to track tasks, Bash for the
+# durable-ledger read/append (cat / echo >>) and git bookkeeping (git log). The
+# implementers/reviewers this skill dispatches are separate subagents with their
+# own tool grants — this contract is for the coordinating (controller) turn only.
+allowed-tools: Read, Glob, Grep, Agent, TodoWrite, Bash
 upstream_source: "https://github.com/obra/superpowers"
 upstream_sha: "917e5f53b16b115b70a3a355ed5f4993b9f8b73d"
 upstream_license: "MIT"
 cherry_picked_in: 216
 cherry_picked_at: "2026-04-10"
+backported_from_sha: "d884ae04edebef577e82ff7c4e143debd0bbec99"
+backported_from_tag: "v6.1.1"
+backported_in: 509
+backported_at: "2026-07-04"
+mercury_adaptation: >-
+  Retains two-stage spec+quality review split (upstream v6.1.x merged both into
+  a single task-reviewer — a style choice, not a bug fix). Back-ports the
+  durable ledger recovery, controller-side status handling, and pre-flight
+  contradiction scan. Does NOT adopt upstream's bash scripts / .superpowers/
+  paths (Mercury is Windows-primary and has its own #385 context-economics
+  guardrails).
 ---
 
 <!-- Cherry-picked from obra/superpowers (MIT, Copyright 2025 Jesse Vincent)
-     Source: https://github.com/obra/superpowers/blob/917e5f5/skills/subagent-driven-development/SKILL.md
-     SHA: 917e5f53b16b115b70a3a355ed5f4993b9f8b73d
-     Date: 2026-04-10
-     Issue: #209 -->
+     Initial import: https://github.com/obra/superpowers/blob/917e5f5/skills/subagent-driven-development/SKILL.md
+     Initial SHA: 917e5f53b16b115b70a3a355ed5f4993b9f8b73d (2026-04-10, Issue #209)
+     Selective back-port: obra/superpowers v6.1.1 (commit d884ae04edebef577e82ff7c4e143debd0bbec99, 2026-07-02)
+     Back-port SHA / Issue: d884ae0 / #509 (2026-07-04)
+     This is a Mercury-owned adaptation, NOT a verbatim mirror — see frontmatter
+     `mercury_adaptation` for what diverges from upstream and why. -->
 
 # Subagent-Driven Development
 
@@ -26,6 +44,8 @@ Execute plan by dispatching fresh subagent per task, with two-stage review after
 **Why subagents:** You delegate tasks to specialized agents with isolated context. By precisely crafting their instructions and context, you ensure they stay focused and succeed at their task. They should never inherit your session's context or history — you construct exactly what they need. This also preserves your own context for coordination work.
 
 **Core principle:** "Fresh subagent per task + two-stage review (spec then quality) = high quality, fast iteration"
+
+**Continuous execution:** Do not pause to check in between tasks. Execute all tasks from the plan without stopping. The only reasons to stop are: a `BLOCKED` status you cannot resolve, ambiguity that genuinely prevents progress, or all tasks complete. "Should I continue?" prompts and progress summaries between tasks waste time — you were asked to execute the plan, so execute it.
 
 ## When to Use
 
@@ -36,20 +56,49 @@ Use subagent-driven development when you have an implementation plan with mostly
 The workflow involves:
 
 1. Reading the plan and extracting all tasks with full context
-2. Creating a TodoWrite to track progress
-3. For each task:
+2. **Pre-flight plan review** — scan the plan once for contradictions before Task 1 (see [Pre-Flight Plan Review](#pre-flight-plan-review))
+3. Creating a TodoWrite **and a durable progress ledger** to track progress (see [Durable Progress](#durable-progress))
+4. For each task:
+   - **Check the ledger first** — a task already marked complete is DONE; do not re-dispatch it (post-compaction recovery)
    - Dispatch an implementer subagent
    - Address any questions before implementation proceeds
    - Implementer implements, tests, commits, and self-reviews
+   - **Handle the implementer's reported status** (`DONE` / `DONE_WITH_CONCERNS` / `BLOCKED` / `NEEDS_CONTEXT` — see [Handling Implementer Status](#handling-implementer-status))
    - Dispatch spec compliance reviewer
    - Dispatch code quality reviewer
-   - Mark task complete once approved
-4. After all tasks, dispatch final code reviewer
-5. Use your project's branch completion workflow (e.g., Mercury's `/pr-flow` skill).
+   - Once approved, mark task complete **in both the todo list and the ledger**
+5. After all tasks, dispatch final code reviewer
+6. Use your project's branch completion workflow (e.g., Mercury's `/pr-flow` skill).
+
+## Pre-Flight Plan Review
+
+Before dispatching Task 1, scan the plan once for conflicts:
+
+- Tasks that contradict each other or the plan's global constraints.
+- Anything the plan explicitly mandates that the review rubric would treat as a defect (a test that asserts nothing, verbatim duplication of a logic block).
+
+Present everything you find as one batched question — each finding beside the plan text that mandates it, asking which governs — **before** execution begins, not one interrupt per discovery mid-plan. If the scan is clean, proceed without comment. The per-task review loop remains the net for conflicts that only emerge from implementation.
 
 ## Model Selection
 
 Tailor model capability to task complexity: "Use the least powerful model that can handle each role to conserve cost and increase speed." Mechanical implementation tasks use faster models; integration tasks use standard models; architecture and review tasks use the most capable models.
+
+**Always specify the model explicitly when dispatching a subagent.** An omitted model silently inherits your session's model — often the most capable and most expensive — which defeats this section. (This matters most when the session model is a premium tier: a fan-out of subagents each inheriting it multiplies the cost.)
+
+## Handling Implementer Status
+
+The implementer subagent reports one of four statuses. Handle each appropriately:
+
+- **DONE:** Proceed to the two-stage review (spec compliance, then code quality).
+- **DONE_WITH_CONCERNS:** The implementer completed the work but flagged doubts. Read the concerns before proceeding. If they are about correctness or scope, address them before review; if they are observations (e.g., "this file is getting large"), note them and proceed to review.
+- **NEEDS_CONTEXT:** The implementer needs information that wasn't provided. Provide the missing context and re-dispatch.
+- **BLOCKED:** The implementer cannot complete the task. Assess the blocker:
+  1. If it's a context problem, provide more context and re-dispatch (same model).
+  2. If the task needs more reasoning, re-dispatch with a more capable model.
+  3. If the task is too large, break it into smaller pieces.
+  4. If the plan itself is wrong, escalate to the human.
+
+**Never** ignore an escalation or force the same model to retry without changes. If the implementer said it's stuck, something must change before the re-dispatch.
 
 ## Key Principles
 
@@ -59,6 +108,22 @@ Tailor model capability to task complexity: "Use the least powerful model that c
 - Implement review loops: when issues are found, the same implementer fixes them, then reviewers verify again
 - Never dispatch multiple implementation subagents in parallel
 - Provide full task context directly rather than having subagents read files
+- Record completed tasks in the durable ledger, not only in todos — todos do not survive compaction
+
+## Durable Progress
+
+Conversation memory does not survive compaction — and Mercury routinely runs long, multi-agent Workflows that hit it. A controller that loses its place can re-dispatch an entire completed task sequence, the single most expensive failure this workflow can produce. Track progress in a **ledger file**, not only in todos.
+
+- **Ledger location:** `<repo-root>/.tmp/sdd/progress.md` (Mercury's `.gitignore` already ignores `.tmp/`, so the ledger is git-ignored scratch and never gets committed). If you run this skill outside Mercury, put the ledger under that repo's scratch convention and confirm the path is git-ignored — a committed ledger is a bug.
+- **At skill start,** read any existing ledger with `Bash`: `cat "$(git rev-parse --show-toplevel)/.tmp/sdd/progress.md" 2>/dev/null`. Tasks listed there as complete are DONE — do not re-dispatch them; resume at the first task not marked complete.
+- **When a task's review comes back clean,** append one line to the ledger with `Bash` in the same bookkeeping step (create the dir on first write):
+  ```bash
+  L="$(git rev-parse --show-toplevel)/.tmp/sdd/progress.md"; mkdir -p "$(dirname "$L")"
+  echo "Task N: complete (commits <base7>..<head7>, review clean)" >> "$L"
+  ```
+  Get the commit range from `git log --oneline` — `<base7>` is the commit before the task, `<head7>` the task's final commit.
+- **The ledger is your recovery map:** the commits it names exist in git even when your context no longer remembers creating them. After compaction, trust the ledger and `git log` over your own recollection.
+- `git clean -fdx` will destroy the ledger (it lives in git-ignored scratch); if that happens, reconstruct progress from `git log`.
 
 ## Subagent Prompt Templates
 
@@ -67,3 +132,13 @@ See the following files in this skill directory for dispatch templates:
 - **[implementer-prompt.md](implementer-prompt.md)** — Template for dispatching implementation subagents
 - **[spec-reviewer-prompt.md](spec-reviewer-prompt.md)** — Template for spec compliance review subagents
 - **[code-quality-reviewer-prompt.md](code-quality-reviewer-prompt.md)** — Template for code quality review subagents
+
+> **Mercury adaptation — two-stage review split.** Mercury deliberately keeps
+> spec compliance and code quality as **two separate reviewer subagents**
+> (`spec-reviewer-prompt.md` → `code-quality-reviewer-prompt.md`, dispatched in
+> that order). Upstream `obra/superpowers` v6.1.x has since **merged** both into
+> a single `task-reviewer` that returns two verdicts in one pass. That merge is
+> a style choice, not a bug fix, and Mercury's split is an intentional,
+> effective adaptation (a clean spec gate before any quality judgment). The two
+> local files are therefore **canonical for Mercury**, not stale references to
+> deleted upstream files — do not "fix" them by collapsing into one reviewer.

--- a/.claude/skills/subagent-driven-development/SKILL.md
+++ b/.claude/skills/subagent-driven-development/SKILL.md
@@ -47,6 +47,8 @@ Execute plan by dispatching fresh subagent per task, with two-stage review after
 
 **Continuous execution:** Do not pause to check in between tasks. Execute all tasks from the plan without stopping. The only reasons to stop are: a `BLOCKED` status you cannot resolve, ambiguity that genuinely prevents progress, or all tasks complete. "Should I continue?" prompts and progress summaries between tasks waste time — you were asked to execute the plan, so execute it.
 
+> **Mercury governance carve-out.** This "don't pause" rule covers routine in-plan tasks. It does NOT override Mercury's human-gate policy: irreversible, cross-repo, or shared-infrastructure decisions still stop for confirmation (via `AskUserQuestion`), and code still passes `/dual-verify` + PR review before merge. Continuous execution means no busywork check-ins — not bypassing a required gate. If a plan task would trip one of those gates, that is exactly the "ambiguity that genuinely prevents progress" case: surface it.
+
 ## When to Use
 
 Use subagent-driven development when you have an implementation plan with mostly independent tasks that you want to execute within the current session. It differs from the "executing-plans" approach by keeping you in the same session while dispatching fresh subagents per task without context pollution.
@@ -115,11 +117,19 @@ The implementer subagent reports one of four statuses. Handle each appropriately
 Conversation memory does not survive compaction — and Mercury routinely runs long, multi-agent Workflows that hit it. A controller that loses its place can re-dispatch an entire completed task sequence, the single most expensive failure this workflow can produce. Track progress in a **ledger file**, not only in todos.
 
 - **Ledger location:** `<repo-root>/.tmp/sdd/progress.md` (Mercury's `.gitignore` already ignores `.tmp/`, so the ledger is git-ignored scratch and never gets committed). If you run this skill outside Mercury, put the ledger under that repo's scratch convention and confirm the path is git-ignored — a committed ledger is a bug.
-- **At skill start,** read any existing ledger with `Bash`: `cat "$(git rev-parse --show-toplevel)/.tmp/sdd/progress.md" 2>/dev/null`. Tasks listed there as complete are DONE — do not re-dispatch them; resume at the first task not marked complete.
-- **When a task's review comes back clean,** append one line to the ledger with `Bash` in the same bookkeeping step (create the dir on first write):
+- **Resolve the ledger path once** with `Bash`, validating the repo root first. A failed `git rev-parse` (not a git repo, or a corrupted checkout) returns empty, and an unvalidated `$ROOT` would point the ledger at `/.tmp/sdd/progress.md` — the wrong location, and a silent loss of progress tracking:
   ```bash
-  L="$(git rev-parse --show-toplevel)/.tmp/sdd/progress.md"; mkdir -p "$(dirname "$L")"
-  echo "Task N: complete (commits <base7>..<head7>, review clean)" >> "$L"
+  ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+  [ -n "$ROOT" ] || { echo "ledger: not a git repo — cannot track progress" >&2; }   # stop; do not proceed unrooted
+  L="$ROOT/.tmp/sdd/progress.md"
+  ```
+  Non-empty is the portable check: `git rev-parse` output is Windows-safe as `D:/…` or `/d/…`, so do NOT additionally require a leading `/` (it would false-reject the `D:/…` form).
+- **At skill start,** read any existing ledger: `cat "$L" 2>/dev/null`. Tasks listed there as complete are DONE — do not re-dispatch them; resume at the first task not marked complete.
+- **When a task's review comes back clean,** append one line — failing loudly if any step fails, so a lost write never masquerades as saved progress (not losing progress is the whole point of the ledger):
+  ```bash
+  mkdir -p "$(dirname "$L")"                     || { echo "ledger: mkdir failed" >&2; exit 1; }
+  echo "Task N: complete (commits <base7>..<head7>, review clean)" >> "$L" \
+                                                  || { echo "ledger: append failed — progress NOT saved" >&2; exit 1; }
   ```
   Get the commit range from `git log --oneline` — `<base7>` is the commit before the task, `<head7>` the task's final commit.
 - **The ledger is your recovery map:** the commits it names exist in git even when your context no longer remembers creating them. After compaction, trust the ledger and `git log` over your own recollection.

--- a/.claude/skills/subagent-driven-development/SKILL.md
+++ b/.claude/skills/subagent-driven-development/SKILL.md
@@ -120,7 +120,7 @@ Conversation memory does not survive compaction — and Mercury routinely runs l
 - **Resolve the ledger path once** with `Bash`, validating the repo root first. A failed `git rev-parse` (not a git repo, or a corrupted checkout) returns empty, and an unvalidated `$ROOT` would point the ledger at `/.tmp/sdd/progress.md` — the wrong location, and a silent loss of progress tracking:
   ```bash
   ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
-  [ -n "$ROOT" ] || { echo "ledger: not a git repo — cannot track progress" >&2; }   # stop; do not proceed unrooted
+  [ -n "$ROOT" ] || { echo "ledger: not a git repo — cannot track progress" >&2; exit 1; }   # stop — do NOT proceed unrooted
   L="$ROOT/.tmp/sdd/progress.md"
   ```
   Non-empty is the portable check: `git rev-parse` output is Windows-safe as `D:/…` or `/d/…`, so do NOT additionally require a leading `/` (it would false-reject the `D:/…` form).

--- a/.claude/skills/subagent-driven-development/SKILL.md
+++ b/.claude/skills/subagent-driven-development/SKILL.md
@@ -62,7 +62,7 @@ The workflow involves:
 3. Creating a TodoWrite **and a durable progress ledger** to track progress (see [Durable Progress](#durable-progress))
 4. For each task:
    - **Check the ledger first** — a task already marked complete is DONE; do not re-dispatch it (post-compaction recovery)
-   - Dispatch an implementer subagent
+   - Dispatch an implementer subagent — **hand it a report-file path** (e.g. `.tmp/sdd/task-N-report.md`, alongside the ledger) as its `[REPORT_FILE]`, so it writes its full report to that file instead of into your context (the report-to-file contract in [implementer-prompt.md](implementer-prompt.md) depends on the controller supplying this path)
    - Address any questions before implementation proceeds
    - Implementer implements, tests, commits, and self-reviews
    - **Handle the implementer's reported status** (`DONE` / `DONE_WITH_CONCERNS` / `BLOCKED` / `NEEDS_CONTEXT` — see [Handling Implementer Status](#handling-implementer-status))

--- a/.claude/skills/subagent-driven-development/code-quality-reviewer-prompt.md
+++ b/.claude/skills/subagent-driven-development/code-quality-reviewer-prompt.md
@@ -1,8 +1,11 @@
 <!-- Cherry-picked from obra/superpowers (MIT, Copyright 2025 Jesse Vincent)
      Source: https://github.com/obra/superpowers/blob/917e5f5/skills/subagent-driven-development/code-quality-reviewer-prompt.md
-     SHA: 917e5f53b16b115b70a3a355ed5f4993b9f8b73d
-     Date: 2026-04-10
-     Issue: #209 -->
+     SHA: 917e5f53b16b115b70a3a355ed5f4993b9f8b73d (2026-04-10, Issue #209)
+     Mercury adaptation (#509, 2026-07-04): upstream v6.1.x merged spec + code-quality
+     review into a single task-reviewer; Mercury intentionally keeps the two-stage
+     split. This file is the CODE-QUALITY stage, dispatched AFTER
+     spec-reviewer-prompt.md passes. Canonical for Mercury, not a stale reference
+     to a deleted upstream file — see SKILL.md "Mercury adaptation" note. -->
 
 # Code Quality Reviewer Prompt Template
 

--- a/.claude/skills/subagent-driven-development/implementer-prompt.md
+++ b/.claude/skills/subagent-driven-development/implementer-prompt.md
@@ -1,8 +1,9 @@
 <!-- Cherry-picked from obra/superpowers (MIT, Copyright 2025 Jesse Vincent)
-     Source: https://github.com/obra/superpowers/blob/917e5f5/skills/subagent-driven-development/implementer-prompt.md
-     SHA: 917e5f53b16b115b70a3a355ed5f4993b9f8b73d
-     Date: 2026-04-10
-     Issue: #209 -->
+     Initial import: https://github.com/obra/superpowers/blob/917e5f5/skills/subagent-driven-development/implementer-prompt.md
+     Initial SHA: 917e5f53b16b115b70a3a355ed5f4993b9f8b73d (2026-04-10, Issue #209)
+     Selective back-port: obra/superpowers v6.1.1 (commit d884ae04edebef577e82ff7c4e143debd0bbec99, 2026-07-02)
+     Back-port SHA / Issue: d884ae0 / #509 (2026-07-04) — report-to-file contract
+     Mercury-owned adaptation, NOT a verbatim mirror. -->
 
 # Implementer Subagent Prompt Template
 
@@ -67,19 +68,28 @@ Task tool (general-purpose):
 
     ## Report Format
 
-    Status: DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT
+    Write your FULL report to the report file the controller named in this
+    dispatch ([REPORT_FILE]). Put the detail there:
+    - What I implemented: [list of changes]
+    - Tests: [commands run + results]
+    - Files changed: [list]
+    - Concerns (if any): [list]
 
-    What I implemented:
-    - [list of changes]
+    Then in your FINAL MESSAGE, report back with ONLY a compact summary —
+    the detail lives in the report file, which keeps it out of the
+    controller's context:
+    - Status: DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT
+    - Commits created (short SHA + subject)
+    - One-line test summary (e.g. "14/14 passing, output pristine")
+    - Concerns, if any
+    - The report file path
 
-    Tests:
-    - [test results]
+    If BLOCKED or NEEDS_CONTEXT, put the specifics in the final message
+    itself — the controller acts on it directly without opening the report file.
 
-    Files changed:
-    - [list]
-
-    Concerns (if any):
-    - [list]
+    (If no [REPORT_FILE] path was provided, put the full report in your final
+    message instead — but the file handoff is preferred: it keeps bulk output
+    out of the controller's context.)
 
     Never silently produce work you're unsure about.
 ```

--- a/.claude/skills/subagent-driven-development/implementer-prompt.md
+++ b/.claude/skills/subagent-driven-development/implementer-prompt.md
@@ -69,7 +69,9 @@ Task tool (general-purpose):
     ## Report Format
 
     Write your FULL report to the report file the controller named in this
-    dispatch ([REPORT_FILE]). Put the detail there:
+    dispatch ([REPORT_FILE]) — use the Write tool to create it (or a `Bash`
+    heredoc/redirect if you prefer). Do NOT put the full report in your final
+    message. Put the detail in the file:
     - What I implemented: [list of changes]
     - Tests: [commands run + results]
     - Files changed: [list]

--- a/.claude/skills/subagent-driven-development/spec-reviewer-prompt.md
+++ b/.claude/skills/subagent-driven-development/spec-reviewer-prompt.md
@@ -1,8 +1,11 @@
 <!-- Cherry-picked from obra/superpowers (MIT, Copyright 2025 Jesse Vincent)
      Source: https://github.com/obra/superpowers/blob/917e5f5/skills/subagent-driven-development/spec-reviewer-prompt.md
-     SHA: 917e5f53b16b115b70a3a355ed5f4993b9f8b73d
-     Date: 2026-04-10
-     Issue: #209 -->
+     SHA: 917e5f53b16b115b70a3a355ed5f4993b9f8b73d (2026-04-10, Issue #209)
+     Mercury adaptation (#509, 2026-07-04): upstream v6.1.x merged spec + code-quality
+     review into a single task-reviewer; Mercury intentionally keeps the two-stage
+     split. This file is the SPEC-COMPLIANCE stage, dispatched BEFORE
+     code-quality-reviewer-prompt.md. Canonical for Mercury, not a stale reference
+     to a deleted upstream file — see SKILL.md "Mercury adaptation" note. -->
 
 # Spec Compliance Reviewer Prompt Template
 


### PR DESCRIPTION
## Issue
Closes #509

## Summary
选择性同步 `obra/superpowers` v6.1.1 (commit `d884ae0`) → Mercury-owned 本地 `subagent-driven-development` skill 副本(4 文件,纯文档):

- **Durable Progress ledger**(最实质,finding #2):新增 post-compaction 恢复章节。ledger 在 `.tmp/sdd/progress.md`(git-ignored scratch);controller 撞 compaction 后信 ledger + `git log` 恢复,不重派已完成任务 —— Mercury 跑长多 agent Workflow 的真实恢复缺口。
- **Handling Implementer Status**(finding #3):controller 侧 `DONE` / `DONE_WITH_CONCERNS` / `BLOCKED` / `NEEDS_CONTEXT` 四状态处理。
- **Pre-Flight Plan Review**(finding #4):Task 1 前批量扫描计划冲突。
- **report-to-file 契约**(implementer-prompt.md):大 report 走文件、final message 只回精简状态,对齐 #385 context 经济学。
- **修 SKILL.md 内部不一致**(finding #1):说明 Mercury 保留两段式 spec+quality split 是**刻意适配**(上游 v6.1.x 已合并为单 `task-reviewer`,风格选择非 bug),两 reviewer 文件为 Mercury canonical;两 reviewer 文件头部各加 back-note。
- frontmatter 加 back-port lineage 字段(保留初始 cherry-pick 起点 `917e5f5`);`allowed-tools` 扩展 `TodoWrite`+`Bash` 匹配 ledger workflow 的 tool contract(dual-verify 修复项)。

### 刻意不做
- 不引入上游 bash scripts(`review-package`/`task-brief`/`sdd-workspace`)+ `.superpowers/` 路径 —— Windows-primary + Mercury 已有 #385 护栏 + adapter 精简原则。
- 不动 `.mercury/state/upstream-manifest.json`(`last_drift_check` 回写归 #508 周期机制)。
- root-cause-tracing Graphviz 图 = 纯 cosmetic,不 back-port。

## 上游核实(cherry-pick 协议)
- Source: `obra/superpowers` v6.1.1, commit `d884ae04edebef577e82ff7c4e143debd0bbec99` (2026-07-02), MIT。
- 经 `gh api` 核实一手源:目录结构 + `SKILL.md`/`implementer-prompt.md`/`task-reviewer-prompt.md` 全文 + 完整 SHA(非凭记忆)。

## dual-verify
- Claude Code deep-review: **PASS**(锚点链接 / frontmatter YAML / ledger gitignore / #527 XML lint 全绿)
- Codex code-audit: NEEDS-CHANGES(Medium×1:`allowed-tools` 与 workflow tool contract 落差)→ **已修复重验**
- Final: **PASS**

## Test plan
- [x] frontmatter YAML 合法(pyyaml 解析,14 key)
- [x] 3 个 in-page 锚点链接匹配对应 `## Heading`
- [x] ledger 路径 `.tmp/sdd/progress.md` 被 `.gitignore` 忽略(`git check-ignore` 确认)
- [x] #527 `toolcall-xml-lint` PASS(4 文件 + 全量 exit 0)
- [x] skill 运行时重新加载成功(description 正确)

Generated with Claude Code