### PR TITLE
fix(#552): push-guard 加仓库感知 —— 非 Mercury 仓的 push 不再被误拦

### DIFF
--- a/.claude/hooks/push-guard.sh
+++ b/.claude/hooks/push-guard.sh
@@ -255,6 +255,49 @@
 #     attempts to parse what is actually inside them — remain out of
 #     scope. All require deliberately constructing an indirection this
 #     hook cannot see into; not addressed here.
+#
+#     Iter 6 (performance — coordinator-measured): an unconditional `git
+#     rev-parse` (for Mercury's own common-dir) plus an unconditional `jq`
+#     call (for the hook stdin JSON's `cwd` field) ran at the TOP of this
+#     script regardless of command content, adding ~180ms (44%) to EVERY
+#     single Bash tool call — including ones with nothing to do with git
+#     at all — since this hook's PreToolUse matcher fires on every Bash
+#     invocation and Windows process-spawn overhead is expensive. Fixed:
+#     both are now resolved LAZILY via `_mercury_common_dir()`/
+#     `_hook_cwd()` cached accessor functions, only called from the exact
+#     points that actually need the value (Phase 0's Mercury-common-dir
+#     comparison; Pass B's cd/pushd same-repo check; process_segment's
+#     Phase 0 entry-cwd resolution) — each guarded so a command with no
+#     `cd`/`pushd` and no eligible `git push` segment never triggers
+#     either subprocess. `EFFECTIVE_CWD` (Pass B's cd-tracking seed) uses
+#     an explicit "unresolved" sentinel value instead of eagerly reading
+#     `HOOK_CWD`, resolved to the real value at the first point Pass B or
+#     process_segment's Phase 0 actually dereferences it. Benchmarked
+#     (`echo hi`, n=5, same synthetic JSON payload): pre-#552 baseline
+#     396ms average → iter-5 (pre-perf-fix) 576ms average (+180ms/+45%,
+#     confirms the regression) → post-fix 406ms average (+10ms/+2.5% vs
+#     baseline, well inside the ≤+30ms target). `git push`/`cd`-chain
+#     commands retain their necessary subprocess cost (both still resolve
+#     Mercury's common-dir and/or walk cd tracking, as they must).
+#
+#     Considered and NOT added: a cheap "command text contains no `git`
+#     substring → exit 0 immediately, skip the awk tokenizer entirely"
+#     pre-check. Rejected on correctness grounds, not measured need — the
+#     benchmark above shows awk's own cost is already negligible (the
+#     dominant 180ms was the two unconditional subprocess launches this
+#     iteration made lazy, not tokenization), so there is no remaining
+#     performance case for it. Adding it would also reopen exactly the
+#     kind of naive-regex bypass this hook's whole iter-1..3 history
+#     exists to close: the awk tokenizer already unescapes backslash
+#     sequences OUTSIDE and INSIDE double quotes (Codex iter-2 High #1,
+#     iter-3 Medium), meaning a token can read as literal `git` even when
+#     the substring `git` never appears unbroken in the raw command text
+#     (e.g. `g\it push origin develop` — bash executes this as `git push
+#     origin develop`, but a naive raw-text substring scan for `git` would
+#     miss it, since the literal bytes are `g`, `\`, `i`, `t`). A
+#     substring pre-check would have to replicate the same escape-aware
+#     scanning the tokenizer already does to stay safe — at which point it
+#     is not meaningfully cheaper than just running the tokenizer.
 
 INPUT=$(cat)
 
@@ -326,13 +369,27 @@ _git_common_dir() {
   esac
 }
 
-# Issue #552 — Mercury repo's own git common-dir, resolved once. Used by
-# the Phase 0 repo-awareness check in process_segment() to decide whether a
-# `git push` segment targets THIS repo (protection applies) or a different
-# one (out of scope, allowed through). Empty on resolution failure — Phase 0
-# treats that as "cannot determine", falling through to the existing
-# fail-closed Phase 1-3 logic unchanged.
-MERCURY_COMMON_DIR=$(_git_common_dir "$_PROJECT")
+# Issue #552 iter-6 (performance — coordinator-measured regression: an
+# unconditional `git rev-parse` here added ~180ms/44% to EVERY single Bash
+# tool call, including ones with no `git` anywhere in them, since this
+# hook's PreToolUse matcher fires on every Bash invocation and Windows
+# process-spawn overhead is expensive). Mercury's own git common-dir is
+# now resolved LAZILY — only the FIRST time `_mercury_common_dir()` is
+# actually called (from inside Phase 0, which itself only runs for a real
+# `git push` segment with no disabling gate already tripped) — and cached
+# so repeated calls within the same hook invocation (e.g. a command with
+# several push segments) cost one subprocess, not one per segment. Empty
+# on resolution failure — Phase 0 treats that as "cannot determine",
+# falling through to the existing fail-closed Phase 1-3 logic unchanged.
+_MERCURY_COMMON_DIR_COMPUTED=0
+_MERCURY_COMMON_DIR_CACHE=""
+_mercury_common_dir() {
+  if [ "$_MERCURY_COMMON_DIR_COMPUTED" -eq 0 ]; then
+    _MERCURY_COMMON_DIR_CACHE=$(_git_common_dir "$_PROJECT")
+    _MERCURY_COMMON_DIR_COMPUTED=1
+  fi
+  printf '%s' "$_MERCURY_COMMON_DIR_CACHE"
+}
 
 if [ "${GUARD_DEBUG:-0}" = "1" ] && [ -f "$LOG_FILE" ] && [ "$(wc -c < "$LOG_FILE")" -gt 102400 ]; then
   tail -100 "$LOG_FILE" > "$LOG_FILE.tmp" && mv "$LOG_FILE.tmp" "$LOG_FILE"
@@ -386,18 +443,35 @@ fi
 
 if [ "$HAS_JQ" -eq 1 ]; then
   COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
-  # Issue #552 — hook stdin JSON's top-level `cwd` field: "Current working
-  # directory when the hook is invoked" (confirmed present on all hook
-  # events, https://code.claude.com/docs/en/hooks). Fallback target-repo
-  # signal for the Phase 0 repo-awareness check when the push segment has
-  # no explicit `-C <path>`. Empty on missing/malformed field — Phase 0
-  # then has nothing to resolve and falls through fail-closed.
-  HOOK_CWD=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null)
 else
   # HAS_JQ=0 AND HAS_CMD_KEY=0 — INPUT did not carry a "command" key (e.g.
   # tool wasn't Bash). Nothing to gate.
   exit 0
 fi
+
+# Issue #552 — hook stdin JSON's top-level `cwd` field: "Current working
+# directory when the hook is invoked" (confirmed present on all hook
+# events, https://code.claude.com/docs/en/hooks). Fallback target-repo
+# signal for the Phase 0 repo-awareness check when a push segment has no
+# explicit `-C <path>`, and the seed value for the Pass B cd-tracker's
+# EFFECTIVE_CWD. Empty on missing/malformed field — Phase 0 then has
+# nothing to resolve and falls through fail-closed.
+#
+# Issue #552 iter-6 (performance): also resolved LAZILY now (one jq
+# subprocess, only when a `cd`/`pushd` or an eligible push segment
+# actually needs it — most Bash tool calls have neither), same rationale
+# and cache pattern as `_mercury_common_dir()` above.
+_HOOK_CWD_COMPUTED=0
+_HOOK_CWD_CACHE=""
+_hook_cwd() {
+  if [ "$_HOOK_CWD_COMPUTED" -eq 0 ]; then
+    if [ "$HAS_JQ" -eq 1 ]; then
+      _HOOK_CWD_CACHE=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null)
+    fi
+    _HOOK_CWD_COMPUTED=1
+  fi
+  printf '%s' "$_HOOK_CWD_CACHE"
+}
 
 debug_log "COMMAND=$COMMAND"
 
@@ -736,7 +810,16 @@ _find_command_position() {
 # specific `cd` "really" ran. This closes all 6 reproduced cases (short-
 # circuit, subshell, pipe, coproc, `if false; then cd; fi`) uniformly,
 # without needing to model any of their control-flow semantics.
-EFFECTIVE_CWD="$HOOK_CWD"
+# Issue #552 iter-6 (performance): EFFECTIVE_CWD starts as an UNRESOLVED
+# sentinel rather than eagerly calling `_hook_cwd()` (which would force
+# the jq subprocess even for commands with no `cd`/`pushd` and no `git
+# push` at all — the dominant case). It is resolved to the real HOOK_CWD
+# value lazily, at the FIRST point something actually needs it: either
+# Pass B's own cd/pushd handling below, or process_segment's Phase 0 (see
+# its sentinel-resolution at the top of the Phase 0 block). Any command
+# with neither construct never pays this cost.
+_LAZY_HOOK_CWD_SENTINEL="__push_guard_lazy_hook_cwd_unresolved__"
+EFFECTIVE_CWD="$_LAZY_HOOK_CWD_SENTINEL"
 EFFECTIVE_COMMON_DIR=""
 _eff_common_computed=0
 declare -a SEG_ENTRY_CWD=()
@@ -789,6 +872,13 @@ for _pb_sz in "${SEG_SIZES[@]}"; do
               # literal value).
               UNSAFE_STATE=1 ;;
             *)
+              # Issue #552 iter-6: this is the first point Pass B actually
+              # needs EFFECTIVE_CWD's real value (to join a relative `cd`
+              # arg, or as the baseline for the same-repo common-dir
+              # check below) — resolve the lazy sentinel now.
+              if [ "$EFFECTIVE_CWD" = "$_LAZY_HOOK_CWD_SENTINEL" ]; then
+                EFFECTIVE_CWD=$(_hook_cwd)
+              fi
               _pb_candidate=""
               case "$_pb_arg" in
                 /*|[A-Za-z]:[\\/]*|\\\\*)
@@ -1015,6 +1105,15 @@ process_segment() {
   #     transition or repo-redirection construct this hook cannot safely
   #     model, even if the construct itself lives in a DIFFERENT segment.
   if [ "$UNRESOLVABLE_SELECTOR" -eq 0 ] && [ "$UNSAFE_STATE" -eq 0 ]; then
+    # Issue #552 iter-6 (performance): this is the ONLY place a real `git
+    # push` segment (with no disabling gate already tripped) actually
+    # needs HOOK_CWD's value — resolve the Pass B lazy sentinel here, not
+    # before. A command with no eligible push segment at all (the
+    # dominant case — most Bash calls aren't `git push`) never reaches
+    # this line, so `_hook_cwd()`'s jq subprocess is never spent on it.
+    if [ "$_seg_entry_cwd" = "$_LAZY_HOOK_CWD_SENTINEL" ]; then
+      _seg_entry_cwd=$(_hook_cwd)
+    fi
     # Resolve which repo this segment's `git push` actually targets:
     # `-C <path>` (authoritative — overrides cwd for this invocation) else
     # `_seg_entry_cwd` — this segment's EFFECTIVE_CWD snapshot from the
@@ -1042,15 +1141,25 @@ process_segment() {
 
     # If that resolves to a git common-dir that differs from Mercury's own,
     # this push is out of this guard's scope — allow it through. Any
-    # failure to resolve (rev-parse errors, empty signal, MERCURY_COMMON_DIR
-    # itself unresolved) falls through unchanged to Phase 1-3 below —
-    # fail-closed, never a bypass source.
-    if [ -n "$_repo_path" ] && [ -n "$MERCURY_COMMON_DIR" ]; then
-      local _target_common_dir
-      _target_common_dir=$(_git_common_dir "$_repo_path")
-      if [ -n "$_target_common_dir" ] && [ "$(_normalize_path "$_target_common_dir")" != "$(_normalize_path "$MERCURY_COMMON_DIR")" ]; then
-        debug_log "ALLOWED (non-Mercury repo): target='$_target_common_dir' mercury='$MERCURY_COMMON_DIR'"
-        return 0
+    # failure to resolve (rev-parse errors, empty signal, Mercury's own
+    # common-dir itself unresolved) falls through unchanged to Phase 1-3
+    # below — fail-closed, never a bypass source.
+    #
+    # Issue #552 iter-6 (performance): `_mercury_common_dir()` (lazy,
+    # cached) instead of a plain `$MERCURY_COMMON_DIR` variable — this is
+    # the ONLY call site, and it only runs for a real push segment with no
+    # disabling gate already tripped, so the `git rev-parse` subprocess it
+    # spends on first call is never paid by a command with no such segment.
+    if [ -n "$_repo_path" ]; then
+      local _mercury_common_dir_val
+      _mercury_common_dir_val=$(_mercury_common_dir)
+      if [ -n "$_mercury_common_dir_val" ]; then
+        local _target_common_dir
+        _target_common_dir=$(_git_common_dir "$_repo_path")
+        if [ -n "$_target_common_dir" ] && [ "$(_normalize_path "$_target_common_dir")" != "$(_normalize_path "$_mercury_common_dir_val")" ]; then
+          debug_log "ALLOWED (non-Mercury repo): target='$_target_common_dir' mercury='$_mercury_common_dir_val'"
+          return 0
+        fi
       fi
     fi
   fi

--- a/.claude/hooks/push-guard.sh
+++ b/.claude/hooks/push-guard.sh
@@ -600,6 +600,24 @@ function flush_tok() {
     }
     if (c == "&") {
       nc = (i < n) ? substr(line, i+1, 1) : ""
+      # Issue #552 iter-7: `&` is ALSO used inside four bash redirection
+      # operators — `>&` `<&` (fd-duplication, e.g. `2>&1`) and `&>` `&>>`
+      # (redirect both stdout+stderr) — not just as the AND-operator/
+      # background-job separator this branch otherwise treats it as.
+      # Disambiguate WITHOUT touching the `&&`/background-job cases below:
+      #   - `>&`/`<&`: the token being built so far already ends in `>`
+      #     or `<` (e.g. tok=="2>" when we reach the `&` in "2>&1") —
+      #     append `&` and keep building, do not emit SEG.
+      #   - `&>`/`&>>`: `&` is the FIRST character (tok is still empty)
+      #     and the very NEXT character is `>` — same treatment.
+      # Any other `&` (empty tok, next char not `>`; or non-empty tok not
+      # ending in `>`/`<`) is unchanged: AND-operator (`&&`, consumes the
+      # second `&`) or background-job separator (bare `&`).
+      if ((length(tok) > 0 && (substr(tok, length(tok), 1) == ">" || substr(tok, length(tok), 1) == "<")) || (length(tok) == 0 && nc == ">")) {
+        tok = tok c
+        in_tok = 1
+        continue
+      }
       flush_tok(); print "SEG"
       if (nc == "&") i++
       continue
@@ -709,23 +727,98 @@ UNSAFE_STATE=0
 # every token (ignoring segment/command-position) is correct and
 # sufficient — unchanged from iter-3 for these three triggers specifically
 # (`cd`/`pushd`/`popd` moved OUT of this flat scan in iter-4 — see Pass B).
+#
+# Issue #552 iter-7 (dual-verify round 5 — Codex, real Critical,
+# reproduced live): `CDPATH=<mercury> cd <relative-dir> && git push origin
+# develop` from an external repo — bash's `cd` builtin, for a RELATIVE
+# target not found directly under the current directory, searches each
+# directory listed in $CDPATH BEFORE giving up (verified live:
+# `CDPATH=D:/Mercury/Mercury cd .probe` in an unrelated cwd actually lands
+# in `D:/Mercury/Mercury/.probe`). Pass B's cd-tracker resolves a relative
+# `cd` argument by naively joining it onto the current EFFECTIVE_CWD,
+# which is wrong whenever CDPATH is in play — the real landing directory
+# could be somewhere CDPATH points to instead. An inline `CDPATH=*` token
+# anywhere gets the same UNSAFE_STATE treatment as `GIT_DIR=`/
+# `GIT_WORK_TREE=` (it, too, redirects where a later `cd` actually lands,
+# regardless of position); the INHERITED case (CDPATH already set in this
+# hook process's own environment, no inline token needed) is handled
+# separately in Pass B below, since it depends on whether a tracked `cd`'s
+# argument is relative — an absolute `cd` target is NOT affected by
+# CDPATH (bash only consults it for a relative, not-found-directly
+# target), so absolute-target tracking is unaffected either way.
 for _t in "${ALL_TOKENS[@]}"; do
   case "$_t" in
-    GIT_DIR=*|GIT_WORK_TREE=*) UNSAFE_STATE=1 ;;
+    GIT_DIR=*|GIT_WORK_TREE=*|CDPATH=*) UNSAFE_STATE=1 ;;
     --chdir|--chdir=*) UNSAFE_STATE=1 ;;
     -C?*) UNSAFE_STATE=1 ;;
   esac
 done
 
+# Issue #552 iter-7 (dual-verify round 5 — Codex, source-inlined review,
+# real Critical, reproduced): bash's simple-command grammar is
+# `[assignment|redirection]* command-name [argument|redirection]*` — ANY
+# number of assignments AND redirections may appear, interleaved, BEFORE
+# the command name. Both wrapper-strip loops (this one and
+# process_segment()'s) already modeled the ASSIGNMENT half of that prefix
+# (`VAR=value` skip) but never the REDIRECTION half, so a leading
+# redirection token — `>/dev/null cd <mercury> && git push origin
+# develop` — stopped the walker before it ever reached `cd`, silently
+# treating the whole segment as "not a recognized command" (in
+# process_segment: falls through as "not git", so `git push` reached via
+# this pattern was ALSO undetected — `>/dev/null git push origin develop`
+# in Mercury went unblocked even BEFORE Issue #552, this closes that too).
+# This is completing an already-partially-modeled grammar production, not
+# adding a new heuristic — the assignment half was already there.
+#
+# Bash redirection operators recognized here (fd number 0+ digits
+# optional before the operator; the operator's TARGET may be glued
+# directly onto the same token — `>/dev/null`, `2>&1`, `1>&2` — or a
+# separate following token — `>` `/dev/null`):
+#   <   >   >>   <<   <<<   <&   >&   &>   &>>
+# Uses POSIX ERE (`[[ =~ ]]`) rather than a `case` glob: a glob pattern
+# precise enough to require "optional leading digits immediately followed
+# by exactly one of these multi-character operators" without ALSO
+# over-matching unrelated tokens is not expressible with plain shell
+# globbing (`[0-9]*` in a glob matches "one digit then anything", not
+# "zero-or-more digits" — using it here would make the match too loose
+# and risk skipping past a real command name that happens to start with a
+# digit followed by unrelated characters).
+_is_redirect_prefix_token() {
+  [[ "$1" =~ ^[0-9]*(\<\<\<|\<\<|\<\&|\&\>\>|\&\>|\>\>|\>\&|\>|\<) ]]
+}
+
+# Skips ONE redirection-prefix construct starting at tokens[$1] (an array
+# passed by name via nameref, iter-7 — needs the CALLER's own `i`/`tokens`
+# so it can both read and advance the index in place). Precondition:
+# `_is_redirect_prefix_token "${tokens[$i]}"` already true. Advances by 1
+# if the target is glued onto the same token (matched-length < token
+# length), else by 2 (bare operator token + a separate following target
+# token — if there is no following token, this command is malformed and
+# the caller's own `i<ntok` bounds check simply stops the loop next turn,
+# no crash).
+_skip_redirect_prefix() {
+  local -n _srp_i_ref="$1"
+  local -n _srp_tokens_ref="$2"
+  local _srp_tok="${_srp_tokens_ref[$_srp_i_ref]}"
+  [[ "$_srp_tok" =~ ^[0-9]*(\<\<\<|\<\<|\<\&|\&\>\>|\&\>|\>\>|\>\&|\>|\<) ]]
+  local _srp_op="${BASH_REMATCH[0]}"
+  if [ "${#_srp_tok}" -gt "${#_srp_op}" ]; then
+    _srp_i_ref=$(( _srp_i_ref + 1 ))
+  else
+    _srp_i_ref=$(( _srp_i_ref + 2 ))
+  fi
+}
+
 # Issue #552 iter-4 — find the "command position" token index within a
 # segment's token array: the first token that is not a wrapper (env var
-# assignment, an env/command/exec/builtin/sudo/doas/nohup/time wrapper,
-# `!`, a control-flow keyword, or a flag). This is a SEPARATE, purpose-
-# built copy of process_segment's own wrapper-strip loop rather than a
-# shared refactor — process_segment's copy also sets UNRESOLVABLE_SELECTOR
-# as a side effect while walking (iter-2, segment-scoped), which is out of
-# scope for this pure lookup used only by Pass B below. If either wrapper-
-# strip rule set changes, update BOTH copies.
+# assignment, a redirection, an env/command/exec/builtin/sudo/doas/nohup/
+# time wrapper, `!`, a control-flow keyword, or a flag). This is a
+# SEPARATE, purpose-built copy of process_segment's own wrapper-strip loop
+# rather than a shared refactor — process_segment's copy also sets
+# UNRESOLVABLE_SELECTOR as a side effect while walking (iter-2, segment-
+# scoped), which is out of scope for this pure lookup used only by Pass B
+# below. If either wrapper-strip rule set changes, update BOTH copies —
+# iter-7's redirection-skip is one such shared addition, applied to both.
 # Echoes the index (may equal $#, i.e. one past the last token, if the
 # segment is entirely wrapper tokens with no command found).
 _find_command_position() {
@@ -736,6 +829,15 @@ _find_command_position() {
   while [ "$_seen_change" -eq 1 ] && [ "$i" -lt "$ntok" ]; do
     _seen_change=0
     local tok="${tokens[$i]}"
+    # Issue #552 iter-7 — redirection prefix (see the `_is_redirect_prefix_
+    # token()` comment above for the full grammar rationale). Checked
+    # first, ahead of the `case`, since it needs its own multi-token
+    # skip-count logic rather than a fixed per-pattern offset.
+    if _is_redirect_prefix_token "$tok"; then
+      _skip_redirect_prefix i tokens
+      _seen_change=1
+      continue
+    fi
     case "$tok" in
       "!")
         i=$((i + 1)); _seen_change=1 ;;
@@ -882,13 +984,30 @@ for _pb_sz in "${SEG_SIZES[@]}"; do
               _pb_candidate=""
               case "$_pb_arg" in
                 /*|[A-Za-z]:[\\/]*|\\\\*)
-                  # Already absolute (POSIX root, Windows drive-letter, or UNC).
+                  # Already absolute (POSIX root, Windows drive-letter, or
+                  # UNC) — bash's `cd` never consults CDPATH for an
+                  # absolute target, so this stays safe to track even when
+                  # CDPATH is set in the hook's own inherited environment.
                   _pb_candidate="$_pb_arg" ;;
                 *)
-                  # Relative — join onto the current EFFECTIVE_CWD. If
-                  # there is nothing to anchor a relative path against,
-                  # this is unresolvable rather than silently wrong.
-                  [ -n "$EFFECTIVE_CWD" ] && _pb_candidate="$EFFECTIVE_CWD/$_pb_arg"
+                  # Issue #552 iter-7: RELATIVE target — if this hook
+                  # process inherited a non-empty $CDPATH, bash's real `cd`
+                  # would search CDPATH's directories (verified live:
+                  # `CDPATH=D:/Mercury/Mercury cd .probe` from an unrelated
+                  # cwd actually lands in `D:/Mercury/Mercury/.probe`) —
+                  # the naive "join onto EFFECTIVE_CWD" resolution below
+                  # would be silently wrong about where this really lands.
+                  # A normal environment never has CDPATH set, so this
+                  # check is cheap and does not affect the common case
+                  # (`cd docs && git push origin master` stays trackable).
+                  if [ -n "${CDPATH:-}" ]; then
+                    UNSAFE_STATE=1
+                  else
+                    # Join onto the current EFFECTIVE_CWD. If there is
+                    # nothing to anchor a relative path against, this is
+                    # unresolvable rather than silently wrong.
+                    [ -n "$EFFECTIVE_CWD" ] && _pb_candidate="$EFFECTIVE_CWD/$_pb_arg"
+                  fi
                   ;;
               esac
               # Iter-5 same-repo-only gate: only advance if the resolved
@@ -954,6 +1073,15 @@ process_segment() {
   while [ "$_seen_change" -eq 1 ] && [ "$i" -lt "$ntok" ]; do
     _seen_change=0
     local tok="${tokens[$i]}"
+    # Issue #552 iter-7 — redirection prefix (`_is_redirect_prefix_token()`
+    # comment above has the full grammar rationale). Checked first, ahead
+    # of the `case`, mirroring `_find_command_position()`'s copy — keeps
+    # both wrapper-strip walkers' redirection handling identical.
+    if _is_redirect_prefix_token "$tok"; then
+      _skip_redirect_prefix i tokens
+      _seen_change=1
+      continue
+    fi
     case "$tok" in
       # Bash logical-NOT (`! cmd` runs cmd, inverts exit code). `(` `{` are
       # NOT in this list — iter-5 promotes them to segment separators (awk

--- a/.claude/hooks/push-guard.sh
+++ b/.claude/hooks/push-guard.sh
@@ -456,7 +456,12 @@ if [ "$HAS_JQ" -eq 0 ] && [ "$HAS_CMD_KEY" -eq 1 ]; then
 fi
 
 if [ "$HAS_JQ" -eq 1 ]; then
-  COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+  # `printf '%s'` rather than `echo` (Argus): `echo` is allowed to interpret
+  # backslash escapes depending on shell build / `xpg_echo`, and this payload is
+  # arbitrary JSON that routinely contains backslashes. `printf '%s'` never
+  # interprets its argument, and matches how the tokenizer below already feeds
+  # `$COMMAND` to awk — one convention for all untrusted-data pipes in this file.
+  COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
 else
   # HAS_JQ=0 AND HAS_CMD_KEY=0 — INPUT did not carry a "command" key (e.g.
   # tool wasn't Bash). Nothing to gate.
@@ -488,7 +493,8 @@ _HOOK_CWD_CACHE=""
 _ensure_hook_cwd() {
   if [ "$_HOOK_CWD_COMPUTED" -eq 0 ]; then
     if [ "$HAS_JQ" -eq 1 ]; then
-      _HOOK_CWD_CACHE=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null)
+      # `printf '%s'` not `echo` — see the COMMAND extraction above for why.
+      _HOOK_CWD_CACHE=$(printf '%s' "$INPUT" | jq -r '.cwd // empty' 2>/dev/null)
     fi
     _HOOK_CWD_COMPUTED=1
   fi
@@ -1116,7 +1122,27 @@ for _pb_sz in "${SEG_SIZES[@]}"; do
                     # Join onto the current EFFECTIVE_CWD. If there is
                     # nothing to anchor a relative path against, this is
                     # unresolvable rather than silently wrong.
-                    [ -n "$EFFECTIVE_CWD" ] && _pb_candidate="$EFFECTIVE_CWD/$_pb_arg"
+                    #
+                    # Argus (PR #555): normalize the join instead of keeping
+                    # `..` / symlink segments as raw string. An unnormalized
+                    # join can make the same-repo comparison below judge a
+                    # different directory than the one the command's shell
+                    # will really be in. `pwd` here is bash's LOGICAL form on
+                    # purpose — this models a bash `cd`, and bash `cd` is
+                    # logical by default (`a/symlink/..` returns to `a`).
+                    # The `-C` join in Phase 0 uses `pwd -P` instead, because
+                    # `git -C` chdir()s physically; see that site's comment.
+                    # Normalization is BEST-EFFORT (same rationale as the
+                    # `-C` join in Phase 0 — see that site's comment): a
+                    # non-existent target keeps the raw join rather than
+                    # blanking, because a path that does not exist holds no
+                    # repo, so the same-repo gate below gets an empty
+                    # common-dir for it and sets UNSAFE_STATE regardless.
+                    # The traversal hazard only exists for real directories.
+                    if [ -n "$EFFECTIVE_CWD" ]; then
+                      _pb_candidate=$( cd "$EFFECTIVE_CWD/$_pb_arg" 2>/dev/null && pwd )
+                      [ -n "$_pb_candidate" ] || _pb_candidate="$EFFECTIVE_CWD/$_pb_arg"
+                    fi
                   fi
                   ;;
               esac
@@ -1397,7 +1423,31 @@ process_segment() {
           # Already absolute (POSIX root, Windows drive-letter, or UNC).
           _repo_path="$GIT_C_PATH" ;;
         *)
-          [ -n "$_seg_entry_cwd" ] && _repo_path="$_seg_entry_cwd/$GIT_C_PATH" ;;
+          # Argus (PR #555): normalize the join rather than leaving `..` /
+          # symlink segments in the string, so the common-dir comparison
+          # below judges the directory git will really operate in. `pwd -P`
+          # (PHYSICAL) on purpose here — `git -C <path>` chdir()s, which
+          # resolves symlinks physically. The Pass B `cd` join above uses
+          # bash's LOGICAL `pwd` instead, because it models a bash `cd`;
+          # see that site's comment. A failed `cd` yields empty, which the
+          # `[ -n "$_repo_path" ]` guard below turns into fall-through to
+          # Phase 1-3 (fail-closed), never an allow.
+          #
+          # Normalization is BEST-EFFORT: if the joined path does not exist
+          # (so `cd` into it fails) we keep the raw join instead of blanking
+          # it. That is safe, and NOT a weakening — the traversal hazard this
+          # normalization exists to close ("our verdict names a different
+          # directory than the one git really operates in") can only arise
+          # for a path that EXISTS. A path that does not exist holds no repo,
+          # so `_git_common_dir` on it returns empty and Phase 0 fails closed
+          # by the guard below anyway. Blanking it here instead would make
+          # this hook's verdict depend on the filesystem in a way it never
+          # did before, which is a behaviour change with no security payoff.
+          if [ -n "$_seg_entry_cwd" ]; then
+            _repo_path=$( cd "$_seg_entry_cwd/$GIT_C_PATH" 2>/dev/null && pwd -P )
+            [ -n "$_repo_path" ] || _repo_path="$_seg_entry_cwd/$GIT_C_PATH"
+          fi
+          ;;
       esac
     else
       _repo_path="$_seg_entry_cwd"

--- a/.claude/hooks/push-guard.sh
+++ b/.claude/hooks/push-guard.sh
@@ -374,21 +374,35 @@ _git_common_dir() {
 # tool call, including ones with no `git` anywhere in them, since this
 # hook's PreToolUse matcher fires on every Bash invocation and Windows
 # process-spawn overhead is expensive). Mercury's own git common-dir is
-# now resolved LAZILY — only the FIRST time `_mercury_common_dir()` is
-# actually called (from inside Phase 0, which itself only runs for a real
-# `git push` segment with no disabling gate already tripped) — and cached
-# so repeated calls within the same hook invocation (e.g. a command with
-# several push segments) cost one subprocess, not one per segment. Empty
+# now resolved LAZILY — only the FIRST time `_ensure_mercury_common_dir()`
+# is actually called (from inside Phase 0, which itself only runs for a
+# real `git push` segment with no disabling gate already tripped). Empty
 # on resolution failure — Phase 0 treats that as "cannot determine",
 # falling through to the existing fail-closed Phase 1-3 logic unchanged.
+#
+# Issue #552 iter-8 (Codex Low, confirmed and fixed): the iter-6 version
+# of this cache was named `_mercury_common_dir()` and called via command
+# substitution — `_val=$(_mercury_common_dir)` — which bash always forks
+# into a SUBSHELL. The `_MERCURY_COMMON_DIR_COMPUTED=1` write inside that
+# subshell never propagated back to the parent shell, so the "cache" was
+# silently a no-op on every call past the first — each call re-forked
+# `git rev-parse` regardless. Fixed by NOT going through command
+# substitution for the cache-check itself: `_ensure_mercury_common_dir()`
+# is a plain function call (no subshell) that mutates the two globals
+# directly; callers read `$_MERCURY_COMMON_DIR_CACHE` afterward instead
+# of capturing a return value. This is a genuine perf detail ONLY when a
+# single command has multiple push segments (the common single-push case
+# was already only ever going to call this once, so iter-6's core
+# "unconditional-call is gone" fix stands on its own regardless of this
+# bug) — documented honestly rather than left as a cache that looks like
+# it works but does not.
 _MERCURY_COMMON_DIR_COMPUTED=0
 _MERCURY_COMMON_DIR_CACHE=""
-_mercury_common_dir() {
+_ensure_mercury_common_dir() {
   if [ "$_MERCURY_COMMON_DIR_COMPUTED" -eq 0 ]; then
     _MERCURY_COMMON_DIR_CACHE=$(_git_common_dir "$_PROJECT")
     _MERCURY_COMMON_DIR_COMPUTED=1
   fi
-  printf '%s' "$_MERCURY_COMMON_DIR_CACHE"
 }
 
 if [ "${GUARD_DEBUG:-0}" = "1" ] && [ -f "$LOG_FILE" ] && [ "$(wc -c < "$LOG_FILE")" -gt 102400 ]; then
@@ -460,17 +474,24 @@ fi
 # Issue #552 iter-6 (performance): also resolved LAZILY now (one jq
 # subprocess, only when a `cd`/`pushd` or an eligible push segment
 # actually needs it — most Bash tool calls have neither), same rationale
-# and cache pattern as `_mercury_common_dir()` above.
+# and cache pattern as `_ensure_mercury_common_dir()` above.
+#
+# Issue #552 iter-8 (Codex Low, confirmed and fixed — same bug and same
+# fix shape as `_ensure_mercury_common_dir()` above): renamed from
+# `_hook_cwd()`, no longer called via command substitution (which forked
+# a subshell and silently discarded the `_HOOK_CWD_COMPUTED=1` cache
+# write, making the "cache" a no-op past the first call). Callers now
+# invoke `_ensure_hook_cwd` as a plain function call, then read
+# `$_HOOK_CWD_CACHE` directly.
 _HOOK_CWD_COMPUTED=0
 _HOOK_CWD_CACHE=""
-_hook_cwd() {
+_ensure_hook_cwd() {
   if [ "$_HOOK_CWD_COMPUTED" -eq 0 ]; then
     if [ "$HAS_JQ" -eq 1 ]; then
       _HOOK_CWD_CACHE=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null)
     fi
     _HOOK_CWD_COMPUTED=1
   fi
-  printf '%s' "$_HOOK_CWD_CACHE"
 }
 
 debug_log "COMMAND=$COMMAND"
@@ -594,6 +615,24 @@ function flush_tok() {
     if (c == ";")  { flush_tok(); print "SEG"; continue }
     if (c == "|") {
       nc = (i < n) ? substr(line, i+1, 1) : ""
+      # Issue #552 iter-8: `|` is ALSO the second character of the `>|`
+      # redirection operator (force-overwrite target even under `set -C`/
+      # noclobber) — do not treat it as a pipe/OR separator when the token
+      # being built so far already ends in `>` (e.g. tok==">" when we
+      # reach the `|` in ">|/dev/null"). Discovered via real reproduction:
+      # `>|/dev/null cd <mercury> && git push origin develop` fragmented
+      # into token ">" (its own segment) + a fresh segment starting with
+      # the innocuous-looking "/dev/null" token, hiding the `cd` from
+      # Pass B cd-tracker (mirrors the iter-7 fix for `&`-containing
+      # operators `>&`/`<&`/`&>`/`&>>` — same root-cause class: an
+      # operator character unconditionally treated as a separator,
+      # regardless of what precedes it). Any other `|` (bare pipe, or
+      # `||`) is unchanged.
+      if (length(tok) > 0 && substr(tok, length(tok), 1) == ">") {
+        tok = tok c
+        in_tok = 1
+        continue
+      }
       flush_tok(); print "SEG"
       if (nc == "|") i++
       continue
@@ -746,9 +785,21 @@ UNSAFE_STATE=0
 # argument is relative — an absolute `cd` target is NOT affected by
 # CDPATH (bash only consults it for a relative, not-found-directly
 # target), so absolute-target tracking is unaffected either way.
+# Issue #552 iter-8: `GIT_COMMON_DIR` added defensively, NOT because a
+# bypass through it was demonstrated — it was NOT. Codex iter-8 raised it
+# as a theoretical redirect-git's-repo-selection candidate alongside
+# `GIT_DIR`/`GIT_WORK_TREE`; real testing (twice, independently) showed
+# setting `GIT_COMMON_DIR` alone does NOT actually redirect which repo
+# git operates on (branch list unchanged, `develop` still fails to
+# resolve as a ref under the redirected value) — i.e. this specific
+# concern did not reproduce. Included anyway because the cost is zero
+# (one more `case` pattern) and, unlike the other entries in this list,
+# this one is explicitly NOT a confirmed-exploitable trigger — recorded
+# here so a future reader does not mistake its presence for proof it was
+# ever actually exploitable.
 for _t in "${ALL_TOKENS[@]}"; do
   case "$_t" in
-    GIT_DIR=*|GIT_WORK_TREE=*|CDPATH=*) UNSAFE_STATE=1 ;;
+    GIT_DIR=*|GIT_WORK_TREE=*|CDPATH=*|GIT_COMMON_DIR=*) UNSAFE_STATE=1 ;;
     --chdir|--chdir=*) UNSAFE_STATE=1 ;;
     -C?*) UNSAFE_STATE=1 ;;
   esac
@@ -809,6 +860,45 @@ _skip_redirect_prefix() {
   fi
 }
 
+# Issue #552 iter-8 (dual-verify round 6 — Codex source-inlined review;
+# coordinator independently confirmed 1 of 3 findings as a real gap, `>|`,
+# and 1 as a genuine pre-existing/non-#552 bug, Phase 3's implicit-push
+# branch resolution — see the iter-8 fix-history comment near the top of
+# this file for the full investigation, including why `GIT_COMMON_DIR`
+# was NOT confirmed exploitable and was added defensively rather than as
+# a proven-bug fix). DEFAULT-DENY reversal: every wrapper-strip case
+# above this point is a SPECIFIC, deliberately-recognized safe-prefix
+# shape (an assignment, a known wrapper keyword, a known flag, a known
+# redirection). Iter-1 through iter-7 all shared the OPPOSITE default —
+# a token matching none of those known shapes was silently treated as
+# "the command name found, stop here" — which is exactly how `>|` slipped
+# through (see the iter-8 fix-history comment: `>|` fragments into
+# innocuous-looking pieces at the awk-tokenizer level that never contain
+# a shell metacharacter themselves, so no reasonable enumeration of
+# "known redirect operators" alone can catch every future variant).
+# This function is the reversed default: a token that stops the
+# wrapper-strip walker is trusted as a real command name ONLY if it
+# contains NONE of the shell metacharacters a legitimate bare command
+# name/argument would never contain (`< > & | $` backtick `= ( ) { }`).
+# Any of those surviving to this point means an unmodeled shell construct
+# reached here — untrusted by default, not enumerated by exception.
+# `=` is included even though ordinary `VAR=value` assignments are
+# already consumed by the `[A-Za-z_]*=*` case above; a token that STILL
+# contains `=` here failed to match that pattern (e.g. starts with a
+# digit) and is unusual enough to distrust rather than guess at.
+# Deliberately does NOT distinguish "this token is the command name
+# itself" from "this token is an argument at the command position" —
+# either way, if it looks like an operator fragment rather than a word,
+# treat it as unsafe.
+_is_unsafe_command_token() {
+  case "$1" in
+    *'<'*|*'>'*|*'&'*|*'|'*|*'$'*|*'`'*|*'='*|*'('*|*')'*|*'{'*|*'}'*)
+      return 0 ;;
+    *)
+      return 1 ;;
+  esac
+}
+
 # Issue #552 iter-4 — find the "command position" token index within a
 # segment's token array: the first token that is not a wrapper (env var
 # assignment, a redirection, an env/command/exec/builtin/sudo/doas/nohup/
@@ -818,9 +908,18 @@ _skip_redirect_prefix() {
 # UNRESOLVABLE_SELECTOR as a side effect while walking (iter-2, segment-
 # scoped), which is out of scope for this pure lookup used only by Pass B
 # below. If either wrapper-strip rule set changes, update BOTH copies —
-# iter-7's redirection-skip is one such shared addition, applied to both.
-# Echoes the index (may equal $#, i.e. one past the last token, if the
-# segment is entirely wrapper tokens with no command found).
+# iter-7's redirection-skip and iter-8's default-deny check are two such
+# shared additions, applied to both.
+#
+# Echoes TWO space-separated values on one line: "<index> <unsafe>".
+# <index> may equal $#, i.e. one past the last token, if the segment is
+# entirely wrapper tokens with no command found. <unsafe> is "1" (iter-8
+# default-deny — see `_is_unsafe_command_token()` above) when the token
+# at <index> looks like an unmodeled shell-construct fragment rather than
+# a legitimate command name, else "0". This function runs inside a
+# command-substitution subshell (`$(...)`, forked by the caller), so it
+# CANNOT set the caller's global `UNSAFE_STATE` directly — the caller
+# must read this second value and act on it itself.
 _find_command_position() {
   local -a tokens=( "$@" )
   local ntok=${#tokens[@]}
@@ -865,7 +964,11 @@ _find_command_position() {
         i=$((i + 1)); _seen_change=1 ;;
     esac
   done
-  printf '%s' "$i"
+  local _unsafe=0
+  if [ "$i" -lt "$ntok" ] && _is_unsafe_command_token "${tokens[$i]}"; then
+    _unsafe=1
+  fi
+  printf '%s %s' "$i" "$_unsafe"
 }
 
 # ── Pass B: per-segment cd/pushd tracking (Issue #552 iter-4/iter-5) ──
@@ -929,7 +1032,13 @@ _pb_off=0
 for _pb_sz in "${SEG_SIZES[@]}"; do
   declare -a _pb_seg=( "${ALL_TOKENS[@]:$_pb_off:$_pb_sz}" )
   SEG_ENTRY_CWD+=( "$EFFECTIVE_CWD" )
-  _pb_cmd_idx=$(_find_command_position "${_pb_seg[@]}")
+  read -r _pb_cmd_idx _pb_prefix_unsafe <<< "$(_find_command_position "${_pb_seg[@]}")"
+  # Issue #552 iter-8 default-deny: an unmodeled prefix construct anywhere
+  # ahead of this segment's command position means we cannot trust
+  # whatever cd/pushd-tracking conclusion we would otherwise draw from it
+  # — whole-command UNSAFE_STATE, same treatment as every other
+  # unresolvable Pass B construct.
+  [ "$_pb_prefix_unsafe" = "1" ] && UNSAFE_STATE=1
   if [ "$_pb_cmd_idx" -lt "$_pb_sz" ]; then
     _pb_cmd_tok="${_pb_seg[$_pb_cmd_idx]}"
     case "$_pb_cmd_tok" in
@@ -979,7 +1088,8 @@ for _pb_sz in "${SEG_SIZES[@]}"; do
               # arg, or as the baseline for the same-repo common-dir
               # check below) — resolve the lazy sentinel now.
               if [ "$EFFECTIVE_CWD" = "$_LAZY_HOOK_CWD_SENTINEL" ]; then
-                EFFECTIVE_CWD=$(_hook_cwd)
+                _ensure_hook_cwd
+                EFFECTIVE_CWD="$_HOOK_CWD_CACHE"
               fi
               _pb_candidate=""
               case "$_pb_arg" in
@@ -1064,6 +1174,14 @@ process_segment() {
   # Phase 1-3 logic, exactly as if Issue #552 had never shipped. Never used
   # to grant a skip, only to withhold one.
   local UNRESOLVABLE_SELECTOR=0
+
+  # Issue #552 iter-8 — declared at function scope (not just inside the
+  # Phase 0 `if` block below) so Phase 3 (implicit-push branch check,
+  # further down) can also read it. Populated only when Phase 0 actually
+  # runs (UNRESOLVABLE_SELECTOR==0 && UNSAFE_STATE==0) and resolution
+  # succeeds; stays empty otherwise, in which case Phase 3 falls back to
+  # its pre-#552 behavior — see the Phase 3 fix-history comment there.
+  local _repo_path=""
 
   # Wrapper-strip: skip leading env-var assignments, command wrappers, and
   # subshell/group open chars. Loop until no transformation applies — no
@@ -1163,6 +1281,23 @@ process_segment() {
     esac
   done
 
+  # Issue #552 iter-8 default-deny (`_is_unsafe_command_token()` comment
+  # above has the full rationale, and `_find_command_position()`'s
+  # matching copy — kept in sync per this file's established convention).
+  # If wrapper-strip stopped at a token that is not shaped like a
+  # legitimate command name (a shell metacharacter this hook does not
+  # model survived to this point), do not silently trust the "not git,
+  # nothing to check" conclusion the two lines below would otherwise
+  # reach. Sets UNRESOLVABLE_SELECTOR — in the CURRENT architecture this
+  # mainly withholds Phase 0's allow for this segment (Phase 1-3 below
+  # still requires literal `git` recognition to activate either way, so
+  # this is primarily defense-in-depth/consistency rather than closing a
+  # concretely demonstrated bypass THROUGH this exact code path today —
+  # be honest about that rather than overclaiming).
+  if [ "$i" -lt "$ntok" ] && _is_unsafe_command_token "${tokens[$i]}"; then
+    UNRESOLVABLE_SELECTOR=1
+  fi
+
   [ "$i" -lt "$ntok" ] || return 0
   [ "${tokens[$i]}" = "git" ] || return 0
   i=$((i + 1))
@@ -1238,9 +1373,10 @@ process_segment() {
     # needs HOOK_CWD's value — resolve the Pass B lazy sentinel here, not
     # before. A command with no eligible push segment at all (the
     # dominant case — most Bash calls aren't `git push`) never reaches
-    # this line, so `_hook_cwd()`'s jq subprocess is never spent on it.
+    # this line, so `_ensure_hook_cwd()`'s jq subprocess is never spent on it.
     if [ "$_seg_entry_cwd" = "$_LAZY_HOOK_CWD_SENTINEL" ]; then
-      _seg_entry_cwd=$(_hook_cwd)
+      _ensure_hook_cwd
+      _seg_entry_cwd="$_HOOK_CWD_CACHE"
     fi
     # Resolve which repo this segment's `git push` actually targets:
     # `-C <path>` (authoritative — overrides cwd for this invocation) else
@@ -1253,8 +1389,8 @@ process_segment() {
     # runs). If `-C` is relative and `_seg_entry_cwd` is unavailable to
     # anchor it, there is nothing safe to resolve, so `_repo_path` stays
     # empty and Phase 0 falls through below exactly like any other
-    # resolution failure.
-    local _repo_path=""
+    # resolution failure. (Declared at function scope above, not `local`
+    # here — Phase 3 further down also reads it, iter-8.)
     if [ -n "$GIT_C_PATH" ]; then
       case "$GIT_C_PATH" in
         /*|[A-Za-z]:[\\/]*|\\\\*)
@@ -1273,14 +1409,16 @@ process_segment() {
     # common-dir itself unresolved) falls through unchanged to Phase 1-3
     # below — fail-closed, never a bypass source.
     #
-    # Issue #552 iter-6 (performance): `_mercury_common_dir()` (lazy,
-    # cached) instead of a plain `$MERCURY_COMMON_DIR` variable — this is
-    # the ONLY call site, and it only runs for a real push segment with no
-    # disabling gate already tripped, so the `git rev-parse` subprocess it
-    # spends on first call is never paid by a command with no such segment.
+    # Issue #552 iter-6 (performance): `_ensure_mercury_common_dir()`
+    # (lazy, cached — iter-8 fixed the cache to actually persist, see its
+    # definition above) instead of a plain `$MERCURY_COMMON_DIR` variable —
+    # this is the ONLY call site, and it only runs for a real push segment
+    # with no disabling gate already tripped, so the `git rev-parse`
+    # subprocess it spends on first call is never paid by a command with
+    # no such segment.
     if [ -n "$_repo_path" ]; then
-      local _mercury_common_dir_val
-      _mercury_common_dir_val=$(_mercury_common_dir)
+      _ensure_mercury_common_dir
+      local _mercury_common_dir_val="$_MERCURY_COMMON_DIR_CACHE"
       if [ -n "$_mercury_common_dir_val" ]; then
         local _target_common_dir
         _target_common_dir=$(_git_common_dir "$_repo_path")
@@ -1366,11 +1504,55 @@ process_segment() {
   done
 
   # ── Phase 3: implicit push from current branch (no explicit refspec) ──
+  # Issue #552 iter-8 — pre-existing bug, NOT introduced by #552 (Phase 3
+  # predates it): this used a BARE `git rev-parse --abbrev-ref HEAD`,
+  # resolving the branch in the HOOK PROCESS's own cwd rather than the
+  # repo this specific push actually targets. Reproduced live: external
+  # repo on a non-protected branch, `git -C <mercury> push origin`
+  # (implicit, no refspec) — the bare check read the EXTERNAL repo's
+  # branch (non-protected) and allowed it through, while the real push
+  # (via the explicit `-C`) hits Mercury's actual current branch
+  # (`develop`, protected). Fixed (iter-8): when `_repo_path` was
+  # successfully resolved above (Phase 0 ran and determined a concrete
+  # target repo for THIS segment), query the branch THERE via `-C`, not
+  # in the hook's own cwd — this also fixes a symmetric case within "same
+  # repo as Mercury" verdicts: a linked worktree can be on a different
+  # branch than the hook process's own cwd even though both share a
+  # common-dir.
+  #
+  # Issue #552 iter-9 — iter-8 only fixed HALF of this: when `_repo_path`
+  # is unavailable (Phase 0 was gated off by UNRESOLVABLE_SELECTOR /
+  # UNSAFE_STATE, e.g. a cross-repo `cd` that legitimately triggers the
+  # default-deny fallback, or resolution failed), iter-8 fell back to the
+  # bare `git rev-parse --abbrev-ref HEAD` check — which is the exact
+  # same wrong-cwd resolution this fix exists to eliminate. Reproduced
+  # live: hook process cwd = external repo (non-protected branch),
+  # `cd <mercury> && git push origin` (implicit) — the cross-repo `cd`
+  # sets UNSAFE_STATE so Phase 0 never runs and `_repo_path` stays empty;
+  # the bare fallback then read the EXTERNAL repo's branch and allowed a
+  # push that actually lands on Mercury's `develop`. Fixed: when
+  # `_repo_path` is empty, this hook has NO positive evidence about which
+  # repo the implicit push targets — per the fail-closed/default-deny
+  # invariant threaded through every phase of this hook (Phase 0 only
+  # grants an allow on positive confirmation; any uncertainty falls back
+  # to a block), block unconditionally instead of guessing via a
+  # known-wrong bare rev-parse. Every code path that reaches Phase 3 with
+  # `_repo_path` unset is exactly one of: (a) the real target is Mercury
+  # (should block), or (b) the real target is genuinely unknown (should
+  # also block, per the invariant) — there is no code path here where
+  # falling back to "allow" would be correct, since Phase 0 itself
+  # already returns 0 (allow) earlier whenever it can positively confirm
+  # a non-Mercury repo; reaching Phase 3 at all means that confirmation
+  # never happened.
   if [ "$HAS_EXPLICIT_TARGET" = false ]; then
-    local CURRENT_BRANCH
-    CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
-    if printf '%s' "$CURRENT_BRANCH" | grep -qE "$PROTECTED"; then
-      block_push "implicit push from current branch '$CURRENT_BRANCH'"
+    if [ -n "$_repo_path" ]; then
+      local CURRENT_BRANCH
+      CURRENT_BRANCH=$(git -C "$_repo_path" rev-parse --abbrev-ref HEAD 2>/dev/null)
+      if printf '%s' "$CURRENT_BRANCH" | grep -qE "$PROTECTED"; then
+        block_push "implicit push from current branch '$CURRENT_BRANCH'"
+      fi
+    else
+      block_push "implicit push with unresolvable target repo (fail-closed)"
     fi
   fi
 }

--- a/.claude/hooks/push-guard.sh
+++ b/.claude/hooks/push-guard.sh
@@ -58,6 +58,46 @@
 #     Any failure to resolve either toplevel falls through unchanged to
 #     the existing fail-closed Phase 1-3 logic — this check can only ever
 #     grant a POSITIVELY CONFIRMED skip, never a bypass from uncertainty.
+#
+#     Iter 2 (dual-verify NEEDS-CHANGES on both sides, real hook-call
+#     reproductions, not theoretical) found 3 regressive bypasses in the
+#     iter-1 Phase 0:
+#       - Critical: wrong identity predicate. `--show-toplevel` returns the
+#         PER-WORKTREE path; a Mercury dev-agent linked worktree (this
+#         hook's own normal execution context, `.claude/worktrees/<id>/`)
+#         has a toplevel that differs from the main checkout's, so a push
+#         FROM a worktree was misclassified as "a different repo" and
+#         allowed through — the worst possible direction of error. Fixed:
+#         compare `--git-common-dir` instead (identical across all linked
+#         worktrees of the same repo; verified via `git worktree list` +
+#         `rev-parse` on this exact environment, see Phase 0 comment below).
+#       - Critical: unmodelled repo selectors treated as harmless noise.
+#         `--git-dir`/`--work-tree` (space or `=` form) were silently
+#         skipped by the global-option walker without being recorded;
+#         inline `GIT_DIR=`/`GIT_WORK_TREE=` env assignments were absorbed
+#         by the generic `VAR=value` wrapper-strip case the same way;
+#         repeated `-C` (git's real semantics: each accumulates RELATIVE TO
+#         the previous, not "last wins") only kept the final occurrence.
+#         Any of these let a command's ACTUAL target repo diverge from
+#         what Phase 0 resolved, silently allowing a Mercury push through
+#         under a resolved-but-wrong "different repo" verdict. Fixed: any
+#         of these three signals sets UNRESOLVABLE_SELECTOR and Phase 0 is
+#         skipped ENTIRELY for that segment (falls to Phase 1-3 unchanged)
+#         — fail-closed, never a source of leniency.
+#       - Medium: a relative `-C <path>` was resolved against the HOOK
+#         PROCESS's own cwd, not against `HOOK_CWD` (where the actual
+#         command executes) — base mismatch. Fixed: relative `-C` values
+#         are joined onto `$HOOK_CWD`; if `HOOK_CWD` is unavailable to
+#         anchor it, treated as unresolvable (falls under the same
+#         fail-closed skip as above, not as "no -C at all").
+#
+#     Documented non-fix (Low, out of threat model, same tier as the
+#     existing `bash -c "..."` recursive-shell limitation noted elsewhere
+#     in this file): a `subst` drive letter, UNC path, junction, or
+#     symlink can make the SAME physical repo resolve to two different
+#     `--git-common-dir` strings, which would incorrectly allow a Mercury
+#     push through. Requires deliberately constructing such an alias;
+#     not addressed here.
 
 INPUT=$(cat)
 
@@ -83,13 +123,59 @@ _normalize_path() {
   printf '%s' "$p"
 }
 
-# Issue #552 — Mercury repo's own git toplevel, resolved once. Used by the
-# Phase 0 repo-awareness check in process_segment() to decide whether a
+# Issue #552 iter-2 — resolve a directory's git COMMON dir (the shared
+# `.git` across all linked worktrees of the same repo), NOT its toplevel.
+# A Mercury dev-agent worktree (`.claude/worktrees/<id>/`, this hook's own
+# normal execution context) has its own distinct toplevel but shares the
+# SAME common-dir as the main checkout — comparing toplevel wrongly
+# classified a worktree-originated push as "a different repo" (a real
+# regression, reproduced with real hook calls: worktree toplevel
+# `D:/Mercury/Mercury/.claude/worktrees/agent-.../`, main-checkout toplevel
+# `D:/Mercury/Mercury` — different strings, same repo). Common-dir is
+# identical for both: `D:/Mercury/Mercury/.git`.
+#
+# `--path-format=absolute` (forces the printed path to be absolute and
+# canonical) requires git >= 2.31 — verified via the official upstream
+# release notes: "git rev-parse can be explicitly told to give output as
+# absolute or relative path with the --path-format=(absolute|relative)
+# option" (https://github.com/git/git/blob/master/Documentation/RelNotes/2.31.0.adoc,
+# 2026-08-08). `--git-common-dir` itself is unaffected by `--path-format`
+# per the git-rev-parse manual page (https://git-scm.com/docs/git-rev-parse)
+# and has existed since git's worktree feature (long predates 2.31), so it
+# still works standalone on older git — but may then print a path relative
+# to the queried directory rather than absolute. `_git_common_dir()` tries
+# the modern absolute form first and falls back to resolving a relative
+# result with `cd`.
+_git_common_dir() {
+  local dir="$1"
+  local out
+  out=$(git -C "$dir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)
+  if [ -n "$out" ]; then
+    printf '%s' "$out"
+    return 0
+  fi
+  # --path-format unsupported (git < 2.31) or the combined call failed for
+  # another reason — retry the plain (pre-2.31-compatible) form.
+  out=$(git -C "$dir" rev-parse --git-common-dir 2>/dev/null)
+  [ -n "$out" ] || return 1
+  case "$out" in
+    /*|[A-Za-z]:[\\/]*|\\\\*)
+      # Already absolute (POSIX root, Windows drive-letter, or UNC).
+      printf '%s' "$out" ;;
+    *)
+      # Relative result — resolve it against the queried directory.
+      ( cd "$dir" 2>/dev/null && cd "$out" 2>/dev/null && pwd )
+      ;;
+  esac
+}
+
+# Issue #552 — Mercury repo's own git common-dir, resolved once. Used by
+# the Phase 0 repo-awareness check in process_segment() to decide whether a
 # `git push` segment targets THIS repo (protection applies) or a different
 # one (out of scope, allowed through). Empty on resolution failure — Phase 0
 # treats that as "cannot determine", falling through to the existing
 # fail-closed Phase 1-3 logic unchanged.
-MERCURY_TOPLEVEL=$(git -C "$_PROJECT" rev-parse --show-toplevel 2>/dev/null)
+MERCURY_COMMON_DIR=$(_git_common_dir "$_PROJECT")
 
 if [ "${GUARD_DEBUG:-0}" = "1" ] && [ -f "$LOG_FILE" ] && [ "$(wc -c < "$LOG_FILE")" -gt 102400 ]; then
   tail -100 "$LOG_FILE" > "$LOG_FILE.tmp" && mv "$LOG_FILE.tmp" "$LOG_FILE"
@@ -346,6 +432,14 @@ process_segment() {
   local ntok=${#tokens[@]}
   local i=0
 
+  # Issue #552 iter-2 — set to 1 the instant this segment carries a repo
+  # selector Phase 0 cannot safely model (inline GIT_DIR=/GIT_WORK_TREE=,
+  # --git-dir/--work-tree, or repeated -C). When set, Phase 0 is skipped
+  # ENTIRELY below — this segment falls straight through to the existing
+  # Phase 1-3 logic, exactly as if Issue #552 had never shipped. Never used
+  # to grant a skip, only to withhold one.
+  local UNRESOLVABLE_SELECTOR=0
+
   # Wrapper-strip: skip leading env-var assignments, command wrappers, and
   # subshell/group open chars. Loop until no transformation applies — no
   # iteration cap (closes the iter-1 6+ env wrapper bypass; transforms shrink
@@ -410,7 +504,17 @@ process_segment() {
       --|--*|-[A-Za-z]*)
         i=$((i + 1)); _seen_change=1 ;;
       # VAR=value assignment (now quote-aware via awk tokenization).
+      # Issue #552 iter-2 (Codex): `GIT_DIR=`/`GIT_WORK_TREE=` inline env
+      # assignments — whether as a direct prefix (`GIT_DIR=x git push ...`)
+      # or via `env` (`env GIT_DIR=x git push ...`, since `env` itself is
+      # already stripped by the wrapper case above, leaving this same
+      # `VAR=value` token next) — silently redirect which repo the
+      # subsequent `git` invocation targets. Flag as unresolvable rather
+      # than let Phase 0 resolve against the wrong (unmodified) directory.
       [A-Za-z_]*=*)
+        case "$tok" in
+          GIT_DIR=*|GIT_WORK_TREE=*) UNRESOLVABLE_SELECTOR=1 ;;
+        esac
         i=$((i + 1)); _seen_change=1 ;;
     esac
   done
@@ -426,17 +530,37 @@ process_segment() {
   # authoritative signal for which repo this segment's push targets.
   local push_idx=-1
   local GIT_C_PATH=""
+  local GIT_C_COUNT=0
   while [ "$i" -lt "$ntok" ]; do
     local tok="${tokens[$i]}"
     case "$tok" in
       push) push_idx=$i; break ;;
       -C)
+        # Issue #552 iter-2 (Codex): git's real multi -C semantics is
+        # cumulative-relative (`git -C a -C b` == `-C a/b`, each new -C
+        # resolved relative to the previous one's result), not "last
+        # value wins". Modeling that correctly needs a full relative-path
+        # join chain; instead we just count occurrences and flag >1 as
+        # unresolvable below (GIT_C_PATH is still captured for the common
+        # single-`-C` case, but ignored whenever GIT_C_COUNT>1).
         GIT_C_PATH="${tokens[$((i + 1))]:-}"
+        GIT_C_COUNT=$((GIT_C_COUNT + 1))
         i=$((i + 2)); continue ;;
-      -c|--git-dir|--work-tree|--namespace|--super-prefix)
+      --git-dir|--work-tree)
+        # Issue #552 iter-2 (Codex): these redirect which repo/worktree
+        # git operates on independently of cwd/-C — Phase 0 cannot safely
+        # resolve the true target without replicating git's own selector
+        # precedence rules. Flag as unresolvable; still skip flag+value so
+        # the rest of the walker (Phase 1-3 fallback) is unaffected.
+        UNRESOLVABLE_SELECTOR=1
+        i=$((i + 2)); continue ;;
+      -c|--namespace|--super-prefix)
         # value-taking global option: skip flag + value in one step
         i=$((i + 2)); continue ;;
-      --git-dir=*|--work-tree=*|--namespace=*|--super-prefix=*)
+      --git-dir=*|--work-tree=*)
+        UNRESOLVABLE_SELECTOR=1
+        i=$((i + 1)); continue ;;
+      --namespace=*|--super-prefix=*)
         # inlined value: skip flag only
         i=$((i + 1)); continue ;;
       --help|--version|-h|-v|-p|--paginate|-P|--no-pager|--bare|--no-replace-objects|--literal-pathspecs|--no-optional-locks)
@@ -451,21 +575,46 @@ process_segment() {
 
   [ "$push_idx" -ge 0 ] || return 0
 
+  [ "$GIT_C_COUNT" -gt 1 ] && UNRESOLVABLE_SELECTOR=1
+
   # ── Phase 0: repo-awareness (Issue #552) ──────────────────────────────
-  # Resolve which repo this segment's `git push` actually targets:
-  # `-C <path>` (authoritative, overrides cwd for this invocation) else the
-  # hook stdin JSON's `cwd` field. If that resolves to a git toplevel that
-  # differs from Mercury's own toplevel, this push is out of this guard's
-  # scope — allow it through. Any failure to resolve (rev-parse errors,
-  # empty signal, MERCURY_TOPLEVEL itself unresolved) falls through
-  # unchanged to Phase 1-3 below — fail-closed, never a bypass source.
-  local _repo_path="${GIT_C_PATH:-$HOOK_CWD}"
-  if [ -n "$_repo_path" ] && [ -n "$MERCURY_TOPLEVEL" ]; then
-    local _target_toplevel
-    _target_toplevel=$(git -C "$_repo_path" rev-parse --show-toplevel 2>/dev/null)
-    if [ -n "$_target_toplevel" ] && [ "$(_normalize_path "$_target_toplevel")" != "$(_normalize_path "$MERCURY_TOPLEVEL")" ]; then
-      debug_log "ALLOWED (non-Mercury repo): target='$_target_toplevel' mercury='$MERCURY_TOPLEVEL'"
-      return 0
+  # Skipped entirely (falls straight to Phase 1-3, as if #552 never
+  # shipped) whenever this segment carries a repo selector we cannot
+  # safely model — see UNRESOLVABLE_SELECTOR comment above.
+  if [ "$UNRESOLVABLE_SELECTOR" -eq 0 ]; then
+    # Resolve which repo this segment's `git push` actually targets:
+    # `-C <path>` (authoritative — overrides cwd for this invocation) else
+    # the hook stdin JSON's `cwd` field. A relative `-C` value is resolved
+    # against `HOOK_CWD` (where the command actually executes), NOT this
+    # hook process's own cwd — those can differ. If `-C` is relative and
+    # `HOOK_CWD` is unavailable to anchor it, there is nothing safe to
+    # resolve, so `_repo_path` stays empty and Phase 0 falls through below
+    # exactly like any other resolution failure.
+    local _repo_path=""
+    if [ -n "$GIT_C_PATH" ]; then
+      case "$GIT_C_PATH" in
+        /*|[A-Za-z]:[\\/]*|\\\\*)
+          # Already absolute (POSIX root, Windows drive-letter, or UNC).
+          _repo_path="$GIT_C_PATH" ;;
+        *)
+          [ -n "$HOOK_CWD" ] && _repo_path="$HOOK_CWD/$GIT_C_PATH" ;;
+      esac
+    else
+      _repo_path="$HOOK_CWD"
+    fi
+
+    # If that resolves to a git common-dir that differs from Mercury's own,
+    # this push is out of this guard's scope — allow it through. Any
+    # failure to resolve (rev-parse errors, empty signal, MERCURY_COMMON_DIR
+    # itself unresolved) falls through unchanged to Phase 1-3 below —
+    # fail-closed, never a bypass source.
+    if [ -n "$_repo_path" ] && [ -n "$MERCURY_COMMON_DIR" ]; then
+      local _target_common_dir
+      _target_common_dir=$(_git_common_dir "$_repo_path")
+      if [ -n "$_target_common_dir" ] && [ "$(_normalize_path "$_target_common_dir")" != "$(_normalize_path "$MERCURY_COMMON_DIR")" ]; then
+        debug_log "ALLOWED (non-Mercury repo): target='$_target_common_dir' mercury='$MERCURY_COMMON_DIR'"
+        return 0
+      fi
     fi
   fi
 

--- a/.claude/hooks/push-guard.sh
+++ b/.claude/hooks/push-guard.sh
@@ -44,6 +44,20 @@
 #     Quote-strip in Phase 2 normalization handles literal quote chars
 #     defensively. `(` `)` `{` `}` are tokenized; `(` `{` are skipped during
 #     wrapper-strip. Hard-block on awk failure or unrecoverable extraction.
+#
+#   Issue #552 — Bug: no repository awareness. This guard's protection
+#     semantics (direct-push-to-protected-branch forbidden) are a Mercury-
+#     repo-specific CLAUDE.md rule, but the hook fired on ANY repo's
+#     `git push`, including a design-library repo whose established
+#     workflow is master-direct-commit. Fix: Phase 0 repo-awareness check
+#     inserted before Phase 1-3, per push segment — resolves the segment's
+#     actual target repo (`-C <path>` if present, else the hook stdin
+#     JSON's `cwd` field, confirmed present on all hook events per
+#     https://code.claude.com/docs/en/hooks) and compares its git toplevel
+#     against Mercury's toplevel. Non-Mercury repos are allowed through.
+#     Any failure to resolve either toplevel falls through unchanged to
+#     the existing fail-closed Phase 1-3 logic — this check can only ever
+#     grant a POSITIVELY CONFIRMED skip, never a bypass from uncertainty.
 
 INPUT=$(cat)
 
@@ -56,6 +70,26 @@ LOG_FILE="$STATE_DIR/push-guard-debug.log"
 debug_log() {
   [ "${GUARD_DEBUG:-0}" = "1" ] && echo "[$(date -Iseconds)] $1" >> "$LOG_FILE"
 }
+
+# Issue #552 — path normalization for repo-awareness comparisons. Lowercase
+# + backslash-to-slash + strip trailing slash so Windows drive-letter paths
+# with differing case or separator style (e.g. `D:\Mercury\Mercury` vs
+# `d:/mercury/mercury/`) compare equal.
+_normalize_path() {
+  local p="$1"
+  p="${p,,}"
+  p="${p//\\//}"
+  p="${p%/}"
+  printf '%s' "$p"
+}
+
+# Issue #552 — Mercury repo's own git toplevel, resolved once. Used by the
+# Phase 0 repo-awareness check in process_segment() to decide whether a
+# `git push` segment targets THIS repo (protection applies) or a different
+# one (out of scope, allowed through). Empty on resolution failure — Phase 0
+# treats that as "cannot determine", falling through to the existing
+# fail-closed Phase 1-3 logic unchanged.
+MERCURY_TOPLEVEL=$(git -C "$_PROJECT" rev-parse --show-toplevel 2>/dev/null)
 
 if [ "${GUARD_DEBUG:-0}" = "1" ] && [ -f "$LOG_FILE" ] && [ "$(wc -c < "$LOG_FILE")" -gt 102400 ]; then
   tail -100 "$LOG_FILE" > "$LOG_FILE.tmp" && mv "$LOG_FILE.tmp" "$LOG_FILE"
@@ -109,6 +143,13 @@ fi
 
 if [ "$HAS_JQ" -eq 1 ]; then
   COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+  # Issue #552 — hook stdin JSON's top-level `cwd` field: "Current working
+  # directory when the hook is invoked" (confirmed present on all hook
+  # events, https://code.claude.com/docs/en/hooks). Fallback target-repo
+  # signal for the Phase 0 repo-awareness check when the push segment has
+  # no explicit `-C <path>`. Empty on missing/malformed field — Phase 0
+  # then has nothing to resolve and falls through fail-closed.
+  HOOK_CWD=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null)
 else
   # HAS_JQ=0 AND HAS_CMD_KEY=0 — INPUT did not carry a "command" key (e.g.
   # tool wasn't Bash). Nothing to gate.
@@ -379,12 +420,20 @@ process_segment() {
   i=$((i + 1))
 
   # Walk git global options until `push` or non-option non-push token.
+  # GIT_C_PATH captures a `-C <path>` global option value (if present) —
+  # used by the Phase 0 repo-awareness check below (Issue #552) since `-C`
+  # overrides the process cwd for that git invocation and is therefore the
+  # authoritative signal for which repo this segment's push targets.
   local push_idx=-1
+  local GIT_C_PATH=""
   while [ "$i" -lt "$ntok" ]; do
     local tok="${tokens[$i]}"
     case "$tok" in
       push) push_idx=$i; break ;;
-      -C|-c|--git-dir|--work-tree|--namespace|--super-prefix)
+      -C)
+        GIT_C_PATH="${tokens[$((i + 1))]:-}"
+        i=$((i + 2)); continue ;;
+      -c|--git-dir|--work-tree|--namespace|--super-prefix)
         # value-taking global option: skip flag + value in one step
         i=$((i + 2)); continue ;;
       --git-dir=*|--work-tree=*|--namespace=*|--super-prefix=*)
@@ -401,6 +450,24 @@ process_segment() {
   done
 
   [ "$push_idx" -ge 0 ] || return 0
+
+  # ── Phase 0: repo-awareness (Issue #552) ──────────────────────────────
+  # Resolve which repo this segment's `git push` actually targets:
+  # `-C <path>` (authoritative, overrides cwd for this invocation) else the
+  # hook stdin JSON's `cwd` field. If that resolves to a git toplevel that
+  # differs from Mercury's own toplevel, this push is out of this guard's
+  # scope — allow it through. Any failure to resolve (rev-parse errors,
+  # empty signal, MERCURY_TOPLEVEL itself unresolved) falls through
+  # unchanged to Phase 1-3 below — fail-closed, never a bypass source.
+  local _repo_path="${GIT_C_PATH:-$HOOK_CWD}"
+  if [ -n "$_repo_path" ] && [ -n "$MERCURY_TOPLEVEL" ]; then
+    local _target_toplevel
+    _target_toplevel=$(git -C "$_repo_path" rev-parse --show-toplevel 2>/dev/null)
+    if [ -n "$_target_toplevel" ] && [ "$(_normalize_path "$_target_toplevel")" != "$(_normalize_path "$MERCURY_TOPLEVEL")" ]; then
+      debug_log "ALLOWED (non-Mercury repo): target='$_target_toplevel' mercury='$MERCURY_TOPLEVEL'"
+      return 0
+    fi
+  fi
 
   # Slice push tokens (after the `push` token itself).
   local -a push_toks=()

--- a/.claude/hooks/push-guard.sh
+++ b/.claude/hooks/push-guard.sh
@@ -420,6 +420,78 @@ END {
 }
 ') || block_parser_fail "awk tokenizer exited non-zero"
 
+# Issue #552 iter-3 (dual-verify NEEDS-CHANGES, real hook-call
+# reproductions from `cd`/`pushd`/exported `GIT_DIR=`/`env --chdir=`/glued
+# `-C<path>` — see fix-history comment near the top of this file) —
+# COMMAND-LEVEL simplicity gate. Phase 0 (below) infers the target repo
+# from a STATIC snapshot: the `-C <path>` on the specific push segment, or
+# else the hook stdin JSON's `cwd` field captured once at hook invocation.
+# That snapshot is only valid if NOTHING in the whole command changes the
+# shell's working directory or git's repo-selection env vars BEFORE the
+# push runs — and shell state transitions are not segment-scoped: `cd
+# /other/repo && git push origin develop` puts the `cd` in segment 1 and
+# the vulnerable push in segment 2, so a per-segment check (like the
+# iter-2 UNRESOLVABLE_SELECTOR gate) cannot catch it. This gate therefore
+# scans the ENTIRE token stream (every segment) BEFORE any segment is
+# processed, and — if triggered — disables Phase 0 for the WHOLE command
+# (every segment falls back to Phase 1-3, exactly as if Issue #552 had
+# never shipped), not just the segment that carries the trigger token.
+#
+# Triggers (each verified against real git/env behavior, not assumed):
+#   - `cd` / `pushd` / `popd` as an exact token anywhere — real shell-state
+#     transitions. Real hook-call repro: `cd D:/Mercury/Mercury && git push
+#     origin develop` (external cwd, no other selector) was ALLOWED
+#     pre-fix; that push actually executes inside Mercury.
+#   - Any token matching `GIT_DIR=*` / `GIT_WORK_TREE=*` — catches the
+#     prefix form (`GIT_DIR=x git push ...`), the `export` form (`export
+#     GIT_DIR=x; git push ...` — `export` itself is stripped as a no-op
+#     wrapper by process_segment's wrapper-strip loop, leaving this same
+#     `GIT_DIR=x` token), and the `env`-wrapped form, in ANY segment,
+#     regardless of the iter-2 per-segment UNRESOLVABLE_SELECTOR gate
+#     (which only sees the segment carrying the actual `git push`).
+#   - `--chdir` / `--chdir=*` — `env --chdir=<dir> <cmd>` is a real,
+#     verified way to run a command in another directory (GNU coreutils
+#     env(1)); a `git` invocation reached through it inherits the changed
+#     cwd, invalidating any `cwd`-derived Phase 0 signal.
+#   - `-C<path>` glued with no separator (e.g. `git -CD:/Mercury/Mercury
+#     push ...`) — verified live: git itself rejects this as `unknown
+#     option` (git requires `-C` and its value as separate tokens, or
+#     none at all — never glued), so it is not exploitable today. Included
+#     anyway as a zero-cost defensive trigger in case that ever changes,
+#     and because the token-level scan cannot tell "not exploitable now"
+#     from "not exploitable ever" — being conservative here costs nothing.
+#
+# This is a coarse, command-level trigger by design — it does NOT try to
+# determine whether a `cd`/`GIT_DIR=`/etc. token actually AFFECTS the
+# specific push segment being evaluated (that would require full shell
+# control-flow modeling, which this hook explicitly does not attempt
+# elsewhere either — see the awk tokenizer's documented `bash -c "..."`
+# limitation). A "simple" command (no such tokens anywhere) keeps full
+# Phase 0 behavior; a command containing ANY of these constructs loses
+# Phase 0 for its ENTIRE duration. This does not regress real non-Mercury-
+# repo usage: `git add -A && git commit -m x && git push origin master`
+# run inside an external repo contains no state-transition construct, so
+# it is unaffected and still allowed through.
+COMMAND_LEVEL_UNSAFE=0
+TAB=$(printf '\t')
+TOK_PREFIX="TOK${TAB}"
+while IFS= read -r _gate_line; do
+  case "$_gate_line" in
+    "${TOK_PREFIX}"*)
+      _gate_tok="${_gate_line#${TOK_PREFIX}}"
+      case "$_gate_tok" in
+        cd|pushd|popd) COMMAND_LEVEL_UNSAFE=1 ;;
+        GIT_DIR=*|GIT_WORK_TREE=*) COMMAND_LEVEL_UNSAFE=1 ;;
+        --chdir|--chdir=*) COMMAND_LEVEL_UNSAFE=1 ;;
+        -C?*) COMMAND_LEVEL_UNSAFE=1 ;;
+      esac
+      ;;
+  esac
+done <<EOF
+$_TOK_STREAM
+EOF
+[ "$COMMAND_LEVEL_UNSAFE" -eq 1 ] && debug_log "Phase 0 disabled for whole command (simplicity gate triggered)"
+
 # Group tokens into segments and run Phase 1/2/3 inline per segment.
 # Per-segment phase evaluation closes the iter-1 break-on-first bypass:
 #   `git push origin lane/foo && git push origin develop` evaluates BOTH.
@@ -579,9 +651,17 @@ process_segment() {
 
   # ── Phase 0: repo-awareness (Issue #552) ──────────────────────────────
   # Skipped entirely (falls straight to Phase 1-3, as if #552 never
-  # shipped) whenever this segment carries a repo selector we cannot
-  # safely model — see UNRESOLVABLE_SELECTOR comment above.
-  if [ "$UNRESOLVABLE_SELECTOR" -eq 0 ]; then
+  # shipped) whenever EITHER gate fires:
+  #   - UNRESOLVABLE_SELECTOR (iter-2, segment-scoped): THIS segment's own
+  #     `git` invocation carries a selector Phase 0 cannot safely model
+  #     (--git-dir/--work-tree, repeated -C).
+  #   - COMMAND_LEVEL_UNSAFE (iter-3, whole-command, computed once above
+  #     before segmenting): ANY segment anywhere in the full command
+  #     contains a shell-state-transition or repo-redirection construct
+  #     (cd/pushd/popd, GIT_DIR=/GIT_WORK_TREE=, --chdir, glued -C<path>)
+  #     that could invalidate this segment's HOOK_CWD/-C snapshot even
+  #     though the construct itself lives in a DIFFERENT segment.
+  if [ "$UNRESOLVABLE_SELECTOR" -eq 0 ] && [ "$COMMAND_LEVEL_UNSAFE" -eq 0 ]; then
     # Resolve which repo this segment's `git push` actually targets:
     # `-C <path>` (authoritative — overrides cwd for this invocation) else
     # the hook stdin JSON's `cwd` field. A relative `-C` value is resolved
@@ -705,8 +785,8 @@ process_segment() {
 # and process. Lines beginning with `TOK<TAB>` are tokens (with the TAB-and-
 # everything-before stripped); the bare line `SEG` is a segment terminator.
 # Any other line shape is a protocol violation — ignored to fail closed.
-TAB=$(printf '\t')
-TOK_PREFIX="TOK${TAB}"
+# TAB/TOK_PREFIX already computed above for the Issue #552 iter-3
+# command-level simplicity gate pre-scan — reused here unchanged.
 while IFS= read -r line; do
   if [ "$line" = "SEG" ]; then
     if [ "${#CUR_SEG[@]}" -gt 0 ]; then

--- a/.claude/hooks/push-guard.sh
+++ b/.claude/hooks/push-guard.sh
@@ -98,6 +98,83 @@
 #     `--git-common-dir` strings, which would incorrectly allow a Mercury
 #     push through. Requires deliberately constructing such an alias;
 #     not addressed here.
+#
+#     Iter 3 (dual-verify NEEDS-CHANGES round 2) found a NEW class: a
+#     shell-state-transition construct (`cd`, `export GIT_DIR=`, `env
+#     --chdir=`, `pushd`) can invalidate Phase 0's HOOK_CWD/-C snapshot
+#     from a DIFFERENT segment than the one containing the vulnerable
+#     `git push` (`cd /other && git push origin develop` — `cd` in
+#     segment 1, push in segment 2 — no segment-scoped check sees both
+#     halves). Fixed with a coarse COMMAND-LEVEL token scan disabling
+#     Phase 0 for the whole command if any such construct appeared
+#     ANYWHERE, regardless of segment.
+#
+#     Iter 4 (dual-verify NEEDS-CHANGES round 3 — Codex + coordinator
+#     independent repro, same 3 findings, high-confidence) found the
+#     iter-3 coarse scan was wrong on BOTH ends at once:
+#       - Under-blocking (Critical): `eval "cd <mercury> && git push origin
+#         develop"` (content inside quotes, the `cd` token never appears
+#         bare), `source ./x.sh; git push origin develop` / `. ./x.sh &&
+#         ...` (verified live: sourcing a script containing `cd` DOES
+#         change the shell's cwd — the transition isn't even IN the
+#         command text), and `X=cd; $X <mercury> && ...` (verified live:
+#         bash really does execute the resulting `cd` after variable
+#         expansion) all changed cwd to Mercury while going undetected —
+#         the iter-3 scan only recognized `cd`/`pushd`/`popd` as LITERAL
+#         tokens, missing every indirection.
+#       - Over-blocking (Medium, but directly undermines #552's purpose):
+#         the iter-3 scan matched `cd` ANYWHERE in the token stream, so a
+#         non-Mercury-repo `cd docs && git push origin master` (the most
+#         natural way to write "go do something in a subdirectory") or
+#         even `git commit -m cd && git push origin master` (`cd` as
+#         literal COMMIT MESSAGE CONTENT, not a command) both lost Phase 0
+#         and got needlessly blocked — reintroducing the exact "workflow
+#         loses continuity" complaint Issue #552 exists to fix.
+#
+#     Iter 4 fix replaces the blunt token scan with `cd`/`pushd`
+#     TRACKING: `EFFECTIVE_CWD` starts at `HOOK_CWD` and advances,
+#     segment-by-segment IN ORDER, whenever a segment's COMMAND-POSITION
+#     token (the first non-wrapper token — same wrapper-strip rule set as
+#     process_segment's own git-detection, see `_find_command_position()`)
+#     is `cd` or `pushd` with EXACTLY ONE literal argument (no `$`,
+#     backtick, or glob metachar, and not bare `cd`/`cd -` which target an
+#     unknowable `$HOME`/previous-dir). A push segment's Phase 0 resolves
+#     against `EFFECTIVE_CWD` AS OF ENTERING THAT SEGMENT (its own
+#     `SEG_ENTRY_CWD` snapshot), not the raw original `HOOK_CWD`. This is
+#     STRICTER than the iter-3 scan where it needs to be (indirection
+#     through `eval`/`source`/`.`/a variable holding `cd`, or any
+#     unresolvable `cd` form, still disables Phase 0 for the WHOLE
+#     command via `UNSAFE_STATE`) and LOOSER where it should be (a bare
+#     `cd` to a subdirectory of a non-Mercury repo, or `cd` appearing only
+#     as DATA at a non-command position, no longer costs the allow).
+#     `UNSAFE_STATE` triggers, still whole-command and position-scanned
+#     exactly as noted for each:
+#       - command-position token is `eval`/`source`/`.` (recursing into
+#         unknown content this hook cannot parse)
+#       - command-position token contains `$` or a backtick (COMMAND
+#         position only — deliberately NOT scanning data/argument
+#         positions, so `git commit -m "fix $foo"` in an external repo is
+#         unaffected; scanning data positions would reintroduce the same
+#         class of over-blocking iter-4 exists to fix)
+#       - `cd`/`pushd` with zero args, `cd -`, a variable/glob-containing
+#         arg, or more than one arg (ambiguous — e.g. a flag alongside the
+#         directory) — cannot be tracked safely
+#       - `popd` (needs a directory-stack, not modeled) at ANY command
+#         position
+#       - `GIT_DIR=*`/`GIT_WORK_TREE=*` at ANY token position in ANY
+#         segment (unchanged from iter-3 — position-agnostic, since these
+#         redirect git's repo selection regardless of where they appear)
+#       - `--chdir`/`--chdir=*` at ANY token position (unchanged)
+#       - glued `-C<path>` at ANY token position (unchanged — still
+#         defensive-only, git rejects this syntax today)
+#
+#     Documented non-fix (Low, out of threat model, same tier as the
+#     existing `bash -c "..."` limitation): a `bash -c "..."` (or any
+#     other recursive-shell invocation) hiding a `cd`, a pre-existing
+#     opaque shell function/alias that itself changes cwd, and the
+#     path-aliasing cases already documented above (subst/UNC/junction/
+#     symlink) remain out of scope — all require deliberately constructing
+#     an indirection this hook cannot see into; not addressed here.
 
 INPUT=$(cat)
 
@@ -420,86 +497,229 @@ END {
 }
 ') || block_parser_fail "awk tokenizer exited non-zero"
 
-# Issue #552 iter-3 (dual-verify NEEDS-CHANGES, real hook-call
-# reproductions from `cd`/`pushd`/exported `GIT_DIR=`/`env --chdir=`/glued
-# `-C<path>` — see fix-history comment near the top of this file) —
-# COMMAND-LEVEL simplicity gate. Phase 0 (below) infers the target repo
-# from a STATIC snapshot: the `-C <path>` on the specific push segment, or
-# else the hook stdin JSON's `cwd` field captured once at hook invocation.
-# That snapshot is only valid if NOTHING in the whole command changes the
-# shell's working directory or git's repo-selection env vars BEFORE the
-# push runs — and shell state transitions are not segment-scoped: `cd
-# /other/repo && git push origin develop` puts the `cd` in segment 1 and
-# the vulnerable push in segment 2, so a per-segment check (like the
-# iter-2 UNRESOLVABLE_SELECTOR gate) cannot catch it. This gate therefore
-# scans the ENTIRE token stream (every segment) BEFORE any segment is
-# processed, and — if triggered — disables Phase 0 for the WHOLE command
-# (every segment falls back to Phase 1-3, exactly as if Issue #552 had
-# never shipped), not just the segment that carries the trigger token.
+# ── Parse the awk-emitted typed line-protocol stream into a flat token
+# array + per-segment size array (Issue #552 iter-4 groundwork). Lines
+# beginning with `TOK<TAB>` are tokens (with the TAB-and-everything-before
+# stripped); the bare line `SEG` is a segment terminator. Any other line
+# shape is a protocol violation — ignored to fail closed.
 #
-# Triggers (each verified against real git/env behavior, not assumed):
-#   - `cd` / `pushd` / `popd` as an exact token anywhere — real shell-state
-#     transitions. Real hook-call repro: `cd D:/Mercury/Mercury && git push
-#     origin develop` (external cwd, no other selector) was ALLOWED
-#     pre-fix; that push actually executes inside Mercury.
-#   - Any token matching `GIT_DIR=*` / `GIT_WORK_TREE=*` — catches the
-#     prefix form (`GIT_DIR=x git push ...`), the `export` form (`export
-#     GIT_DIR=x; git push ...` — `export` itself is stripped as a no-op
-#     wrapper by process_segment's wrapper-strip loop, leaving this same
-#     `GIT_DIR=x` token), and the `env`-wrapped form, in ANY segment,
-#     regardless of the iter-2 per-segment UNRESOLVABLE_SELECTOR gate
-#     (which only sees the segment carrying the actual `git push`).
-#   - `--chdir` / `--chdir=*` — `env --chdir=<dir> <cmd>` is a real,
-#     verified way to run a command in another directory (GNU coreutils
-#     env(1)); a `git` invocation reached through it inherits the changed
-#     cwd, invalidating any `cwd`-derived Phase 0 signal.
-#   - `-C<path>` glued with no separator (e.g. `git -CD:/Mercury/Mercury
-#     push ...`) — verified live: git itself rejects this as `unknown
-#     option` (git requires `-C` and its value as separate tokens, or
-#     none at all — never glued), so it is not exploitable today. Included
-#     anyway as a zero-cost defensive trigger in case that ever changes,
-#     and because the token-level scan cannot tell "not exploitable now"
-#     from "not exploitable ever" — being conservative here costs nothing.
-#
-# This is a coarse, command-level trigger by design — it does NOT try to
-# determine whether a `cd`/`GIT_DIR=`/etc. token actually AFFECTS the
-# specific push segment being evaluated (that would require full shell
-# control-flow modeling, which this hook explicitly does not attempt
-# elsewhere either — see the awk tokenizer's documented `bash -c "..."`
-# limitation). A "simple" command (no such tokens anywhere) keeps full
-# Phase 0 behavior; a command containing ANY of these constructs loses
-# Phase 0 for its ENTIRE duration. This does not regress real non-Mercury-
-# repo usage: `git add -A && git commit -m x && git push origin master`
-# run inside an external repo contains no state-transition construct, so
-# it is unaffected and still allowed through.
-COMMAND_LEVEL_UNSAFE=0
+# ALL_TOKENS is every token across the WHOLE command, segment boundaries
+# concatenated away — used by the Pass A flat scan below (position-
+# agnostic triggers). SEG_SIZES[k] is segment k's token count — used to
+# re-slice ALL_TOKENS into per-segment arrays for Pass B (cd-tracking) and
+# the final per-segment process_segment() dispatch, without re-parsing
+# $_TOK_STREAM a second or third time.
 TAB=$(printf '\t')
 TOK_PREFIX="TOK${TAB}"
-while IFS= read -r _gate_line; do
-  case "$_gate_line" in
-    "${TOK_PREFIX}"*)
-      _gate_tok="${_gate_line#${TOK_PREFIX}}"
-      case "$_gate_tok" in
-        cd|pushd|popd) COMMAND_LEVEL_UNSAFE=1 ;;
-        GIT_DIR=*|GIT_WORK_TREE=*) COMMAND_LEVEL_UNSAFE=1 ;;
-        --chdir|--chdir=*) COMMAND_LEVEL_UNSAFE=1 ;;
-        -C?*) COMMAND_LEVEL_UNSAFE=1 ;;
-      esac
-      ;;
-  esac
+declare -a ALL_TOKENS=()
+declare -a SEG_SIZES=()
+declare -a CUR_SEG=()
+while IFS= read -r _p_line; do
+  if [ "$_p_line" = "SEG" ]; then
+    if [ "${#CUR_SEG[@]}" -gt 0 ]; then
+      SEG_SIZES+=( "${#CUR_SEG[@]}" )
+      ALL_TOKENS+=( "${CUR_SEG[@]}" )
+      CUR_SEG=()
+    fi
+  else
+    case "$_p_line" in
+      "${TOK_PREFIX}"*)
+        CUR_SEG+=( "${_p_line#${TOK_PREFIX}}" )
+        ;;
+      *)
+        # Unrecognized line shape — defensive ignore. The awk tokenizer is
+        # the sole producer; this branch only fires under tampering.
+        ;;
+    esac
+  fi
 done <<EOF
 $_TOK_STREAM
 EOF
-[ "$COMMAND_LEVEL_UNSAFE" -eq 1 ] && debug_log "Phase 0 disabled for whole command (simplicity gate triggered)"
+# Defensive flush: awk's END block always emits a trailing SEG, but guard
+# the case where the stream was empty or truncated.
+if [ "${#CUR_SEG[@]}" -gt 0 ]; then
+  SEG_SIZES+=( "${#CUR_SEG[@]}" )
+  ALL_TOKENS+=( "${CUR_SEG[@]}" )
+fi
+
+# Issue #552 iter-4 — see the iter-4 fix-history comment near the top of
+# this file for the full before/after rationale. `UNSAFE_STATE` (renamed
+# from iter-3's `COMMAND_LEVEL_UNSAFE`) disables Phase 0 for the WHOLE
+# command when set — every segment falls back to Phase 1-3, exactly as if
+# Issue #552 had never shipped.
+UNSAFE_STATE=0
+
+# ── Pass A: position-agnostic whole-stream flat scan ──────────────────
+# These triggers redirect git's repo selection (or are defensive-only)
+# regardless of WHERE in the command they appear, so a flat scan over
+# every token (ignoring segment/command-position) is correct and
+# sufficient — unchanged from iter-3 for these three triggers specifically
+# (`cd`/`pushd`/`popd` moved OUT of this flat scan in iter-4 — see Pass B).
+for _t in "${ALL_TOKENS[@]}"; do
+  case "$_t" in
+    GIT_DIR=*|GIT_WORK_TREE=*) UNSAFE_STATE=1 ;;
+    --chdir|--chdir=*) UNSAFE_STATE=1 ;;
+    -C?*) UNSAFE_STATE=1 ;;
+  esac
+done
+
+# Issue #552 iter-4 — find the "command position" token index within a
+# segment's token array: the first token that is not a wrapper (env var
+# assignment, an env/command/exec/builtin/sudo/doas/nohup/time wrapper,
+# `!`, a control-flow keyword, or a flag). This is a SEPARATE, purpose-
+# built copy of process_segment's own wrapper-strip loop rather than a
+# shared refactor — process_segment's copy also sets UNRESOLVABLE_SELECTOR
+# as a side effect while walking (iter-2, segment-scoped), which is out of
+# scope for this pure lookup used only by Pass B below. If either wrapper-
+# strip rule set changes, update BOTH copies.
+# Echoes the index (may equal $#, i.e. one past the last token, if the
+# segment is entirely wrapper tokens with no command found).
+_find_command_position() {
+  local -a tokens=( "$@" )
+  local ntok=${#tokens[@]}
+  local i=0
+  local _seen_change=1
+  while [ "$_seen_change" -eq 1 ] && [ "$i" -lt "$ntok" ]; do
+    _seen_change=0
+    local tok="${tokens[$i]}"
+    case "$tok" in
+      "!")
+        i=$((i + 1)); _seen_change=1 ;;
+      if|then|else|elif|do|while|until)
+        i=$((i + 1)); _seen_change=1 ;;
+      env|command|exec|builtin|nohup|time|sudo|doas)
+        i=$((i + 1)); _seen_change=1 ;;
+      coproc|function)
+        i=$((i + 1)); _seen_change=1
+        if [ "$i" -lt "$ntok" ]; then
+          local _next="${tokens[$i]}"
+          case "$_next" in
+            git|cd|pushd|popd|eval|source) ;;  # don't consume, caller needs to match
+            [A-Za-z_][A-Za-z0-9_-]*) i=$((i + 1)) ;;
+          esac
+        fi
+        ;;
+      -u|-S|-C|--unset|--split-string|--chdir)
+        i=$((i + 2)); _seen_change=1 ;;
+      --*=*)
+        i=$((i + 1)); _seen_change=1 ;;
+      --|--*|-[A-Za-z]*)
+        i=$((i + 1)); _seen_change=1 ;;
+      [A-Za-z_]*=*)
+        i=$((i + 1)); _seen_change=1 ;;
+    esac
+  done
+  printf '%s' "$i"
+}
+
+# ── Pass B: per-segment cd/pushd tracking (Issue #552 iter-4) ─────────
+# EFFECTIVE_CWD starts at HOOK_CWD and advances, segment-by-segment IN
+# ORDER, whenever a segment's command-position token is `cd`/`pushd` with
+# exactly one safely-literal argument. SEG_ENTRY_CWD[k] snapshots
+# EFFECTIVE_CWD as of ENTERING segment k (i.e. BEFORE that segment's own
+# cd/pushd, if any, is applied) — this is what a push in segment k should
+# resolve against, not the raw original HOOK_CWD. Any construct this
+# cannot safely track sets UNSAFE_STATE=1 (whole-command, same as Pass A).
+EFFECTIVE_CWD="$HOOK_CWD"
+declare -a SEG_ENTRY_CWD=()
+_pb_off=0
+for _pb_sz in "${SEG_SIZES[@]}"; do
+  declare -a _pb_seg=( "${ALL_TOKENS[@]:$_pb_off:$_pb_sz}" )
+  SEG_ENTRY_CWD+=( "$EFFECTIVE_CWD" )
+  _pb_cmd_idx=$(_find_command_position "${_pb_seg[@]}")
+  if [ "$_pb_cmd_idx" -lt "$_pb_sz" ]; then
+    _pb_cmd_tok="${_pb_seg[$_pb_cmd_idx]}"
+    case "$_pb_cmd_tok" in
+      # Recursing into content this hook cannot parse (quoted `eval`
+      # payload, an external script's contents via `source`/`.`), or a
+      # command-position token built from an expansion this hook cannot
+      # resolve (`$X`, `` `cmd` ``) — MUST NOT trust EFFECTIVE_CWD past
+      # this point. Deliberately COMMAND-POSITION ONLY: a `$`/backtick
+      # appearing in a DATA position (e.g. `git commit -m "fix $foo"`)
+      # must NOT trigger this — that would reintroduce the exact
+      # over-blocking iter-4 exists to fix.
+      eval)
+        # `eval "cd <mercury> && git push origin develop"` — the awk
+        # tokenizer buffers the whole double-quoted argument as ONE
+        # token (spaces/`&&`/etc. inside quotes are literal, not
+        # separators), so the `git`/`push` tokens are NEVER independently
+        # visible to process_segment's own detection. Unlike `source`/`.`
+        # (whose risky content lives in an EXTERNAL FILE this hook has no
+        # visibility into regardless), `eval`'s payload IS present, in
+        # full, right here in the command string — just quote-shielded
+        # from segmentation. So Phase 1-3 provides ZERO protection for
+        # this case (it never sees a `git push` to check), unlike the
+        # `source ./x.sh; git push origin develop` case where the visible
+        # push in the SEPARATE segment after `;` still gets caught by
+        # Phase 1-3 normally. A narrow, deliberately coarse defensive scan
+        # of the payload text closes this gap: if it textually looks like
+        # `git ... push ... <protected-branch>`, block outright (not just
+        # disable Phase 0 — there is nothing else that will catch it).
+        # Over-blocking risk here is accepted and narrow (scoped only to
+        # `eval` payloads, an already-rare Claude Code pattern combined
+        # with these exact words).
+        _pb_payload="${_pb_seg[*]:$((_pb_cmd_idx + 1))}"
+        if printf '%s' "$_pb_payload" | grep -qE '(^|[^A-Za-z0-9_])git([^A-Za-z0-9_].*)?push' \
+           && printf '%s' "$_pb_payload" | grep -qE '(^|[^A-Za-z0-9_])(develop|master|main)([^A-Za-z0-9_]|$)'; then
+          block_push "eval payload textually contains a protected-branch push: '$_pb_payload'"
+        fi
+        UNSAFE_STATE=1
+        ;;
+      source|.|*'$'*|*'`'*)
+        UNSAFE_STATE=1 ;;
+      cd|pushd)
+        _pb_nargs=$(( _pb_sz - _pb_cmd_idx - 1 ))
+        if [ "$_pb_nargs" -ne 1 ]; then
+          # Zero args (bare `cd` → unknowable $HOME) or 2+ args
+          # (ambiguous — e.g. a flag alongside the directory, or a
+          # `pushd +N` stack-rotation form) — cannot track safely.
+          UNSAFE_STATE=1
+        else
+          _pb_arg="${_pb_seg[$((_pb_cmd_idx + 1))]}"
+          case "$_pb_arg" in
+            -|*'$'*|*'`'*|*'*'*|*'?'*|*'['*)
+              # `cd -` (previous dir, unknowable without a history we
+              # don't track) or an argument containing a variable/
+              # command-substitution/glob metachar (cannot resolve its
+              # literal value).
+              UNSAFE_STATE=1 ;;
+            /*|[A-Za-z]:[\\/]*|\\\\*)
+              # Absolute (POSIX root, Windows drive-letter, or UNC).
+              EFFECTIVE_CWD="$_pb_arg" ;;
+            *)
+              # Relative — join onto the current EFFECTIVE_CWD. If there
+              # is nothing to anchor a relative path against, this is
+              # unresolvable rather than silently wrong.
+              if [ -n "$EFFECTIVE_CWD" ]; then
+                EFFECTIVE_CWD="$EFFECTIVE_CWD/$_pb_arg"
+              else
+                UNSAFE_STATE=1
+              fi
+              ;;
+          esac
+        fi
+        ;;
+      popd)
+        # Needs a directory stack, which this hook does not model.
+        UNSAFE_STATE=1 ;;
+    esac
+  fi
+  _pb_off=$((_pb_off + _pb_sz))
+done
+[ "$UNSAFE_STATE" -eq 1 ] && debug_log "Phase 0 disabled for whole command (UNSAFE_STATE triggered)"
 
 # Group tokens into segments and run Phase 1/2/3 inline per segment.
 # Per-segment phase evaluation closes the iter-1 break-on-first bypass:
 #   `git push origin lane/foo && git push origin develop` evaluates BOTH.
 PROTECTED='^(develop|master|main)$'
 
-declare -a CUR_SEG=()
-
 process_segment() {
+  # Issue #552 iter-4 — first positional arg is this segment's
+  # SEG_ENTRY_CWD (EFFECTIVE_CWD as of entering this segment, per the
+  # Pass B cd-tracking above), NOT the raw original HOOK_CWD. The
+  # remaining args are the segment's tokens, unchanged.
+  local _seg_entry_cwd="$1"
+  shift
   local -a tokens=( "$@" )
   local ntok=${#tokens[@]}
   local i=0
@@ -655,21 +875,24 @@ process_segment() {
   #   - UNRESOLVABLE_SELECTOR (iter-2, segment-scoped): THIS segment's own
   #     `git` invocation carries a selector Phase 0 cannot safely model
   #     (--git-dir/--work-tree, repeated -C).
-  #   - COMMAND_LEVEL_UNSAFE (iter-3, whole-command, computed once above
-  #     before segmenting): ANY segment anywhere in the full command
-  #     contains a shell-state-transition or repo-redirection construct
-  #     (cd/pushd/popd, GIT_DIR=/GIT_WORK_TREE=, --chdir, glued -C<path>)
-  #     that could invalidate this segment's HOOK_CWD/-C snapshot even
-  #     though the construct itself lives in a DIFFERENT segment.
-  if [ "$UNRESOLVABLE_SELECTOR" -eq 0 ] && [ "$COMMAND_LEVEL_UNSAFE" -eq 0 ]; then
+  #   - UNSAFE_STATE (iter-3/iter-4, whole-command, computed once above
+  #     before segmenting — Pass A flat scan + Pass B cd-tracking): ANY
+  #     segment anywhere in the full command contains a shell-state-
+  #     transition or repo-redirection construct this hook cannot safely
+  #     model, even if the construct itself lives in a DIFFERENT segment.
+  if [ "$UNRESOLVABLE_SELECTOR" -eq 0 ] && [ "$UNSAFE_STATE" -eq 0 ]; then
     # Resolve which repo this segment's `git push` actually targets:
     # `-C <path>` (authoritative — overrides cwd for this invocation) else
-    # the hook stdin JSON's `cwd` field. A relative `-C` value is resolved
-    # against `HOOK_CWD` (where the command actually executes), NOT this
-    # hook process's own cwd — those can differ. If `-C` is relative and
-    # `HOOK_CWD` is unavailable to anchor it, there is nothing safe to
-    # resolve, so `_repo_path` stays empty and Phase 0 falls through below
-    # exactly like any other resolution failure.
+    # `_seg_entry_cwd` — this segment's EFFECTIVE_CWD snapshot from the
+    # Pass B cd-tracking above (i.e. HOOK_CWD as modified by any tracked
+    # `cd`/`pushd` in EARLIER segments — see iter-4 fix-history comment),
+    # NOT the raw original HOOK_CWD and NOT this hook process's own cwd.
+    # A relative `-C` value is likewise resolved against `_seg_entry_cwd`
+    # (the cwd in effect when THIS segment's `git` invocation actually
+    # runs). If `-C` is relative and `_seg_entry_cwd` is unavailable to
+    # anchor it, there is nothing safe to resolve, so `_repo_path` stays
+    # empty and Phase 0 falls through below exactly like any other
+    # resolution failure.
     local _repo_path=""
     if [ -n "$GIT_C_PATH" ]; then
       case "$GIT_C_PATH" in
@@ -677,10 +900,10 @@ process_segment() {
           # Already absolute (POSIX root, Windows drive-letter, or UNC).
           _repo_path="$GIT_C_PATH" ;;
         *)
-          [ -n "$HOOK_CWD" ] && _repo_path="$HOOK_CWD/$GIT_C_PATH" ;;
+          [ -n "$_seg_entry_cwd" ] && _repo_path="$_seg_entry_cwd/$GIT_C_PATH" ;;
       esac
     else
-      _repo_path="$HOOK_CWD"
+      _repo_path="$_seg_entry_cwd"
     fi
 
     # If that resolves to a git common-dir that differs from Mercury's own,
@@ -781,39 +1004,18 @@ process_segment() {
   fi
 }
 
-# Read the awk-emitted typed line-protocol stream, group tokens into segments,
-# and process. Lines beginning with `TOK<TAB>` are tokens (with the TAB-and-
-# everything-before stripped); the bare line `SEG` is a segment terminator.
-# Any other line shape is a protocol violation — ignored to fail closed.
-# TAB/TOK_PREFIX already computed above for the Issue #552 iter-3
-# command-level simplicity gate pre-scan — reused here unchanged.
-while IFS= read -r line; do
-  if [ "$line" = "SEG" ]; then
-    if [ "${#CUR_SEG[@]}" -gt 0 ]; then
-      process_segment "${CUR_SEG[@]}"
-      CUR_SEG=()
-    fi
-  else
-    case "$line" in
-      "${TOK_PREFIX}"*)
-        # Strip the TOK\t prefix; the remainder (which may itself equal
-        # the literal string `SEG`) is the token value.
-        CUR_SEG+=( "${line#${TOK_PREFIX}}" )
-        ;;
-      *)
-        # Unrecognized line shape — defensive ignore. The awk tokenizer is
-        # the sole producer; this branch only fires under tampering.
-        ;;
-    esac
-  fi
-done <<EOF
-$_TOK_STREAM
-EOF
-
-# Defensive flush: awk's END block always emits a trailing SEG, but guard
-# the case where the stream was empty or truncated.
-if [ "${#CUR_SEG[@]}" -gt 0 ]; then
-  process_segment "${CUR_SEG[@]}"
-fi
+# Dispatch each segment to process_segment(), re-slicing ALL_TOKENS via
+# SEG_SIZES (both already built above alongside the Pass A/B scans — no
+# need to re-parse $_TOK_STREAM a second time). Each call is prefixed with
+# that segment's SEG_ENTRY_CWD snapshot (Issue #552 iter-4) as the new
+# first positional argument process_segment() now expects.
+_disp_off=0
+_disp_idx=0
+for _disp_sz in "${SEG_SIZES[@]}"; do
+  declare -a _disp_seg=( "${ALL_TOKENS[@]:$_disp_off:$_disp_sz}" )
+  process_segment "${SEG_ENTRY_CWD[$_disp_idx]}" "${_disp_seg[@]}"
+  _disp_off=$((_disp_off + _disp_sz))
+  _disp_idx=$((_disp_idx + 1))
+done
 
 exit 0

--- a/.claude/hooks/push-guard.sh
+++ b/.claude/hooks/push-guard.sh
@@ -168,13 +168,93 @@
 #       - glued `-C<path>` at ANY token position (unchanged — still
 #         defensive-only, git rejects this syntax today)
 #
+#     Iter 5 (dual-verify round 4 — Codex + coordinator independent repro,
+#     6/6 reproduced, high-confidence) found the iter-4 tracker's core
+#     assumption was wrong: it treated TEXTUAL/SYNTACTIC token order as
+#     EXECUTION order, and assumed every `cd` it walked past actually runs
+#     in the parent shell. Neither holds for a short-circuited segment
+#     (`false && cd <dir>` — the `cd` never executes, but the iter-4
+#     tracker walked it anyway) or a `cd` that DOES execute but not in the
+#     parent shell's environment (a subshell `( cd <dir> ; : )`, a
+#     pipeline stage `cd <dir> | cat`, a `coproc` background job, or a
+#     never-taken `if false; then cd <dir>; fi` branch). Reproduced live,
+#     6/6:
+#       - `false && cd <external>; git push origin develop` (cwd=Mercury)
+#       - `true || cd <external>; git push origin develop`
+#       - `( cd <external> ; : ) ; git push origin develop`
+#       - `cd <external> | cat ; git push origin develop`
+#       - `coproc cd <external>; git push origin develop`
+#       - `if false; then cd <external>; fi; git push origin develop`
+#     All six ran INSIDE Mercury (the real push executes with the
+#     process's actual, unchanged cwd — none of these `cd` forms actually
+#     took effect), yet the iter-4 tracker updated EFFECTIVE_CWD to the
+#     external path anyway and Phase 0 granted a false ALLOW — the
+#     dangerous direction (Mercury→external, i.e. Phase 0 permits a push
+#     that is really hitting Mercury).
+#
+#     Iter 5 fix — SAME-REPO-ONLY ADVANCEMENT: a tracked `cd`/`pushd` only
+#     actually advances `EFFECTIVE_CWD` if its resolved target's git
+#     common-dir (via the SAME `_git_common_dir()` comparison Phase 0
+#     itself uses) matches the CURRENT `EFFECTIVE_CWD`'s common-dir — i.e.
+#     the `cd` stays inside the repo already being tracked. A `cd` that
+#     would cross OUT of that repo (or whose target/current common-dir
+#     cannot be resolved at all) sets `UNSAFE_STATE=1` INSTEAD of adopting
+#     the new directory. This makes the fix correct WITHOUT needing to
+#     model execution order, short-circuiting, or subshell/pipeline/coproc
+#     scoping at all: it doesn't matter whether a given `cd` "really" ran —
+#     only which direction crossing it implies matters, and disbelieving
+#     a cross-repo `cd` can only ever produce EXTRA blocking (the existing
+#     fail-closed path), never a false ALLOW. Re-examining the iter-4
+#     over-blocking fix under this rule: `cd docs && git push origin
+#     master` in a non-Mercury repo still resolves `docs` to the SAME
+#     repo (common-dir matches) and stays allowed — the fix that closed
+#     iter-4's over-blocking gap is preserved. A GENUINE cross-repo `cd`
+#     starting from Mercury (`cd <external> && git push origin master`,
+#     run with Mercury as the actual cwd) now sets `UNSAFE_STATE=1` and
+#     falls back to Phase 1-3, which is STRICTER than #552's pre-fix
+#     behavior would have been for a develop/master/main target anyway
+#     (Issue #552 never shipped for a push that is genuinely reached FROM
+#     Mercury) — accepted as an intentionally conservative trade-off, not
+#     a regression.
+#
+#     Also removed in iter-5 (Codex, accepted): the iter-4 `eval` branch's
+#     supplementary textual payload scan (grep for `git...push...
+#     <protected>` inside the quoted `eval` argument, block directly on
+#     match). Removed because it was both bypassable (`eval "git
+#     pu$(printf sh) origin develop"` never matches the literal substring
+#     scan — trivially defeated by any string-construction technique) and
+#     a false-positive source (`eval 'echo git push origin develop'` just
+#     PRINTS that text and would have been wrongly hard-blocked). Since
+#     `eval` hiding a real push inside its quoted payload was ALREADY
+#     unreachable by this hook before Issue #552 existed (the awk
+#     tokenizer has never recursed into quoted `eval`/`bash -c` content to
+#     find a nested `git push` — this is the same class of gap as the
+#     long-documented `bash -c "..."` limitation below), removing an
+#     unreliable ad-hoc scan does not reintroduce a gap that #552 had
+#     actually closed; `eval` still sets `UNSAFE_STATE=1` unconditionally
+#     (disabling Phase 0's potential ALLOW for the whole command), which
+#     is the correct and sufficient response given the payload's content
+#     is fundamentally unparseable here.
+#
+#     Iter-5 cleanliness (Codex, non-security): `process_segment`'s own
+#     wrapper-strip `coproc`/`function` NAME-skip exclusion list is now
+#     kept identical to `_find_command_position()`'s (both exclude
+#     `git`/`cd`/`pushd`/`popd`/`eval`/`source` as "never a coproc/function
+#     NAME") so the two independent wrapper-strip copies don't silently
+#     drift apart on a shared concept — no longer security-relevant given
+#     the same-repo-only gate above makes a `coproc`-hidden `cd`'s
+#     recognition non-exploitable either way.
+#
 #     Documented non-fix (Low, out of threat model, same tier as the
 #     existing `bash -c "..."` limitation): a `bash -c "..."` (or any
 #     other recursive-shell invocation) hiding a `cd`, a pre-existing
-#     opaque shell function/alias that itself changes cwd, and the
+#     opaque shell function/alias that itself changes cwd, the
 #     path-aliasing cases already documented above (subst/UNC/junction/
-#     symlink) remain out of scope — all require deliberately constructing
-#     an indirection this hook cannot see into; not addressed here.
+#     symlink), and (iter-5) `eval`/`source`/`.` payload CONTENT — this
+#     hook disables Phase 0 whenever any of these appear but never
+#     attempts to parse what is actually inside them — remain out of
+#     scope. All require deliberately constructing an indirection this
+#     hook cannot see into; not addressed here.
 
 INPUT=$(cat)
 
@@ -612,7 +692,7 @@ _find_command_position() {
   printf '%s' "$i"
 }
 
-# ── Pass B: per-segment cd/pushd tracking (Issue #552 iter-4) ─────────
+# ── Pass B: per-segment cd/pushd tracking (Issue #552 iter-4/iter-5) ──
 # EFFECTIVE_CWD starts at HOOK_CWD and advances, segment-by-segment IN
 # ORDER, whenever a segment's command-position token is `cd`/`pushd` with
 # exactly one safely-literal argument. SEG_ENTRY_CWD[k] snapshots
@@ -620,7 +700,45 @@ _find_command_position() {
 # cd/pushd, if any, is applied) — this is what a push in segment k should
 # resolve against, not the raw original HOOK_CWD. Any construct this
 # cannot safely track sets UNSAFE_STATE=1 (whole-command, same as Pass A).
+#
+# Iter-5 (dual-verify round 4 — Codex + coordinator independent repro, 6/6
+# reproduced): the iter-4 tracker treated TEXTUAL/SYNTACTIC token order as
+# EXECUTION order and assumed every `cd` it sees always runs in the parent
+# shell. Both assumptions are false for short-circuited segments
+# (`false && cd <dir>`, `true || cd <dir>` — the `cd` segment is walked
+# even though real bash would never execute it), and for `cd` that
+# genuinely executes but NOT in the parent shell's environment (a subshell
+# `( cd <dir> ; : )`, a pipeline stage `cd <dir> | cat`, a `coproc`
+# background job). In the Mercury→external direction this was merely
+# over-cautious (an untaken/scoped `cd` still degraded EFFECTIVE_CWD, at
+# worst causing an unnecessary UNSAFE_STATE — safe). In the EXTERNAL→
+# Mercury direction it was a real bypass: a syntactically-present-but-
+# never-really-effective `cd` INTO Mercury still updated EFFECTIVE_CWD,
+# which a later real push then resolved against — Phase 0 granted an
+# ALLOW on a push that actually ran inside Mercury.
+#
+# Fix — SAME-REPO-ONLY ADVANCEMENT: a tracked `cd`/`pushd`'s resolved
+# target is compared, via `_git_common_dir()` (the same real-git
+# comparison Phase 0 itself uses), against the CURRENT EFFECTIVE_CWD's
+# common-dir. Only if they match (the `cd` stays inside the repo we were
+# already tracking) does EFFECTIVE_CWD actually advance. Any cross-REPO
+# `cd` — or one whose target/current common-dir cannot be resolved at all
+# — sets UNSAFE_STATE=1 and EFFECTIVE_CWD is NOT updated. This does not
+# require correctly modeling execution order or subshell/pipeline scoping:
+# it doesn't matter WHETHER a given `cd` actually ran — the only thing
+# that matters is which DIRECTION crossing it implies, and this hook only
+# needs to distrust the ONE dangerous direction. A `cd` crossing OUT of
+# whatever repo was previously being tracked can never produce a false
+# ALLOW (crossing out just triggers UNSAFE_STATE, the existing fail-closed
+# path); a `cd` that (falsely, per mis-tracked execution order) appears to
+# stay WITHIN the same repo is harmless BY DEFINITION — if it's the same
+# repo, Phase 0's eventual verdict is identical whether or not that
+# specific `cd` "really" ran. This closes all 6 reproduced cases (short-
+# circuit, subshell, pipe, coproc, `if false; then cd; fi`) uniformly,
+# without needing to model any of their control-flow semantics.
 EFFECTIVE_CWD="$HOOK_CWD"
+EFFECTIVE_COMMON_DIR=""
+_eff_common_computed=0
 declare -a SEG_ENTRY_CWD=()
 _pb_off=0
 for _pb_sz in "${SEG_SIZES[@]}"; do
@@ -638,34 +756,21 @@ for _pb_sz in "${SEG_SIZES[@]}"; do
       # appearing in a DATA position (e.g. `git commit -m "fix $foo"`)
       # must NOT trigger this — that would reintroduce the exact
       # over-blocking iter-4 exists to fix.
-      eval)
-        # `eval "cd <mercury> && git push origin develop"` — the awk
-        # tokenizer buffers the whole double-quoted argument as ONE
-        # token (spaces/`&&`/etc. inside quotes are literal, not
-        # separators), so the `git`/`push` tokens are NEVER independently
-        # visible to process_segment's own detection. Unlike `source`/`.`
-        # (whose risky content lives in an EXTERNAL FILE this hook has no
-        # visibility into regardless), `eval`'s payload IS present, in
-        # full, right here in the command string — just quote-shielded
-        # from segmentation. So Phase 1-3 provides ZERO protection for
-        # this case (it never sees a `git push` to check), unlike the
-        # `source ./x.sh; git push origin develop` case where the visible
-        # push in the SEPARATE segment after `;` still gets caught by
-        # Phase 1-3 normally. A narrow, deliberately coarse defensive scan
-        # of the payload text closes this gap: if it textually looks like
-        # `git ... push ... <protected-branch>`, block outright (not just
-        # disable Phase 0 — there is nothing else that will catch it).
-        # Over-blocking risk here is accepted and narrow (scoped only to
-        # `eval` payloads, an already-rare Claude Code pattern combined
-        # with these exact words).
-        _pb_payload="${_pb_seg[*]:$((_pb_cmd_idx + 1))}"
-        if printf '%s' "$_pb_payload" | grep -qE '(^|[^A-Za-z0-9_])git([^A-Za-z0-9_].*)?push' \
-           && printf '%s' "$_pb_payload" | grep -qE '(^|[^A-Za-z0-9_])(develop|master|main)([^A-Za-z0-9_]|$)'; then
-          block_push "eval payload textually contains a protected-branch push: '$_pb_payload'"
-        fi
-        UNSAFE_STATE=1
-        ;;
-      source|.|*'$'*|*'`'*)
+      #
+      # Iter-5 (Codex, accepted): the iter-4 `eval` branch additionally
+      # ran a textual "does the payload look like `git ... push ...
+      # <protected>`" scan and hard-blocked on a match. Removed — it is
+      # both bypassable (`eval "git pu$(printf sh) origin develop"` never
+      # matches the literal substring scan) and a false-positive source
+      # (`eval 'echo git push origin develop'` just PRINTS that text and
+      # would have been wrongly blocked). `eval` hiding a real push was
+      # already unreachable by this hook BEFORE Issue #552 ever existed
+      # (same as the documented `bash -c "..."` limitation — the awk
+      # tokenizer has never recursed into a quoted eval/bash -c payload
+      # to find a nested `git push`), so removing an unreliable ad-hoc
+      # scan does not reintroduce a gap that iter-4 had actually closed.
+      # Documented in the file-header limitation list instead.
+      eval|source|.|*'$'*|*'`'*)
         UNSAFE_STATE=1 ;;
       cd|pushd)
         _pb_nargs=$(( _pb_sz - _pb_cmd_idx - 1 ))
@@ -683,17 +788,36 @@ for _pb_sz in "${SEG_SIZES[@]}"; do
               # command-substitution/glob metachar (cannot resolve its
               # literal value).
               UNSAFE_STATE=1 ;;
-            /*|[A-Za-z]:[\\/]*|\\\\*)
-              # Absolute (POSIX root, Windows drive-letter, or UNC).
-              EFFECTIVE_CWD="$_pb_arg" ;;
             *)
-              # Relative — join onto the current EFFECTIVE_CWD. If there
-              # is nothing to anchor a relative path against, this is
-              # unresolvable rather than silently wrong.
-              if [ -n "$EFFECTIVE_CWD" ]; then
-                EFFECTIVE_CWD="$EFFECTIVE_CWD/$_pb_arg"
-              else
+              _pb_candidate=""
+              case "$_pb_arg" in
+                /*|[A-Za-z]:[\\/]*|\\\\*)
+                  # Already absolute (POSIX root, Windows drive-letter, or UNC).
+                  _pb_candidate="$_pb_arg" ;;
+                *)
+                  # Relative — join onto the current EFFECTIVE_CWD. If
+                  # there is nothing to anchor a relative path against,
+                  # this is unresolvable rather than silently wrong.
+                  [ -n "$EFFECTIVE_CWD" ] && _pb_candidate="$EFFECTIVE_CWD/$_pb_arg"
+                  ;;
+              esac
+              # Iter-5 same-repo-only gate: only advance if the resolved
+              # candidate's common-dir matches the CURRENT EFFECTIVE_CWD's
+              # common-dir (computed lazily — most commands never `cd` at
+              # all, so most runs never pay this git-subprocess cost).
+              if [ "$_eff_common_computed" -eq 0 ]; then
+                EFFECTIVE_COMMON_DIR=""
+                [ -n "$EFFECTIVE_CWD" ] && EFFECTIVE_COMMON_DIR=$(_git_common_dir "$EFFECTIVE_CWD")
+                _eff_common_computed=1
+              fi
+              _pb_target_common=""
+              [ -n "$_pb_candidate" ] && _pb_target_common=$(_git_common_dir "$_pb_candidate")
+              if [ -z "$_pb_target_common" ] || [ -z "$EFFECTIVE_COMMON_DIR" ] \
+                 || [ "$(_normalize_path "$_pb_target_common")" != "$(_normalize_path "$EFFECTIVE_COMMON_DIR")" ]; then
                 UNSAFE_STATE=1
+              else
+                EFFECTIVE_CWD="$_pb_candidate"
+                EFFECTIVE_COMMON_DIR="$_pb_target_common"
               fi
               ;;
           esac
@@ -771,12 +895,22 @@ process_segment() {
       # of `function f { ... }` is segregated into its own segment by the
       # `{` separator, so we only need to handle the declaration prefix here.
       # Closes Codex iter-4 High (`coproc git push ...` + `function f {...}`).
+      # Iter-5 cleanliness (Codex): the exclusion list here now matches
+      # `_find_command_position()`'s (git/cd/pushd/popd/eval/source) even
+      # though THIS walker only ever needs to match `git` — keeping both
+      # copies' wrapper-strip rule sets identical avoids the two functions
+      # silently drifting apart on a shared concept (which token names are
+      # never a coproc/function NAME). No longer security-relevant either
+      # way since the iter-5 same-repo-only cd-tracking gate (see Pass B
+      # above) makes correct/incorrect `cd` recognition inside a `coproc`
+      # non-exploitable — a cross-repo `cd` blocks regardless of whether
+      # either walker "recognizes" it as `cd` specifically.
       coproc|function)
         i=$((i + 1)); _seen_change=1
         if [ "$i" -lt "$ntok" ]; then
           local _next="${tokens[$i]}"
           case "$_next" in
-            git) ;;  # don't consume, walker needs to match
+            git|cd|pushd|popd|eval|source) ;;  # don't consume, walker needs to match
             [A-Za-z_][A-Za-z0-9_-]*) i=$((i + 1)) ;;
           esac
         fi

--- a/scripts/test-push-guard.sh
+++ b/scripts/test-push-guard.sh
@@ -1354,80 +1354,36 @@ scenario \
   'JSON_CWD='
 
 # ===========================================================================
-# Issue #552 iter-3 (dual-verify NEEDS-CHANGES round 2, real hook-call
-# reproductions of a whole NEW class Codex found — see the "command-level
-# simplicity gate" fix-history comment in push-guard.sh for full rationale)
-#
-# All iter-1/iter-2 fixes gated Phase 0 at the SEGMENT level. This class of
-# bypass works because a shell-state-transition construct (cd/pushd/
-# GIT_DIR=/--chdir) can live in a DIFFERENT segment than the vulnerable
-# `git push`, so no segment-scoped check ever sees both halves together.
-# The command-level simplicity gate scans the WHOLE token stream once,
-# before segmenting, and disables Phase 0 for the ENTIRE command if
-# triggered — these scenarios use `JSON_CWD=/other/repo` (so, absent the
-# gate, Phase 0 would otherwise resolve "different repo" and ALLOW the
-# push) specifically to prove the gate overrides that and still blocks.
+# Issue #552 iter-3 (superseded by iter-4 below for `cd`/`pushd`/`popd` —
+# see the iter-4 block for those; `--chdir`/glued `-C<path>` are still
+# flat, position-agnostic Pass A triggers unaffected by the iter-4
+# cd-tracking rewrite, kept here unchanged)
 # ===========================================================================
 
-# G1: `cd` anywhere -> whole-command gate fires. Real git behavior: `cd
-# <dir> && <cmd>` genuinely runs <cmd> inside <dir> — this is the single
-# most natural way to write "go do something in another repo".
+# `env --chdir=<dir> <cmd>` — verified real GNU coreutils env(1) behavior,
+# runs <cmd> with its cwd changed to <dir> before exec. Unlike `cd`/
+# `pushd` (now tracked precisely — see iter-4 below), `--chdir` stays a
+# blunt "disable Phase 0 for the whole command" trigger regardless of
+# where it appears, since resolving its exact effect on a later segment's
+# cwd would require the same tracking complexity for comparatively rare
+# real-world usage.
 scenario \
-  '#552 iter-3 G1: `cd <dir> && git push origin develop` (real state transition) -> gate fires, still blocked' \
-  'cd /somewhere && git push origin develop' \
-  2 'BLOCKED' '' \
-  'JSON_CWD=/other/repo'
-
-scenario \
-  '#552 iter-3 G1b: `cd` in an EARLIER segment than the push -> gate fires (whole-command, not segment-local)' \
-  'cd /somewhere && git add -A && git push origin develop' \
-  2 'BLOCKED' '' \
-  'JSON_CWD=/other/repo'
-
-# G2: `GIT_DIR=`/`GIT_WORK_TREE=` via `export` — `export` is stripped as a
-# no-op wrapper by process_segment's wrapper-strip loop (same handling as
-# `env`), leaving the `GIT_DIR=x` token exposed to the gate scan exactly
-# like the plain-prefix and `env`-wrapped forms already covered by the
-# iter-2 per-segment UNRESOLVABLE_SELECTOR check — this scenario proves the
-# whole-command gate also catches it when `export ...; git push ...` are
-# TWO SEPARATE STATEMENTS (`;`-joined), i.e. two different segments, which
-# UNRESOLVABLE_SELECTOR (segment-scoped) cannot see across.
-scenario \
-  '#552 iter-3 G2: `export GIT_DIR=...; git push origin develop` (two segments) -> gate fires, still blocked' \
-  'export GIT_DIR=/mercury/.git; git push origin develop' \
-  2 'BLOCKED' '' \
-  'JSON_CWD=/other/repo'
-
-# G3: `env --chdir=<dir> <cmd>` — verified real GNU coreutils env(1)
-# behavior, runs <cmd> with its cwd changed to <dir> before exec.
-scenario \
-  '#552 iter-3 G3: `env --chdir=<dir> git push origin develop` -> gate fires, still blocked' \
+  '#552 `env --chdir=<dir> git push origin develop` -> whole-command Phase 0 disabled, still blocked' \
   'env --chdir=/mercury git push origin develop' \
   2 'BLOCKED' '' \
   'JSON_CWD=/other/repo'
 
 scenario \
-  '#552 iter-3 G3b: `env --chdir <dir> git push origin develop` (separate-arg form) -> gate fires, still blocked' \
+  '#552 `env --chdir <dir> git push origin develop` (separate-arg form) -> still blocked' \
   'env --chdir /mercury git push origin develop' \
   2 'BLOCKED' '' \
   'JSON_CWD=/other/repo'
 
-# G4: `pushd` — same real state-transition property as `cd`.
+# Glued `-C<path>` (no separator) — verified live that real git rejects
+# this as `unknown option`, so it is NOT exploitable today; still flagged
+# defensively (zero-cost — see fix-history comment in push-guard.sh).
 scenario \
-  '#552 iter-3 G4: `pushd <dir> && git push origin develop` -> gate fires, still blocked' \
-  'pushd /mercury && git push origin develop' \
-  2 'BLOCKED' '' \
-  'JSON_CWD=/other/repo'
-
-# G5: glued `-C<path>` (no separator) — verified live that real git
-# rejects this as `unknown option`, so it is NOT exploitable today; the
-# gate still fires defensively (zero-cost — see fix-history comment).
-# Either outcome (blocked via the gate, or allowed because Phase 0 would
-# have resolved a genuinely different repo) would be acceptable per the
-# coordinator's acceptance table, since git itself already refuses this
-# syntax; this harness asserts the gate's defensive behavior (blocked).
-scenario \
-  '#552 iter-3 G5: glued `-C<path>` (git rejects this syntax; gate is defensive-only) -> gate fires, still blocked' \
+  '#552 glued `-C<path>` (git rejects this syntax; defensive-only) -> still blocked' \
   'git -C/mercury push origin develop' \
   2 'BLOCKED' '' \
   'JSON_CWD=/other/repo'
@@ -1447,19 +1403,154 @@ scenario \
   0 '' '' \
   'JSON_CWD=/other/repo'
 
-# Regression net: a "simple" command (no state-transition construct
-# anywhere) run inside a non-Mercury repo must remain fully unaffected by
-# the iter-3 gate — this is #552's entire reason to exist.
 scenario \
-  '#552 iter-3 regression: simple external-repo add+commit+push chain (no state-transition token) -> unaffected, still allowed' \
-  'git add -A && git commit -m x && git push origin master' \
+  '#552 regression: `-C <absolute-path>` (properly separated, not glued) still resolves and allows a force-push to +master' \
+  'git -C /other/repo push origin +master' \
+  0 ''
+
+# ===========================================================================
+# Issue #552 iter-4 (dual-verify NEEDS-CHANGES round 3 — Codex + coordinator
+# independent repro, same 3 findings, high-confidence; see the iter-4
+# fix-history comment in push-guard.sh for the full before/after
+# rationale). The iter-3 blunt "cd anywhere disables Phase 0" scan was
+# wrong on BOTH ends:
+#   - Under-blocking: `eval "cd <dir> && ..."` / `source ./x.sh` / `X=cd;
+#     $X <dir>` all really change cwd while going undetected (the literal
+#     token `cd` never appears bare in the command text).
+#   - Over-blocking: `cd docs && git push origin master` in a non-Mercury
+#     repo (the most natural way to write "go do something in a
+#     subdirectory") or `git commit -m cd && ...` (`cd` as literal COMMIT
+#     MESSAGE content) both lost Phase 0 needlessly, reintroducing the
+#     exact "workflow loses continuity" complaint #552 exists to fix.
+#
+# Fix: replace the blunt scan with `cd`/`pushd` TRACKING (EFFECTIVE_CWD
+# threaded across segments in order) — see push-guard.sh Pass B. Mock
+# semantics for these scenarios: `MOCK_COMMON_DIR=pinned-mercury` models
+# "wherever `cd` lands, its common-dir happens to BE Mercury's" (since the
+# pin wins for ALL common-dir queries regardless of the literal path
+# string queried) — this is how these tests simulate "the tracked cd
+# target genuinely resolves to Mercury" without needing a real git repo at
+# a literal `D:/Mercury/Mercury`-shaped path inside the test harness.
+# ===========================================================================
+
+# ── MUST BLOCK: cd/pushd/popd/eval/source/indirection actually reaches
+# Mercury (mocked via MOCK_COMMON_DIR pin) ─────────────────────────────
+scenario \
+  '#552 iter-4: `cd <mercury> && git push origin develop` -> tracked, resolves to Mercury, still blocked' \
+  'cd /mercury-placeholder && git push origin develop' \
+  2 'BLOCKED' '' \
+  'JSON_CWD=/other/repo;MOCK_COMMON_DIR=pinned-mercury'
+
+scenario \
+  '#552 iter-4: `\cd <mercury> && git push origin develop` (backslash-escaped, awk still tokenizes to bare `cd`) -> tracked, still blocked' \
+  '\cd /mercury-placeholder && git push origin develop' \
+  2 'BLOCKED' '' \
+  'JSON_CWD=/other/repo;MOCK_COMMON_DIR=pinned-mercury'
+
+scenario \
+  '#552 iter-4: `builtin cd <mercury> && git push origin develop` (wrapper-stripped before cd-detection) -> tracked, still blocked' \
+  'builtin cd /mercury-placeholder && git push origin develop' \
+  2 'BLOCKED' '' \
+  'JSON_CWD=/other/repo;MOCK_COMMON_DIR=pinned-mercury'
+
+scenario \
+  '#552 iter-4: `command cd <mercury> && git push origin develop` -> tracked, still blocked' \
+  'command cd /mercury-placeholder && git push origin develop' \
+  2 'BLOCKED' '' \
+  'JSON_CWD=/other/repo;MOCK_COMMON_DIR=pinned-mercury'
+
+scenario \
+  '#552 iter-4: `pushd <mercury> && git push origin develop` -> tracked same as cd, still blocked' \
+  'pushd /mercury-placeholder && git push origin develop' \
+  2 'BLOCKED' '' \
+  'JSON_CWD=/other/repo;MOCK_COMMON_DIR=pinned-mercury'
+
+scenario \
+  '#552 iter-4: `popd && git push origin develop` -> popd needs an untracked stack, UNSAFE_STATE unconditionally, still blocked' \
+  'popd && git push origin develop' \
+  2 'BLOCKED' '' \
+  'JSON_CWD=/other/repo'
+
+scenario \
+  '#552 iter-4: `eval "cd <mercury> && git push origin develop"` (quoted payload, opaque to segmentation) -> defensive payload scan blocks directly' \
+  'eval "cd /mercury-placeholder && git push origin develop"' \
+  2 'BLOCKED'
+
+scenario \
+  '#552 iter-4: `source ./x.sh; git push origin develop` (two segments — the VISIBLE push in segment 2 blocks via ordinary Phase 1-3, independent of Phase 0)' \
+  'source ./x.sh; git push origin develop' \
+  2 'BLOCKED' '' \
+  'JSON_CWD=/other/repo'
+
+scenario \
+  '#552 iter-4: `. ./x.sh && git push origin develop` (dot-source form) -> same as source, still blocked' \
+  '. ./x.sh && git push origin develop' \
+  2 'BLOCKED' '' \
+  'JSON_CWD=/other/repo'
+
+scenario \
+  '#552 iter-4: `X=cd; $X <mercury> && git push origin develop` (variable holding "cd") -> command-position token is `$X`, contains `$`, UNSAFE_STATE, still blocked' \
+  'X=cd; $X /mercury-placeholder && git push origin develop' \
+  2 'BLOCKED' '' \
+  'JSON_CWD=/other/repo'
+
+# ── MUST ALLOW: cd stays within (or `cd` is not really a shell cd at
+# all in) a non-Mercury repo — Issue #552's entire reason to exist ────
+scenario \
+  '#552 iter-4: external repo `cd docs && git push origin master` (natural subdirectory workflow) -> tracked, still resolves to the SAME non-Mercury repo, allowed' \
+  'cd docs && git push origin master' \
   0 '' '' \
   'JSON_CWD=/other/repo'
 
 scenario \
-  '#552 iter-3 regression: `-C <absolute-path>` (properly separated, not glued) still resolves and allows a force-push to +master' \
-  'git -C /other/repo push origin +master' \
-  0 ''
+  '#552 iter-4: external repo `git commit -m cd && git push origin master` (`cd` is COMMIT MESSAGE DATA, not command position) -> not treated as cd, allowed' \
+  'git commit -m cd && git push origin master' \
+  0 '' '' \
+  'JSON_CWD=/other/repo'
+
+scenario \
+  '#552 iter-4: external repo `echo cd && git push origin master` (`cd` is an argument to echo, not command position) -> not treated as cd, allowed' \
+  'echo cd && git push origin master' \
+  0 '' '' \
+  'JSON_CWD=/other/repo'
+
+scenario \
+  '#552 iter-4: external repo `git add -A && git commit -m x && git push origin master` (no state-transition token at all) -> unaffected, allowed' \
+  'git add -A && git commit -m x && git push origin master' \
+  0 '' '' \
+  'JSON_CWD=/other/repo'
+
+# ── cd-tracking correctness: unsafe forms fall back to whole-command
+# disable (fail-closed) rather than being silently mistracked ─────────
+scenario \
+  '#552 iter-4: bare `cd` (no args, targets unknowable $HOME) && git push origin develop -> UNSAFE_STATE, still blocked' \
+  'cd && git push origin develop' \
+  2 'BLOCKED' '' \
+  'JSON_CWD=/other/repo'
+
+scenario \
+  '#552 iter-4: `cd -` (previous dir, unknowable) && git push origin develop -> UNSAFE_STATE, still blocked' \
+  'cd - && git push origin develop' \
+  2 'BLOCKED' '' \
+  'JSON_CWD=/other/repo'
+
+scenario \
+  '#552 iter-4: `cd $VAR` (variable in arg) && git push origin develop -> UNSAFE_STATE, still blocked' \
+  'cd $VAR && git push origin develop' \
+  2 'BLOCKED' '' \
+  'JSON_CWD=/other/repo'
+
+scenario \
+  '#552 iter-4: `cd dir1 dir2` (multiple args, ambiguous) && git push origin develop -> UNSAFE_STATE, still blocked' \
+  'cd dir1 dir2 && git push origin develop' \
+  2 'BLOCKED' '' \
+  'JSON_CWD=/other/repo'
+
+scenario \
+  '#552 iter-4: `cd *` (glob metachar in arg) && git push origin develop -> UNSAFE_STATE, still blocked' \
+  'cd * && git push origin develop' \
+  2 'BLOCKED' '' \
+  'JSON_CWD=/other/repo'
 
 # ===========================================================================
 # Summary

--- a/scripts/test-push-guard.sh
+++ b/scripts/test-push-guard.sh
@@ -73,16 +73,37 @@ trap '[[ -n "${WORK_DIR:-}" && -d "$WORK_DIR" ]] && rm -rf "$WORK_DIR"' EXIT
 BIN_DIR="$WORK_DIR/bin"
 mkdir -p "$BIN_DIR"
 
-# Mock git shim. push-guard.sh only invokes `git rev-parse --abbrev-ref HEAD`
-# during Phase 3 implicit-push detection. The mock returns $MOCK_CURRENT_BRANCH
-# (default `feature/test`) so explicit-target scenarios are unaffected and
-# implicit-push scenarios can exercise both protected and non-protected
-# branch states deterministically.
+# Mock git shim. push-guard.sh invokes `git rev-parse --abbrev-ref HEAD`
+# during Phase 3 implicit-push detection, and (Issue #552) `git -C <path>
+# rev-parse --show-toplevel` during the Phase 0 repo-awareness check
+# (the hook ALWAYS supplies `-C` for this call — see _repo_path usage).
+# The mock returns $MOCK_CURRENT_BRANCH (default `feature/test`) for the
+# former. For the latter: if $MOCK_TOPLEVEL is explicitly SET (even to an
+# empty string, e.g. to simulate a resolution failure), it wins; otherwise
+# the mock echoes the queried `-C <path>` back as its own toplevel — this
+# makes "same path queried twice" naturally resolve to "same repo" without
+# any override, so Mercury-repo scenarios (MERCURY_TOPLEVEL computed from
+# CLAUDE_PROJECT_DIR, target resolved from the same default cwd) match by
+# construction, while a `-C /other/repo` or a divergent JSON `cwd` value
+# naturally resolves to a different toplevel.
 cat > "$BIN_DIR/git" <<'MOCK_EOF'
 #!/usr/bin/env bash
-# mock git used by test-push-guard.sh — only emulates rev-parse HEAD
+# mock git used by test-push-guard.sh — emulates rev-parse HEAD / --show-toplevel
+raw_c_path=""
+if [[ "${1:-}" == "-C" ]]; then
+  raw_c_path="${2:-}"
+  shift 2
+fi
 if [[ "${1:-}" == "rev-parse" && "${2:-}" == "--abbrev-ref" && "${3:-}" == "HEAD" ]]; then
   printf '%s\n' "${MOCK_CURRENT_BRANCH:-feature/test}"
+  exit 0
+fi
+if [[ "${1:-}" == "rev-parse" && "${2:-}" == "--show-toplevel" ]]; then
+  if [[ -n "${MOCK_TOPLEVEL+set}" ]]; then
+    printf '%s\n' "${MOCK_TOPLEVEL}"
+  else
+    printf '%s\n' "${raw_c_path}"
+  fi
   exit 0
 fi
 exit 0
@@ -109,6 +130,44 @@ chmod +x "$BIN_DIR/git"
 run_hook() {
   local cmd="$1"
   local extra_env="${2:-}"
+  local fake_project="$WORK_DIR/proj-$RANDOM"
+  mkdir -p "$fake_project"
+  # Issue #552: `cwd` mirrors the hook stdin JSON's real top-level field
+  # (https://code.claude.com/docs/en/hooks — "current working directory
+  # when the hook is invoked"). Defaults to $fake_project (== the process's
+  # CLAUDE_PROJECT_DIR) so pre-#552 scenarios naturally resolve "same repo"
+  # via the mock git's `-C <path>` echo-back behavior and stay unaffected.
+  # A scenario can override via the special `JSON_CWD=<value>` pair in
+  # extra_env (stripped below before forwarding the rest as real env vars —
+  # it is a test-harness-only signal, not read by the hook process itself).
+  #
+  # MSYS2_ARG_CONV_EXCL note (Windows/Git-Bash only, harmless elsewhere):
+  # `jq` below is a native Windows binary (jq.exe). MSYS auto-translates
+  # any argv that LOOKS like a POSIX path (e.g. our mktemp-produced
+  # `/tmp/push-guard-test.XXXXXX/proj-NNNNN`) into its Windows form
+  # (`C:/Users/.../Temp/...`) before jq ever sees it — but only for THAT
+  # jq invocation's argv, not for the same value used directly as a bash
+  # env var (`CLAUDE_PROJECT_DIR="$fake_project"` below, untouched). Same
+  # physical directory, two divergent string forms reaching push-guard.sh's
+  # Phase 0 repo-awareness check — a false "different repo" positive that
+  # is purely a test-fixture MSYS artifact (production `cwd` values come
+  # from Claude Code itself, never through this argv-translation path).
+  # `MSYS2_ARG_CONV_EXCL='*'` suppresses the translation for this jq call
+  # so `$json_cwd` reaches the JSON payload byte-for-byte identical to how
+  # `CLAUDE_PROJECT_DIR` reaches the hook process.
+  local json_cwd="$fake_project"
+  local -a extra_env_kv=()
+  if [[ -n "$extra_env" ]]; then
+    IFS=';' read -r -a extra_env_kv <<< "$extra_env"
+  fi
+  local -a real_env_kv=()
+  local kv
+  for kv in "${extra_env_kv[@]}"; do
+    case "$kv" in
+      JSON_CWD=*) json_cwd="${kv#JSON_CWD=}" ;;
+      *) real_env_kv+=( "$kv" ) ;;
+    esac
+  done
   # Build JSON via jq -n so all JSON escape rules are handled correctly
   # (closes Copilot iter-2 line-117 finding: the previous manual escape
   # only covered \\, ", and \n; control chars like \r, \t, and 0x00..0x1f
@@ -117,19 +176,13 @@ run_hook() {
   # the harness is a robustness no-op for our environment but eliminates
   # a class of test-side input encoding bugs.
   local input
-  input=$(jq -nc --arg cmd "$cmd" '{tool_input: {command: $cmd}}') || {
+  input=$(MSYS2_ARG_CONV_EXCL='*' jq -nc --arg cmd "$cmd" --arg cwd "$json_cwd" '{tool_input: {command: $cmd}, cwd: $cwd}') || {
     printf 'run_hook: jq -n failed to encode JSON input\n' >&2
     return 1
   }
-  local fake_project="$WORK_DIR/proj-$RANDOM"
-  mkdir -p "$fake_project"
   local rc
-  local -a extra_env_kv=()
-  if [[ -n "$extra_env" ]]; then
-    IFS=';' read -r -a extra_env_kv <<< "$extra_env"
-  fi
   env "PATH=$BIN_DIR:$PATH" "CLAUDE_PROJECT_DIR=$fake_project" \
-    "${extra_env_kv[@]}" bash "$HOOK" 2> "$WORK_DIR/stderr.$$" <<<"$input" >/dev/null
+    "${real_env_kv[@]}" bash "$HOOK" 2> "$WORK_DIR/stderr.$$" <<<"$input" >/dev/null
   rc=$?
   cat "$WORK_DIR/stderr.$$" 2>/dev/null || true
   rm -f "$WORK_DIR/stderr.$$"
@@ -450,10 +503,17 @@ scenario \
 # git global options (-C, -c) before the push subcommand
 # ===========================================================================
 
+# Issue #552: `-C /repo` is a fake, non-existent path — under repo-awareness
+# it now (correctly) resolves as "a different repo" and would be ALLOWED
+# through on its own. This scenario predates #552 and exists to test `-C`
+# TOKEN PARSING robustness (quote/wrapper handling), not repo identity, so
+# MOCK_TOPLEVEL pins the resolved toplevel to match Mercury's regardless of
+# the literal `-C` value, isolating the parsing behavior under test.
 scenario \
   '`git -C /repo push origin develop` -> blocked' \
   'git -C /repo push origin develop' \
-  2 'BLOCKED'
+  2 'BLOCKED' '' \
+  'MOCK_TOPLEVEL=pinned-same-repo'
 
 scenario \
   '`git -c user.name=foo push origin develop` -> blocked' \
@@ -621,10 +681,14 @@ scenario \
   'env A="1 2" git push origin develop' \
   2 'BLOCKED'
 
+# Issue #552: same rationale as the `-C /repo` scenario above — pin
+# MOCK_TOPLEVEL so this stays a pure quote-parsing test, unaffected by the
+# new repo-awareness check.
 scenario \
   '`git -C "C:/repo with spaces" push origin develop` (quoted -C path) -> blocked' \
   'git -C "C:/repo with spaces" push origin develop' \
-  2 'BLOCKED'
+  2 'BLOCKED' '' \
+  'MOCK_TOPLEVEL=pinned-same-repo'
 
 scenario \
   "git -c 'user.name=A B' push origin develop (quoted -c value w/ space) -> blocked" \
@@ -1076,6 +1140,91 @@ scenario \
   $'CR in body (literal \\r) does not crash JSON encoding — not blocked' \
   $'git commit -m "develop\\rmaster" && git push origin lane/foo' \
   0 ''
+
+# ===========================================================================
+# Issue #552 — repo-awareness: non-Mercury-repo pushes must be allowed
+# through even when they target develop/master/main; Mercury-repo pushes
+# must still be blocked in every form.
+#
+# Mock semantics (see mock git above): a `-C <path>` query echoes <path>
+# back as its own toplevel, unless $MOCK_TOPLEVEL is explicitly set (even
+# to empty), which then wins for ALL toplevel queries. So:
+#   - `-C /other/repo` or a JSON `cwd` of `/other/repo` naturally resolves
+#     to a toplevel that differs from MERCURY_TOPLEVEL (resolved from
+#     CLAUDE_PROJECT_DIR == $fake_project) -> Phase 0 fires -> allowed.
+#   - Omitting any override, or targeting $fake_project itself, resolves
+#     "same repo" -> falls through to existing Phase 1-3 -> blocked as before.
+#   - `MOCK_TOPLEVEL=` (explicitly empty) forces BOTH sides to resolve
+#     empty, simulating a real `rev-parse` failure -> Phase 0 cannot
+#     determine anything -> fail-closed -> falls through -> blocked.
+# ===========================================================================
+
+scenario \
+  '#552 non-Mercury repo `git push origin master` via cwd -> allowed (out of scope)' \
+  'git push origin master' \
+  0 '' '' \
+  'JSON_CWD=/other/repo'
+
+scenario \
+  '#552 non-Mercury repo `git push origin develop` via cwd -> allowed' \
+  'git push origin develop' \
+  0 '' '' \
+  'JSON_CWD=/other/repo'
+
+scenario \
+  '#552 non-Mercury repo `git -C /other/repo push origin master` (-C authoritative) -> allowed' \
+  'git -C /other/repo push origin master' \
+  0 ''
+
+scenario \
+  '#552 non-Mercury repo implicit `git push` from branch=develop -> allowed (Phase 3 also skipped)' \
+  'git push' \
+  0 '' '' \
+  'JSON_CWD=/other/repo;MOCK_CURRENT_BRANCH=develop'
+
+scenario \
+  '#552 non-Mercury repo refspec `git push origin HEAD:master` -> allowed' \
+  'git push origin HEAD:master' \
+  0 '' '' \
+  'JSON_CWD=/other/repo'
+
+scenario \
+  '#552 non-Mercury repo `-C` wins over a Mercury-repo cwd -> allowed' \
+  'git -C /other/repo push origin develop' \
+  0 '' '' \
+  'JSON_CWD=/keep/this/as/mercury'
+
+# Regression net: Mercury-repo pushes (no cwd/-C divergence — the run_hook
+# default) still block in every existing form.
+scenario \
+  '#552 Mercury repo `git push origin develop` (default cwd) -> still blocked' \
+  'git push origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  '#552 Mercury repo `git -C <mercury-path> push origin master` -> still blocked' \
+  'git push origin master' \
+  2 'BLOCKED'
+
+scenario \
+  '#552 Mercury repo implicit `git push` from branch=master -> still blocked' \
+  'git push' \
+  2 'BLOCKED' '' \
+  'MOCK_CURRENT_BRANCH=master'
+
+# Fail-closed: toplevel resolution fails (rev-parse returns nothing for
+# EITHER side) -> falls through to existing Phase 1-3 logic -> still blocked.
+scenario \
+  '#552 toplevel resolution fails (MOCK_TOPLEVEL empty) -> fail-closed, still blocked' \
+  'git push origin develop' \
+  2 'BLOCKED' '' \
+  'MOCK_TOPLEVEL=;JSON_CWD=/other/repo'
+
+scenario \
+  '#552 non-Mercury repo, safe target `git push origin lane/foo` -> allowed (unaffected either way)' \
+  'git push origin lane/foo' \
+  0 '' '' \
+  'JSON_CWD=/other/repo'
 
 # ===========================================================================
 # Summary

--- a/scripts/test-push-guard.sh
+++ b/scripts/test-push-guard.sh
@@ -1354,6 +1354,114 @@ scenario \
   'JSON_CWD='
 
 # ===========================================================================
+# Issue #552 iter-3 (dual-verify NEEDS-CHANGES round 2, real hook-call
+# reproductions of a whole NEW class Codex found — see the "command-level
+# simplicity gate" fix-history comment in push-guard.sh for full rationale)
+#
+# All iter-1/iter-2 fixes gated Phase 0 at the SEGMENT level. This class of
+# bypass works because a shell-state-transition construct (cd/pushd/
+# GIT_DIR=/--chdir) can live in a DIFFERENT segment than the vulnerable
+# `git push`, so no segment-scoped check ever sees both halves together.
+# The command-level simplicity gate scans the WHOLE token stream once,
+# before segmenting, and disables Phase 0 for the ENTIRE command if
+# triggered — these scenarios use `JSON_CWD=/other/repo` (so, absent the
+# gate, Phase 0 would otherwise resolve "different repo" and ALLOW the
+# push) specifically to prove the gate overrides that and still blocks.
+# ===========================================================================
+
+# G1: `cd` anywhere -> whole-command gate fires. Real git behavior: `cd
+# <dir> && <cmd>` genuinely runs <cmd> inside <dir> — this is the single
+# most natural way to write "go do something in another repo".
+scenario \
+  '#552 iter-3 G1: `cd <dir> && git push origin develop` (real state transition) -> gate fires, still blocked' \
+  'cd /somewhere && git push origin develop' \
+  2 'BLOCKED' '' \
+  'JSON_CWD=/other/repo'
+
+scenario \
+  '#552 iter-3 G1b: `cd` in an EARLIER segment than the push -> gate fires (whole-command, not segment-local)' \
+  'cd /somewhere && git add -A && git push origin develop' \
+  2 'BLOCKED' '' \
+  'JSON_CWD=/other/repo'
+
+# G2: `GIT_DIR=`/`GIT_WORK_TREE=` via `export` — `export` is stripped as a
+# no-op wrapper by process_segment's wrapper-strip loop (same handling as
+# `env`), leaving the `GIT_DIR=x` token exposed to the gate scan exactly
+# like the plain-prefix and `env`-wrapped forms already covered by the
+# iter-2 per-segment UNRESOLVABLE_SELECTOR check — this scenario proves the
+# whole-command gate also catches it when `export ...; git push ...` are
+# TWO SEPARATE STATEMENTS (`;`-joined), i.e. two different segments, which
+# UNRESOLVABLE_SELECTOR (segment-scoped) cannot see across.
+scenario \
+  '#552 iter-3 G2: `export GIT_DIR=...; git push origin develop` (two segments) -> gate fires, still blocked' \
+  'export GIT_DIR=/mercury/.git; git push origin develop' \
+  2 'BLOCKED' '' \
+  'JSON_CWD=/other/repo'
+
+# G3: `env --chdir=<dir> <cmd>` — verified real GNU coreutils env(1)
+# behavior, runs <cmd> with its cwd changed to <dir> before exec.
+scenario \
+  '#552 iter-3 G3: `env --chdir=<dir> git push origin develop` -> gate fires, still blocked' \
+  'env --chdir=/mercury git push origin develop' \
+  2 'BLOCKED' '' \
+  'JSON_CWD=/other/repo'
+
+scenario \
+  '#552 iter-3 G3b: `env --chdir <dir> git push origin develop` (separate-arg form) -> gate fires, still blocked' \
+  'env --chdir /mercury git push origin develop' \
+  2 'BLOCKED' '' \
+  'JSON_CWD=/other/repo'
+
+# G4: `pushd` — same real state-transition property as `cd`.
+scenario \
+  '#552 iter-3 G4: `pushd <dir> && git push origin develop` -> gate fires, still blocked' \
+  'pushd /mercury && git push origin develop' \
+  2 'BLOCKED' '' \
+  'JSON_CWD=/other/repo'
+
+# G5: glued `-C<path>` (no separator) — verified live that real git
+# rejects this as `unknown option`, so it is NOT exploitable today; the
+# gate still fires defensively (zero-cost — see fix-history comment).
+# Either outcome (blocked via the gate, or allowed because Phase 0 would
+# have resolved a genuinely different repo) would be acceptable per the
+# coordinator's acceptance table, since git itself already refuses this
+# syntax; this harness asserts the gate's defensive behavior (blocked).
+scenario \
+  '#552 iter-3 G5: glued `-C<path>` (git rejects this syntax; gate is defensive-only) -> gate fires, still blocked' \
+  'git -C/mercury push origin develop' \
+  2 'BLOCKED' '' \
+  'JSON_CWD=/other/repo'
+
+# ── Phase-0-existence pin (Codex: fail-closed scenarios alone cannot
+# prove Phase 0 is doing anything, since Phase 1-3 blocks by default with
+# or without it) ──────────────────────────────────────────────────────
+# This scenario ONLY passes if Phase 0 is actually resolving the target
+# repo and granting an allow: with Phase 0 deleted entirely, Phase 1-3
+# alone would see `push origin develop` and unconditionally block it
+# regardless of `cwd`. A non-Mercury-repo push to a branch NAMED `develop`
+# passing with exit 0 is therefore direct positive evidence that Phase 0
+# is live, not just that Phase 1-3 didn't misfire.
+scenario \
+  '#552 Phase-0-existence pin: non-Mercury repo push to a branch literally named `develop` -> allowed (only possible because Phase 0 is active)' \
+  'git push origin develop' \
+  0 '' '' \
+  'JSON_CWD=/other/repo'
+
+# Regression net: a "simple" command (no state-transition construct
+# anywhere) run inside a non-Mercury repo must remain fully unaffected by
+# the iter-3 gate — this is #552's entire reason to exist.
+scenario \
+  '#552 iter-3 regression: simple external-repo add+commit+push chain (no state-transition token) -> unaffected, still allowed' \
+  'git add -A && git commit -m x && git push origin master' \
+  0 '' '' \
+  'JSON_CWD=/other/repo'
+
+scenario \
+  '#552 iter-3 regression: `-C <absolute-path>` (properly separated, not glued) still resolves and allows a force-push to +master' \
+  'git -C /other/repo push origin +master' \
+  0 ''
+
+# ===========================================================================
 # Summary
 # ===========================================================================
 

--- a/scripts/test-push-guard.sh
+++ b/scripts/test-push-guard.sh
@@ -74,37 +74,57 @@ BIN_DIR="$WORK_DIR/bin"
 mkdir -p "$BIN_DIR"
 
 # Mock git shim. push-guard.sh invokes `git rev-parse --abbrev-ref HEAD`
-# during Phase 3 implicit-push detection, and (Issue #552) `git -C <path>
-# rev-parse --show-toplevel` during the Phase 0 repo-awareness check
-# (the hook ALWAYS supplies `-C` for this call — see _repo_path usage).
+# during Phase 3 implicit-push detection, and (Issue #552 iter-2) `git
+# -C <path> rev-parse --path-format=absolute --git-common-dir` (falling
+# back to the same call without `--path-format` on older git — the mock
+# recognizes both by just checking for `--git-common-dir` anywhere in the
+# rev-parse args) during the Phase 0 repo-awareness check.
+#
 # The mock returns $MOCK_CURRENT_BRANCH (default `feature/test`) for the
-# former. For the latter: if $MOCK_TOPLEVEL is explicitly SET (even to an
-# empty string, e.g. to simulate a resolution failure), it wins; otherwise
-# the mock echoes the queried `-C <path>` back as its own toplevel — this
-# makes "same path queried twice" naturally resolve to "same repo" without
-# any override, so Mercury-repo scenarios (MERCURY_TOPLEVEL computed from
-# CLAUDE_PROJECT_DIR, target resolved from the same default cwd) match by
-# construction, while a `-C /other/repo` or a divergent JSON `cwd` value
-# naturally resolves to a different toplevel.
+# HEAD query. For the common-dir query: if $MOCK_COMMON_DIR is explicitly
+# SET (even to an empty string, e.g. to simulate a resolution failure), it
+# wins; otherwise the mock echoes the queried `-C <path>` back as its own
+# common-dir (with a trailing `/.` stripped, crudely mirroring git's own
+# path canonicalization — enough to let a relative `-C .` resolve as "same
+# directory" in tests). This makes "same path queried twice" naturally
+# resolve to "same repo" without any override — so Mercury-repo scenarios
+# (MERCURY_COMMON_DIR computed from CLAUDE_PROJECT_DIR, target resolved
+# from the same default cwd) match by construction, while a `-C
+# /other/repo` or a divergent JSON `cwd` value naturally resolves to a
+# different common-dir. $MOCK_COMMON_DIR pins BOTH queries to the same
+# fixed value regardless of the path argument — used to simulate "two
+# different paths, same underlying repo" (e.g. a linked worktree vs its
+# main checkout, which is exactly the iter-1 regression this iteration
+# fixes: `--show-toplevel` differs per-worktree, `--git-common-dir` does
+# not).
 cat > "$BIN_DIR/git" <<'MOCK_EOF'
 #!/usr/bin/env bash
-# mock git used by test-push-guard.sh — emulates rev-parse HEAD / --show-toplevel
+# mock git used by test-push-guard.sh — emulates rev-parse HEAD / --git-common-dir
 raw_c_path=""
 if [[ "${1:-}" == "-C" ]]; then
   raw_c_path="${2:-}"
   shift 2
 fi
+# Crude canonicalization: strip a trailing "/." so `-C .` (relative,
+# resolved by the hook against HOOK_CWD before reaching here) echoes back
+# identically to querying HOOK_CWD directly.
+raw_c_path="${raw_c_path%/.}"
 if [[ "${1:-}" == "rev-parse" && "${2:-}" == "--abbrev-ref" && "${3:-}" == "HEAD" ]]; then
   printf '%s\n' "${MOCK_CURRENT_BRANCH:-feature/test}"
   exit 0
 fi
-if [[ "${1:-}" == "rev-parse" && "${2:-}" == "--show-toplevel" ]]; then
-  if [[ -n "${MOCK_TOPLEVEL+set}" ]]; then
-    printf '%s\n' "${MOCK_TOPLEVEL}"
-  else
-    printf '%s\n' "${raw_c_path}"
-  fi
-  exit 0
+if [[ "${1:-}" == "rev-parse" ]]; then
+  shift
+  for a in "$@"; do
+    if [[ "$a" == "--git-common-dir" ]]; then
+      if [[ -n "${MOCK_COMMON_DIR+set}" ]]; then
+        printf '%s\n' "${MOCK_COMMON_DIR}"
+      else
+        printf '%s\n' "${raw_c_path}"
+      fi
+      exit 0
+    fi
+  done
 fi
 exit 0
 MOCK_EOF
@@ -507,13 +527,13 @@ scenario \
 # it now (correctly) resolves as "a different repo" and would be ALLOWED
 # through on its own. This scenario predates #552 and exists to test `-C`
 # TOKEN PARSING robustness (quote/wrapper handling), not repo identity, so
-# MOCK_TOPLEVEL pins the resolved toplevel to match Mercury's regardless of
-# the literal `-C` value, isolating the parsing behavior under test.
+# MOCK_COMMON_DIR pins the resolved common-dir to match Mercury's regardless
+# of the literal `-C` value, isolating the parsing behavior under test.
 scenario \
   '`git -C /repo push origin develop` -> blocked' \
   'git -C /repo push origin develop' \
   2 'BLOCKED' '' \
-  'MOCK_TOPLEVEL=pinned-same-repo'
+  'MOCK_COMMON_DIR=pinned-same-repo'
 
 scenario \
   '`git -c user.name=foo push origin develop` -> blocked' \
@@ -682,13 +702,13 @@ scenario \
   2 'BLOCKED'
 
 # Issue #552: same rationale as the `-C /repo` scenario above — pin
-# MOCK_TOPLEVEL so this stays a pure quote-parsing test, unaffected by the
-# new repo-awareness check.
+# MOCK_COMMON_DIR so this stays a pure quote-parsing test, unaffected by
+# the new repo-awareness check.
 scenario \
   '`git -C "C:/repo with spaces" push origin develop` (quoted -C path) -> blocked' \
   'git -C "C:/repo with spaces" push origin develop' \
   2 'BLOCKED' '' \
-  'MOCK_TOPLEVEL=pinned-same-repo'
+  'MOCK_COMMON_DIR=pinned-same-repo'
 
 scenario \
   "git -c 'user.name=A B' push origin develop (quoted -c value w/ space) -> blocked" \
@@ -1147,16 +1167,19 @@ scenario \
 # must still be blocked in every form.
 #
 # Mock semantics (see mock git above): a `-C <path>` query echoes <path>
-# back as its own toplevel, unless $MOCK_TOPLEVEL is explicitly set (even
-# to empty), which then wins for ALL toplevel queries. So:
+# back as its own common-dir, unless $MOCK_COMMON_DIR is explicitly set
+# (even to empty), which then wins for ALL common-dir queries. So:
 #   - `-C /other/repo` or a JSON `cwd` of `/other/repo` naturally resolves
-#     to a toplevel that differs from MERCURY_TOPLEVEL (resolved from
+#     to a common-dir that differs from MERCURY_COMMON_DIR (resolved from
 #     CLAUDE_PROJECT_DIR == $fake_project) -> Phase 0 fires -> allowed.
 #   - Omitting any override, or targeting $fake_project itself, resolves
 #     "same repo" -> falls through to existing Phase 1-3 -> blocked as before.
-#   - `MOCK_TOPLEVEL=` (explicitly empty) forces BOTH sides to resolve
+#   - `MOCK_COMMON_DIR=` (explicitly empty) forces BOTH sides to resolve
 #     empty, simulating a real `rev-parse` failure -> Phase 0 cannot
 #     determine anything -> fail-closed -> falls through -> blocked.
+#   - `MOCK_COMMON_DIR=<fixed value>` (non-empty) pins BOTH sides to the
+#     SAME value regardless of path — models "different path, same repo"
+#     (e.g. a linked worktree vs its main checkout).
 # ===========================================================================
 
 scenario \
@@ -1202,7 +1225,7 @@ scenario \
   2 'BLOCKED'
 
 scenario \
-  '#552 Mercury repo `git -C <mercury-path> push origin master` -> still blocked' \
+  '#552 Mercury repo `git push origin master` (default cwd, no -C) -> still blocked' \
   'git push origin master' \
   2 'BLOCKED'
 
@@ -1212,19 +1235,123 @@ scenario \
   2 'BLOCKED' '' \
   'MOCK_CURRENT_BRANCH=master'
 
-# Fail-closed: toplevel resolution fails (rev-parse returns nothing for
+# Fail-closed: common-dir resolution fails (rev-parse returns nothing for
 # EITHER side) -> falls through to existing Phase 1-3 logic -> still blocked.
 scenario \
-  '#552 toplevel resolution fails (MOCK_TOPLEVEL empty) -> fail-closed, still blocked' \
+  '#552 common-dir resolution fails (MOCK_COMMON_DIR empty) -> fail-closed, still blocked' \
   'git push origin develop' \
   2 'BLOCKED' '' \
-  'MOCK_TOPLEVEL=;JSON_CWD=/other/repo'
+  'MOCK_COMMON_DIR=;JSON_CWD=/other/repo'
 
 scenario \
   '#552 non-Mercury repo, safe target `git push origin lane/foo` -> allowed (unaffected either way)' \
   'git push origin lane/foo' \
   0 '' '' \
   'JSON_CWD=/other/repo'
+
+# ===========================================================================
+# Issue #552 iter-2 (dual-verify NEEDS-CHANGES, real hook-call
+# reproductions — see Issue #552 fix-history comment in push-guard.sh for
+# the T1-T5 evidence this section formalizes into the regression suite)
+# ===========================================================================
+
+# T1 (Critical, most severe): a linked-worktree cwd — the hook's own NORMAL
+# execution context for every Mercury dev agent — must NOT be misread as
+# "a different repo" just because its `-C`/cwd path string differs from
+# CLAUDE_PROJECT_DIR. MOCK_COMMON_DIR pins both sides to the SAME value,
+# modeling "worktree path differs, but --git-common-dir agrees" (exactly
+# what real git does — verified live: `D:/Mercury/Mercury/.claude/
+# worktrees/agent-.../` and `D:/Mercury/Mercury` both resolve
+# --git-common-dir to `D:/Mercury/Mercury/.git`).
+scenario \
+  '#552 iter-2 T1: worktree cwd (differs from CLAUDE_PROJECT_DIR) but same git-common-dir -> still blocked' \
+  'git push origin develop' \
+  2 'BLOCKED' '' \
+  'JSON_CWD=/some/worktree/path;MOCK_COMMON_DIR=pinned-common-dir'
+
+# T2: inline `GIT_DIR=`/`GIT_WORK_TREE=` env assignments (direct prefix and
+# `env`-wrapped form) redirect the real target repo — Phase 0 must not be
+# swayed by an accompanying non-Mercury cwd; the whole segment falls back
+# to Phase 1-3 fail-closed instead.
+scenario \
+  '#552 iter-2 T2a: inline GIT_DIR= assignment -> fail-closed, still blocked despite non-Mercury cwd' \
+  'GIT_DIR=/other/repo/.git git push origin develop' \
+  2 'BLOCKED' '' \
+  'JSON_CWD=/other/repo'
+
+scenario \
+  '#552 iter-2 T2b: inline GIT_WORK_TREE= assignment -> fail-closed, still blocked' \
+  'GIT_WORK_TREE=/other/repo git push origin develop' \
+  2 'BLOCKED' '' \
+  'JSON_CWD=/other/repo'
+
+scenario \
+  '#552 iter-2 T2c: `env GIT_DIR=... GIT_WORK_TREE=...` wrapper form -> fail-closed, still blocked' \
+  'env GIT_DIR=/other/repo/.git GIT_WORK_TREE=/other/repo git push origin develop' \
+  2 'BLOCKED' '' \
+  'JSON_CWD=/other/repo'
+
+# T3: `--git-dir`/`--work-tree` global options (both `=` and separate-arg
+# forms) — same rationale as T2, expressed as git flags instead of env vars.
+scenario \
+  '#552 iter-2 T3a: `--git-dir=`/`--work-tree=` inline -> fail-closed, still blocked' \
+  'git --git-dir=/other/repo/.git --work-tree=/other/repo push origin develop' \
+  2 'BLOCKED' '' \
+  'JSON_CWD=/other/repo'
+
+scenario \
+  '#552 iter-2 T3b: `--git-dir`/`--work-tree` separate-arg -> fail-closed, still blocked' \
+  'git --git-dir /other/repo/.git --work-tree /other/repo push origin develop' \
+  2 'BLOCKED' '' \
+  'JSON_CWD=/other/repo'
+
+# T4/T5 regression net (already covered above by the pre-existing "default
+# cwd" and "non-Mercury repo" scenarios, restated here for direct
+# traceability to the Issue #552 iter-2 review table).
+scenario \
+  '#552 iter-2 T4: main-checkout cwd, `git push origin develop` -> still blocked (unchanged)' \
+  'git push origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  '#552 iter-2 T5: non-Mercury-repo cwd, `git push origin master` -> allowed (unchanged)' \
+  'git push origin master' \
+  0 '' '' \
+  'JSON_CWD=/other/repo'
+
+# Repeated `-C`: git's real semantics is cumulative-relative (`-C a -C b`
+# == `-C a/b`), not "last value wins" — unmodeled, so Phase 0 must skip
+# entirely (fail-closed) rather than resolve against just the last `-C`.
+# A protected target must still block; a safe target is unaffected (Phase
+# 0 skip only withholds an ALLOW, it never manufactures a BLOCK).
+scenario \
+  '#552 iter-2: repeated `-C` (cumulative-relative semantics unmodeled) -> fail-closed, protected target still blocked' \
+  'git -C /other/repo -C /another/segment push origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  '#552 iter-2: repeated `-C`, safe target -> not blocked (Phase 0 skip does not manufacture a block)' \
+  'git -C /other/repo -C /another/segment push origin lane/foo' \
+  0 ''
+
+# Relative `-C` must resolve against HOOK_CWD (where the command actually
+# executes), not the hook process's own cwd.
+scenario \
+  '#552 iter-2: relative `-C .` resolves against HOOK_CWD (default = CLAUDE_PROJECT_DIR) -> still blocked (same repo)' \
+  'git -C . push origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  '#552 iter-2: relative `-C sub` from a non-Mercury HOOK_CWD -> allowed (still resolves to the non-Mercury repo)' \
+  'git -C sub push origin develop' \
+  0 '' '' \
+  'JSON_CWD=/other/repo'
+
+scenario \
+  '#552 iter-2: relative `-C` with no HOOK_CWD to anchor it -> cannot resolve, fail-closed, still blocked' \
+  'git -C sub push origin develop' \
+  2 'BLOCKED' '' \
+  'JSON_CWD='
 
 # ===========================================================================
 # Summary

--- a/scripts/test-push-guard.sh
+++ b/scripts/test-push-guard.sh
@@ -111,7 +111,9 @@ cat > "$BIN_DIR/git" <<'MOCK_EOF'
 #!/usr/bin/env bash
 # mock git used by test-push-guard.sh — emulates rev-parse HEAD / --git-common-dir
 raw_c_path=""
+had_dash_c=0
 if [[ "${1:-}" == "-C" ]]; then
+  had_dash_c=1
   raw_c_path="${2:-}"
   shift 2
 fi
@@ -120,7 +122,20 @@ fi
 # identically to querying HOOK_CWD directly.
 raw_c_path="${raw_c_path%/.}"
 if [[ "${1:-}" == "rev-parse" && "${2:-}" == "--abbrev-ref" && "${3:-}" == "HEAD" ]]; then
-  printf '%s\n' "${MOCK_CURRENT_BRANCH:-feature/test}"
+  # Issue #552 iter-8 item2: a `-C <path>`-qualified query answers with
+  # $MOCK_CURRENT_BRANCH (the RESOLVED target repo's branch); a bare query
+  # (no `-C`, simulating the hook process's own unrelated cwd) answers with
+  # $MOCK_CURRENT_BRANCH_BARE, falling back to $MOCK_CURRENT_BRANCH when
+  # unset so every pre-iter-8 scenario (which never sets
+  # MOCK_CURRENT_BRANCH_BARE) is unaffected. This split is what lets a
+  # scenario PROVE Phase 3 now queries the Phase-0-resolved repo instead of
+  # the bare process cwd: pin the two to different branches and only the
+  # fixed code path reaches the protected one.
+  if [[ "$had_dash_c" -eq 1 ]]; then
+    printf '%s\n' "${MOCK_CURRENT_BRANCH:-feature/test}"
+  else
+    printf '%s\n' "${MOCK_CURRENT_BRANCH_BARE:-${MOCK_CURRENT_BRANCH:-feature/test}}"
+  fi
   exit 0
 fi
 if [[ "${1:-}" == "rev-parse" ]]; then
@@ -1736,6 +1751,129 @@ scenario \
   '#552 iter-7 regression: `git push origin develop > log.txt` (trailing redirect, Mercury, protected target) -> still blocked' \
   'git push origin develop > log.txt' \
   2 'BLOCKED'
+
+# ===========================================================================
+# Issue #552 iter-8 (dual-verify round 6 — Codex 3-Critical claim,
+# coordinator cross-checked each independently: only `>|` was a real gap;
+# `GIT_COMMON_DIR` alone does NOT redirect git's repo selection (verified
+# twice, added defensively anyway at zero cost); implicit-push wrong-repo
+# resolution is real but PRE-EXISTING (present before #552 ever shipped).
+# Direction this round: reverse the prefix-token default from "unknown ==
+# harmless" to "unknown == unsafe" instead of enumerating a 4th redirect
+# operator; item1 additionally needed a root-cause awk tokenizer fix
+# (`|` was unconditionally treated as a pipe/OR separator, fragmenting
+# `>|/dev/null` into a bare `>` token + a fresh, metacharacter-free
+# `/dev/null` segment that a pure default-deny check alone would NOT have
+# caught — see the push-guard.sh iter-8 fix-history comment for detail).
+# ===========================================================================
+
+# item1: `>|` (force-overwrite redirect, closes even under `set -C`) was
+# fragmented by the awk tokenizer's unconditional `|`-as-separator rule,
+# hiding the `cd`/`git` pair from the wrapper-strip walker exactly like the
+# iter-7 `&`-fragmentation bug did for `2>&1`. Fixed at the tokenizer level
+# (not by enumerating `>|` in the redirect-prefix operator list).
+scenario \
+  '#552 iter-8 item1: `>|/dev/null cd <mercury> && git push origin develop` (force-overwrite redirect, awk `|`-fragmentation fix) -> tracked, still blocked' \
+  '>|/dev/null cd __MERCURY_PATH__ && git push origin develop' \
+  2 'BLOCKED' '' \
+  'JSON_CWD=/other/repo'
+
+# item1 regression net (coordinator's explicit acceptance-list ask): a tail
+# redirect and a `$`-in-data-position construct must remain unaffected by
+# both the awk `|`-fix and the default-deny reversal.
+scenario \
+  '#552 iter-8 regression: `git push origin master > log.txt` (external, tail redirect) -> unaffected, still allowed' \
+  'git push origin master > log.txt' \
+  0 '' '' \
+  'JSON_CWD=/other/repo'
+
+scenario \
+  '#552 iter-8 regression: `git commit -m "fix $foo" && git push origin master` (external, `$` in data position, not prefix) -> unaffected, still allowed' \
+  'git commit -m "fix $foo" && git push origin master' \
+  0 '' '' \
+  'JSON_CWD=/other/repo'
+
+scenario \
+  '#552 iter-8 regression: `cd docs && git push origin master` (external, plain relative cd) -> unaffected, still allowed' \
+  'cd docs && git push origin master' \
+  0 '' '' \
+  'JSON_CWD=/other/repo'
+
+# item (default-deny reversal, general case): an unrecognized token
+# containing shell metacharacters in prefix position (neither a known safe
+# prefix shape nor a plain command-name token) now falls back to
+# Phase 1-3 instead of being silently skipped as "probably harmless".
+scenario \
+  '#552 iter-8: `<>` glued token (Codex claimed leak; coordinator verified this ALREADY blocked pre-iter-8 too) in prefix position -> tracked, still blocked' \
+  '<> cd __MERCURY_PATH__ && git push origin develop' \
+  2 'BLOCKED' '' \
+  'JSON_CWD=/other/repo'
+
+# item2 (Phase 3 pre-existing bug, closed incidentally by #552's
+# repo-awareness plumbing): implicit push (`git push`/`git push origin`,
+# no refspec) must resolve the current branch of the ACTUAL target repo
+# (Phase-0-resolved `-C`/GIT_DIR path), not the bare hook-process cwd.
+# MOCK_CURRENT_BRANCH answers `-C`-qualified queries (the resolved Mercury
+# target); MOCK_CURRENT_BRANCH_BARE answers bare queries (the hook
+# process's own external cwd) — pinning them to different branches proves
+# which one Phase 3 actually consults.
+scenario \
+  '#552 iter-8 item2: `git -C <mercury> push origin` (implicit, no refspec) from external hook cwd -> resolves Mercury target repo branch (develop), not bare hook cwd branch -> blocked' \
+  'git -C __MERCURY_PATH__ push origin' \
+  2 'BLOCKED' '' \
+  'JSON_CWD=/other/repo;MOCK_CURRENT_BRANCH=develop;MOCK_CURRENT_BRANCH_BARE=feature/unrelated'
+
+scenario \
+  '#552 iter-8 item2 regression: `git -C <other> push origin` (implicit, hook cwd = Mercury, target repo = external on unprotected branch) -> allowed, not wrongly blocked by bare-cwd branch' \
+  'git -C /other/repo push origin' \
+  0 '' '' \
+  'MOCK_CURRENT_BRANCH=feature/unrelated;MOCK_CURRENT_BRANCH_BARE=develop'
+
+# item3: GIT_COMMON_DIR added to the unsafe-env-var set defensively (zero
+# cost) even though real testing found it does NOT actually redirect git's
+# repo selection on its own — see the push-guard.sh comment for the
+# honest caveat. This scenario only proves the trigger fires, not that a
+# real bypass existed.
+scenario \
+  '#552 iter-8 item3: `GIT_COMMON_DIR=<mercury>/.git git push origin master` (external, defensive trigger) -> UNSAFE_STATE, blocked' \
+  'GIT_COMMON_DIR=__MERCURY_PATH__/.git git push origin master' \
+  2 'BLOCKED' '' \
+  'JSON_CWD=/other/repo'
+
+# ===========================================================================
+# Issue #552 iter-9 (dual-verify round 7 — coordinator caught iter-8's
+# Phase 3 fix as only half-done): a cross-repo `cd` legitimately triggers
+# UNSAFE_STATE (per the iter-5 same-repo-only-advancement invariant), so
+# Phase 0 never runs and `_repo_path` stays empty. iter-8 fell back to the
+# bare `git rev-parse --abbrev-ref HEAD` check in that case — the exact
+# wrong-cwd resolution the fix exists to eliminate. iter-9: when
+# `_repo_path` is empty at Phase 3, block unconditionally (fail-closed)
+# instead of guessing via a known-wrong bare rev-parse.
+# ===========================================================================
+
+scenario \
+  '#552 iter-9: `cd <mercury> && git push origin` (implicit, no refspec, cross-repo cd -> UNSAFE_STATE -> unresolvable target) -> fail-closed, now blocked' \
+  'cd __MERCURY_PATH__ && git push origin' \
+  2 'BLOCKED' '' \
+  'JSON_CWD=/other/repo'
+
+scenario \
+  '#552 iter-9 regression: `git -C <mercury> push origin` (implicit, iter-8 path, _repo_path resolves) -> still blocked via `-C` branch query, not the new fail-closed branch' \
+  'git -C __MERCURY_PATH__ push origin' \
+  2 'BLOCKED' '' \
+  'JSON_CWD=/other/repo;MOCK_CURRENT_BRANCH=develop;MOCK_CURRENT_BRANCH_BARE=feature/unrelated'
+
+scenario \
+  '#552 iter-9 regression: external repo, no cross-repo cd, implicit `git push origin` on unprotected branch -> _repo_path resolves to external, Phase 0 returns early, Phase 3 never reached, still allowed' \
+  'git push origin' \
+  0 '' '' \
+  'JSON_CWD=/other/repo'
+
+scenario \
+  '#552 iter-9 regression: external repo, same-repo `cd docs && git push origin` (tracked, same-repo advancement, not UNSAFE_STATE) -> _repo_path resolves to external, still allowed' \
+  'cd docs && git push origin' \
+  0 '' '' \
+  'JSON_CWD=/other/repo'
 
 # ===========================================================================
 # Summary

--- a/scripts/test-push-guard.sh
+++ b/scripts/test-push-guard.sh
@@ -74,29 +74,39 @@ BIN_DIR="$WORK_DIR/bin"
 mkdir -p "$BIN_DIR"
 
 # Mock git shim. push-guard.sh invokes `git rev-parse --abbrev-ref HEAD`
-# during Phase 3 implicit-push detection, and (Issue #552 iter-2) `git
-# -C <path> rev-parse --path-format=absolute --git-common-dir` (falling
-# back to the same call without `--path-format` on older git — the mock
-# recognizes both by just checking for `--git-common-dir` anywhere in the
-# rev-parse args) during the Phase 0 repo-awareness check.
+# during Phase 3 implicit-push detection, and `git -C <path> rev-parse
+# [--path-format=absolute] --git-common-dir` (Issue #552 iter-2, checked
+# by just looking for `--git-common-dir` anywhere in the rev-parse args)
+# both during the Phase 0 repo-awareness check AND (iter-5) during Pass
+# B's same-repo-only cd/pushd tracking gate.
 #
 # The mock returns $MOCK_CURRENT_BRANCH (default `feature/test`) for the
-# HEAD query. For the common-dir query: if $MOCK_COMMON_DIR is explicitly
-# SET (even to an empty string, e.g. to simulate a resolution failure), it
-# wins; otherwise the mock echoes the queried `-C <path>` back as its own
-# common-dir (with a trailing `/.` stripped, crudely mirroring git's own
-# path canonicalization — enough to let a relative `-C .` resolve as "same
-# directory" in tests). This makes "same path queried twice" naturally
-# resolve to "same repo" without any override — so Mercury-repo scenarios
-# (MERCURY_COMMON_DIR computed from CLAUDE_PROJECT_DIR, target resolved
-# from the same default cwd) match by construction, while a `-C
-# /other/repo` or a divergent JSON `cwd` value naturally resolves to a
-# different common-dir. $MOCK_COMMON_DIR pins BOTH queries to the same
-# fixed value regardless of the path argument — used to simulate "two
-# different paths, same underlying repo" (e.g. a linked worktree vs its
-# main checkout, which is exactly the iter-1 regression this iteration
-# fixes: `--show-toplevel` differs per-worktree, `--git-common-dir` does
-# not).
+# HEAD query. For the common-dir query, in priority order:
+#   1. $MOCK_COMMON_DIR explicitly SET (even empty, to simulate a
+#      resolution failure) — wins unconditionally, for ANY queried path.
+#      Used by scenarios that need to isolate pure token-parsing behavior
+#      from repo-identity behavior (e.g. the `-C "quoted path"` tests).
+#   2. PATH-AWARE PREFIX MATCH (Issue #552 iter-5 — Codex Medium, mutation
+#      sensitivity): if the queried `-C <path>` starts with
+#      $MOCK_MERCURY_PREFIX (default set by run_hook to $fake_project ==
+#      CLAUDE_PROJECT_DIR) it resolves to a fixed `mercury-common-dir`
+#      sentinel; if it starts with $MOCK_OTHER_PREFIX (default
+#      `/other/repo`) it resolves to a DIFFERENT fixed
+#      `other-repo-common-dir` sentinel. This is what makes cd-tracking
+#      scenarios actually PROVE the tracker is live: without it, "cd to
+#      Mercury" and "stay in the external repo" scenarios could not be
+#      told apart by the mock at all (an earlier revision pinned BOTH
+#      sides to the same value regardless of path, which passed whether
+#      or not Pass B's cd-tracking code ran — no mutation sensitivity).
+#      With prefix matching, a scenario proving "cd tracked into Mercury
+#      → blocked" only passes if EFFECTIVE_CWD genuinely advanced to a
+#      Mercury-prefixed path; deleting Pass B would leave EFFECTIVE_CWD at
+#      the original (non-Mercury-prefixed) HOOK_CWD and the scenario would
+#      flip to "allowed", failing the assertion.
+#   3. Fallback: echo the queried `-C <path>` back as its own common-dir
+#      (with a trailing `/.` stripped, crudely mirroring git's own path
+#      canonicalization). Used by scenarios with paths outside both
+#      prefixes.
 cat > "$BIN_DIR/git" <<'MOCK_EOF'
 #!/usr/bin/env bash
 # mock git used by test-push-guard.sh — emulates rev-parse HEAD / --git-common-dir
@@ -119,6 +129,10 @@ if [[ "${1:-}" == "rev-parse" ]]; then
     if [[ "$a" == "--git-common-dir" ]]; then
       if [[ -n "${MOCK_COMMON_DIR+set}" ]]; then
         printf '%s\n' "${MOCK_COMMON_DIR}"
+      elif [[ -n "${MOCK_MERCURY_PREFIX:-}" && ( "$raw_c_path" == "$MOCK_MERCURY_PREFIX" || "$raw_c_path" == "$MOCK_MERCURY_PREFIX"/* ) ]]; then
+        printf '%s\n' "mercury-common-dir-sentinel"
+      elif [[ -n "${MOCK_OTHER_PREFIX:-}" && ( "$raw_c_path" == "$MOCK_OTHER_PREFIX" || "$raw_c_path" == "$MOCK_OTHER_PREFIX"/* ) ]]; then
+        printf '%s\n' "other-repo-common-dir-sentinel"
       else
         printf '%s\n' "${raw_c_path}"
       fi
@@ -152,6 +166,14 @@ run_hook() {
   local extra_env="${2:-}"
   local fake_project="$WORK_DIR/proj-$RANDOM"
   mkdir -p "$fake_project"
+  # Issue #552 iter-5: scenarios that need the LITERAL Mercury path inside
+  # the command string itself (e.g. `cd __MERCURY_PATH__ && git push
+  # origin develop`) cannot reference `$fake_project` directly — it's a
+  # fresh mktemp-random value generated INSIDE this function, unknown to
+  # the static scenario string written before run_hook ever runs. The
+  # `__MERCURY_PATH__` placeholder is substituted here, after
+  # `$fake_project` is computed, closing that chicken-and-egg gap.
+  cmd="${cmd//__MERCURY_PATH__/$fake_project}"
   # Issue #552: `cwd` mirrors the hook stdin JSON's real top-level field
   # (https://code.claude.com/docs/en/hooks — "current working directory
   # when the hook is invoked"). Defaults to $fake_project (== the process's
@@ -201,7 +223,14 @@ run_hook() {
     return 1
   }
   local rc
+  # MOCK_MERCURY_PREFIX/MOCK_OTHER_PREFIX default to $fake_project (==
+  # CLAUDE_PROJECT_DIR, so unqualified scenarios naturally see "the same
+  # repo as Mercury" by construction) and the conventional `/other/repo`
+  # literal already used throughout this suite's `JSON_CWD=`/`-C` values.
+  # Scenarios needing a different mapping override via extra_env (later
+  # `env` argv entries win).
   env "PATH=$BIN_DIR:$PATH" "CLAUDE_PROJECT_DIR=$fake_project" \
+    "MOCK_MERCURY_PREFIX=$fake_project" "MOCK_OTHER_PREFIX=/other/repo" \
     "${real_env_kv[@]}" bash "$HOOK" 2> "$WORK_DIR/stderr.$$" <<<"$input" >/dev/null
   rc=$?
   cat "$WORK_DIR/stderr.$$" 2>/dev/null || true
@@ -1409,113 +1438,169 @@ scenario \
   0 ''
 
 # ===========================================================================
-# Issue #552 iter-4 (dual-verify NEEDS-CHANGES round 3 — Codex + coordinator
-# independent repro, same 3 findings, high-confidence; see the iter-4
-# fix-history comment in push-guard.sh for the full before/after
-# rationale). The iter-3 blunt "cd anywhere disables Phase 0" scan was
-# wrong on BOTH ends:
-#   - Under-blocking: `eval "cd <dir> && ..."` / `source ./x.sh` / `X=cd;
-#     $X <dir>` all really change cwd while going undetected (the literal
-#     token `cd` never appears bare in the command text).
-#   - Over-blocking: `cd docs && git push origin master` in a non-Mercury
-#     repo (the most natural way to write "go do something in a
-#     subdirectory") or `git commit -m cd && ...` (`cd` as literal COMMIT
-#     MESSAGE content) both lost Phase 0 needlessly, reintroducing the
-#     exact "workflow loses continuity" complaint #552 exists to fix.
+# Issue #552 iter-4/iter-5 (dual-verify NEEDS-CHANGES rounds 3-4 — Codex +
+# coordinator independent repro; see the iter-4/iter-5 fix-history
+# comments in push-guard.sh for full before/after rationale).
 #
-# Fix: replace the blunt scan with `cd`/`pushd` TRACKING (EFFECTIVE_CWD
-# threaded across segments in order) — see push-guard.sh Pass B. Mock
-# semantics for these scenarios: `MOCK_COMMON_DIR=pinned-mercury` models
-# "wherever `cd` lands, its common-dir happens to BE Mercury's" (since the
-# pin wins for ALL common-dir queries regardless of the literal path
-# string queried) — this is how these tests simulate "the tracked cd
-# target genuinely resolves to Mercury" without needing a real git repo at
-# a literal `D:/Mercury/Mercury`-shaped path inside the test harness.
+# Mutation-sensitivity note (Codex iter-5 Medium, accepted): these
+# scenarios use PATH-AWARE mock mapping (`MOCK_MERCURY_PREFIX`/
+# `MOCK_OTHER_PREFIX`, defaulted by run_hook to `$fake_project`/
+# `/other/repo` — see the mock git comment above) instead of a blanket
+# `MOCK_COMMON_DIR` pin. A blanket pin makes BOTH sides of every
+# comparison resolve identically regardless of whether the tracker ran at
+# all, so a scenario built on it passes whether or not Pass B's cd-
+# tracking exists — it proves nothing. With prefix-based mapping, a "cd
+# INTO Mercury -> blocked" scenario genuinely requires EFFECTIVE_CWD to
+# have advanced to a Mercury-prefixed path (via `__MERCURY_PATH__`,
+# substituted to the real `$fake_project` at run_hook time — see its
+# comment) for Phase 0 to correctly withhold the allow; deleting Pass B
+# would leave `EFFECTIVE_CWD` at the original `/other/repo` HOOK_CWD and
+# the scenario would flip results.
 # ===========================================================================
 
-# ── MUST BLOCK: cd/pushd/popd/eval/source/indirection actually reaches
-# Mercury (mocked via MOCK_COMMON_DIR pin) ─────────────────────────────
+# ── MUST BLOCK: cd/pushd/popd/source/indirection actually reaches
+# Mercury, tracked from an external starting cwd ───────────────────────
 scenario \
-  '#552 iter-4: `cd <mercury> && git push origin develop` -> tracked, resolves to Mercury, still blocked' \
-  'cd /mercury-placeholder && git push origin develop' \
+  '#552: `cd <mercury> && git push origin develop` -> tracked (path-aware mock), resolves to Mercury, still blocked' \
+  'cd __MERCURY_PATH__ && git push origin develop' \
   2 'BLOCKED' '' \
-  'JSON_CWD=/other/repo;MOCK_COMMON_DIR=pinned-mercury'
+  'JSON_CWD=/other/repo'
 
 scenario \
-  '#552 iter-4: `\cd <mercury> && git push origin develop` (backslash-escaped, awk still tokenizes to bare `cd`) -> tracked, still blocked' \
-  '\cd /mercury-placeholder && git push origin develop' \
+  '#552: `\cd <mercury> && git push origin develop` (backslash-escaped, awk still tokenizes to bare `cd`) -> tracked, still blocked' \
+  '\cd __MERCURY_PATH__ && git push origin develop' \
   2 'BLOCKED' '' \
-  'JSON_CWD=/other/repo;MOCK_COMMON_DIR=pinned-mercury'
+  'JSON_CWD=/other/repo'
 
 scenario \
-  '#552 iter-4: `builtin cd <mercury> && git push origin develop` (wrapper-stripped before cd-detection) -> tracked, still blocked' \
-  'builtin cd /mercury-placeholder && git push origin develop' \
+  '#552: `builtin cd <mercury> && git push origin develop` (wrapper-stripped before cd-detection) -> tracked, still blocked' \
+  'builtin cd __MERCURY_PATH__ && git push origin develop' \
   2 'BLOCKED' '' \
-  'JSON_CWD=/other/repo;MOCK_COMMON_DIR=pinned-mercury'
+  'JSON_CWD=/other/repo'
 
 scenario \
-  '#552 iter-4: `command cd <mercury> && git push origin develop` -> tracked, still blocked' \
-  'command cd /mercury-placeholder && git push origin develop' \
+  '#552: `command cd <mercury> && git push origin develop` -> tracked, still blocked' \
+  'command cd __MERCURY_PATH__ && git push origin develop' \
   2 'BLOCKED' '' \
-  'JSON_CWD=/other/repo;MOCK_COMMON_DIR=pinned-mercury'
+  'JSON_CWD=/other/repo'
 
 scenario \
-  '#552 iter-4: `pushd <mercury> && git push origin develop` -> tracked same as cd, still blocked' \
-  'pushd /mercury-placeholder && git push origin develop' \
+  '#552: `pushd <mercury> && git push origin develop` -> tracked same as cd, still blocked' \
+  'pushd __MERCURY_PATH__ && git push origin develop' \
   2 'BLOCKED' '' \
-  'JSON_CWD=/other/repo;MOCK_COMMON_DIR=pinned-mercury'
+  'JSON_CWD=/other/repo'
 
 scenario \
-  '#552 iter-4: `popd && git push origin develop` -> popd needs an untracked stack, UNSAFE_STATE unconditionally, still blocked' \
+  '#552: `popd && git push origin develop` -> popd needs an untracked stack, UNSAFE_STATE unconditionally, still blocked' \
   'popd && git push origin develop' \
   2 'BLOCKED' '' \
   'JSON_CWD=/other/repo'
 
 scenario \
-  '#552 iter-4: `eval "cd <mercury> && git push origin develop"` (quoted payload, opaque to segmentation) -> defensive payload scan blocks directly' \
-  'eval "cd /mercury-placeholder && git push origin develop"' \
-  2 'BLOCKED'
-
-scenario \
-  '#552 iter-4: `source ./x.sh; git push origin develop` (two segments — the VISIBLE push in segment 2 blocks via ordinary Phase 1-3, independent of Phase 0)' \
+  '#552: `source ./x.sh; git push origin develop` (two segments — the VISIBLE push in segment 2 blocks via ordinary Phase 1-3, independent of Phase 0)' \
   'source ./x.sh; git push origin develop' \
   2 'BLOCKED' '' \
   'JSON_CWD=/other/repo'
 
 scenario \
-  '#552 iter-4: `. ./x.sh && git push origin develop` (dot-source form) -> same as source, still blocked' \
+  '#552: `. ./x.sh && git push origin develop` (dot-source form) -> same as source, still blocked' \
   '. ./x.sh && git push origin develop' \
   2 'BLOCKED' '' \
   'JSON_CWD=/other/repo'
 
 scenario \
-  '#552 iter-4: `X=cd; $X <mercury> && git push origin develop` (variable holding "cd") -> command-position token is `$X`, contains `$`, UNSAFE_STATE, still blocked' \
-  'X=cd; $X /mercury-placeholder && git push origin develop' \
+  '#552: `X=cd; $X <mercury> && git push origin develop` (variable holding "cd") -> command-position token is `$X`, contains `$`, UNSAFE_STATE, still blocked' \
+  'X=cd; $X __MERCURY_PATH__ && git push origin develop' \
   2 'BLOCKED' '' \
   'JSON_CWD=/other/repo'
+
+# ── Issue #552 iter-5: MUST BLOCK — the REVERSE direction (cwd=Mercury,
+# push genuinely executes IN Mercury; a `cd` toward an external repo is
+# present in the token stream but never actually takes effect in the
+# parent shell — short-circuited, subshell, pipeline, coproc, or a
+# never-taken branch). Default `run_hook` cwd (no JSON_CWD override) IS
+# Mercury (`$fake_project` == `CLAUDE_PROJECT_DIR`); the `cd` targets
+# `/other/repo` (the default `MOCK_OTHER_PREFIX`). The iter-4 tracker
+# would have wrongly advanced EFFECTIVE_CWD to `/other/repo` for all six;
+# the iter-5 same-repo-only gate refuses to cross OUT of Mercury and sets
+# UNSAFE_STATE instead — Phase 0 never gets a chance to grant a false
+# ALLOW on a push that is really hitting Mercury.
+# ===========================================================================
+scenario \
+  '#552 iter-5: `false && cd <external>; git push origin develop` (short-circuited, cd never runs) -> UNSAFE_STATE, still blocked' \
+  'false && cd /other/repo; git push origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  '#552 iter-5: `true || cd <external>; git push origin develop` (short-circuited, cd never runs) -> UNSAFE_STATE, still blocked' \
+  'true || cd /other/repo; git push origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  '#552 iter-5: `( cd <external> ; : ) ; git push origin develop` (subshell — cd does not affect the parent shell) -> UNSAFE_STATE, still blocked' \
+  '( cd /other/repo ; : ) ; git push origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  '#552 iter-5: `cd <external> | cat ; git push origin develop` (pipeline stage — builtin cd in a pipeline runs in a subshell) -> UNSAFE_STATE, still blocked' \
+  'cd /other/repo | cat ; git push origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  '#552 iter-5: `coproc cd <external>; git push origin develop` (background coproc job, not the parent shell) -> UNSAFE_STATE, still blocked' \
+  'coproc cd /other/repo; git push origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  '#552 iter-5: `if false; then cd <external>; fi; git push origin develop` (never-taken branch) -> UNSAFE_STATE, still blocked' \
+  'if false; then cd /other/repo; fi; git push origin develop' \
+  2 'BLOCKED'
+
+# ── `eval`: iter-5 removes the iter-4 supplementary text-payload scan
+# (unreliable — bypassable via string construction, false-positive-prone
+# on benign payloads). `eval` still sets UNSAFE_STATE (disables Phase 0's
+# potential ALLOW) but Phase 1-3 has no visibility into the quoted payload
+# either (same as the pre-#552 `bash -c "..."` limitation) — so a push
+# hidden entirely inside `eval`'s quotes is neither allowed NOR blocked by
+# this hook; it is simply invisible, exactly as it always was before #552
+# shipped. Not a regression: this hook never protected against it.
+scenario \
+  '#552 iter-5: `eval "cd <mercury> && git push origin develop"` -> UNSAFE_STATE only (no hard-block; payload invisible to Phase 1-3, same as pre-#552)' \
+  'eval "cd __MERCURY_PATH__ && git push origin develop"' \
+  0 ''
+scenario \
+  '#552 iter-5: `eval '"'"'echo git push origin develop'"'"'` (benign payload that only PRINTS the text) -> not blocked (the removed scan would have false-positived here)' \
+  "eval 'echo git push origin develop'; git push origin lane/foo" \
+  0 ''
 
 # ── MUST ALLOW: cd stays within (or `cd` is not really a shell cd at
 # all in) a non-Mercury repo — Issue #552's entire reason to exist ────
 scenario \
-  '#552 iter-4: external repo `cd docs && git push origin master` (natural subdirectory workflow) -> tracked, still resolves to the SAME non-Mercury repo, allowed' \
+  '#552: external repo `cd docs && git push origin master` (natural subdirectory workflow) -> tracked, same-repo (path-aware mock), allowed' \
   'cd docs && git push origin master' \
   0 '' '' \
   'JSON_CWD=/other/repo'
 
 scenario \
-  '#552 iter-4: external repo `git commit -m cd && git push origin master` (`cd` is COMMIT MESSAGE DATA, not command position) -> not treated as cd, allowed' \
+  '#552 iter-5: external repo `cd docs && cd .. && git push origin master` (multi-hop same-repo tracking) -> both hops resolve to the SAME repo, allowed' \
+  'cd docs && cd .. && git push origin master' \
+  0 '' '' \
+  'JSON_CWD=/other/repo'
+
+scenario \
+  '#552: external repo `git commit -m cd && git push origin master` (`cd` is COMMIT MESSAGE DATA, not command position) -> not treated as cd, allowed' \
   'git commit -m cd && git push origin master' \
   0 '' '' \
   'JSON_CWD=/other/repo'
 
 scenario \
-  '#552 iter-4: external repo `echo cd && git push origin master` (`cd` is an argument to echo, not command position) -> not treated as cd, allowed' \
+  '#552: external repo `echo cd && git push origin master` (`cd` is an argument to echo, not command position) -> not treated as cd, allowed' \
   'echo cd && git push origin master' \
   0 '' '' \
   'JSON_CWD=/other/repo'
 
 scenario \
-  '#552 iter-4: external repo `git add -A && git commit -m x && git push origin master` (no state-transition token at all) -> unaffected, allowed' \
+  '#552: external repo `git add -A && git commit -m x && git push origin master` (no state-transition token at all) -> unaffected, allowed' \
   'git add -A && git commit -m x && git push origin master' \
   0 '' '' \
   'JSON_CWD=/other/repo'
@@ -1523,34 +1608,40 @@ scenario \
 # ── cd-tracking correctness: unsafe forms fall back to whole-command
 # disable (fail-closed) rather than being silently mistracked ─────────
 scenario \
-  '#552 iter-4: bare `cd` (no args, targets unknowable $HOME) && git push origin develop -> UNSAFE_STATE, still blocked' \
+  '#552: bare `cd` (no args, targets unknowable $HOME) && git push origin develop -> UNSAFE_STATE, still blocked' \
   'cd && git push origin develop' \
   2 'BLOCKED' '' \
   'JSON_CWD=/other/repo'
 
 scenario \
-  '#552 iter-4: `cd -` (previous dir, unknowable) && git push origin develop -> UNSAFE_STATE, still blocked' \
+  '#552: `cd -` (previous dir, unknowable) && git push origin develop -> UNSAFE_STATE, still blocked' \
   'cd - && git push origin develop' \
   2 'BLOCKED' '' \
   'JSON_CWD=/other/repo'
 
 scenario \
-  '#552 iter-4: `cd $VAR` (variable in arg) && git push origin develop -> UNSAFE_STATE, still blocked' \
+  '#552: `cd $VAR` (variable in arg) && git push origin develop -> UNSAFE_STATE, still blocked' \
   'cd $VAR && git push origin develop' \
   2 'BLOCKED' '' \
   'JSON_CWD=/other/repo'
 
 scenario \
-  '#552 iter-4: `cd dir1 dir2` (multiple args, ambiguous) && git push origin develop -> UNSAFE_STATE, still blocked' \
+  '#552: `cd dir1 dir2` (multiple args, ambiguous) && git push origin develop -> UNSAFE_STATE, still blocked' \
   'cd dir1 dir2 && git push origin develop' \
   2 'BLOCKED' '' \
   'JSON_CWD=/other/repo'
 
 scenario \
-  '#552 iter-4: `cd *` (glob metachar in arg) && git push origin develop -> UNSAFE_STATE, still blocked' \
+  '#552: `cd *` (glob metachar in arg) && git push origin develop -> UNSAFE_STATE, still blocked' \
   'cd * && git push origin develop' \
   2 'BLOCKED' '' \
   'JSON_CWD=/other/repo'
+
+scenario \
+  '#552 iter-5: `cd <unresolvable-target>` (candidate common-dir resolution fails) -> UNSAFE_STATE, still blocked' \
+  'cd /nonexistent-target && git push origin develop' \
+  2 'BLOCKED' '' \
+  'JSON_CWD=/other/repo;MOCK_COMMON_DIR='
 
 # ===========================================================================
 # Summary

--- a/scripts/test-push-guard.sh
+++ b/scripts/test-push-guard.sh
@@ -1644,6 +1644,100 @@ scenario \
   'JSON_CWD=/other/repo;MOCK_COMMON_DIR='
 
 # ===========================================================================
+# Issue #552 iter-7 (dual-verify round 5 — Codex source-inlined review,
+# 2 real Critical regressions reproduced live by the coordinator; see the
+# iter-7 fix-history comment in push-guard.sh for the full grammar
+# rationale). Bash's simple-command grammar is `[assignment|redirection]*
+# command-name [argument|redirection]*` — the wrapper-strip walkers
+# already modeled the assignment half (`VAR=value` skip); iter-7 completes
+# the redirection half. This also incidentally closes a PRE-EXISTING gap
+# (present before Issue #552 ever shipped): `>/dev/null git push origin
+# develop` in Mercury was never blocked because the walker required `git`
+# at the very first token, and a leading redirect token stopped it cold.
+# ===========================================================================
+
+# Both coordinator-reproduced Critical cases (external cwd, cd genuinely
+# lands in Mercury, redirect prefix previously hid the `cd`/`git` from the
+# wrapper-strip walker entirely).
+scenario \
+  '#552 iter-7: `>/dev/null cd <mercury> && git push origin develop` (glued redirect prefix) -> tracked, still blocked' \
+  '>/dev/null cd __MERCURY_PATH__ && git push origin develop' \
+  2 'BLOCKED' '' \
+  'JSON_CWD=/other/repo'
+
+scenario \
+  '#552 iter-7: `CDPATH=<mercury> cd <relative> && git push origin develop` (inline CDPATH token) -> UNSAFE_STATE, still blocked' \
+  'CDPATH=__MERCURY_PATH__ cd .probe && git push origin develop' \
+  2 'BLOCKED' '' \
+  'JSON_CWD=/other/repo'
+
+# Pre-existing gap (present before #552, closed incidentally by the same
+# redirect-prefix fix): a leading redirect previously hid `git` itself
+# from process_segment's own wrapper-strip walker.
+scenario \
+  '#552 iter-7: `>/dev/null git push origin develop` in Mercury (pre-existing gap, not #552-introduced) -> now blocked' \
+  '>/dev/null git push origin develop' \
+  2 'BLOCKED'
+
+# Redirect-prefix operator-form coverage: glued target, separate target,
+# fd-numbered, and chained (multiple redirects before the command name).
+scenario \
+  '#552 iter-7: `2>&1 cd <mercury> && git push origin develop` (fd-duplication operator, glued) -> tracked, still blocked' \
+  '2>&1 cd __MERCURY_PATH__ && git push origin develop' \
+  2 'BLOCKED' '' \
+  'JSON_CWD=/other/repo'
+
+scenario \
+  '#552 iter-7: `> /dev/null cd <mercury> && git push origin develop` (separate-token target) -> tracked, still blocked' \
+  '> /dev/null cd __MERCURY_PATH__ && git push origin develop' \
+  2 'BLOCKED' '' \
+  'JSON_CWD=/other/repo'
+
+scenario \
+  '#552 iter-7: `2> /dev/null git push origin develop` in Mercury (fd-numbered, separate target) -> blocked' \
+  '2> /dev/null git push origin develop' \
+  2 'BLOCKED'
+
+scenario \
+  '#552 iter-7: `>/dev/null 2>&1 cd <mercury> && git push origin develop` (chained redirects) -> tracked, still blocked' \
+  '>/dev/null 2>&1 cd __MERCURY_PATH__ && git push origin develop' \
+  2 'BLOCKED' '' \
+  'JSON_CWD=/other/repo'
+
+# CDPATH: inherited hook-process environment (no inline token) — a
+# RELATIVE `cd` argument cannot be safely tracked when CDPATH is set
+# (bash may search CDPATH's directories instead of the naive
+# EFFECTIVE_CWD-join this hook otherwise assumes); an ABSOLUTE `cd`
+# argument is unaffected (bash never consults CDPATH for it) and stays
+# trackable.
+scenario \
+  '#552 iter-7: inherited $CDPATH (hook env, no inline token) + relative `cd` -> UNSAFE_STATE, still blocked' \
+  'cd .probe && git push origin develop' \
+  2 'BLOCKED' '' \
+  'JSON_CWD=/other/repo;CDPATH=/some/cdpath/entry'
+
+scenario \
+  '#552 iter-7: inherited $CDPATH (hook env) + ABSOLUTE `cd` -> unaffected, tracking still works, allowed' \
+  'cd /other/repo && git push origin master' \
+  0 '' '' \
+  'JSON_CWD=/other/repo;CDPATH=/some/cdpath/entry'
+
+# ── Regression net (Codex Medium — "verify these are not broken", the
+# coordinator's explicit acceptance-list item): a redirect AFTER the real
+# command name (not a prefix) must be handled exactly as before — this is
+# NOT prefix territory, so the iter-7 skip logic must never touch it.
+scenario \
+  '#552 iter-7 regression: `git push origin master > log.txt` (trailing redirect, external repo) -> unaffected, still allowed' \
+  'git push origin master > log.txt' \
+  0 '' '' \
+  'JSON_CWD=/other/repo'
+
+scenario \
+  '#552 iter-7 regression: `git push origin develop > log.txt` (trailing redirect, Mercury, protected target) -> still blocked' \
+  'git push origin develop > log.txt' \
+  2 'BLOCKED'
+
+# ===========================================================================
 # Summary
 # ===========================================================================
 


### PR DESCRIPTION
Closes #552

## 问题

push-guard 只做命令文本分析、不看目标仓库，把「Mercury 仓保护」推广成了全局拦截。后果：在 Mercury session 里操作任何其他仓库（如设计库 `SoT-fyc-space`，其既定工作方式是 master 直提）都会被拦，工作流被生硬切断。memory `feedback_push_guard_cross_repo` 早已记录此误拦为已知问题。

## 方案

在既有 Phase 1-3 之前加 **Phase 0 仓库判定**。核心不变式贯穿全部实现：

> **Phase 0 只能撤销拦截，永远不能制造放行。授予放行必须基于「正面确证目标仓不是 Mercury」；任何不确定一律落回 Phase 1-3（即 #552 之前的原行为）。**

关键实现点：

1. **身份判据用 `--git-common-dir` 而非 `--show-toplevel`**。后者对每个 linked worktree 返回各自路径，会把 Mercury 自己的 worktree（所有 dev agent 的常驻工作场所）误判成外仓。`--path-format=absolute` 需 git ≥ 2.31（[官方 release notes](https://github.com/git/git/blob/master/Documentation/RelNotes/2.31.0.adoc)），带 pre-2.31 兜底。

2. **cd 追踪只许收紧不许放宽**：命令位 `cd`/`pushd` 且参数字面单一时推进有效 cwd，但**跨出当前仓或解析不了 → fail-closed，不采纳新 cwd**。这条规则使执行序语义**无需建模**——跨仓 cd 至多多一次安全方向的拦截，同仓 cd 不可能改变后续 push 的目标仓。短路未执行段、子 shell、管道、coproc、未进入分支因此全部自动正确。

3. **默认方向反转（default-deny）**：wrapper-strip 走到的 token，只有**不含任何 shell 元字符**（`< > & | $` 反引号 `= ( ) { }`）才被信任为真实命令名，否则判为未建模构造 → fail-closed。此前七轮共同的默认是「未知即无害」，正是各类旁路的共同来源；反转后**未来新出现的操作符无需枚举即自动安全**。

4. **无法建模的仓库选择器一律 fail-closed**：`--git-dir` / `--work-tree`（两种形式）、`GIT_DIR=` / `GIT_WORK_TREE=` / `CDPATH=`（裸赋值 / export / env 包装，任意位置）、重复 `-C`（git 真实语义是逐个相对累积）、`--chdir`、紧连 `-C`、`popd`、命令位的 `eval` / `source` / `.` / 含 `$` 或反引号。

5. **惰性求值**：Mercury common-dir 与 hook cwd 改为按需计算。此前它们在脚本顶层无条件执行，给**每次 Bash 工具调用**加了 180 ms（+44%），而绝大多数命令不含推送。

6. **顺带修两处既有 bug**（非 #552 引入，定位到即修）：awk 分词器把 `&`、`|` 无条件当分段符，导致 `2>&1`、`>|` 等操作符被切碎；Phase 3 隐式 push 用裸 `git rev-parse` 在 hook 进程自己的 cwd 解析分支，而非本次 push 的真实目标仓。

## 验证

**Claude 侧**：全量套件 **383 pass / 0 fail**；数十个真实 hook 调用场景（JSON 由 `jq -n --arg` 构造以消除转义误差）；**双向差分**（对比 `origin/develop` 版本，判据为「推送实际落在 Mercury 却从拦变放行」）→ **零回归**。

覆盖面包括：正向（外仓 cd 进 Mercury）全族；反向（Mercury cd 到外仓但未真生效：`&&`/`||` 短路、子 shell、管道、coproc、未进入 if）全族；重定向前缀全形态（`> >> < << <<< >& <& &> &>> >|`，带/不带 fd 数字，紧连/分离）；选择器族全形态；Mercury 各形态（worktree 及子目录、主检出、引号分支名、refspec、链式段、相对 `-C`）；段序交错；以及**必须放行**的场景（外仓保护名分支、外仓内 `cd` 后推送、多级同仓 cd、提交信息含 `cd` 字面、尾部重定向、数据位未展开变量、add/commit/push 链、pull+push、`push -u`、force-with-lease、`-C` 绝对外仓路径、Mercury 与 worktree 的 feature 分支）。

**性能**：`echo hi` 场景 415 ms（改前基线）→ 420 ms（本 PR），在噪声范围内。含推送的命令保留必要开销。

**Dual-verify**：Claude 侧 PASS。Codex 侧共审 7 轮，能执行的各轮均发现真实问题并已全部修复——未建模的仓库选择器、shell 状态转移、shell 间接与过度封堵、cd 追踪的方向性缺陷、重定向前缀与 CDPATH、`>|` 与 Phase 3 隐式 push。其中「方向性缺陷」是 Claude 侧验证的盲区（只测了误差偏拦的一侧），由 Codex 补上；反之 worktree 旁路与过度封堵是 Codex 的盲区，由 Claude 侧补上。**互补性充分体现，任一单侧都会漏。**

Codex 曾三次因沙箱拒绝其只读命令而无法审计（诚实报告 NOT ASSESSED 而非 PASS），改用「源码全文内联进提示、不执行任何命令」后恢复；沙箱自锁的疑似机制已单独立项 #554。

## 已文档化的限制（写在文件头，不在威胁模型内）

与长期存在的 `bash -c "..."` 递归 shell 限制同级，且**在 #552 之前同样拦不住**（非本 PR 引入的退步）：`eval` 藏推送；预先存在的不透明 shell 函数 / 别名；路径别名（subst 盘符 / UNC / junction / symlink）。

## 关联

- #553 pr-create-guard / pr-merge-guard 的同类跨仓误拦面评估
- #554 本 session 实测的两类护栏摩擦（Codex 在本仓可能无法执行 Bash；push-guard 对 heredoc 文本误报）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
