### PR TITLE
fix(workflows): pin .claude/workflows to LF in the working tree (#551)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,23 @@
 # Shell scripts must stay LF so the shebang execs on Linux CI even when a contributor has
 # core.autocrlf=true — a CRLF `#!/usr/bin/env bash\r` fails to run on Linux. (Issue #527)
 *.sh text eol=lf
+
+# Workflow templates must stay LF in the *working tree*, not just in the index. When a
+# Workflow is invoked by `name` or `scriptPath`, Claude Code's permission pipeline reads
+# the file off disk into the `script` field and re-validates it; a CR (0x0D) is rejected as
+# "script contains control characters that would be hidden in the approval dialog", so
+# every template becomes uncallable by name under core.autocrlf=true. (Issue #551)
+#
+# Scoped to the directory rather than to *.js because the constraint follows the
+# directory's role as the template host (CLAUDE.md: "模板库宿主在 .claude/workflows/"),
+# so a future .mjs/.ts template inherits the protection without another drift incident.
+#
+# `text=auto` rather than a bare `text`: a bare `text` marks EVERY present and future
+# file in the directory as text, so a binary asset added later (a diagram in the README,
+# say) would be silently mangled by EOL conversion on checkout. Measured, not assumed —
+# in a throwaway repo with core.autocrlf=true, a 24-byte file starting with the PNG magic
+# \x89PNG\r\n\x1a\n came back 21 bytes under `text eol=lf` and byte-identical under
+# `text=auto eol=lf`, while a .js file converted to LF under both. Note that
+# `git ls-files --eol` reported the binary as `i/-text w/-text` in BOTH cases, so that
+# output is not evidence of binary safety — only comparing bytes is.
+.claude/workflows/** text=auto eol=lf


### PR DESCRIPTION
## Issue

Closes #551

## Summary

One rule in `.gitattributes` so `.claude/workflows/` is checked out LF in the **working tree**:

```
.claude/workflows/** text=auto eol=lf
```

Under `core.autocrlf=true` the templates were checked out CRLF. When a Workflow is invoked by `name` or `scriptPath`, Claude Code's permission pipeline reads the file off disk into the `script` field and re-validates it; a CR (0x0D) makes it reject the call with `script contains control characters that would be hidden in the approval dialog`. All 7 templates were uncallable by name on Windows.

The diff is only the rule + comment because **repository content does not change** — the index was already LF. What changes is what `git checkout` writes to disk.

### Why the existing `*.sh` rule (#527) did not already cover this

Different thing being protected. `*.sh text eol=lf` protects the index and Linux CI checkouts; a CRLF `.sh` still runs fine locally under Git Bash. Verified in passing during this work: `scripts/codex-sync-audit.sh` has a literal `bash\r\n` shebang in the working tree and executed four times without trouble. Here the reader is the **local** permission pipeline, so the working tree itself must be LF. The comment in the file records this distinction so the next person doesn't "simplify" the two rules into one.

### Why `text=auto` and not a bare `text`

Codex caught this in round 1 of dual-verify: a bare `text` marks every present *and future* file under the directory as text, so a binary asset dropped in later (a diagram for the README, say) gets silently mangled on checkout. Neither remedy Codex proposed was taken — extension-scoping loses the forward protection the rule exists for, and an exclusion list has to be maintained and will be forgotten. `text=auto` makes Git detect binary content itself.

Measured in a throwaway repo with `core.autocrlf=true`, committing a 24-byte file starting with the PNG magic `\x89PNG\r\n\x1a\n` plus a CRLF `.js`, then deleting both and re-checking-out:

| rule | binary | text |
|---|---|---|
| `** text eol=lf` | 24B → **21B, corrupted** | → LF ok |
| `** text=auto eol=lf` | 24B → **24B, intact** | → LF ok |

Corruption form: `\x89PNG\r\n\x1a\n` → `\x89PNG\n\x1a\n`. (The PNG magic contains `\r\n\x1a\n` precisely so naive text-mode mangling is detectable — the fixture lands on the format's own tripwire.)

Worth recording: `git ls-files --eol` reported the binary as `i/-text w/-text` under **both** rules, including the one that corrupted it. That output is not evidence of binary safety; only comparing bytes is.

## Test plan

- [x] All 8 files report `i/lf w/lf`; CR count 0 in each
- [x] `git check-attr` — positive: all 8 resolve `text: auto`, `eol: lf`
- [x] `git check-attr` — negative: `adapters/…/hook.cjs`, `.codex/hooks.json`, `CLAUDE.md`, `scripts/sot_id_map/checker.py` all `unspecified`, so nothing outside the directory is touched
- [x] `git check-attr` — the `*.sh` rule still resolves independently and is not shadowed
- [x] **Real-environment**: `Workflow({scriptPath: …})` on two different templates (`mercury-adversarial-plan-review.js`, `talent-validate.js`) starts and returns its missing-args result — 8ms and 18ms, 0 agents, 0 subagent tokens
- [x] **Negative control**: the same script copied outside the repo and converted to CRLF still fails with the exact original error. This also settles the open question in the issue body: upstream Claude Code has **not** fixed the CRLF intolerance, so the fix is necessary rather than incidental
- [x] Control for the control: the same script copied outside the repo but left LF starts normally, so the failure is caused by the CRLF and not by the file's location
- [x] Fixture sanity check before use — LF copy 0 CR / 6226B, CRLF copy 117 CR / 6343B, byte-identical after stripping CR
- [x] `scripts/toolcall-xml-lint.sh` PASS (128 files, exit 0)
- [x] Re-verified every check above **after** switching to `text=auto`, rather than carrying over the earlier round's results

## Out of scope (found while auditing, deliberately not fixed here)

- `packages/core/src/types.ts` is CRLF **in the index** (`i/crlf`) — the only such file in the repo. Unrelated failure mode, not touched.
- 13 `.cjs` files under `adapters/` are CRLF in the working tree. They are executed by `node`, which tolerates CRLF, and they do not pass through the permission pipeline's `script` field — so they are not affected by this class of bug.

## Dual-verify

- Claude side: PASS
- Codex side: round 1 NEEDS-CHANGES (1 Low, accepted and fixed) → round 2 **PASS, 0 findings**

Codex was able to audit normally despite #554, by declaring the permitted command set in the prompt and naming `git rev-parse` as off-limits. Root cause for that is now posted on #554.

Generated with Claude Code
