### PR TITLE
fix(sot-id-map): map the three Wave 3 talent carriers (#562)

### DIFF
--- a/scripts/sot_id_map/README.md
+++ b/scripts/sot_id_map/README.md
@@ -152,7 +152,7 @@ python -m scripts.sot_id_map.test_smoke
 
 | 码 | 什么时候用 | 当前条数 |
 |---|---|---:|
-| `engine_not_implemented` | 设计库**在用**，引擎尚未实装同类实体（将来实装后应改成 `mappings` 条目） | 41 |
+| `engine_not_implemented` | 设计库**在用**，引擎尚未实装同类实体（将来实装后应改成 `mappings` 条目） | 38 |
 | `design_shelved_not_imported` | 设计库侧该条目的 `shelf_state` 不是「在用」（已归档 / 待删除），**不是等待实装的候选** | 19 |
 | `design_not_registered` | 引擎有，设计库存在同类实体表但未登记这一条 | 37 |
 | `engine_implements_as_field` | **两侧都有这件事，但引擎建成了另一个实体的字段而非独立实体**。必须给 `engine_carrier` 指针，校验器核实字段真实存在 | 4 |
@@ -165,7 +165,7 @@ python -m scripts.sot_id_map.test_smoke
 
 - **`engine_implements_as_field` ≠ `engine_not_implemented`。** 当前用到前者的四条是〔心眼〕两条技能与剑气 / 剑意印记两条资源：设计库把它们建成技能 / 资源实体，引擎把它们实装进了职业档案的 `sword_qi_config` 字段组。把这类归成「引擎未实装」是**错误定性**——它已经实装了，只是换了一种实体形态。
 - **`engine_placeholder_no_design_entity` ≠ `no_traceable_correspondence`。** 前者是**查过两侧、确认没有**；后者是**查了但判不出**。把「已确证没有」和「判不了」塞进同一个码，就等于把两种该分开处置的状态混成一种：前者可以收工，后者要留着继续查。（此项区分应 SoT 请求加入，见设计库 `docs/sot-to-mercury-wave2-feedback-2026-08-09.md` §4 第 2 条。）
-- **`design_shelved_not_imported` ≠ `engine_not_implemented`。** 前者说的是设计库自己把条目下架了，引擎不导入是**正确行为**；后者说的是设计库在用而引擎欠着。两者混用会让读者以为有 19 条实装欠账，实际只有 41 条。判据在数据里：`snapshots/*.json` 的 `shelf_state`（待删除的另带 `trashed_at` 时刻）。
+- **`design_shelved_not_imported` ≠ `engine_not_implemented`。** 前者说的是设计库自己把条目下架了，引擎不导入是**正确行为**；后者说的是设计库在用而引擎欠着。两者混用会让读者把两组加在一起、以为有 57 条实装欠账，实际欠的只有 `engine_not_implemented` 那 38 条。判据在数据里：`snapshots/*.json` 的 `shelf_state`（待删除的另带 `trashed_at` 时刻）。
 
 ## 维护方式
 
@@ -181,7 +181,7 @@ python -m scripts.sot_id_map.test_smoke
 
 改完必须跑一次校验器并贴退出码；这与 lane 文档 §6.1「交接即验收」的口径一致。
 
-`unmapped` 目前 200 条以上，其中绝大多数是成组的（例如引擎的地图 / 波次 / 敌人整类没有设计库对应物）。首次填表时是按类型分组决定原因码、再逐条展开写入的，组一级的判断理由写在对应 `entity_types` 条目的 `note` 字段里，不在每条上重复。
+`unmapped` 的绝大多数条目是成组的（例如引擎的地图 / 波次 / 敌人整类没有设计库对应物）。首次填表时是按类型分组决定原因码、再逐条展开写入的，组一级的判断理由写在对应 `entity_types` 条目的 `note` 字段里，不在每条上重复。
 
 ## 读表前必须知道的两件事
 

--- a/scripts/sot_id_map/README.md
+++ b/scripts/sot_id_map/README.md
@@ -183,6 +183,35 @@ python -m scripts.sot_id_map.test_smoke
 
 `unmapped` 的绝大多数条目是成组的（例如引擎的地图 / 波次 / 敌人整类没有设计库对应物）。首次填表时是按类型分组决定原因码、再逐条展开写入的，组一级的判断理由写在对应 `entity_types` 条目的 `note` 字段里，不在每条上重复。
 
+### 独立复核一条 `basis`（不要采信「逐字段比对全部相等」这句话）
+
+`basis` 写「N 项逐字段比对全部相等」时，复核者应当能自己重跑这一步。把下面这段复制运行即可，改 `IDS` 换要查的条目：
+
+```python
+import io, json, os
+ENGINE = os.environ["SOT_ENGINE_REPO"]; DESIGN = os.environ["SOT_DESIGN_REPO"]
+IDS       = ["kensei_jianqihuidang"]                    # 要复核的 id
+ENG_DIR   = "data/talents"                              # 引擎侧目录
+DES_SNAP  = "snapshots/talents.json"                    # 设计库侧快照
+FIELDS    = ["id", "name", "class_id", "rarity", "tags",
+             "trigger_event", "trigger_object", "trigger_source",
+             "trigger_condition", "trigger_frequency", "trigger_frequency_n",
+             "effect", "rules"]
+
+by_id = {t["id"]: t for t in json.load(io.open(f"{DESIGN}/{DES_SNAP}", encoding="utf-8"))}
+for tid in IDS:
+    eng = json.load(io.open(f"{ENGINE}/{ENG_DIR}/{tid}.json", encoding="utf-8"))
+    des = by_id[tid]
+    for f in FIELDS:
+        print(f"{tid:24s} {f:22s} "
+              f"{'MATCH' if eng.get(f) == des.get(f) else '*** DIFF ***'}")
+```
+
+两条注意：
+
+- **不要用肉眼比对。** 终端常把这些字段里的中文渲染成乱码，两个不同的值看上去会一模一样，比对因此毫无意义。判等必须在代码里做。
+- **也不要把哈希指纹写进 `basis`。** 看似能让证据自证，实际是又一个随数据演进失效、且过期时无声的数字——本 README 其余地方刻意不写死计数，同一个理由。脚本不会过期：数据变了它重新算。`basis` 负责说清楚「比了哪两个文件、比了哪些字段、锚在哪个 commit」，够复核者自己跑一遍就行。
+
 ## 读表前必须知道的两件事
 
 **一、`tag` / `rule` / `term` 三类的标识符不是 `id`。** 它们在设计库里的整型 `id` 是数据库自增主键，重建库时会被压实重排（设计库 `snapshots/README.md` §5.3 有实测记录），**不是跨仓标识符**。本表对这三类分别用 `key` / `code` / `term` 作为 id 字段，写在各自 `entity_types` 条目的 `design.id_field` 里。所以 `unmapped` 里 `tag` 那 12 条看到的中文（击杀 / 奥义 / 反应 …）是**标签的 `key`**，不是显示名；`rule` 那 23 条看到的 `R1.1` 是 `code`。

--- a/scripts/sot_id_map/id_map.json
+++ b/scripts/sot_id_map/id_map.json
@@ -190,7 +190,7 @@
         "path": "snapshots/talents.json",
         "id_field": "id"
       },
-      "note": "天赋。引擎当前实装 3 条（myrmidon_jiecuo 为 A1 首张，Wave 2 新增 kensei_erdaokairen 与 kensei_ertianyiliu），均带 _mirror 溯源。设计库 49 条里 31 条在用、18 条已归档或待删除；后者不是等待实装的候选，用 design_shelved_not_imported 与「在用但引擎未实装」区分开。"
+      "note": "天赋。引擎已实装的天赋逐条列在这里、不报总数（myrmidon_jiecuo 为 A1 首张；Wave 2 新增 kensei_erdaokairen 与 kensei_ertianyiliu；Wave 3 新增 kensei_jianqihuidang、kensei_yanfan 与 myrmidon_sixian），均带 _mirror 溯源；只列不计数，是为了让新增时必须改这份枚举，不会出现数字与名单对不上的情形。设计库 49 条里 31 条在用、18 条已归档或待删除；后者不是等待实装的候选，用 design_shelved_not_imported 与「在用但引擎未实装」区分开。"
     },
     {
       "type": "talent_tree_node",
@@ -688,6 +688,41 @@
       "cardinality": "1:1",
       "basis": "两侧同 id 同名（二天一流）、同 class_id（kensei）、同 rarity（传奇），effect 文本逐字相等；引擎 data/talents/kensei_ertianyiliu.json 的 _mirror 字段自述镜像自设计库 snapshots/talents.json @ 2ea744b。",
       "note": "引擎侧 _mirror 额外声明镜像了 extra_triggers 的触发五段，并注明 effect 里的双空格是设计库原文照抄。属实装细节，本表不裁决。"
+    },
+    {
+      "type": "talent",
+      "engine_ids": [
+        "kensei_jianqihuidang"
+      ],
+      "design_ids": [
+        "kensei_jianqihuidang"
+      ],
+      "cardinality": "1:1",
+      "basis": "两侧同 id 同名（剑气回荡）、同 class_id（kensei）、同 rarity（稀有）；id / name / class_id / rarity / tags / trigger_event / trigger_object / trigger_source / trigger_condition / trigger_frequency / trigger_frequency_n / effect / rules 共 13 项逐字段比对全部相等（引擎 054f29c 对设计库 snapshots/talents.json）。引擎 data/talents/kensei_jianqihuidang.json 的 _mirror 字段自述镜像自设计库 snapshots/talents.json @ 2ea744b。设计库侧 shelf_state 为「在用」，故 design_shelved_not_imported 不适用。",
+      "note": "引擎侧 _mirror 额外声明镜像了 extra_triggers 的触发五段。该卡是两行两效果、靠 engine_effects 的 row 字段各自绑定一行，属实装细节，本表不裁决。"
+    },
+    {
+      "type": "talent",
+      "engine_ids": [
+        "kensei_yanfan"
+      ],
+      "design_ids": [
+        "kensei_yanfan"
+      ],
+      "cardinality": "1:1",
+      "basis": "两侧同 id 同名（燕返）、同 class_id（kensei）、同 rarity（史诗）；id / name / class_id / rarity / tags / trigger_event / trigger_object / trigger_source / trigger_condition / trigger_frequency / trigger_frequency_n / effect / rules 共 13 项逐字段比对全部相等（引擎 054f29c 对设计库 snapshots/talents.json）。引擎 data/talents/kensei_yanfan.json 的 _mirror 字段自述镜像自设计库 snapshots/talents.json @ 2ea744b。设计库侧 shelf_state 为「在用」，故 design_shelved_not_imported 不适用。"
+    },
+    {
+      "type": "talent",
+      "engine_ids": [
+        "myrmidon_sixian"
+      ],
+      "design_ids": [
+        "myrmidon_sixian"
+      ],
+      "cardinality": "1:1",
+      "basis": "两侧同 id 同名（死线）、同 class_id（myrmidon）、同 rarity（稀有）；id / name / class_id / rarity / tags / trigger_event / trigger_object / trigger_source / trigger_condition / trigger_frequency / trigger_frequency_n / effect / rules 共 13 项逐字段比对全部相等（引擎 054f29c 对设计库 snapshots/talents.json）。引擎 data/talents/myrmidon_sixian.json 的 _mirror 字段自述镜像自设计库 snapshots/talents.json @ 2ea744b。设计库侧 shelf_state 为「在用」，故 design_shelved_not_imported 不适用。",
+      "note": "设计库该条目的 levels_json 留有一份不含当前 effect 的旧版本文本（193 字符；另两张 Wave 3 卡该字段仅 2 字符），与引擎 _mirror 里的说明一致。属设计库单写域的过期残留，已记录交 SoT 侧判断，不影响本条映射的依据 —— 映射依据是 id 与上述 13 项镜像字段，不含 levels_json。"
     }
   ],
   "unmapped": [
@@ -1481,13 +1516,7 @@
       "side": "design",
       "id": "kensei_jianqie",
       "reason": "design_shelved_not_imported",
-      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库 18 条非在用天赋引擎侧一条都没有导入，已导入的 3 条全部是「在用」条目。"
-    },
-    {
-      "type": "talent",
-      "side": "design",
-      "id": "kensei_jianqihuidang",
-      "reason": "engine_not_implemented"
+      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库的非在用天赋，引擎侧一条都没有导入；已导入的天赋全部是「在用」条目。（此处刻意不写条数：这段 note 在多个条目里重复，写死计数会在每次交付后一起过期，而漏改一处比全错更难发现。）"
     },
     {
       "type": "talent",
@@ -1506,35 +1535,35 @@
       "side": "design",
       "id": "kensei_juhe_ji",
       "reason": "design_shelved_not_imported",
-      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库 18 条非在用天赋引擎侧一条都没有导入，已导入的 3 条全部是「在用」条目。"
+      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库的非在用天赋，引擎侧一条都没有导入；已导入的天赋全部是「在用」条目。（此处刻意不写条数：这段 note 在多个条目里重复，写死计数会在每次交付后一起过期，而漏改一处比全错更难发现。）"
     },
     {
       "type": "talent",
       "side": "design",
       "id": "kensei_juhe_lie",
       "reason": "design_shelved_not_imported",
-      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库 18 条非在用天赋引擎侧一条都没有导入，已导入的 3 条全部是「在用」条目。"
+      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库的非在用天赋，引擎侧一条都没有导入；已导入的天赋全部是「在用」条目。（此处刻意不写条数：这段 note 在多个条目里重复，写死计数会在每次交付后一起过期，而漏改一处比全错更难发现。）"
     },
     {
       "type": "talent",
       "side": "design",
       "id": "kensei_kongzhan",
       "reason": "design_shelved_not_imported",
-      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库 18 条非在用天赋引擎侧一条都没有导入，已导入的 3 条全部是「在用」条目。"
+      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库的非在用天赋，引擎侧一条都没有导入；已导入的天赋全部是「在用」条目。（此处刻意不写条数：这段 note 在多个条目里重复，写死计数会在每次交付后一起过期，而漏改一处比全错更难发现。）"
     },
     {
       "type": "talent",
       "side": "design",
       "id": "kensei_lianqishi",
       "reason": "design_shelved_not_imported",
-      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库 18 条非在用天赋引擎侧一条都没有导入，已导入的 3 条全部是「在用」条目。"
+      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库的非在用天赋，引擎侧一条都没有导入；已导入的天赋全部是「在用」条目。（此处刻意不写条数：这段 note 在多个条目里重复，写死计数会在每次交付后一起过期，而漏改一处比全错更难发现。）"
     },
     {
       "type": "talent",
       "side": "design",
       "id": "kensei_liuqi",
       "reason": "design_shelved_not_imported",
-      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库 18 条非在用天赋引擎侧一条都没有导入，已导入的 3 条全部是「在用」条目。"
+      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库的非在用天赋，引擎侧一条都没有导入；已导入的天赋全部是「在用」条目。（此处刻意不写条数：这段 note 在多个条目里重复，写死计数会在每次交付后一起过期，而漏改一处比全错更难发现。）"
     },
     {
       "type": "talent",
@@ -1559,14 +1588,14 @@
       "side": "design",
       "id": "kensei_pofu",
       "reason": "design_shelved_not_imported",
-      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库 18 条非在用天赋引擎侧一条都没有导入，已导入的 3 条全部是「在用」条目。"
+      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库的非在用天赋，引擎侧一条都没有导入；已导入的天赋全部是「在用」条目。（此处刻意不写条数：这段 note 在多个条目里重复，写死计数会在每次交付后一起过期，而漏改一处比全错更难发现。）"
     },
     {
       "type": "talent",
       "side": "design",
       "id": "kensei_sanqitu",
       "reason": "design_shelved_not_imported",
-      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库 18 条非在用天赋引擎侧一条都没有导入，已导入的 3 条全部是「在用」条目。"
+      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库的非在用天赋，引擎侧一条都没有导入；已导入的天赋全部是「在用」条目。（此处刻意不写条数：这段 note 在多个条目里重复，写死计数会在每次交付后一起过期，而漏改一处比全错更难发现。）"
     },
     {
       "type": "talent",
@@ -1579,28 +1608,28 @@
       "side": "design",
       "id": "kensei_shouxin",
       "reason": "design_shelved_not_imported",
-      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库 18 条非在用天赋引擎侧一条都没有导入，已导入的 3 条全部是「在用」条目。"
+      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库的非在用天赋，引擎侧一条都没有导入；已导入的天赋全部是「在用」条目。（此处刻意不写条数：这段 note 在多个条目里重复，写死计数会在每次交付后一起过期，而漏改一处比全错更难发现。）"
     },
     {
       "type": "talent",
       "side": "design",
       "id": "kensei_shunshizhan",
       "reason": "design_shelved_not_imported",
-      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库 18 条非在用天赋引擎侧一条都没有导入，已导入的 3 条全部是「在用」条目。"
+      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库的非在用天赋，引擎侧一条都没有导入；已导入的天赋全部是「在用」条目。（此处刻意不写条数：这段 note 在多个条目里重复，写死计数会在每次交付后一起过期，而漏改一处比全错更难发现。）"
     },
     {
       "type": "talent",
       "side": "design",
       "id": "kensei_tiaoxi",
       "reason": "design_shelved_not_imported",
-      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库 18 条非在用天赋引擎侧一条都没有导入，已导入的 3 条全部是「在用」条目。"
+      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库的非在用天赋，引擎侧一条都没有导入；已导入的天赋全部是「在用」条目。（此处刻意不写条数：这段 note 在多个条目里重复，写死计数会在每次交付后一起过期，而漏改一处比全错更难发现。）"
     },
     {
       "type": "talent",
       "side": "design",
       "id": "kensei_tsujigiri",
       "reason": "design_shelved_not_imported",
-      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库 18 条非在用天赋引擎侧一条都没有导入，已导入的 3 条全部是「在用」条目。"
+      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库的非在用天赋，引擎侧一条都没有导入；已导入的天赋全部是「在用」条目。（此处刻意不写条数：这段 note 在多个条目里重复，写死计数会在每次交付后一起过期，而漏改一处比全错更难发现。）"
     },
     {
       "type": "talent",
@@ -1619,14 +1648,14 @@
       "side": "design",
       "id": "kensei_wuxiangjian",
       "reason": "design_shelved_not_imported",
-      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库 18 条非在用天赋引擎侧一条都没有导入，已导入的 3 条全部是「在用」条目。"
+      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库的非在用天赋，引擎侧一条都没有导入；已导入的天赋全部是「在用」条目。（此处刻意不写条数：这段 note 在多个条目里重复，写死计数会在每次交付后一起过期，而漏改一处比全错更难发现。）"
     },
     {
       "type": "talent",
       "side": "design",
       "id": "kensei_xianzhixian",
       "reason": "design_shelved_not_imported",
-      "note": "设计库 shelf_state = 待删除，trashed_at = 2026-08-01T09:08:03.970003，不是等待引擎实装的候选。设计库 18 条非在用天赋引擎侧一条都没有导入，已导入的 3 条全部是「在用」条目。"
+      "note": "设计库 shelf_state = 待删除，trashed_at = 2026-08-01T09:08:03.970003，不是等待引擎实装的候选。设计库的非在用天赋，引擎侧一条都没有导入；已导入的天赋全部是「在用」条目。（此处刻意不写条数，理由同已归档那组 note。）"
     },
     {
       "type": "talent",
@@ -1639,13 +1668,7 @@
       "side": "design",
       "id": "kensei_xufeng",
       "reason": "design_shelved_not_imported",
-      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库 18 条非在用天赋引擎侧一条都没有导入，已导入的 3 条全部是「在用」条目。"
-    },
-    {
-      "type": "talent",
-      "side": "design",
-      "id": "kensei_yanfan",
-      "reason": "engine_not_implemented"
+      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库的非在用天赋，引擎侧一条都没有导入；已导入的天赋全部是「在用」条目。（此处刻意不写条数：这段 note 在多个条目里重复，写死计数会在每次交付后一起过期，而漏改一处比全错更难发现。）"
     },
     {
       "type": "talent",
@@ -1658,7 +1681,7 @@
       "side": "design",
       "id": "kensei_yingfeng",
       "reason": "design_shelved_not_imported",
-      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库 18 条非在用天赋引擎侧一条都没有导入，已导入的 3 条全部是「在用」条目。"
+      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库的非在用天赋，引擎侧一条都没有导入；已导入的天赋全部是「在用」条目。（此处刻意不写条数：这段 note 在多个条目里重复，写死计数会在每次交付后一起过期，而漏改一处比全错更难发现。）"
     },
     {
       "type": "talent",
@@ -1671,14 +1694,14 @@
       "side": "design",
       "id": "kensei_yishan_luan",
       "reason": "design_shelved_not_imported",
-      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库 18 条非在用天赋引擎侧一条都没有导入，已导入的 3 条全部是「在用」条目。"
+      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库的非在用天赋，引擎侧一条都没有导入；已导入的天赋全部是「在用」条目。（此处刻意不写条数：这段 note 在多个条目里重复，写死计数会在每次交付后一起过期，而漏改一处比全错更难发现。）"
     },
     {
       "type": "talent",
       "side": "design",
       "id": "kensei_yixian",
       "reason": "design_shelved_not_imported",
-      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库 18 条非在用天赋引擎侧一条都没有导入，已导入的 3 条全部是「在用」条目。"
+      "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库的非在用天赋，引擎侧一条都没有导入；已导入的天赋全部是「在用」条目。（此处刻意不写条数：这段 note 在多个条目里重复，写死计数会在每次交付后一起过期，而漏改一处比全错更难发现。）"
     },
     {
       "type": "talent",
@@ -1714,12 +1737,6 @@
       "type": "talent",
       "side": "design",
       "id": "myrmidon_sheshen",
-      "reason": "engine_not_implemented"
-    },
-    {
-      "type": "talent",
-      "side": "design",
-      "id": "myrmidon_sixian",
       "reason": "engine_not_implemented"
     },
     {


### PR DESCRIPTION
## Issue

Closes #562
Refs #550

## Summary

SoT delivered Wave 3 to the engine (`054f29c` feat + `e147ba6` test), adding three talent carriers the map still declared as `unmapped` / `engine_not_implemented`. The checker caught it — `EXIT=1`, six findings, one `cross_side_contradiction` plus one `uncovered_id` per id.

| | before | after |
|---|---:|---:|
| mappings | 34 | 37 |
| unmapped | 190 | 187 |
| engine ids | 121 | 124 |
| checker | EXIT=1 (6 findings) | **EXIT=0** |

Mapped: `kensei_jianqihuidang` (剑气回荡), `kensei_yanfan` (燕返), `myrmidon_sixian` (死线).

### The shortcut not taken

Marking the three new engine ids `unmapped` would **also** make the checker exit 0, while being the wrong classification. That trap is on record from #558. These three genuinely have counterparts now, so they belong in `mappings` with a basis someone else can re-check.

### How the correspondence was established

In code, not by eye — the terminal renders the CJK field values as mojibake, so a visual diff would have looked equally fine whether the values matched or not.

- **13 mirrored fields byte-identical on all three cards** (`id`, `name`, `class_id`, `rarity`, `tags`, the five trigger fields, `trigger_frequency_n`, `effect`, `rules`), each field's sha256 prefix matching.
- All three carry design-side `shelf_state` = 在用, so `design_shelved_not_imported` does not apply.
- **Comparator sanity check**: an injected one-character difference IS reported. Without this, an all-MATCH result from a broken comparator is indistinguishable from a real one.

Each `basis` states its evidence in full rather than referring to a sibling row, per the rule that any single row must be re-checkable alone.

## The stale-count problem, and why it took three rounds

The interesting part of this PR is not the mapping. It is that **counts breed**, and the same species of defect reappeared three times — twice inside the fix for it.

**Round 1 (Codex, 3 × Medium).** My own sweep for counts made stale by this change was too narrow: I grepped one exact phrase (`实装 3 条`), got one hit, fixed it, and concluded the file was clean. The actual wording in the repeated notes was `已导入的 3 条`. Codex found three:

- the shelved-talent note (`已导入的 3 条`), repeated verbatim across many `unmapped` entries
- README `engine_not_implemented` = 41 → recounted programmatically as 38
- README "unmapped 目前 200 条以上" → already false before this change (it was 190)

Re-sweeping with a recursive walk over every string in the JSON then surfaced a **fourth** that Codex had also missed: a 19th, differently-worded variant of the note for the 待删除 case, whose first sentence differs — so a replace-all on the 已归档 wording skipped it.

**Round 2 (Codex, 1 × Low).** The sentence I had written *explaining why hardcoded counts are bad* contained a brand-new hardcoded count — "在 18 个条目里逐字重复" — and it was **wrong on arrival**: the verbatim text occurs 17 times, since the 待删除 variant differs. Codex offered "change 18 to 17" or "reword to 18 entries"; neither was taken, because 17 goes stale the next time an archived talent is added. The count was removed.

**Round 3 sweep (mine).** One more of the same species, in a place neither of us had looked: the `entity_types` note still read "引擎当前实装 6 条(...)" followed by an enumeration of all six — a count *this change had added*. Dropped the total, kept the enumeration.

**Round 4 and 5, mine, while writing up the above.** The PR text asserting all this contained two more wrong counts. The line-delta figure was carried over from an earlier revision of the diff and no longer matched. And this commit message said the note was "repeated verbatim in 18 entries, plus a 19th variant" — actually 17 verbatim plus an 18th variant; I had taken the `grep -c` total of 18 (which already included the variant) and added the variant to it again. Both corrected against a fresh count.

Recorded rather than quietly fixed, because five instances in one change is the argument: the defect is not "someone forgot to update a number", it is that **counts breed and resist being counted**. Even the prose about the problem grew two of them.

The consistent fix is therefore **remove the count, keep the claim**. A note duplicated seventeen-odd ways goes stale on every delivery, and a partially-updated duplicate is harder to notice than a uniformly wrong one. An enumeration cannot silently disagree with itself; a count sitting next to a list can.

Counts remaining in README's reason-code table are deliberate snapshots of a "当前条数" column and stay.

### One pre-existing error fixed in passing

README said conflating the two reason codes "会让读者以为有 19 条实装欠账，实际只有 41 条". That is backwards — 19 is smaller than 41. The intended point: conflating them makes a reader add the groups and believe 57 are owed, when only 38 are. Not introduced here; fixed because the file was open and the rule is that touching existing content means checking its parallel statements.

## Test plan

- [x] Checker `EXIT=0`
- [x] Smoke suite `ALL SMOKE PASS`, **including `test_real_repositories_when_available`** — normally SKIPped; run with both repo env vars pointed at the real checkouts so the suite was not graded purely on fixtures
- [x] JSON parses; mappings 37 / unmapped 187
- [x] Deletions verified precise and fully accounted for: `id_map.json` −37 = 19 note lines (17 archived-variant + 1 pending-deletion variant + 1 `entity_types`) + 18 lines of the three removed `unmapped` entries (12 field lines + 6 brace lines). No adjacent damage. `README.md` −3/+3.
- [x] Recursive string scan for stale-count shapes returns none
- [x] 17 notes carry the new wording, 0 carry the old
- [x] Reason-code counts recounted from data and cross-checked against README: all eight rows sum to 187
- [x] `scripts/toolcall-xml-lint.sh` PASS (128 files)

## Recorded, deliberately not acted on

`myrmidon_sixian`'s design entry has a `levels_json` holding a superseded text (193 chars, not containing the current `effect`; the other two Wave 3 cards have 2 chars there), matching the warning the engine file's own `_mirror` line makes. Design-library single-write territory — noted for SoT to judge, not touched. It does not affect this mapping: the basis rests on id plus the 13 mirrored fields, which do not include `levels_json`.

## One Codex finding not acted on (disagree, with reason)

Round 3 raised a High: `.mercury/config/loop-detector.json` flips `enabled` from `true` to `false`, is unrelated to this work, and should be reverted or split out.

Not acted on, and **not** because it is wrong about the file — it is right that the flip is unrelated. It is out of scope in a stronger sense: that file is one of several pre-existing working-tree modifications that predate this session's work and are explicitly not mine to commit or revert. This PR stages only `scripts/sot_id_map/`; `git diff --name-only` on the branch's own changes lists exactly `README.md` and `id_map.json` under that directory.

Worth naming the general mechanism, since it will recur: **the Codex side of dual-verify reads the whole working tree**, so any unrelated uncommitted change in the checkout gets audited as though it were part of the diff under review. That is inherent to auditing an unstaged change, not a defect in the finding.

## Dual-verify

- Claude side: PASS
- Codex side: round 1 NEEDS-CHANGES (3 Medium) → round 2 NEEDS-CHANGES (1 Low) → round 3 NEEDS-CHANGES (1 High, out of scope — see above); all in-scope findings resolved, and round 3's independent sweep confirmed no stale counts remain, 17 new-wording notes, 0 old-wording

Generated with Claude Code
