### PR TITLE
docs(dual-verify): tell Codex which commands work before it gives up (#554)

### DIFF
--- a/.claude/skills/dual-verify/SKILL.md
+++ b/.claude/skills/dual-verify/SKILL.md
@@ -102,6 +102,18 @@ Audit branch <branch> vs <base>. Focus on: code style, edge cases,
 error handling, metrics completeness, memory leak / cleanup on terminal paths,
 Windows/PowerShell compat. TypeScript typecheck is not required (Claude side handles it).
 
+SANDBOX NOTE: some harnesses permit only a narrow set of commands. These are
+known to work and are enough to audit a diff — prefer them:
+    git status --porcelain | git log -1 --oneline | git diff --stat
+    git diff <base>...HEAD | git branch --show-current | cat <file> | ls <dir>
+These were observed to be refused on one harness (Windows app-server path). They
+may work on yours; if one is refused, just don't retry it:
+    git rev-parse (any form) | git rev-list | git show-ref | git config --get
+    git stash | git push | git commit | git checkout | bash / bash -c (anything)
+A refusal is not a reason to stop. Note which command was refused, continue with
+whatever works, and report your findings. Do NOT conclude from a few refusals
+that the sandbox blocks everything and abandon the audit.
+
 Return:
   Critical: N  High: N  Medium: N  Low: N
   - <finding-1>
@@ -128,6 +140,14 @@ Branch on the wrapper's exit code:
 | `2` | (usage error) | Bug in the dual-verify skill caller — fix the invocation, do not skip. |
 
 > Note: `scripts/codex-sync-audit.sh` bypasses the `codex-rescue` subagent (saves ~25k tokens of forwarder boot per audit per Issue #326 Update 1). The codex-rescue subagent remains available for general "hand a long task to Codex" use cases — only dual-verify uses the direct sync path.
+
+### Why the prompt declares a command allowlist
+
+Measured on Windows with codex-cli 0.129.0 going through the app-server path (Issue #554), across four probe rounds covering about twenty distinct commands. The ones named above were declined by the policy layer **before dispatch** — the job log shows `Command declined ... (exit -1)` one millisecond after `Running command`, versus 0.5–1.3s for commands that actually run. Refusal is deterministic for a given command: the same one issued twice was refused both times. That sample does not establish where the boundary sits in general, which is why the note above says "prefer these" rather than "only these exist".
+
+The failure this prevents is not the refusal itself but what Codex concludes from it. Given a couple of refusals, Codex reports that the sandbox blocked everything and declines to audit at all — which is what made #554 look like "Codex cannot run any Bash in this repo". It can: in the one probe round that deliberately mixed both kinds, 7 of its 11 commands ran and returned real output, including the `git diff <base>...HEAD` this skill actually depends on. Telling it up front which commands work, and that a refusal is not a reason to stop, is what turns the audit from "unavailable" into "normal".
+
+Upstream tracking: [openai/codex-plugin-cc#57](https://github.com/openai/codex-plugin-cc/issues/57) — as filed, the app-server's `thread/start` RPC does not accept `sandboxPermissions` and `config.toml` sandbox settings are ignored on that path, which is why this is not configurable away from Mercury's side. Check the issue for its current state rather than trusting this paragraph; if it has been fixed, the note costs nothing but should be re-measured before anyone leans on it further.
 
 ### Recovery commands
 

--- a/.claude/skills/dual-verify/SKILL.md
+++ b/.claude/skills/dual-verify/SKILL.md
@@ -106,10 +106,13 @@ SANDBOX NOTE: some harnesses permit only a narrow set of commands. These are
 known to work and are enough to audit a diff — prefer them:
     git status --porcelain | git log -1 --oneline | git diff --stat
     git diff <base>...HEAD | git branch --show-current | cat <file> | ls <dir>
-These were observed to be refused on one harness (Windows app-server path). They
-may work on yours; if one is refused, just don't retry it:
+The following were refused on ONE specific harness (Windows app-server path).
+That is an observation about that environment, not a general rule — they may
+work fine on yours, so try them if you need them. Only if one is actually
+refused, don't retry it:
     git rev-parse (any form) | git rev-list | git show-ref | git config --get
-    git stash | git push | git commit | git checkout | bash / bash -c (anything)
+    git stash | git push | git commit | git checkout
+    bash / bash -c (any argument, including ones with no git in them)
 A refusal is not a reason to stop. Note which command was refused, continue with
 whatever works, and report your findings. Do NOT conclude from a few refusals
 that the sandbox blocks everything and abandon the audit.
@@ -147,7 +150,9 @@ Measured on Windows with codex-cli 0.129.0 going through the app-server path (Is
 
 The failure this prevents is not the refusal itself but what Codex concludes from it. Given a couple of refusals, Codex reports that the sandbox blocked everything and declines to audit at all — which is what made #554 look like "Codex cannot run any Bash in this repo". It can: in the one probe round that deliberately mixed both kinds, 7 of its 11 commands ran and returned real output, including the `git diff <base>...HEAD` this skill actually depends on. Telling it up front which commands work, and that a refusal is not a reason to stop, is what turns the audit from "unavailable" into "normal".
 
-Upstream tracking: [openai/codex-plugin-cc#57](https://github.com/openai/codex-plugin-cc/issues/57) — as filed, the app-server's `thread/start` RPC does not accept `sandboxPermissions` and `config.toml` sandbox settings are ignored on that path, which is why this is not configurable away from Mercury's side. Check the issue for its current state rather than trusting this paragraph; if it has been fixed, the note costs nothing but should be re-measured before anyone leans on it further.
+Upstream tracking: [openai/codex-plugin-cc#57](https://github.com/openai/codex-plugin-cc/issues/57) — as filed, the app-server's `thread/start` RPC does not accept `sandboxPermissions` and `config.toml` sandbox settings are ignored on that path, which is why this was not configurable away from Mercury's side.
+
+**Don't take this section's word for any of it — re-measure instead.** It is cheap: ask Codex to issue one command from each list above and report the outcome verbatim — one command per tool call, so each outcome is attributable to a single command. A policy refusal is distinguishable from a real execution failure by its *shape*, not by the message: the job log (path is in the `result --json` payload under `.storedJob.logFile`) shows `Command declined … (exit -1)` about a millisecond after `Running command`, whereas anything that genuinely ran took 0.5–1.3s in the same log and reports a real exit code. If the refused list now runs, this note costs nothing and can be trimmed. If commands from the permitted list start failing, stop trusting the rest of this section and re-measure before acting on it.
 
 ### Recovery commands
 


### PR DESCRIPTION
## Issue

Refs #554

(Refs, not Closes — #554 has a second part, the push-guard heredoc false-positive, which is untouched here.)

## Summary

18 lines added to `.claude/skills/dual-verify/SKILL.md`. No code, no behavior change to the wrapper, the exit-code contract, or the fallback rules.

**The root cause of the Codex-side dual-verify outage turned out not to be what #554 assumed.** Full investigation is posted on the issue; the operative part:

Codex was never blocked from running Bash. On the Windows app-server path, 7 of the 11 commands in one probe round ran and returned real output — including the `git diff <base>...HEAD` this skill actually depends on. What failed was the *conclusion*. `git rev-parse` is refused, and it is the natural first thing to reach for; given a couple of refusals up front, Codex reported that the sandbox had blocked everything and declined to audit at all. Three audits in a row were lost that way.

So the fix is not code. It is telling Codex up front which commands work, and that a refusal is not a reason to stop.

### Both of #554's original hypotheses are disproved

| Hypothesis | Verdict |
|---|---|
| "Codex cannot execute any Bash in this repo" | **False** — 7 of 11 probed commands ran |
| "`$(git rev-parse ...)` in `.codex/hooks.json` causes hook self-lock" | **False** — `bash -c "test -f X && echo Y"` contains no git at all and is still refused, so refusal is a program allowlist, not hook-failure propagation |

Refusal happens **before dispatch**, not as an execution failure — the job log shows `Command declined ... (exit -1)` one millisecond after `Running command`, versus 0.5–1.3s for commands that actually run.

Upstream: [openai/codex-plugin-cc#57](https://github.com/openai/codex-plugin-cc/issues/57) — the app-server's `thread/start` RPC does not accept `sandboxPermissions` and `config.toml` sandbox settings are ignored on that path, so it is not configurable from Mercury's side. Worth noting a **discrepancy recorded rather than smoothed over**: that issue reports *all* commands blocked including `git status --short`, while here `git status --porcelain` passes consistently. Version or call-path difference, not verified.

### This retires the expensive workaround

#554 recorded the workaround as "inline the entire source under review into the prompt so Codex needs no commands". That is no longer necessary — and it was expensive (36–62KB prompts). Two full audits ran normally under this note during this work, one of which produced a real finding that was accepted (a `.gitattributes` rule that would have silently corrupted binary files — see #560).

### The note is a preference, not a prohibition — because Codex caught that it shouldn't be

Round 1 of Codex's own review on this change found that an unconditional "do not attempt" would make it skip useful commands on Linux/macOS where the allowlist is likely wider, **and that the wording contradicted the very paragraph claiming the note was harmless there**. It also caught "everything else is declined" overgeneralizing from a finite probe set, and a hardcoded upstream `(OPEN)` status that would go stale — the same class of expiring-assertion the SoT lane contract §6.3 exists to prevent. All accepted, none argued with.

## Test plan

- [x] Round 1: 1 High + 1 Medium + 1 Low, all accepted and fixed
- [x] Round 2: 1 Low (the "twenty commands" and "7 of 11" figures were internally ambiguous — 11 was one round of four, and the text never said so), accepted and fixed
- [x] Round 3: re-audit of the rewrite
- [x] `scripts/toolcall-xml-lint.sh` PASS (128 files, exit 0) — this file is a Claude-context file under `.claude/**`, so #527's guard applies
- [x] Diff scope confirmed: 1 file, no other path touched
- [x] Self-review pass reading the final section end-to-end for coherence after three rounds of edits

## Deliberately not done

- **`.codex/hooks.json` is NOT changed.** #554's todo 2 was to replace `$(git rev-parse --show-toplevel)` with an injected project-root variable. Declined, and the reason matters: the risk it would mitigate is already zero — probe 4 confirmed `git push --dry-run`, `git commit`, and `git checkout` are all refused by the policy layer, so mutating commands never reach a hook at all. And there is no way to observe whether a hook ran under Codex, so **there would be no assertion capable of confirming the change worked**. Per this repo's own verification discipline, that is not a change worth merging.
  - Stated precisely: this does **not** prove hooks are functional under Codex. It proves the sandbox is a stronger outer layer, so hook behavior does not change the safety outcome. Whether the hook runner is subject to the same policy layer was **not** observable and is not claimed either way.
- **The heredoc false-positive (part 2 of #554) is untouched.** Its workaround — write the prompt with the Write tool instead of building it in a shell command — is cheap and was used throughout this work without friction, so the case for touching a guard is weak. Same reasoning as #553's closure.

## Not claimed

One observation was left **out** of the file for lack of evidence: Codex reported that a combined/chained inspection command was refused while the same commands issued individually succeeded, suggesting compound forms fare worse. That is a single second-hand report, not a controlled probe, so it is recorded on #554 as a to-verify rather than written into the skill as fact.

## Dual-verify

- Claude side: PASS
- Codex side: see Test plan — three rounds, converging

Generated with Claude Code
