### PR TITLE
chore(#530): 上游漂移 triage + drift-check UPSTREAM_GONE 修复

### DIFF
--- a/.mercury/state/upstream-manifest.json
+++ b/.mercury/state/upstream-manifest.json
@@ -9,7 +9,7 @@
     "import_pr": 216,
     "import_date": "2026-04-10",
     "import_rationale": "DEC-4 approved cherry-pick: root-cause debugging enforcement for Mercury quality workflow (Issue #209)",
-    "last_drift_check": "2026-06-24"
+    "last_drift_check": "2026-07-04"
   },
   {
     "path": ".claude/skills/systematic-debugging/condition-based-waiting.md",
@@ -21,7 +21,7 @@
     "import_pr": 216,
     "import_date": "2026-04-10",
     "import_rationale": "Supporting doc for systematic-debugging skill (Issue #209)",
-    "last_drift_check": "2026-06-24"
+    "last_drift_check": "2026-07-04"
   },
   {
     "path": ".claude/skills/systematic-debugging/condition-based-waiting-example.ts",
@@ -33,7 +33,7 @@
     "import_pr": 216,
     "import_date": "2026-04-10",
     "import_rationale": "Supporting example for systematic-debugging skill (Issue #209)",
-    "last_drift_check": "2026-06-24"
+    "last_drift_check": "2026-07-04"
   },
   {
     "path": ".claude/skills/systematic-debugging/defense-in-depth.md",
@@ -45,7 +45,7 @@
     "import_pr": 216,
     "import_date": "2026-04-10",
     "import_rationale": "Supporting doc for systematic-debugging skill (Issue #209)",
-    "last_drift_check": "2026-06-24"
+    "last_drift_check": "2026-07-04"
   },
   {
     "path": ".claude/skills/systematic-debugging/find-polluter.sh",
@@ -57,7 +57,7 @@
     "import_pr": 216,
     "import_date": "2026-04-10",
     "import_rationale": "Supporting script for systematic-debugging skill (Issue #209)",
-    "last_drift_check": "2026-06-24"
+    "last_drift_check": "2026-07-04"
   },
   {
     "path": ".claude/skills/systematic-debugging/root-cause-tracing.md",
@@ -69,55 +69,31 @@
     "import_pr": 216,
     "import_date": "2026-04-10",
     "import_rationale": "Supporting doc for systematic-debugging skill (Issue #209)",
-    "last_drift_check": "2026-06-24"
+    "last_drift_check": "2026-07-04"
   },
   {
     "path": ".claude/skills/subagent-driven-development/SKILL.md",
     "scope": "project",
     "upstream_repo": "obra/superpowers",
     "upstream_path": "skills/subagent-driven-development/SKILL.md",
-    "upstream_sha_at_import": "917e5f53b16b115b70a3a355ed5f4993b9f8b73d",
+    "upstream_sha_at_import": "d884ae04edebef577e82ff7c4e143debd0bbec99",
     "upstream_license": "MIT",
     "import_pr": 216,
     "import_date": "2026-04-10",
     "import_rationale": "DEC-4 approved cherry-pick: fresh-subagent-per-task execution pattern (Issue #209)",
-    "last_drift_check": "2026-06-24"
-  },
-  {
-    "path": ".claude/skills/subagent-driven-development/code-quality-reviewer-prompt.md",
-    "scope": "project",
-    "upstream_repo": "obra/superpowers",
-    "upstream_path": "skills/subagent-driven-development/code-quality-reviewer-prompt.md",
-    "upstream_sha_at_import": "917e5f53b16b115b70a3a355ed5f4993b9f8b73d",
-    "upstream_license": "MIT",
-    "import_pr": 216,
-    "import_date": "2026-04-10",
-    "import_rationale": "Supporting prompt template for subagent-driven-development skill (Issue #209)",
-    "last_drift_check": "2026-06-24"
+    "last_drift_check": "2026-07-04"
   },
   {
     "path": ".claude/skills/subagent-driven-development/implementer-prompt.md",
     "scope": "project",
     "upstream_repo": "obra/superpowers",
     "upstream_path": "skills/subagent-driven-development/implementer-prompt.md",
-    "upstream_sha_at_import": "917e5f53b16b115b70a3a355ed5f4993b9f8b73d",
+    "upstream_sha_at_import": "d884ae04edebef577e82ff7c4e143debd0bbec99",
     "upstream_license": "MIT",
     "import_pr": 216,
     "import_date": "2026-04-10",
     "import_rationale": "Supporting prompt template for subagent-driven-development skill (Issue #209)",
-    "last_drift_check": "2026-06-24"
-  },
-  {
-    "path": ".claude/skills/subagent-driven-development/spec-reviewer-prompt.md",
-    "scope": "project",
-    "upstream_repo": "obra/superpowers",
-    "upstream_path": "skills/subagent-driven-development/spec-reviewer-prompt.md",
-    "upstream_sha_at_import": "917e5f53b16b115b70a3a355ed5f4993b9f8b73d",
-    "upstream_license": "MIT",
-    "import_pr": 216,
-    "import_date": "2026-04-10",
-    "import_rationale": "Supporting prompt template for subagent-driven-development skill (Issue #209)",
-    "last_drift_check": "2026-06-24"
+    "last_drift_check": "2026-07-04"
   },
   {
     "path": ".claude/skills/verification-before-completion/SKILL.md",
@@ -129,7 +105,7 @@
     "import_pr": 216,
     "import_date": "2026-04-10",
     "import_rationale": "DEC-4 approved cherry-pick: evidence-before-claims verification enforcement (Issue #209)",
-    "last_drift_check": "2026-06-24"
+    "last_drift_check": "2026-07-04"
   },
   {
     "path": ".claude/skills/caveman-toggle/SKILL.md",
@@ -141,7 +117,7 @@
     "import_pr": 214,
     "import_date": "2026-04-10",
     "import_rationale": "Adapted caveman prompt text into Mercury-native persistent toggle skill (Issue #213)",
-    "last_drift_check": "2026-06-24"
+    "last_drift_check": "2026-07-04"
   },
   {
     "path": "CLAUDE.local.md.example",
@@ -153,7 +129,7 @@
     "import_pr": 214,
     "import_date": "2026-04-10",
     "import_rationale": "Contains caveman prompt text extracted from upstream SKILL.md for use as CLAUDE.local.md injection template (Issue #213)",
-    "last_drift_check": "2026-06-24"
+    "last_drift_check": "2026-07-04"
   },
   {
     "path": ".claude/agents/game-researcher.md",
@@ -165,7 +141,7 @@
     "import_pr": 281,
     "import_date": "2026-04-21",
     "import_rationale": "Game-dev A→B→C subagent chain stage 1 (information aggregation) for SoT production trial (Issue #281)",
-    "last_drift_check": "2026-06-24"
+    "last_drift_check": "2026-07-04"
   },
   {
     "path": ".claude/agents/game-analyst.md",
@@ -177,7 +153,7 @@
     "import_pr": 281,
     "import_date": "2026-04-21",
     "import_rationale": "Game-dev A→B→C subagent chain stage 2 (feasibility analysis) for SoT production trial (Issue #281)",
-    "last_drift_check": "2026-06-24"
+    "last_drift_check": "2026-07-04"
   },
   {
     "path": ".claude/agents/game-critic.md",
@@ -189,7 +165,7 @@
     "import_pr": 281,
     "import_date": "2026-04-21",
     "import_rationale": "Game-dev A→B→C subagent chain stage 3 (adversarial validation) for SoT production trial (Issue #281)",
-    "last_drift_check": "2026-06-24"
+    "last_drift_check": "2026-07-04"
   },
   {
     "path": "adapters/gpt-image-2/invoke.py",
@@ -201,7 +177,7 @@
     "import_pr": 354,
     "import_date": "2026-05-08",
     "import_rationale": "Phase 2 Slice A — wuyoscar/gpt_image_2_skill MIT mount via uvx-pinned-SHA per ADR pixel-animation-workflow §7.2.1 + S87 refinement (Issue #351). No upstream source vendored. upstream_path=pyproject.toml tracks the canonical version contract (deps, entry points) so scripts/upstream-drift-check.sh can detect upstream version bumps that affect this adapter's pinned SHA.",
-    "last_drift_check": "2026-06-24"
+    "last_drift_check": "2026-07-04"
   },
   {
     "path": "adapters/playwright-mcp/UPSTREAM.md",
@@ -213,6 +189,6 @@
     "import_pr": 459,
     "import_date": "2026-05-26",
     "import_rationale": "Phase 2 Slice A (Issue #458, ADR issue-154-web-automation) — npm-version-pinned MCP server runtime mount (third mount mode, alongside git submodule and uvx git+SHA). Execution contract = pinned npm version @playwright/mcp@0.0.75; upstream_sha_at_import = the git tag v0.0.75 commit (audit metadata mapping the pinned npm version back to an upstream git tag, NOT the execution contract). upstream_path=package.json tracks the canonical version/deps/bin contract so scripts/upstream-drift-check.sh can detect upstream version bumps that may require re-pinning this adapter. No upstream source vendored; adapters/playwright-mcp/launch.cjs is a Mercury config-gate wrapper only.",
-    "last_drift_check": "2026-06-24"
+    "last_drift_check": "2026-07-04"
   }
 ]

--- a/scripts/upstream-drift-check.sh
+++ b/scripts/upstream-drift-check.sh
@@ -131,26 +131,25 @@ for ((i=0; i<count; i++)); do
   # URL-encode upstream_path to handle spaces, #, ? and other special characters
   encoded_path=$(jq -rn --arg p "$upstream_path" '$p | @uri')
 
-  # Get blob SHA of the file at the recorded import commit.
-  # Branch on gh's EXIT CODE, not on whether the captured string is empty: gh api
-  # prints the HTTP-error body (e.g. {"message":"Not Found",...,"status":"404"}) to
-  # STDOUT on a 404, so `--jq '.sha'` yields a NON-empty string there. An emptiness
-  # check would sail past it and mis-compare a deleted file as CHANGED instead of
-  # UPSTREAM_GONE. (Root-caused in #530: obra/superpowers deleted spec-reviewer-prompt.md
-  # / code-quality-reviewer-prompt.md upstream; the old `|| true` + `-z` guard reported
-  # CHANGED, never GONE, and exited 1 instead of 2.)
-  snap_err="$(mktemp)"
-  if snap_blob=$(gh api "repos/$upstream_repo/contents/$encoded_path?ref=$recorded_sha" --jq '.sha' 2>"$snap_err"); then
-    rm -f "$snap_err"
+  # Fetch the blob SHA at the recorded import commit. Branch on gh's EXIT CODE, not
+  # on whether the capture is empty: gh api prints the HTTP-error body — a JSON object
+  # carrying a "status" field — to STDOUT on failure, so a non-empty capture does NOT
+  # mean success (a 404 body would sail past a `-z` check and be mis-compared as
+  # CHANGED instead of UPSTREAM_GONE). On failure we read that JSON's "status" field
+  # STRUCTURALLY (via jq) rather than grepping localized stderr text, so a format /
+  # locale change in gh's stderr can't cause a mis-classification. This also removes
+  # the need for a stderr temp file entirely. (Root-caused in #530: obra/superpowers
+  # deleted spec-reviewer-prompt.md / code-quality-reviewer-prompt.md upstream; the old
+  # `|| true` + `-z` guard reported CHANGED, never GONE, and exited 1 instead of 2.)
+  if snap_blob=$(gh api "repos/$upstream_repo/contents/$encoded_path?ref=$recorded_sha" --jq '.sha' 2>/dev/null); then
+    :
+  elif [[ "$(printf '%s' "$snap_blob" | jq -r '.status // empty' 2>/dev/null)" == "404" ]]; then
+    echo "UPSTREAM_GONE (import SHA unreachable: $recorded_sha)"
+    gone=$((gone + 1))
+    continue
   else
-    if grep -q "404" "$snap_err" 2>/dev/null; then
-      echo "UPSTREAM_GONE (import SHA unreachable: $recorded_sha)"
-      gone=$((gone + 1))
-    else
-      echo "SKIP (gh api error checking import SHA — not 404)"
-      skipped=$((skipped + 1))
-    fi
-    rm -f "$snap_err"
+    echo "SKIP (gh api error checking import SHA — not 404)"
+    skipped=$((skipped + 1))
     continue
   fi
   # Defensive: a 200 response with no .sha field (unexpected for the contents API)
@@ -160,22 +159,18 @@ for ((i=0; i<count; i++)); do
     continue
   fi
 
-  # Get blob SHA of the file at upstream HEAD (same exit-code discipline as the
-  # import-SHA fetch above — a 404 body is non-empty on STDOUT, so branch on gh's
-  # exit code to catch a file removed from upstream HEAD as UPSTREAM_GONE rather
-  # than CHANGED). See #530.
-  head_err="$(mktemp)"
-  if head_blob=$(gh api "repos/$upstream_repo/contents/$encoded_path" --jq '.sha' 2>"$head_err"); then
-    rm -f "$head_err"
+  # Fetch the blob SHA at upstream HEAD (same exit-code + structural-status discipline
+  # as the import-SHA fetch above — parse the error body's "status" on failure to catch
+  # a file removed from upstream HEAD as UPSTREAM_GONE rather than CHANGED). See #530.
+  if head_blob=$(gh api "repos/$upstream_repo/contents/$encoded_path" --jq '.sha' 2>/dev/null); then
+    :
+  elif [[ "$(printf '%s' "$head_blob" | jq -r '.status // empty' 2>/dev/null)" == "404" ]]; then
+    echo "UPSTREAM_GONE (file removed from upstream HEAD)"
+    gone=$((gone + 1))
+    continue
   else
-    if grep -q "404" "$head_err" 2>/dev/null; then
-      echo "UPSTREAM_GONE (file removed from upstream HEAD)"
-      gone=$((gone + 1))
-    else
-      echo "SKIP (gh api error checking upstream HEAD — not 404)"
-      skipped=$((skipped + 1))
-    fi
-    rm -f "$head_err"
+    echo "SKIP (gh api error checking upstream HEAD — not 404)"
+    skipped=$((skipped + 1))
     continue
   fi
   # Defensive: a 200 response with no .sha field (unexpected for the contents API)

--- a/scripts/upstream-drift-check.sh
+++ b/scripts/upstream-drift-check.sh
@@ -131,11 +131,18 @@ for ((i=0; i<count; i++)); do
   # URL-encode upstream_path to handle spaces, #, ? and other special characters
   encoded_path=$(jq -rn --arg p "$upstream_path" '$p | @uri')
 
-  # Get blob SHA of the file at the recorded import commit
+  # Get blob SHA of the file at the recorded import commit.
+  # Branch on gh's EXIT CODE, not on whether the captured string is empty: gh api
+  # prints the HTTP-error body (e.g. {"message":"Not Found",...,"status":"404"}) to
+  # STDOUT on a 404, so `--jq '.sha'` yields a NON-empty string there. An emptiness
+  # check would sail past it and mis-compare a deleted file as CHANGED instead of
+  # UPSTREAM_GONE. (Root-caused in #530: obra/superpowers deleted spec-reviewer-prompt.md
+  # / code-quality-reviewer-prompt.md upstream; the old `|| true` + `-z` guard reported
+  # CHANGED, never GONE, and exited 1 instead of 2.)
   snap_err="$(mktemp)"
-  snap_blob=$(gh api "repos/$upstream_repo/contents/$encoded_path?ref=$recorded_sha" \
-    --jq '.sha' 2>"$snap_err" || true)
-  if [[ -z "$snap_blob" ]]; then
+  if snap_blob=$(gh api "repos/$upstream_repo/contents/$encoded_path?ref=$recorded_sha" --jq '.sha' 2>"$snap_err"); then
+    rm -f "$snap_err"
+  else
     if grep -q "404" "$snap_err" 2>/dev/null; then
       echo "UPSTREAM_GONE (import SHA unreachable: $recorded_sha)"
       gone=$((gone + 1))
@@ -146,13 +153,21 @@ for ((i=0; i<count; i++)); do
     rm -f "$snap_err"
     continue
   fi
-  rm -f "$snap_err"
+  # Defensive: a 200 response with no .sha field (unexpected for the contents API)
+  if [[ -z "$snap_blob" ]]; then
+    echo "SKIP (import ref returned no .sha)"
+    skipped=$((skipped + 1))
+    continue
+  fi
 
-  # Get blob SHA of the file at upstream HEAD
+  # Get blob SHA of the file at upstream HEAD (same exit-code discipline as the
+  # import-SHA fetch above — a 404 body is non-empty on STDOUT, so branch on gh's
+  # exit code to catch a file removed from upstream HEAD as UPSTREAM_GONE rather
+  # than CHANGED). See #530.
   head_err="$(mktemp)"
-  head_blob=$(gh api "repos/$upstream_repo/contents/$encoded_path" \
-    --jq '.sha' 2>"$head_err" || true)
-  if [[ -z "$head_blob" ]]; then
+  if head_blob=$(gh api "repos/$upstream_repo/contents/$encoded_path" --jq '.sha' 2>"$head_err"); then
+    rm -f "$head_err"
+  else
     if grep -q "404" "$head_err" 2>/dev/null; then
       echo "UPSTREAM_GONE (file removed from upstream HEAD)"
       gone=$((gone + 1))
@@ -163,7 +178,12 @@ for ((i=0; i<count; i++)); do
     rm -f "$head_err"
     continue
   fi
-  rm -f "$head_err"
+  # Defensive: a 200 response with no .sha field (unexpected for the contents API)
+  if [[ -z "$head_blob" ]]; then
+    echo "SKIP (upstream HEAD returned no .sha)"
+    skipped=$((skipped + 1))
+    continue
+  fi
 
   if [[ "$snap_blob" == "$head_blob" ]]; then
     echo "CLEAN"


### PR DESCRIPTION
## Issue
Closes #530

## Summary
月度 upstream-drift(#508 Tier-1)2026-07-01 报 **9 个 CHANGED** cherry-pick artifact。逐条 triage(per `upstream-drift-routine.md`)+ 附带修 triage 中发现的一个 drift-check 脚本 bug。

### Triage 裁决(9 CHANGED)
| 文件 | 裁决 | 依据 |
|---|---|---|
| subagent-driven-development/SKILL.md + implementer-prompt.md | **pull-update 已完成(#509)** | #509 已 back-port v6.1.1;manifest sha `917e5f5` → `d884ae0` → 现 CLEAN |
| subagent-driven-development/spec-reviewer + code-quality-reviewer | **accept-as-owned(移除条目)** | 上游 v6.1.x 删除(合并入 `task-reviewer`);#509 刻意保留两段式 split。移除 manifest 条目(Mercury-owned fork,provenance 在文件 header + #509 SKILL.md);修 bug 后本应报 `UPSTREAM_GONE`,移除避免永久噪音 |
| systematic-debugging/SKILL.md | **accept-as-owned** | cosmetic(`Ultrathink`→`Ultra-think`)|
| systematic-debugging/root-cause-tracing.md | **accept-as-owned** | cosmetic(示例路径 `/Users/jesse/`→`~/`)|
| caveman-toggle/SKILL.md + CLAUDE.local.md.example | **accept-as-owned** | Mercury 自有改写(基线 #508 已定)|
| adapters/playwright-mcp/UPSTREAM.md | **accept-as-owned** | pin `0.0.75` 落后 latest `0.0.77`(2 pre-1.0 patch);挂载 PoC #458 未投用,re-pin 待专项;低优监控 |

裁决后 `--write-back` 刷新全部 16 条 `last_drift_check=2026-07-04`。

### 附带修复:drift-check UPSTREAM_GONE 误判 bug
triage 中发现 `scripts/upstream-drift-check.sh` 对**上游已删文件误报 CHANGED 而非 UPSTREAM_GONE**:
- **根因**:`gh api --jq '.sha'` 遇 404 时,gh 把 error JSON body 打到 STDOUT,`head_blob` 非空 → 绕过 `-z` 空值判据的 GONE 检测 → 走比较 → CHANGED(且 exit 1 而非 2)。
- **修复**:snap/head 两处改为 branch on gh 的 **exit code**(404→exit≠0→else→grep stderr 404→GONE);加「200-但-无-`.sha`」防御性 SKIP。
- **实证验证**:已删文件(spec-reviewer)→ 正确 `UPSTREAM_GONE`;存在文件 → 正常比较。

## 结果
drift-check:16 artifacts,**CLEAN=11 CHANGED=5 UPSTREAM_GONE=0**(5 CHANGED 均已裁决 accept-as-owned,`last_drift_check` 为证)。

## dual-verify
- Claude Code deep-review: **PASS**(exit-code 判定 / mktemp-rm 无泄漏 / manifest reconcile / UTF-8)
- Codex code-audit: **PASS**(0 findings;确认 `d884ae0` = v6.1.1 release commit)

## Test plan
- [x] drift-check GONE 修复:已删文件→`UPSTREAM_GONE`,存在文件→正常比较(针对性测试)
- [x] `bash -n` 语法检查
- [x] manifest JSON 合法(16 条)+ UTF-8 保留(`A→B→C` 未转义)
- [x] subagent-driven SKILL.md/implementer-prompt.md → CLEAN(sha reconcile)
- [x] spec/code-quality reviewer 条目移除
- [x] `--write-back` 刷新 16 条 last_drift_check

Generated with Claude Code