### PR TITLE
fix(ci): auto-verify typecheck 真跑根 tsconfig,删除空转 lint job (#540)

### DIFF
--- a/.github/workflows/auto-verify.yml
+++ b/.github/workflows/auto-verify.yml
@@ -22,38 +22,8 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - name: TypeScript check (core)
-        run: |
-          if [ -f packages/core/tsconfig.json ]; then
-            npx tsc --noEmit -p packages/core/tsconfig.json
-          else
-            echo "No packages/core/tsconfig.json found — skipping"
-          fi
-
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-          cache: "pnpm"
-
-      - run: pnpm install --frozen-lockfile
-
-      - name: ESLint (if configured)
-        run: |
-          if [ -f .eslintrc.json ] || [ -f .eslintrc.js ] || [ -f .eslintrc.cjs ] || [ -f .eslintrc.yml ] || [ -f eslint.config.js ] || [ -f eslint.config.mjs ] || [ -f eslint.config.cjs ] || [ -f eslint.config.ts ]; then
-            npx eslint --max-warnings 0 packages/ adapters/
-          else
-            echo "No ESLint config found — skipping"
-          fi
+      - name: TypeScript check (root tsconfig)
+        run: npx tsc --noEmit -p tsconfig.json
 
   docstring-coverage:
     name: Docstring Coverage


### PR DESCRIPTION
## Issue
Closes #540

## Summary
- **typecheck job(方案 A,最小改动)**:原守卫 `if [ -f packages/core/tsconfig.json ]` 中该文件从不存在 → 每次 CI 走 skip 分支,`packages/core` 的 TS(event-bus/index/types)从未被 CI 类型检查。改为 `npx tsc --noEmit -p tsconfig.json`,根 tsconfig 的 `include: ["packages/*/src/**/*.ts"]` 已覆盖仓库全部 TS 源码(`adapters/` 下无 TS 文件,已核实)。不选方案 B(新增 `packages/core/tsconfig.json`)因当前仅单 package,引入 per-package tsconfig 无增益;未来多 package 时再演进。
- **lint job:删除**。该 job 仅在存在 eslint config 时执行,仓库无 eslint config → 永远 skip,是「有 CI 但没实际检查」的虚假保护。不选「配 eslint」因 TS 面积小(3 个源文件)且 strict tsc 是真实门禁,新增 eslint 依赖收益低。develop 分支保护无 required status checks,删 job 不影响任何 PR 合并;`.github/` 内亦无 `needs: lint` / `workflow_call` 依赖。

## Test plan
- [x] 本地 `tsc --noEmit -p tsconfig.json` EXIT 0(typescript 5.9.3,`pnpm install --frozen-lockfile` 与 CI 同源)
- [x] workflow YAML 语法校验通过
- [ ] 合并后观察 develop 上下一次 auto-verify run:typecheck job 日志应真跑 tsc,不再出现 "No packages/core/tsconfig.json found — skipping"

## Verification
- dual-verify: PASS (Claude: PASS, Codex: PASS, 0 issues)
- Dual-verify Codex side: PASS

Generated with Claude Code