### PR TITLE
fix(sot-id-map): 刷新 id 映射表 —— Wave 2 装备/天赋导入后的首次真实漂移 (#558)

### DIFF
--- a/scripts/sot_id_map/README.md
+++ b/scripts/sot_id_map/README.md
@@ -148,24 +148,31 @@ python -m scripts.sot_id_map.test_smoke
    **两侧的 id 规则是同一条**，不存在一侧更宽松：id 必须是非空字符串，或整数（会被转成字符串——这是为设计库某些表用数据库自增主键做的**显式**让步，不是 `str()` 随手兜底）。空串、null、布尔、浮点、对象一律报 `missing_entity_id`，既不静默收下也不静默丢弃。
 4. **`mappings` / `unmapped`** —— 具体条目。`mappings` 每条必须有 `basis`（对应关系从哪儿溯源），`unmapped` 每条必须有受控原因码。
 
-### 六个原因码
+### 八个原因码
 
-| 码 | 什么时候用 |
-|---|---|
-| `engine_not_implemented` | 设计库有，引擎尚未实装同类实体（将来实装后应改成 `mappings` 条目） |
-| `design_not_registered` | 引擎有，设计库存在同类实体表但未登记这一条 |
-| `engine_implements_as_field` | **两侧都有这件事，但引擎建成了另一个实体的字段而非独立实体**。必须给 `engine_carrier` 指针，校验器核实文件存在 |
-| `engine_no_entity_kind` | 引擎侧根本没有这类实体（设计库的规则条文、判定层） |
-| `design_no_entity_kind` | 设计库侧根本没有这类实体（引擎的 buff、词条、地图、波次） |
-| `no_traceable_correspondence` | 两侧有相近概念，但没有可溯源的 id 级对应。按 #556 界线，溯源不到就写明原因，不猜 |
+| 码 | 什么时候用 | 当前条数 |
+|---|---|---:|
+| `engine_not_implemented` | 设计库**在用**，引擎尚未实装同类实体（将来实装后应改成 `mappings` 条目） | 41 |
+| `design_shelved_not_imported` | 设计库侧该条目的 `shelf_state` 不是「在用」（已归档 / 待删除），**不是等待实装的候选** | 19 |
+| `design_not_registered` | 引擎有，设计库存在同类实体表但未登记这一条 | 37 |
+| `engine_implements_as_field` | **两侧都有这件事，但引擎建成了另一个实体的字段而非独立实体**。必须给 `engine_carrier` 指针，校验器核实字段真实存在 | 4 |
+| `engine_no_entity_kind` | 引擎侧根本没有这类实体（设计库的规则条文、判定层） | 27 |
+| `design_no_entity_kind` | 设计库侧根本没有这类实体（引擎的 buff、词条、地图、波次、敌人、地形） | 37 |
+| `engine_placeholder_no_design_entity` | 引擎侧占位 / 内部派生结构，**已核对确认**设计库没有对应实体 | 13 |
+| `no_traceable_correspondence` | 两侧有相近概念，但**判不出** id 级对应。按 #556 界线，溯源不到就写明原因，不猜 | 12 |
 
-`engine_implements_as_field` 是刻意与 `engine_not_implemented` 分开的。当前用到它的四条是〔心眼〕两条技能与剑气 / 剑意印记两条资源：设计库把它们建成技能 / 资源实体，引擎把它们实装进了职业档案的 `sword_qi_config` 字段组。把这类归成「引擎未实装」是**错误定性**。
+三组容易混淆的边界，都是刻意分开的：
+
+- **`engine_implements_as_field` ≠ `engine_not_implemented`。** 当前用到前者的四条是〔心眼〕两条技能与剑气 / 剑意印记两条资源：设计库把它们建成技能 / 资源实体，引擎把它们实装进了职业档案的 `sword_qi_config` 字段组。把这类归成「引擎未实装」是**错误定性**——它已经实装了，只是换了一种实体形态。
+- **`engine_placeholder_no_design_entity` ≠ `no_traceable_correspondence`。** 前者是**查过两侧、确认没有**；后者是**查了但判不出**。把「已确证没有」和「判不了」塞进同一个码，就等于把两种该分开处置的状态混成一种：前者可以收工，后者要留着继续查。（此项区分应 SoT 请求加入，见设计库 `docs/sot-to-mercury-wave2-feedback-2026-08-09.md` §4 第 2 条。）
+- **`design_shelved_not_imported` ≠ `engine_not_implemented`。** 前者说的是设计库自己把条目下架了，引擎不导入是**正确行为**；后者说的是设计库在用而引擎欠着。两者混用会让读者以为有 19 条实装欠账，实际只有 41 条。判据在数据里：`snapshots/*.json` 的 `shelf_state`（待删除的另带 `trashed_at` 时刻）。
 
 ## 维护方式
 
 `id_map.json` 是人工维护的。典型改动场景：
 
-- **引擎实装了一条设计库已有的东西** → 把对应的 `unmapped`（`engine_not_implemented`）条目删掉，在 `mappings` 里加一条并写 `basis`。
+- **引擎实装了一条设计库已有的东西** → 把对应的 `unmapped`（`engine_not_implemented`）条目删掉，在 `mappings` 里加一条并写 `basis`。**`basis` 要能从数据本身溯源**，最硬的证据是引擎侧文件自带的 `_mirror` 字段（自述镜像自设计库某个快照 commit）加上两侧字段值逐项相等，「看着像」不算。
+- **设计库把某条下架（`shelf_state` 改成已归档 / 待删除）** → 该条的 `unmapped` 原因码从 `engine_not_implemented` 改成 `design_shelved_not_imported`；反之恢复在用则改回。这不影响覆盖，但影响读者判断「引擎到底欠了多少」。
 - **任一侧新增实体** → 校验器会以 `uncovered_id` 报出来。补一条 `mappings` 或 `unmapped`。
 - **任一侧新增整个实体类型（新目录 / 新快照文件）** → 校验器以 `undeclared_scope` 报出来。加 `entity_types` 条目，或列进 `excluded_paths` 并写理由。引擎侧直接落在 `data/` 下的散装 `*.json`、设计库 `snapshots/` 子目录里的快照，同样会被报出来。
 - **任一侧把来源目录 / 快照改名或删掉** → 同时报 `missing_source`（老路径没了）与 `undeclared_scope`（新路径没申报），改 `entity_types` 里那个 `path` 即可。
@@ -206,6 +213,7 @@ python -m scripts.sot_id_map.test_smoke
 
 ## 已知的判断点（复核时优先看这几处）
 
-- **引擎 `data/weapons/`（13 条）标了 `no_traceable_correspondence`**：设计库 `equipment` 表有同名的 `weapon_might` / `weapon_hit` / `weapon_crit` 三字段，schema 同形；但 id 命名空间（`wpn_*` vs `eq_wpn_*`）与用途（职业 / 测试单位内建武器 vs 可拾取装备）都不同，没有一条 id 对得上。判定为「不猜」而非配对。
-- **设计库 `tags`（12 条，标识符是 `key`）标了 `no_traceable_correspondence`**：引擎技能的 `tags` 是自由英文字符串（当前 30 个不同取值），没有注册表。字面上确有近似（奥义 / `ougi`、反应 / `reaction`、被动 / `passive_like`、区域 / `area`），但「位移」与「机动」两条都可能落到 `mobility`，逐条判不了，故整组不猜。
-- **`eq_wpn_iron_sword` 是两侧唯一的装备对应**：同 id 同名（铁剑），但两侧属性模型不同（引擎 `stats {STR:2}` + `tier` + `rarity`，设计库 `weapon_might 5` / `weapon_hit 90` / `weapon_crit 0`）。本表只做 id 对应，数值是否该对齐属于裁决问题，不在此处判断。
+- **引擎 `data/weapons/`（13 条）已从 `no_traceable_correspondence` 改判为 `engine_placeholder_no_design_entity`**（#558）。原先存疑的点是：设计库 `equipment` 表有同名的 `weapon_might` / `weapon_hit` / `weapon_crit` 三字段、schema 同形，判不出它是不是对应物。**Wave 2 把这个疑问用数据回答了**——设计库 `equipment` 的 22 条在用条目 1:1 落到了引擎 `data/equipment/`（引擎侧带 `_mirror` 锚点），与 `data/weapons/` 无关；而 13 条 `weapons` 的 `_note` 自述是 R1.7 结构迁移从旧 `class`/`enemy` json 内联字段搬来的引擎内部产物。所以现在是「已确证没有对应实体」，不再是「判不出」。
+- **设计库 `tags`（12 条，标识符是 `key`）仍是 `no_traceable_correspondence`**，而且现在是**唯一**用这个码的一组：引擎技能的 `tags` 是自由英文字符串（当前 30 个不同取值），没有注册表。字面上确有近似（奥义 / `ougi`、反应 / `reaction`、被动 / `passive_like`、区域 / `area`），但「位移」与「机动」两条都可能落到 `mobility`，逐条判不了，故整组不猜。**这一组保留原样，正是为了让「判不出」这个状态还有地方表达。**
+- **设计库装备现在有 22 条对应，不再是只有铁剑一条**。曾经记在这里的「两侧属性模型不同（引擎 `stats {STR:2}` + `tier`，设计库 `weapon_might`/`hit`/`crit`）」在 Wave 2 之后**已不成立**：引擎改用了设计库的三参数，22 条逐项相等。引擎侧仍多两个设计库没有的字段（`tier` 由 rarity 派生供掉落分桶、`engine_effects` 特效指令），按 lane 文档 §2.2 属引擎独有列、不回流。
+- **`eq_wpn_lancereaver` 是唯一一条设计库有而引擎刻意没导入的装备**：它的 `shelf_state` 是「待删除」（`trashed_at` = 2026-07-09）。判据是导入行为与状态完全对齐——22 条在用全导、1 条非在用不导，所以这是按状态刻意跳过，不是实装欠账。**若把它标成 `engine_not_implemented` 就是错误定性**，会让读者以为引擎欠了一条。

--- a/scripts/sot_id_map/id_map.json
+++ b/scripts/sot_id_map/id_map.json
@@ -31,7 +31,9 @@
     "engine_implements_as_field": "两侧都有这件事，但引擎把它实装成了另一个实体的字段而不是独立实体。必须同时给出 engine_carrier 指针（形如 data/classes/kensei.json#sword_qi_config），校验器会核实该文件存在。不许用 engine_not_implemented 顶替 —— 那是错误定性。",
     "engine_no_entity_kind": "引擎侧根本没有这一类实体（设计库的规则条文、判定层等设计/规格层内容）。",
     "design_no_entity_kind": "设计库侧根本没有这一类实体（引擎的 buff、词条、地图、波次等运行时内容）。",
-    "no_traceable_correspondence": "两侧都有相近概念，但没有可从数据或双方文档溯源的 id 级对应关系。按 Issue #556 界线，溯源不到就标本码写明原因，不猜。"
+    "no_traceable_correspondence": "两侧都有相近概念，但没有可从数据或双方文档溯源的 id 级对应关系——是「判不出」，不是「已确证没有」。按 Issue #556 界线，溯源不到就标本码写明原因，不猜。若后来查清了确实没有对应实体，应改判 engine_placeholder_no_design_entity 或 design_no_entity_kind。",
+    "engine_placeholder_no_design_entity": "引擎侧的占位 / 内部派生结构，且**已核对确认**设计库没有对应实体。与 no_traceable_correspondence 的边界：那个码是查了但判不出；本码是查过两侧、确认没有。与 design_no_entity_kind 的边界：那个码指设计库永久不建模的引擎原生内容（buff / 地图 / 波次 / 敌人）；本码指引擎自己的占位结构，将来若接上真实数据可能被取代，届时要重新归类。",
+    "design_shelved_not_imported": "设计库侧该条目的 shelf_state 不是「在用」（已归档 / 待删除），不是等待引擎实装的候选，引擎不导入是正确行为而不是欠账。与 engine_not_implemented 的边界：那个码是设计库在用、引擎尚未实装（将来实装后应改成 mappings）；本码是设计库自己把条目下架了。判据在数据里：snapshots/*.json 的 shelf_state 字段（待删除的另带 trashed_at 时刻）。"
   },
   "entity_types": [
     {
@@ -106,7 +108,7 @@
         "path": "snapshots/equipment.json",
         "id_field": "id"
       },
-      "note": "可拾取装备。两侧属性模型不同（引擎 stats / tier / rarity，设计库 weapon_might / weapon_hit / weapon_crit），本表只做 id 对应，不做数值判断。"
+      "note": "可拾取装备。Wave 2（引擎 develop @ 424c698）之后设计库 equipment 表的全部 22 条「在用」武器已 1:1 导入引擎 data/equipment/，引擎侧带 _mirror 锚点回指设计库快照；剩下 1 条 shelf_state=待删除 的按状态刻意未导入。引擎另有 7 条设计库未登记的条目（4 件防具 + 3 件非剑类武器）。引擎独有字段 tier / stats / engine_effects 不回流（lane 文档 §2.2）。本表只做 id 对应，不做数值判断。"
     },
     {
       "type": "event",
@@ -188,7 +190,7 @@
         "path": "snapshots/talents.json",
         "id_field": "id"
       },
-      "note": "天赋。引擎当前只实装 1 条（A1 首张接线天赋），同样带 _mirror 溯源。"
+      "note": "天赋。引擎当前实装 3 条（myrmidon_jiecuo 为 A1 首张，Wave 2 新增 kensei_erdaokairen 与 kensei_ertianyiliu），均带 _mirror 溯源。设计库 49 条里 31 条在用、18 条已归档或待删除；后者不是等待实装的候选，用 design_shelved_not_imported 与「在用但引擎未实装」区分开。"
     },
     {
       "type": "talent_tree_node",
@@ -232,7 +234,7 @@
         "id_field": "id"
       },
       "design": null,
-      "note": "引擎单位内建武器属性块（weapon_might / weapon_hit / weapon_crit）。注意：设计库 equipment 表有同名三字段，但那是可拾取装备条目，id 命名空间（wpn_* vs eq_wpn_*）与用途都不同，没有 id 级可溯源对应，故全部标 no_traceable_correspondence 而不是猜一个配对。"
+      "note": "引擎单位内建武器属性块（weapon_might / weapon_hit / weapon_crit），全部 13 条都是 starter / basic / test / dummy 占位，_note 自述由 R1.7 结构迁移从旧 class/enemy json 内联字段搬迁而来。设计库没有对应实体：它的 equipment 表虽有同名三字段，但那是可拾取装备，Wave 2 已证明其对应物是引擎 data/equipment/。故 13 条全部标 engine_placeholder_no_design_entity（已确证没有），不再是 no_traceable_correspondence（判不出）。"
     },
     {
       "type": "resource",
@@ -430,8 +432,262 @@
         "eq_wpn_iron_sword"
       ],
       "cardinality": "1:1",
-      "basis": "两侧同 id 同名（铁剑）。",
-      "note": "属性模型不同：引擎是 stats {STR:2} + tier + rarity，设计库是 weapon_might 5 / weapon_hit 90 / weapon_crit 0。是否需要对齐属于数值裁决，不在本表范围内。"
+      "basis": "两侧同 id 同名（铁剑）；引擎 data/equipment/eq_wpn_iron_sword.json 的 _mirror 字段自述「id / name / slot / rarity / weapon_might / weapon_hit / weapon_crit / description 是设计库 equipment 条目的只读镜像」，版本锚点 = 设计库仓 snapshots/equipment.json @ 2ea744b；两侧 weapon_might / weapon_hit / weapon_crit 逐项相等（5 / 90 / 0）。",
+      "note": "Wave 2（引擎 develop @ 424c698）之前引擎侧是 stats {STR:2} + tier 的另一套属性模型，本表当时记着「两侧属性模型不同」；该导入之后引擎已改用设计库的 weapon_might / weapon_hit / weapon_crit，那句话不再成立，已改写。引擎侧仍多两个设计库没有的字段：tier（由 rarity 派生，供掉落分桶）与 engine_effects（本条为 STR+2 的特效占位），按 lane 文档 §2.2 属引擎独有列、不回流。"
+    },
+    {
+      "type": "equipment",
+      "engine_ids": [
+        "eq_wpn_armorslayer"
+      ],
+      "design_ids": [
+        "eq_wpn_armorslayer"
+      ],
+      "cardinality": "1:1",
+      "basis": "两侧同 id 同名（斩铠剑）；引擎 data/equipment/eq_wpn_armorslayer.json 的 _mirror 字段自述「id / name / slot / rarity / weapon_might / weapon_hit / weapon_crit / description 是设计库 equipment 条目的只读镜像」，版本锚点 = 设计库仓 snapshots/equipment.json @ 2ea744b；两侧 weapon_might / weapon_hit / weapon_crit 逐项相等（8 / 80 / 0）。"
+    },
+    {
+      "type": "equipment",
+      "engine_ids": [
+        "eq_wpn_binding_blade"
+      ],
+      "design_ids": [
+        "eq_wpn_binding_blade"
+      ],
+      "cardinality": "1:1",
+      "basis": "两侧同 id 同名（封印之剑）；引擎 data/equipment/eq_wpn_binding_blade.json 的 _mirror 字段自述「id / name / slot / rarity / weapon_might / weapon_hit / weapon_crit / description 是设计库 equipment 条目的只读镜像」，版本锚点 = 设计库仓 snapshots/equipment.json @ 2ea744b；两侧 weapon_might / weapon_hit / weapon_crit 逐项相等（18 / 95 / 10）。"
+    },
+    {
+      "type": "equipment",
+      "engine_ids": [
+        "eq_wpn_brave_sword"
+      ],
+      "design_ids": [
+        "eq_wpn_brave_sword"
+      ],
+      "cardinality": "1:1",
+      "basis": "两侧同 id 同名（勇者之剑）；引擎 data/equipment/eq_wpn_brave_sword.json 的 _mirror 字段自述「id / name / slot / rarity / weapon_might / weapon_hit / weapon_crit / description 是设计库 equipment 条目的只读镜像」，版本锚点 = 设计库仓 snapshots/equipment.json @ 2ea744b；两侧 weapon_might / weapon_hit / weapon_crit 逐项相等（9 / 75 / 0）。"
+    },
+    {
+      "type": "equipment",
+      "engine_ids": [
+        "eq_wpn_durandal"
+      ],
+      "design_ids": [
+        "eq_wpn_durandal"
+      ],
+      "cardinality": "1:1",
+      "basis": "两侧同 id 同名（迪朗达尔）；引擎 data/equipment/eq_wpn_durandal.json 的 _mirror 字段自述「id / name / slot / rarity / weapon_might / weapon_hit / weapon_crit / description 是设计库 equipment 条目的只读镜像」，版本锚点 = 设计库仓 snapshots/equipment.json @ 2ea744b；两侧 weapon_might / weapon_hit / weapon_crit 逐项相等（17 / 90 / 0）。"
+    },
+    {
+      "type": "equipment",
+      "engine_ids": [
+        "eq_wpn_iron_blade"
+      ],
+      "design_ids": [
+        "eq_wpn_iron_blade"
+      ],
+      "cardinality": "1:1",
+      "basis": "两侧同 id 同名（阔铁剑）；引擎 data/equipment/eq_wpn_iron_blade.json 的 _mirror 字段自述「id / name / slot / rarity / weapon_might / weapon_hit / weapon_crit / description 是设计库 equipment 条目的只读镜像」，版本锚点 = 设计库仓 snapshots/equipment.json @ 2ea744b；两侧 weapon_might / weapon_hit / weapon_crit 逐项相等（9 / 70 / 0）。"
+    },
+    {
+      "type": "equipment",
+      "engine_ids": [
+        "eq_wpn_killing_edge"
+      ],
+      "design_ids": [
+        "eq_wpn_killing_edge"
+      ],
+      "cardinality": "1:1",
+      "basis": "两侧同 id 同名（杀戮之刃）；引擎 data/equipment/eq_wpn_killing_edge.json 的 _mirror 字段自述「id / name / slot / rarity / weapon_might / weapon_hit / weapon_crit / description 是设计库 equipment 条目的只读镜像」，版本锚点 = 设计库仓 snapshots/equipment.json @ 2ea744b；两侧 weapon_might / weapon_hit / weapon_crit 逐项相等（9 / 75 / 30）。"
+    },
+    {
+      "type": "equipment",
+      "engine_ids": [
+        "eq_wpn_light_brand"
+      ],
+      "design_ids": [
+        "eq_wpn_light_brand"
+      ],
+      "cardinality": "1:1",
+      "basis": "两侧同 id 同名（光之剑）；引擎 data/equipment/eq_wpn_light_brand.json 的 _mirror 字段自述「id / name / slot / rarity / weapon_might / weapon_hit / weapon_crit / description 是设计库 equipment 条目的只读镜像」，版本锚点 = 设计库仓 snapshots/equipment.json @ 2ea744b；两侧 weapon_might / weapon_hit / weapon_crit 逐项相等（9 / 70 / 0）。"
+    },
+    {
+      "type": "equipment",
+      "engine_ids": [
+        "eq_wpn_longsword"
+      ],
+      "design_ids": [
+        "eq_wpn_longsword"
+      ],
+      "cardinality": "1:1",
+      "basis": "两侧同 id 同名（长剑）；引擎 data/equipment/eq_wpn_longsword.json 的 _mirror 字段自述「id / name / slot / rarity / weapon_might / weapon_hit / weapon_crit / description 是设计库 equipment 条目的只读镜像」，版本锚点 = 设计库仓 snapshots/equipment.json @ 2ea744b；两侧 weapon_might / weapon_hit / weapon_crit 逐项相等（6 / 85 / 0）。"
+    },
+    {
+      "type": "equipment",
+      "engine_ids": [
+        "eq_wpn_mani_katti"
+      ],
+      "design_ids": [
+        "eq_wpn_mani_katti"
+      ],
+      "cardinality": "1:1",
+      "basis": "两侧同 id 同名（玛尼卡提）；引擎 data/equipment/eq_wpn_mani_katti.json 的 _mirror 字段自述「id / name / slot / rarity / weapon_might / weapon_hit / weapon_crit / description 是设计库 equipment 条目的只读镜像」，版本锚点 = 设计库仓 snapshots/equipment.json @ 2ea744b；两侧 weapon_might / weapon_hit / weapon_crit 逐项相等（8 / 80 / 20）。"
+    },
+    {
+      "type": "equipment",
+      "engine_ids": [
+        "eq_wpn_poison_sword"
+      ],
+      "design_ids": [
+        "eq_wpn_poison_sword"
+      ],
+      "cardinality": "1:1",
+      "basis": "两侧同 id 同名（毒剑）；引擎 data/equipment/eq_wpn_poison_sword.json 的 _mirror 字段自述「id / name / slot / rarity / weapon_might / weapon_hit / weapon_crit / description 是设计库 equipment 条目的只读镜像」，版本锚点 = 设计库仓 snapshots/equipment.json @ 2ea744b；两侧 weapon_might / weapon_hit / weapon_crit 逐项相等（3 / 70 / 0）。"
+    },
+    {
+      "type": "equipment",
+      "engine_ids": [
+        "eq_wpn_rapier"
+      ],
+      "design_ids": [
+        "eq_wpn_rapier"
+      ],
+      "cardinality": "1:1",
+      "basis": "两侧同 id 同名（拉庇亚）；引擎 data/equipment/eq_wpn_rapier.json 的 _mirror 字段自述「id / name / slot / rarity / weapon_might / weapon_hit / weapon_crit / description 是设计库 equipment 条目的只读镜像」，版本锚点 = 设计库仓 snapshots/equipment.json @ 2ea744b；两侧 weapon_might / weapon_hit / weapon_crit 逐项相等（7 / 95 / 10）。"
+    },
+    {
+      "type": "equipment",
+      "engine_ids": [
+        "eq_wpn_regal_blade"
+      ],
+      "design_ids": [
+        "eq_wpn_regal_blade"
+      ],
+      "cardinality": "1:1",
+      "basis": "两侧同 id 同名（王者之剑）；引擎 data/equipment/eq_wpn_regal_blade.json 的 _mirror 字段自述「id / name / slot / rarity / weapon_might / weapon_hit / weapon_crit / description 是设计库 equipment 条目的只读镜像」，版本锚点 = 设计库仓 snapshots/equipment.json @ 2ea744b；两侧 weapon_might / weapon_hit / weapon_crit 逐项相等（20 / 85 / 0）。"
+    },
+    {
+      "type": "equipment",
+      "engine_ids": [
+        "eq_wpn_runesword"
+      ],
+      "design_ids": [
+        "eq_wpn_runesword"
+      ],
+      "cardinality": "1:1",
+      "basis": "两侧同 id 同名（如尼剑）；引擎 data/equipment/eq_wpn_runesword.json 的 _mirror 字段自述「id / name / slot / rarity / weapon_might / weapon_hit / weapon_crit / description 是设计库 equipment 条目的只读镜像」，版本锚点 = 设计库仓 snapshots/equipment.json @ 2ea744b；两侧 weapon_might / weapon_hit / weapon_crit 逐项相等（12 / 65 / 0）。"
+    },
+    {
+      "type": "equipment",
+      "engine_ids": [
+        "eq_wpn_silver_blade"
+      ],
+      "design_ids": [
+        "eq_wpn_silver_blade"
+      ],
+      "cardinality": "1:1",
+      "basis": "两侧同 id 同名（阔银剑）；引擎 data/equipment/eq_wpn_silver_blade.json 的 _mirror 字段自述「id / name / slot / rarity / weapon_might / weapon_hit / weapon_crit / description 是设计库 equipment 条目的只读镜像」，版本锚点 = 设计库仓 snapshots/equipment.json @ 2ea744b；两侧 weapon_might / weapon_hit / weapon_crit 逐项相等（14 / 60 / 0）。"
+    },
+    {
+      "type": "equipment",
+      "engine_ids": [
+        "eq_wpn_silver_sword"
+      ],
+      "design_ids": [
+        "eq_wpn_silver_sword"
+      ],
+      "cardinality": "1:1",
+      "basis": "两侧同 id 同名（银剑）；引擎 data/equipment/eq_wpn_silver_sword.json 的 _mirror 字段自述「id / name / slot / rarity / weapon_might / weapon_hit / weapon_crit / description 是设计库 equipment 条目的只读镜像」，版本锚点 = 设计库仓 snapshots/equipment.json @ 2ea744b；两侧 weapon_might / weapon_hit / weapon_crit 逐项相等（13 / 80 / 0）。"
+    },
+    {
+      "type": "equipment",
+      "engine_ids": [
+        "eq_wpn_slim_sword"
+      ],
+      "design_ids": [
+        "eq_wpn_slim_sword"
+      ],
+      "cardinality": "1:1",
+      "basis": "两侧同 id 同名（细剑）；引擎 data/equipment/eq_wpn_slim_sword.json 的 _mirror 字段自述「id / name / slot / rarity / weapon_might / weapon_hit / weapon_crit / description 是设计库 equipment 条目的只读镜像」，版本锚点 = 设计库仓 snapshots/equipment.json @ 2ea744b；两侧 weapon_might / weapon_hit / weapon_crit 逐项相等（3 / 100 / 5）。"
+    },
+    {
+      "type": "equipment",
+      "engine_ids": [
+        "eq_wpn_sol_katti"
+      ],
+      "design_ids": [
+        "eq_wpn_sol_katti"
+      ],
+      "cardinality": "1:1",
+      "basis": "两侧同 id 同名（索尔卡提）；引擎 data/equipment/eq_wpn_sol_katti.json 的 _mirror 字段自述「id / name / slot / rarity / weapon_might / weapon_hit / weapon_crit / description 是设计库 equipment 条目的只读镜像」，版本锚点 = 设计库仓 snapshots/equipment.json @ 2ea744b；两侧 weapon_might / weapon_hit / weapon_crit 逐项相等（12 / 95 / 25）。"
+    },
+    {
+      "type": "equipment",
+      "engine_ids": [
+        "eq_wpn_steel_blade"
+      ],
+      "design_ids": [
+        "eq_wpn_steel_blade"
+      ],
+      "cardinality": "1:1",
+      "basis": "两侧同 id 同名（阔钢剑）；引擎 data/equipment/eq_wpn_steel_blade.json 的 _mirror 字段自述「id / name / slot / rarity / weapon_might / weapon_hit / weapon_crit / description 是设计库 equipment 条目的只读镜像」，版本锚点 = 设计库仓 snapshots/equipment.json @ 2ea744b；两侧 weapon_might / weapon_hit / weapon_crit 逐项相等（11 / 65 / 0）。"
+    },
+    {
+      "type": "equipment",
+      "engine_ids": [
+        "eq_wpn_steel_sword"
+      ],
+      "design_ids": [
+        "eq_wpn_steel_sword"
+      ],
+      "cardinality": "1:1",
+      "basis": "两侧同 id 同名（钢剑）；引擎 data/equipment/eq_wpn_steel_sword.json 的 _mirror 字段自述「id / name / slot / rarity / weapon_might / weapon_hit / weapon_crit / description 是设计库 equipment 条目的只读镜像」，版本锚点 = 设计库仓 snapshots/equipment.json @ 2ea744b；两侧 weapon_might / weapon_hit / weapon_crit 逐项相等（8 / 75 / 0）。"
+    },
+    {
+      "type": "equipment",
+      "engine_ids": [
+        "eq_wpn_wo_dao"
+      ],
+      "design_ids": [
+        "eq_wpn_wo_dao"
+      ],
+      "cardinality": "1:1",
+      "basis": "两侧同 id 同名（倭刀）；引擎 data/equipment/eq_wpn_wo_dao.json 的 _mirror 字段自述「id / name / slot / rarity / weapon_might / weapon_hit / weapon_crit / description 是设计库 equipment 条目的只读镜像」，版本锚点 = 设计库仓 snapshots/equipment.json @ 2ea744b；两侧 weapon_might / weapon_hit / weapon_crit 逐项相等（8 / 75 / 35）。"
+    },
+    {
+      "type": "equipment",
+      "engine_ids": [
+        "eq_wpn_wyrmslayer"
+      ],
+      "design_ids": [
+        "eq_wpn_wyrmslayer"
+      ],
+      "cardinality": "1:1",
+      "basis": "两侧同 id 同名（龙斩剑）；引擎 data/equipment/eq_wpn_wyrmslayer.json 的 _mirror 字段自述「id / name / slot / rarity / weapon_might / weapon_hit / weapon_crit / description 是设计库 equipment 条目的只读镜像」，版本锚点 = 设计库仓 snapshots/equipment.json @ 2ea744b；两侧 weapon_might / weapon_hit / weapon_crit 逐项相等（7 / 75 / 0）。"
+    },
+    {
+      "type": "talent",
+      "engine_ids": [
+        "kensei_erdaokairen"
+      ],
+      "design_ids": [
+        "kensei_erdaokairen"
+      ],
+      "cardinality": "1:1",
+      "basis": "两侧同 id 同名（二刀开刃）、同 class_id（kensei）、同 rarity（史诗），effect 文本逐字相等；引擎 data/talents/kensei_erdaokairen.json 的 _mirror 字段自述镜像自设计库 snapshots/talents.json @ 2ea744b。"
+    },
+    {
+      "type": "talent",
+      "engine_ids": [
+        "kensei_ertianyiliu"
+      ],
+      "design_ids": [
+        "kensei_ertianyiliu"
+      ],
+      "cardinality": "1:1",
+      "basis": "两侧同 id 同名（二天一流）、同 class_id（kensei）、同 rarity（传奇），effect 文本逐字相等；引擎 data/talents/kensei_ertianyiliu.json 的 _mirror 字段自述镜像自设计库 snapshots/talents.json @ 2ea744b。",
+      "note": "引擎侧 _mirror 额外声明镜像了 extra_triggers 的触发五段，并注明 effect 里的双空格是设计库原文照抄。属实装细节，本表不裁决。"
     }
   ],
   "unmapped": [
@@ -608,134 +864,9 @@
     {
       "type": "equipment",
       "side": "design",
-      "id": "eq_wpn_armorslayer",
-      "reason": "engine_not_implemented"
-    },
-    {
-      "type": "equipment",
-      "side": "design",
-      "id": "eq_wpn_binding_blade",
-      "reason": "engine_not_implemented"
-    },
-    {
-      "type": "equipment",
-      "side": "design",
-      "id": "eq_wpn_brave_sword",
-      "reason": "engine_not_implemented"
-    },
-    {
-      "type": "equipment",
-      "side": "design",
-      "id": "eq_wpn_durandal",
-      "reason": "engine_not_implemented"
-    },
-    {
-      "type": "equipment",
-      "side": "design",
-      "id": "eq_wpn_iron_blade",
-      "reason": "engine_not_implemented"
-    },
-    {
-      "type": "equipment",
-      "side": "design",
-      "id": "eq_wpn_killing_edge",
-      "reason": "engine_not_implemented"
-    },
-    {
-      "type": "equipment",
-      "side": "design",
       "id": "eq_wpn_lancereaver",
-      "reason": "engine_not_implemented"
-    },
-    {
-      "type": "equipment",
-      "side": "design",
-      "id": "eq_wpn_light_brand",
-      "reason": "engine_not_implemented"
-    },
-    {
-      "type": "equipment",
-      "side": "design",
-      "id": "eq_wpn_longsword",
-      "reason": "engine_not_implemented"
-    },
-    {
-      "type": "equipment",
-      "side": "design",
-      "id": "eq_wpn_mani_katti",
-      "reason": "engine_not_implemented"
-    },
-    {
-      "type": "equipment",
-      "side": "design",
-      "id": "eq_wpn_poison_sword",
-      "reason": "engine_not_implemented"
-    },
-    {
-      "type": "equipment",
-      "side": "design",
-      "id": "eq_wpn_rapier",
-      "reason": "engine_not_implemented"
-    },
-    {
-      "type": "equipment",
-      "side": "design",
-      "id": "eq_wpn_regal_blade",
-      "reason": "engine_not_implemented"
-    },
-    {
-      "type": "equipment",
-      "side": "design",
-      "id": "eq_wpn_runesword",
-      "reason": "engine_not_implemented"
-    },
-    {
-      "type": "equipment",
-      "side": "design",
-      "id": "eq_wpn_silver_blade",
-      "reason": "engine_not_implemented"
-    },
-    {
-      "type": "equipment",
-      "side": "design",
-      "id": "eq_wpn_silver_sword",
-      "reason": "engine_not_implemented"
-    },
-    {
-      "type": "equipment",
-      "side": "design",
-      "id": "eq_wpn_slim_sword",
-      "reason": "engine_not_implemented"
-    },
-    {
-      "type": "equipment",
-      "side": "design",
-      "id": "eq_wpn_sol_katti",
-      "reason": "engine_not_implemented"
-    },
-    {
-      "type": "equipment",
-      "side": "design",
-      "id": "eq_wpn_steel_blade",
-      "reason": "engine_not_implemented"
-    },
-    {
-      "type": "equipment",
-      "side": "design",
-      "id": "eq_wpn_steel_sword",
-      "reason": "engine_not_implemented"
-    },
-    {
-      "type": "equipment",
-      "side": "design",
-      "id": "eq_wpn_wo_dao",
-      "reason": "engine_not_implemented"
-    },
-    {
-      "type": "equipment",
-      "side": "design",
-      "id": "eq_wpn_wyrmslayer",
-      "reason": "engine_not_implemented"
+      "reason": "design_shelved_not_imported",
+      "note": "设计库 shelf_state = 待删除（trashed_at = 2026-07-09T07:46:12.512429）。Wave 2 导入时引擎把设计库全部 22 条「在用」武器逐条导入 data/equipment/，只跳过了本条——跳过与 shelf_state 完全对应，所以这是按状态刻意不导入，不是「引擎尚未实装」。若设计库把它改回在用，才应期待引擎导入。"
     },
     {
       "type": "equipment",
@@ -1318,18 +1449,6 @@
     {
       "type": "talent",
       "side": "design",
-      "id": "kensei_erdaokairen",
-      "reason": "engine_not_implemented"
-    },
-    {
-      "type": "talent",
-      "side": "design",
-      "id": "kensei_ertianyiliu",
-      "reason": "engine_not_implemented"
-    },
-    {
-      "type": "talent",
-      "side": "design",
       "id": "kensei_guzhuyizhi",
       "reason": "engine_not_implemented"
     },
@@ -1361,7 +1480,8 @@
       "type": "talent",
       "side": "design",
       "id": "kensei_jianqie",
-      "reason": "engine_not_implemented"
+      "reason": "design_shelved_not_imported",
+      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库 18 条非在用天赋引擎侧一条都没有导入，已导入的 3 条全部是「在用」条目。"
     },
     {
       "type": "talent",
@@ -1385,31 +1505,36 @@
       "type": "talent",
       "side": "design",
       "id": "kensei_juhe_ji",
-      "reason": "engine_not_implemented"
+      "reason": "design_shelved_not_imported",
+      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库 18 条非在用天赋引擎侧一条都没有导入，已导入的 3 条全部是「在用」条目。"
     },
     {
       "type": "talent",
       "side": "design",
       "id": "kensei_juhe_lie",
-      "reason": "engine_not_implemented"
+      "reason": "design_shelved_not_imported",
+      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库 18 条非在用天赋引擎侧一条都没有导入，已导入的 3 条全部是「在用」条目。"
     },
     {
       "type": "talent",
       "side": "design",
       "id": "kensei_kongzhan",
-      "reason": "engine_not_implemented"
+      "reason": "design_shelved_not_imported",
+      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库 18 条非在用天赋引擎侧一条都没有导入，已导入的 3 条全部是「在用」条目。"
     },
     {
       "type": "talent",
       "side": "design",
       "id": "kensei_lianqishi",
-      "reason": "engine_not_implemented"
+      "reason": "design_shelved_not_imported",
+      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库 18 条非在用天赋引擎侧一条都没有导入，已导入的 3 条全部是「在用」条目。"
     },
     {
       "type": "talent",
       "side": "design",
       "id": "kensei_liuqi",
-      "reason": "engine_not_implemented"
+      "reason": "design_shelved_not_imported",
+      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库 18 条非在用天赋引擎侧一条都没有导入，已导入的 3 条全部是「在用」条目。"
     },
     {
       "type": "talent",
@@ -1433,13 +1558,15 @@
       "type": "talent",
       "side": "design",
       "id": "kensei_pofu",
-      "reason": "engine_not_implemented"
+      "reason": "design_shelved_not_imported",
+      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库 18 条非在用天赋引擎侧一条都没有导入，已导入的 3 条全部是「在用」条目。"
     },
     {
       "type": "talent",
       "side": "design",
       "id": "kensei_sanqitu",
-      "reason": "engine_not_implemented"
+      "reason": "design_shelved_not_imported",
+      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库 18 条非在用天赋引擎侧一条都没有导入，已导入的 3 条全部是「在用」条目。"
     },
     {
       "type": "talent",
@@ -1451,25 +1578,29 @@
       "type": "talent",
       "side": "design",
       "id": "kensei_shouxin",
-      "reason": "engine_not_implemented"
+      "reason": "design_shelved_not_imported",
+      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库 18 条非在用天赋引擎侧一条都没有导入，已导入的 3 条全部是「在用」条目。"
     },
     {
       "type": "talent",
       "side": "design",
       "id": "kensei_shunshizhan",
-      "reason": "engine_not_implemented"
+      "reason": "design_shelved_not_imported",
+      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库 18 条非在用天赋引擎侧一条都没有导入，已导入的 3 条全部是「在用」条目。"
     },
     {
       "type": "talent",
       "side": "design",
       "id": "kensei_tiaoxi",
-      "reason": "engine_not_implemented"
+      "reason": "design_shelved_not_imported",
+      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库 18 条非在用天赋引擎侧一条都没有导入，已导入的 3 条全部是「在用」条目。"
     },
     {
       "type": "talent",
       "side": "design",
       "id": "kensei_tsujigiri",
-      "reason": "engine_not_implemented"
+      "reason": "design_shelved_not_imported",
+      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库 18 条非在用天赋引擎侧一条都没有导入，已导入的 3 条全部是「在用」条目。"
     },
     {
       "type": "talent",
@@ -1487,13 +1618,15 @@
       "type": "talent",
       "side": "design",
       "id": "kensei_wuxiangjian",
-      "reason": "engine_not_implemented"
+      "reason": "design_shelved_not_imported",
+      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库 18 条非在用天赋引擎侧一条都没有导入，已导入的 3 条全部是「在用」条目。"
     },
     {
       "type": "talent",
       "side": "design",
       "id": "kensei_xianzhixian",
-      "reason": "engine_not_implemented"
+      "reason": "design_shelved_not_imported",
+      "note": "设计库 shelf_state = 待删除，trashed_at = 2026-08-01T09:08:03.970003，不是等待引擎实装的候选。设计库 18 条非在用天赋引擎侧一条都没有导入，已导入的 3 条全部是「在用」条目。"
     },
     {
       "type": "talent",
@@ -1505,7 +1638,8 @@
       "type": "talent",
       "side": "design",
       "id": "kensei_xufeng",
-      "reason": "engine_not_implemented"
+      "reason": "design_shelved_not_imported",
+      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库 18 条非在用天赋引擎侧一条都没有导入，已导入的 3 条全部是「在用」条目。"
     },
     {
       "type": "talent",
@@ -1523,7 +1657,8 @@
       "type": "talent",
       "side": "design",
       "id": "kensei_yingfeng",
-      "reason": "engine_not_implemented"
+      "reason": "design_shelved_not_imported",
+      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库 18 条非在用天赋引擎侧一条都没有导入，已导入的 3 条全部是「在用」条目。"
     },
     {
       "type": "talent",
@@ -1535,13 +1670,15 @@
       "type": "talent",
       "side": "design",
       "id": "kensei_yishan_luan",
-      "reason": "engine_not_implemented"
+      "reason": "design_shelved_not_imported",
+      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库 18 条非在用天赋引擎侧一条都没有导入，已导入的 3 条全部是「在用」条目。"
     },
     {
       "type": "talent",
       "side": "design",
       "id": "kensei_yixian",
-      "reason": "engine_not_implemented"
+      "reason": "design_shelved_not_imported",
+      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库 18 条非在用天赋引擎侧一条都没有导入，已导入的 3 条全部是「在用」条目。"
     },
     {
       "type": "talent",
@@ -1649,79 +1786,92 @@
       "type": "weapon",
       "side": "engine",
       "id": "wpn_archer_starter",
-      "reason": "no_traceable_correspondence"
+      "reason": "engine_placeholder_no_design_entity",
+      "note": "引擎单位内建武器属性块（弓箭手初始猎弓），_note 自述「[结构迁移] 从旧 class/enemy json 内联字段搬迁而来（Mercury R1.7，2026-07-08）」，即引擎内部重构的产物而非设计内容。本表原先标 no_traceable_correspondence，理由是设计库 equipment 有同名的 weapon_might / weapon_hit / weapon_crit 三字段、判不出是不是对应物；Wave 2 之后这个疑问已被数据回答：设计库 equipment 的 22 条在用条目逐条 1:1 落到了引擎 data/equipment/，与本目录无关，故改判为已确证没有对应实体。（SoT 请求，见设计库 docs/sot-to-mercury-wave2-feedback-2026-08-09.md §4 第 2 条。）"
     },
     {
       "type": "weapon",
       "side": "engine",
       "id": "wpn_cleric_starter",
-      "reason": "no_traceable_correspondence"
+      "reason": "engine_placeholder_no_design_entity",
+      "note": "引擎单位内建武器属性块（牧师初始法杖），_note 自述「[结构迁移] 从旧 class/enemy json 内联字段搬迁而来（Mercury R1.7，2026-07-08）」，即引擎内部重构的产物而非设计内容。本表原先标 no_traceable_correspondence，理由是设计库 equipment 有同名的 weapon_might / weapon_hit / weapon_crit 三字段、判不出是不是对应物；Wave 2 之后这个疑问已被数据回答：设计库 equipment 的 22 条在用条目逐条 1:1 落到了引擎 data/equipment/，与本目录无关，故改判为已确证没有对应实体。（SoT 请求，见设计库 docs/sot-to-mercury-wave2-feedback-2026-08-09.md §4 第 2 条。）"
     },
     {
       "type": "weapon",
       "side": "engine",
       "id": "wpn_knight_starter",
-      "reason": "no_traceable_correspondence"
+      "reason": "engine_placeholder_no_design_entity",
+      "note": "引擎单位内建武器属性块（骑士初始长剑），_note 自述「[结构迁移] 从旧 class/enemy json 内联字段搬迁而来（Mercury R1.7，2026-07-08）」，即引擎内部重构的产物而非设计内容。本表原先标 no_traceable_correspondence，理由是设计库 equipment 有同名的 weapon_might / weapon_hit / weapon_crit 三字段、判不出是不是对应物；Wave 2 之后这个疑问已被数据回答：设计库 equipment 的 22 条在用条目逐条 1:1 落到了引擎 data/equipment/，与本目录无关，故改判为已确证没有对应实体。（SoT 请求，见设计库 docs/sot-to-mercury-wave2-feedback-2026-08-09.md §4 第 2 条。）"
     },
     {
       "type": "weapon",
       "side": "engine",
       "id": "wpn_mage_starter",
-      "reason": "no_traceable_correspondence"
+      "reason": "engine_placeholder_no_design_entity",
+      "note": "引擎单位内建武器属性块（魔法师初始法杖），_note 自述「[结构迁移] 从旧 class/enemy json 内联字段搬迁而来（Mercury R1.7，2026-07-08）」，即引擎内部重构的产物而非设计内容。本表原先标 no_traceable_correspondence，理由是设计库 equipment 有同名的 weapon_might / weapon_hit / weapon_crit 三字段、判不出是不是对应物；Wave 2 之后这个疑问已被数据回答：设计库 equipment 的 22 条在用条目逐条 1:1 落到了引擎 data/equipment/，与本目录无关，故改判为已确证没有对应实体。（SoT 请求，见设计库 docs/sot-to-mercury-wave2-feedback-2026-08-09.md §4 第 2 条。）"
     },
     {
       "type": "weapon",
       "side": "engine",
       "id": "wpn_magical_ranged_basic",
-      "reason": "no_traceable_correspondence"
+      "reason": "engine_placeholder_no_design_entity",
+      "note": "引擎单位内建武器属性块（通用远程魔法基础武器），_note 自述「[结构迁移] 从旧 class/enemy json 内联字段搬迁而来（Mercury R1.7，2026-07-08）」，即引擎内部重构的产物而非设计内容。本表原先标 no_traceable_correspondence，理由是设计库 equipment 有同名的 weapon_might / weapon_hit / weapon_crit 三字段、判不出是不是对应物；Wave 2 之后这个疑问已被数据回答：设计库 equipment 的 22 条在用条目逐条 1:1 落到了引擎 data/equipment/，与本目录无关，故改判为已确证没有对应实体。（SoT 请求，见设计库 docs/sot-to-mercury-wave2-feedback-2026-08-09.md §4 第 2 条。）"
     },
     {
       "type": "weapon",
       "side": "engine",
       "id": "wpn_physical_melee_basic",
-      "reason": "no_traceable_correspondence"
+      "reason": "engine_placeholder_no_design_entity",
+      "note": "引擎单位内建武器属性块（通用近战物理基础武器），_note 自述「[结构迁移] 从旧 class/enemy json 内联字段搬迁而来（Mercury R1.7，2026-07-08）」，即引擎内部重构的产物而非设计内容。本表原先标 no_traceable_correspondence，理由是设计库 equipment 有同名的 weapon_might / weapon_hit / weapon_crit 三字段、判不出是不是对应物；Wave 2 之后这个疑问已被数据回答：设计库 equipment 的 22 条在用条目逐条 1:1 落到了引擎 data/equipment/，与本目录无关，故改判为已确证没有对应实体。（SoT 请求，见设计库 docs/sot-to-mercury-wave2-feedback-2026-08-09.md §4 第 2 条。）"
     },
     {
       "type": "weapon",
       "side": "engine",
       "id": "wpn_physical_ranged_basic",
-      "reason": "no_traceable_correspondence"
+      "reason": "engine_placeholder_no_design_entity",
+      "note": "引擎单位内建武器属性块（通用远程物理基础武器），_note 自述「[结构迁移] 从旧 class/enemy json 内联字段搬迁而来（Mercury R1.7，2026-07-08）」，即引擎内部重构的产物而非设计内容。本表原先标 no_traceable_correspondence，理由是设计库 equipment 有同名的 weapon_might / weapon_hit / weapon_crit 三字段、判不出是不是对应物；Wave 2 之后这个疑问已被数据回答：设计库 equipment 的 22 条在用条目逐条 1:1 落到了引擎 data/equipment/，与本目录无关，故改判为已确证没有对应实体。（SoT 请求，见设计库 docs/sot-to-mercury-wave2-feedback-2026-08-09.md §4 第 2 条。）"
     },
     {
       "type": "weapon",
       "side": "engine",
       "id": "wpn_soldier_starter",
-      "reason": "no_traceable_correspondence"
+      "reason": "engine_placeholder_no_design_entity",
+      "note": "引擎单位内建武器属性块（仆兵初始佩剑），_note 自述「[结构迁移] 从旧 class/enemy json 内联字段搬迁而来（Mercury R1.7，2026-07-08）」，即引擎内部重构的产物而非设计内容。本表原先标 no_traceable_correspondence，理由是设计库 equipment 有同名的 weapon_might / weapon_hit / weapon_crit 三字段、判不出是不是对应物；Wave 2 之后这个疑问已被数据回答：设计库 equipment 的 22 条在用条目逐条 1:1 落到了引擎 data/equipment/，与本目录无关，故改判为已确证没有对应实体。（SoT 请求，见设计库 docs/sot-to-mercury-wave2-feedback-2026-08-09.md §4 第 2 条。）"
     },
     {
       "type": "weapon",
       "side": "engine",
       "id": "wpn_swordsman_starter",
-      "reason": "no_traceable_correspondence"
+      "reason": "engine_placeholder_no_design_entity",
+      "note": "引擎单位内建武器属性块（剑圣初始太刀），_note 自述「[结构迁移] 从旧 class/enemy json 内联字段搬迁而来（Mercury R1.7，2026-07-08）」，即引擎内部重构的产物而非设计内容。本表原先标 no_traceable_correspondence，理由是设计库 equipment 有同名的 weapon_might / weapon_hit / weapon_crit 三字段、判不出是不是对应物；Wave 2 之后这个疑问已被数据回答：设计库 equipment 的 22 条在用条目逐条 1:1 落到了引擎 data/equipment/，与本目录无关，故改判为已确证没有对应实体。（SoT 请求，见设计库 docs/sot-to-mercury-wave2-feedback-2026-08-09.md §4 第 2 条。）"
     },
     {
       "type": "weapon",
       "side": "engine",
       "id": "wpn_test_archer",
-      "reason": "no_traceable_correspondence"
+      "reason": "engine_placeholder_no_design_entity",
+      "note": "引擎单位内建武器属性块（测试用弓箭手武器），_note 自述「[结构迁移] 从旧 class/enemy json 内联字段搬迁而来（Mercury R1.7，2026-07-08）」，即引擎内部重构的产物而非设计内容。本表原先标 no_traceable_correspondence，理由是设计库 equipment 有同名的 weapon_might / weapon_hit / weapon_crit 三字段、判不出是不是对应物；Wave 2 之后这个疑问已被数据回答：设计库 equipment 的 22 条在用条目逐条 1:1 落到了引擎 data/equipment/，与本目录无关，故改判为已确证没有对应实体。（SoT 请求，见设计库 docs/sot-to-mercury-wave2-feedback-2026-08-09.md §4 第 2 条。）"
     },
     {
       "type": "weapon",
       "side": "engine",
       "id": "wpn_test_lancer",
-      "reason": "no_traceable_correspondence"
+      "reason": "engine_placeholder_no_design_entity",
+      "note": "引擎单位内建武器属性块（测试用枪兵武器），_note 自述「[结构迁移] 从旧 class/enemy json 内联字段搬迁而来（Mercury R1.7，2026-07-08）」，即引擎内部重构的产物而非设计内容。本表原先标 no_traceable_correspondence，理由是设计库 equipment 有同名的 weapon_might / weapon_hit / weapon_crit 三字段、判不出是不是对应物；Wave 2 之后这个疑问已被数据回答：设计库 equipment 的 22 条在用条目逐条 1:1 落到了引擎 data/equipment/，与本目录无关，故改判为已确证没有对应实体。（SoT 请求，见设计库 docs/sot-to-mercury-wave2-feedback-2026-08-09.md §4 第 2 条。）"
     },
     {
       "type": "weapon",
       "side": "engine",
       "id": "wpn_test_mage",
-      "reason": "no_traceable_correspondence"
+      "reason": "engine_placeholder_no_design_entity",
+      "note": "引擎单位内建武器属性块（测试用法师武器），_note 自述「[结构迁移] 从旧 class/enemy json 内联字段搬迁而来（Mercury R1.7，2026-07-08）」，即引擎内部重构的产物而非设计内容。本表原先标 no_traceable_correspondence，理由是设计库 equipment 有同名的 weapon_might / weapon_hit / weapon_crit 三字段、判不出是不是对应物；Wave 2 之后这个疑问已被数据回答：设计库 equipment 的 22 条在用条目逐条 1:1 落到了引擎 data/equipment/，与本目录无关，故改判为已确证没有对应实体。（SoT 请求，见设计库 docs/sot-to-mercury-wave2-feedback-2026-08-09.md §4 第 2 条。）"
     },
     {
       "type": "weapon",
       "side": "engine",
       "id": "wpn_training_dummy",
-      "reason": "no_traceable_correspondence"
+      "reason": "engine_placeholder_no_design_entity",
+      "note": "引擎单位内建武器属性块（测试用木桩武器），_note 自述「[结构迁移] 从旧 class/enemy json 内联字段搬迁而来（Mercury R1.7，2026-07-08）」，即引擎内部重构的产物而非设计内容。本表原先标 no_traceable_correspondence，理由是设计库 equipment 有同名的 weapon_might / weapon_hit / weapon_crit 三字段、判不出是不是对应物；Wave 2 之后这个疑问已被数据回答：设计库 equipment 的 22 条在用条目逐条 1:1 落到了引擎 data/equipment/，与本目录无关，故改判为已确证没有对应实体。（SoT 请求，见设计库 docs/sot-to-mercury-wave2-feedback-2026-08-09.md §4 第 2 条。）"
     }
   ]
 }


### PR DESCRIPTION
Closes #558

Refreshes `scripts/sot_id_map/id_map.json` after SoT's Wave 2 import. **Data and documentation only — zero code changes.**

## This is the checker's first real drift event, and it caught it

SoT imported the design library's 22 in-use weapons into the engine's `data/equipment/` and added two talent carriers. The checker immediately went red:

```
FAIL: 46 finding(s)   [uncovered_id] ×23, [cross_side_contradiction] ×24
EXIT=1
```

That is the tool doing exactly what it was built for.

## The trap this change had to avoid

Marking the 23 new ids as `unmapped` would have turned the checker green while being **factually wrong**. The 22 imported weapons and the 3 talents now genuinely *do* have counterparts on both sides — they belong in `mappings`, not `unmapped`. Green was never the goal; correct classification is.

Each of the 22 equipment mappings is corroborated three ways before being written: same id, all three of `weapon_might` / `weapon_hit` / `weapon_crit` equal, and the engine file's `_mirror` field naming the design snapshot it was mirrored from. The per-mapping `basis` records that item's own actual values, so any single row can be re-checked in isolation.

| | before | after |
|---|---:|---:|
| mappings | 11 | 34 |
| unmapped | 213 | 190 |

## Two new reason codes

Both draw distinctions that were previously collapsed:

- **`engine_placeholder_no_design_entity`** (13, the `data/weapons/` entries) — requested by SoT. Separates *confirmed to have no counterpart* from *cannot determine a counterpart*. `no_traceable_correspondence` now holds only the 12 `tags`, which is the genuine "cannot determine" case (the engine has no tag registry at all).
- **`design_shelved_not_imported`** (19 = 18 talents + 1 equipment) — the design library retired these itself; they are not engine implementation debt. Criterion is objective: `shelf_state != 在用`.

The second code corrects a materially misleading count: `engine_not_implemented` previously read 60, implying the engine owed 60 implementations. It actually owes 41; the other 19 were shelved by the design library.

## Review

- Dual-verify Claude side: **PASS**
- Dual-verify Codex side: **PASS** (Critical 0 / High 0 / Medium 0 / Low 0)

Codex was asked specifically whether the 18-talent reclassification is over-reach given its evidence is state correlation rather than observed import behaviour. Its answer: justified, because the code describes present counterpart status rather than a historical decision, and leaving them under `engine_not_implemented` would be *materially misleading* since that code implies an in-use entry awaiting engine work.

The coordinator derived the expected correspondence independently from both repositories **before** reading the delivered table, and every number matched: 22 equipment mappings, 3 talent mappings, the pending-deletion item classified as deliberately skipped rather than unimplemented, and `no_traceable_correspondence` reduced to tags only.

Failure paths were re-exercised on the refreshed table: deleting one of the new mappings reports both sides uncovered; an illegal reason code reports `bad_reason` listing all eight controlled codes; a mapping referencing a non-existent engine id reports `unknown_id` *and* trips `cross_side_contradiction`, which demonstrates the wrong-classification guard is live.

## Also fixed: two stale statements this change invalidated

The `eq_wpn_iron_sword` mapping note and the README both still said the two sides use different attribute models. Wave 2 moved the engine onto the design library's three parameters, so that was no longer true. Both were rewritten — a data file corrected without its prose is how two contradictory accounts get created.

Refs #550
