### PR TITLE
feat(kb): filesystem-first CLI for Mercury_KB, retiring the obsidian MCP (#564)

### DIFF
--- a/scripts/kb.py
+++ b/scripts/kb.py
@@ -261,7 +261,7 @@ _OPENER = urllib.request.build_opener(_NoRedirect)
 
 
 def rest_call(path: str, method: str = "GET", payload: dict | None = None,
-              content_type: str = "application/json") -> dict:
+              content_type: str = "application/json"):
     key = os.environ.get(KEY_ENV, "").strip()
     if not key:
         raise KbError(
@@ -269,6 +269,13 @@ def rest_call(path: str, method: str = "GET", payload: dict | None = None,
             f"REST API, which also requires the Obsidian app to be running. "
             f"Filesystem subcommands (ls/cat/write/append/find/grep) need "
             f"neither.", EXIT_REST)
+    # A key with an embedded newline reaches http.client as a malformed header
+    # and raises ValueError — not an OSError, so main() would traceback on what
+    # is really a config typo. Rejected here with the usual REST exit code.
+    if any(c in key for c in "\r\n\x00") or not key.isprintable():
+        raise KbError(
+            f"{KEY_ENV} contains a newline or control character — check for a "
+            f"stray line break where it is set", EXIT_REST)
     host = os.environ.get(HOST_ENV, "").strip() or DEFAULT_HOST
     # urlopen honours whatever scheme it is handed, `file:` included — so an
     # OBSIDIAN_HOST of `file:///C:/...` would turn this network call into a
@@ -308,6 +315,18 @@ def rest_call(path: str, method: str = "GET", payload: dict | None = None,
             f"cannot reach the Obsidian Local REST API at {host}: {exc.reason}\n"
             f"Is Obsidian running with the Local REST API plugin enabled? "
             f"Filesystem subcommands do not need it.", EXIT_REST) from exc
+    except OSError as exc:
+        # A timeout while reading the body arrives as TimeoutError, an OSError
+        # that URLError does not wrap. Without this it escapes to main(), which
+        # reports it as a generic failure and returns 1 — silently breaking the
+        # documented contract that REST trouble is 3.
+        raise KbError(f"REST {method} {url} failed: {exc}", EXIT_REST) from exc
+    except ValueError as exc:
+        # http.client rejects malformed headers with ValueError. The key is
+        # screened above, but the URL can carry surprises too; keep the exit
+        # code honest rather than tracebacking.
+        raise KbError(f"REST {method} {url} could not be sent: {exc}",
+                      EXIT_REST) from exc
     if len(raw) > MAX_REST_BODY:
         raise KbError(
             f"REST {method} {url} returned more than {MAX_REST_BODY} bytes and "
@@ -325,7 +344,7 @@ def rest_call(path: str, method: str = "GET", payload: dict | None = None,
     if not body.strip():
         return {}
     try:
-        return json.loads(body)
+        parsed_body = json.loads(body)
     except json.JSONDecodeError as exc:
         # A proxy or a wrong port answers with HTML, not JSON. JSONDecodeError
         # is not an OSError, so main()'s handler does not catch it and the
@@ -334,6 +353,30 @@ def rest_call(path: str, method: str = "GET", payload: dict | None = None,
         raise KbError(
             f"REST {method} {url} returned a non-JSON body — is {host} really "
             f"the Local REST API?\n{snippet}", EXIT_REST) from exc
+    # Deliberately NOT narrowed to dict here. The real `/search/simple/`
+    # answers with a JSON *array* — an earlier attempt to enforce dict at this
+    # layer broke `osearch` outright, caught by running it against the live
+    # API. Shape is the caller's business; see `rest_object` for the callers
+    # that genuinely need a mapping.
+    return parsed_body
+
+
+def rest_object(*args, **kwargs) -> dict:
+    """`rest_call` for endpoints that must answer with a JSON object.
+
+    `[]`, `"ok"` and `null` are all valid JSON, so a caller that goes straight
+    to `.get()` would raise AttributeError against a wrong endpoint. Checking
+    here keeps that a reported REST error while leaving array-returning
+    endpoints alone.
+    """
+    result = rest_call(*args, **kwargs)
+    if not isinstance(result, dict):
+        raise KbError(
+            f"expected a JSON object from the Local REST API but got "
+            f"{type(result).__name__} — is "
+            f"{os.environ.get(HOST_ENV, '').strip() or DEFAULT_HOST} really "
+            f"the Local REST API?", EXIT_REST)
+    return result
 
 
 # --------------------------------------------------------------------------
@@ -352,7 +395,7 @@ def cmd_status(args) -> int:
               f"filesystem subcommands unaffected")
         return EXIT_OK
     try:
-        info = rest_call("/")
+        info = rest_object("/")
     except KbError as exc:
         emit(f"rest       unavailable at {host}")
         emit(f"           {exc}".replace("\n", "\n           "))

--- a/scripts/kb.py
+++ b/scripts/kb.py
@@ -250,6 +250,17 @@ def rest_call(path: str, method: str = "GET", payload: dict | None = None,
             f"Filesystem subcommands (ls/cat/write/append/find/grep) need "
             f"neither.", EXIT_REST)
     host = os.environ.get(HOST_ENV, "").strip() or DEFAULT_HOST
+    # urlopen honours whatever scheme it is handed, `file:` included — so an
+    # OBSIDIAN_HOST of `file:///C:/...` would turn this network call into a
+    # local file read, with the Authorization header silently meaningless.
+    # Restricting the scheme also catches the far more likely case: a host
+    # written without `http://`, which would otherwise fail somewhere less
+    # obvious.
+    parsed = urllib.parse.urlparse(host)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        raise KbError(
+            f"invalid {HOST_ENV}={host!r}: expected an http:// or https:// URL "
+            f"with a host, e.g. {DEFAULT_HOST}", EXIT_REST)
     url = urllib.parse.urljoin(host.rstrip("/") + "/", path.lstrip("/"))
     data = json.dumps(payload).encode("utf-8") if payload is not None else None
     req = urllib.request.Request(url, data=data, method=method)
@@ -269,7 +280,18 @@ def rest_call(path: str, method: str = "GET", payload: dict | None = None,
             f"cannot reach the Obsidian Local REST API at {host}: {exc.reason}\n"
             f"Is Obsidian running with the Local REST API plugin enabled? "
             f"Filesystem subcommands do not need it.", EXIT_REST) from exc
-    return json.loads(body) if body.strip() else {}
+    if not body.strip():
+        return {}
+    try:
+        return json.loads(body)
+    except json.JSONDecodeError as exc:
+        # A proxy or a wrong port answers with HTML, not JSON. JSONDecodeError
+        # is not an OSError, so main()'s handler does not catch it and the
+        # command would traceback instead of reporting REST trouble.
+        snippet = body[:400].replace("\n", " ")
+        raise KbError(
+            f"REST {method} {url} returned a non-JSON body — is {host} really "
+            f"the Local REST API?\n{snippet}", EXIT_REST) from exc
 
 
 # --------------------------------------------------------------------------
@@ -322,13 +344,33 @@ def cmd_cat(args) -> int:
 def _write(args, mode: str) -> int:
     root = vault_root()
     path = resolve_in_vault(root, args.path)
-    body = sys.stdin.read()
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open(mode, encoding="utf-8", newline="\n") as handle:
-        handle.write(body)
+    # Each boundary names what it was doing and which path it was doing it to.
+    # main() already turns a stray OSError into a clean EXIT_FAIL, so this is
+    # not about avoiding a traceback — it is that "[Errno 28] No space left"
+    # with no verb and no path makes a write failure and a read-back failure
+    # look identical.
+    try:
+        body = sys.stdin.read()
+    except OSError as exc:
+        raise KbError(f"cannot read the note body from stdin: {exc}",
+                      EXIT_FAIL) from exc
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise KbError(f"cannot create {path.parent}: {exc}", EXIT_FAIL) from exc
+    try:
+        with path.open(mode, encoding="utf-8", newline="\n") as handle:
+            handle.write(body)
+    except OSError as exc:
+        raise KbError(f"cannot write {rel_of(root, path)}: {exc}",
+                      EXIT_FAIL) from exc
     # Read back rather than trusting the write: a successful open() says
     # nothing about what actually landed on disk.
-    written = path.read_text(encoding="utf-8")
+    try:
+        written = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise KbError(f"wrote {rel_of(root, path)} but could not read it back "
+                      f"to verify: {exc}", EXIT_FAIL) from exc
     if mode == "w" and written != body:
         raise KbError(f"write verification failed for {args.path}", EXIT_FAIL)
     print(f"{'wrote' if mode == 'w' else 'appended to'} "

--- a/scripts/kb.py
+++ b/scripts/kb.py
@@ -400,7 +400,13 @@ def cmd_status(args) -> int:
         emit(f"rest       unavailable at {host}")
         emit(f"           {exc}".replace("\n", "\n           "))
         return EXIT_OK  # not a failure: the filesystem path still works
-    versions = info.get("versions", {})
+    # The `{}` default only applies when the key is ABSENT. `{"versions": null}`
+    # and `{"versions": []}` are both valid JSON objects that pass rest_object's
+    # top-level check and then hand a non-mapping to the .get() calls below.
+    # Checking the top level is not the same as checking what you dereference.
+    versions = info.get("versions")
+    if not isinstance(versions, dict):
+        versions = {}
     emit(f"rest       reachable at {host} "
           f"(obsidian {versions.get('obsidian', '?')}, "
           f"plugin {versions.get('self', '?')}, "

--- a/scripts/kb.py
+++ b/scripts/kb.py
@@ -240,6 +240,26 @@ def rel_of(root: Path, path: Path) -> str:
 # REST (only for what the filesystem cannot do)
 # --------------------------------------------------------------------------
 
+MAX_REST_BODY = 8 * 1024 * 1024  # 8 MiB; the real API answers in kilobytes
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Refuse to follow redirects, because urllib would carry the key along.
+
+    Measured, not assumed: a 302 from the configured host to a *different*
+    authority received the exact same `Authorization: Bearer <key>` header.
+    So a hijacked or mistyped OBSIDIAN_HOST needs only to answer with a
+    redirect to harvest the token. The Local REST API has no reason to
+    redirect at all, so any 3xx is an error here rather than a hop to follow.
+    """
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+_OPENER = urllib.request.build_opener(_NoRedirect)
+
+
 def rest_call(path: str, method: str = "GET", payload: dict | None = None,
               content_type: str = "application/json") -> dict:
     key = os.environ.get(KEY_ENV, "").strip()
@@ -268,10 +288,18 @@ def rest_call(path: str, method: str = "GET", payload: dict | None = None,
     if data is not None:
         req.add_header("Content-Type", content_type)
     try:
-        with urllib.request.urlopen(req, timeout=10) as resp:
-            body = resp.read().decode("utf-8")
+        with _OPENER.open(req, timeout=10) as resp:
+            raw = resp.read(MAX_REST_BODY + 1)
     except urllib.error.HTTPError as exc:
-        detail = exc.read().decode("utf-8", "replace")[:400]
+        # Bounded read here too: the truncation below happens after decoding,
+        # so an unbounded read would already have consumed the memory.
+        detail = exc.read(MAX_REST_BODY + 1).decode("utf-8", "replace")[:400]
+        if exc.code in (301, 302, 303, 307, 308):
+            raise KbError(
+                f"REST {method} {url} answered with a redirect (HTTP "
+                f"{exc.code}), which is not followed: urllib would resend the "
+                f"Authorization header to the new host. Point {HOST_ENV} "
+                f"straight at the Local REST API.", EXIT_REST) from exc
         hint = (" — check OBSIDIAN_API_KEY" if exc.code == 401 else "")
         raise KbError(f"REST {method} {url} failed: HTTP {exc.code}{hint}\n"
                       f"{detail}", EXIT_REST) from exc
@@ -280,6 +308,20 @@ def rest_call(path: str, method: str = "GET", payload: dict | None = None,
             f"cannot reach the Obsidian Local REST API at {host}: {exc.reason}\n"
             f"Is Obsidian running with the Local REST API plugin enabled? "
             f"Filesystem subcommands do not need it.", EXIT_REST) from exc
+    if len(raw) > MAX_REST_BODY:
+        raise KbError(
+            f"REST {method} {url} returned more than {MAX_REST_BODY} bytes and "
+            f"was not read further — is {host} really the Local REST API?",
+            EXIT_REST)
+    try:
+        body = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        # Same class of hole as the JSON guard below, one line earlier:
+        # UnicodeDecodeError is a ValueError, not an OSError, so main()'s
+        # handler does not catch it either.
+        raise KbError(
+            f"REST {method} {url} returned a body that is not valid UTF-8 — "
+            f"is {host} really the Local REST API?", EXIT_REST) from exc
     if not body.strip():
         return {}
     try:

--- a/scripts/kb.py
+++ b/scripts/kb.py
@@ -1,0 +1,511 @@
+#!/usr/bin/env python3
+"""kb.py — command-line access to Mercury_KB, filesystem-first.
+
+Replaces the obsidian MCP server for day-to-day knowledge-base work.
+
+Why not route everything through Obsidian
+-----------------------------------------
+All three Obsidian-side options require the desktop app to be running:
+
+  - the official Obsidian CLI — "Note that the Obsidian app must be running."
+    (https://obsidian.md/cli); it is a remote control for a live app, not a
+    headless tool
+  - the Local REST API on localhost — a *plugin*, so it dies with the app
+  - the MCP server — same, plus it leaks processes between sessions
+
+The vault is a plain git repository full of markdown. So reading, writing and
+searching go straight to the files: no app, no network, no daemon. Only the
+things the filesystem genuinely cannot do — Obsidian's own search index, its
+command palette, the currently-open note — go over the REST API, and those
+subcommands say so plainly when it is unavailable rather than pretending.
+
+Configuration (never hardcoded)
+-------------------------------
+  MERCURY_KB_DIR    vault root; falls back to `kb_dir` in .handoff-config
+  OBSIDIAN_HOST     default http://localhost:27123      (REST subcommands only)
+  OBSIDIAN_API_KEY  required for REST subcommands
+
+Exit codes
+----------
+  0  success
+  1  not found / operation failed
+  2  environment problem (vault not configured, path escapes the vault)
+  3  REST API unavailable or unauthenticated (REST subcommands only)
+"""
+
+from __future__ import annotations
+
+import argparse
+import errno
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+KB_DIR_ENV = "MERCURY_KB_DIR"
+HOST_ENV = "OBSIDIAN_HOST"
+KEY_ENV = "OBSIDIAN_API_KEY"
+DEFAULT_HOST = "http://localhost:27123"
+
+# Directories that are vault machinery rather than notes. `.git` also matters
+# for correctness, not just noise: it contains blobs that look like text and
+# would otherwise show up in `grep`.
+SKIP_DIRS = {".git", ".obsidian", ".trash", "node_modules", "__pycache__"}
+
+EXIT_OK, EXIT_FAIL, EXIT_ENV, EXIT_REST = 0, 1, 2, 3
+
+
+def _is_pipe_error(exc: BaseException) -> bool:
+    """True for a downstream-closed-the-pipe error, on any platform.
+
+    Windows raises OSError EINVAL rather than BrokenPipeError, so testing the
+    exception type alone misses it there. Deliberately narrow: a genuine I/O
+    failure must still propagate rather than be reported as success.
+
+    Called from exactly two places, both wrapped tightly around a stdout
+    operation: `emit()` (the write) and `_finish()` (the deliberate flush).
+    An earlier version instead wrapped whole subcommands in `except OSError`,
+    which was wrong — a filesystem EINVAL raised while reading a note was
+    then indistinguishable from a closed pipe and got reported as exit 0.
+    Keeping the predicate narrow is only half of it; where it is applied
+    matters as much.
+
+    KNOWN IMPRECISION: on Windows a closed pipe surfaces as EINVAL, an errno
+    generic enough that a genuine EINVAL from stdout itself would also be
+    read as a closed pipe and keep the command's prior exit code. There is no
+    way found to distinguish the two from the exception alone. The exposure is
+    bounded — it applies only to stdout writes and flushes, not to any
+    filesystem operation — but it is real, and is not claimed to be handled.
+    """
+    return isinstance(exc, BrokenPipeError) or (
+        isinstance(exc, OSError) and exc.errno in (errno.EPIPE, errno.EINVAL))
+
+
+class KbError(Exception):
+    """Fatal, with an exit code attached."""
+
+    def __init__(self, message: str, code: int = EXIT_FAIL) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+class _PipeClosed(Exception):
+    """The downstream reader went away. Normal for `kb ... | head`."""
+
+
+def emit(text: str = "") -> None:
+    """Write one line to stdout, mapping a closed pipe to `_PipeClosed`.
+
+    Every stdout write in this program goes through here, and that scoping is
+    the point. An earlier version wrapped whole subcommands in
+    `except OSError` to catch the pipe, which meant a filesystem EINVAL raised
+    while reading a note was indistinguishable from a closed pipe and got
+    reported as success. Narrowing the predicate was not enough on its own —
+    it has to be applied to the output operation rather than to the command.
+    """
+    try:
+        sys.stdout.write(text + "\n")
+    except OSError as exc:
+        if _is_pipe_error(exc):
+            raise _PipeClosed from exc
+        raise
+
+
+# --------------------------------------------------------------------------
+# vault resolution + path containment
+# --------------------------------------------------------------------------
+
+def vault_root() -> Path:
+    """Resolve the vault root from env, else from .handoff-config."""
+    raw = os.environ.get(KB_DIR_ENV, "").strip()
+    source = KB_DIR_ENV
+    if not raw:
+        cfg = Path(__file__).resolve().parent.parent / ".handoff-config"
+        if cfg.is_file():
+            for line in cfg.read_text(encoding="utf-8").splitlines():
+                key, sep, value = line.partition("=")
+                if sep and key.strip() == "kb_dir":
+                    raw, source = value.strip(), f"{cfg.name}:kb_dir"
+                    break
+    if not raw:
+        raise KbError(
+            f"vault not configured: set {KB_DIR_ENV}, or add kb_dir to "
+            f".handoff-config", EXIT_ENV)
+    root = Path(raw).expanduser()
+    if not root.is_dir():
+        raise KbError(f"vault path from {source} is not a directory: {root}",
+                      EXIT_ENV)
+    return root.resolve()
+
+
+def resolve_in_vault(root: Path, rel: str) -> Path:
+    """Join `rel` under `root`, refusing anything that lands outside.
+
+    Same containment rule as scripts/sot_id_map/sources.py: resolve first,
+    then check, so a `..`-laden path or a symlink/junction cannot walk out of
+    the vault and read or overwrite an unrelated file. `root` is already
+    resolved by `vault_root`.
+    """
+    try:
+        candidate = (root / rel).resolve()
+    except (OSError, RuntimeError) as exc:
+        raise KbError(f"cannot resolve {rel!r} under {root}: {exc}",
+                      EXIT_ENV) from exc
+    if not candidate.is_relative_to(root):
+        raise KbError(
+            f"path {rel!r} resolves to {candidate}, which is outside the vault "
+            f"{root} — refusing", EXIT_ENV)
+    return candidate
+
+
+def is_reparse_dir(path: Path) -> bool:
+    """True for a Windows junction, which `is_symlink()` reports as False."""
+    try:
+        return bool(path.stat(follow_symlinks=False).st_reparse_tag)
+    except (OSError, AttributeError):
+        return False
+
+
+def iter_notes(root: Path, subdir: str = ""):
+    """Every *.md under the vault, skipping machinery directories.
+
+    Uses os.walk with an onerror hook rather than rglob: rglob swallows
+    permission errors and silently yields nothing, which reads exactly like
+    "the directory is empty" (learned the hard way — see #556).
+
+    CONTAINMENT APPLIES HERE TOO, and the obvious reading of `followlinks`
+    is wrong on Windows. `followlinks=False` does NOT stop os.walk from
+    descending into a junction: measured on this machine with a real junction
+    placed inside the vault, os.walk went straight through it and `ls` /
+    `grep` returned a file living outside.
+
+    So aliases are pruned during the walk AND every yielded path is checked
+    for containment. The second check is not redundant: pruning depends on a
+    stat succeeding, and a path can also reach outside via a component that
+    was already resolved before the walk began.
+
+    KNOWN LIMIT — time-of-check/time-of-use. Containment is verified when the
+    path is yielded, not when the caller opens it. An alias swapped into place
+    in between would be followed by the subsequent read. Not fixed: doing so
+    needs open-then-verify against a file handle, and Windows offers no
+    portable O_NOFOLLOW. The threat model also does not motivate it — writing
+    into the vault is already required to set the race up, and anyone with
+    that can read the same content directly. Recorded so the guarantee is not
+    read as stronger than it is.
+    """
+    base = resolve_in_vault(root, subdir) if subdir else root
+    if not base.is_dir():
+        raise KbError(f"not a directory: {base}", EXIT_FAIL)
+
+    problems: list[str] = []
+    for dirpath, dirnames, filenames in os.walk(
+            base, onerror=lambda e: problems.append(str(e)), followlinks=False):
+        keep = []
+        for d in dirnames:
+            if d in SKIP_DIRS:
+                continue
+            child = Path(dirpath) / d
+            if child.is_symlink() or is_reparse_dir(child):
+                print(f"warning: not descending into alias "
+                      f"{child} (symlink or junction)", file=sys.stderr)
+                continue
+            keep.append(d)
+        dirnames[:] = keep
+
+        for name in sorted(filenames):
+            if not name.endswith(".md"):
+                continue
+            candidate = Path(dirpath) / name
+            try:
+                if not candidate.resolve().is_relative_to(root):
+                    print(f"warning: skipping {candidate} — resolves outside "
+                          f"the vault", file=sys.stderr)
+                    continue
+            except (OSError, RuntimeError) as exc:
+                print(f"warning: skipping {candidate}: {exc}", file=sys.stderr)
+                continue
+            yield candidate
+    for problem in problems:
+        print(f"warning: could not read: {problem}", file=sys.stderr)
+
+
+def rel_of(root: Path, path: Path) -> str:
+    return path.relative_to(root).as_posix()
+
+
+# --------------------------------------------------------------------------
+# REST (only for what the filesystem cannot do)
+# --------------------------------------------------------------------------
+
+def rest_call(path: str, method: str = "GET", payload: dict | None = None,
+              content_type: str = "application/json") -> dict:
+    key = os.environ.get(KEY_ENV, "").strip()
+    if not key:
+        raise KbError(
+            f"{KEY_ENV} is not set — this subcommand needs the Obsidian Local "
+            f"REST API, which also requires the Obsidian app to be running. "
+            f"Filesystem subcommands (ls/cat/write/append/find/grep) need "
+            f"neither.", EXIT_REST)
+    host = os.environ.get(HOST_ENV, "").strip() or DEFAULT_HOST
+    url = urllib.parse.urljoin(host.rstrip("/") + "/", path.lstrip("/"))
+    data = json.dumps(payload).encode("utf-8") if payload is not None else None
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("Authorization", f"Bearer {key}")
+    if data is not None:
+        req.add_header("Content-Type", content_type)
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            body = resp.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", "replace")[:400]
+        hint = (" — check OBSIDIAN_API_KEY" if exc.code == 401 else "")
+        raise KbError(f"REST {method} {url} failed: HTTP {exc.code}{hint}\n"
+                      f"{detail}", EXIT_REST) from exc
+    except urllib.error.URLError as exc:
+        raise KbError(
+            f"cannot reach the Obsidian Local REST API at {host}: {exc.reason}\n"
+            f"Is Obsidian running with the Local REST API plugin enabled? "
+            f"Filesystem subcommands do not need it.", EXIT_REST) from exc
+    return json.loads(body) if body.strip() else {}
+
+
+# --------------------------------------------------------------------------
+# subcommands
+# --------------------------------------------------------------------------
+
+def cmd_status(args) -> int:
+    root = vault_root()
+    notes = list(iter_notes(root))
+    emit(f"vault      {root}")
+    emit(f"notes      {len(notes)} markdown file(s)")
+    emit(f"git        {'yes' if (root / '.git').exists() else 'no'}")
+    host = os.environ.get(HOST_ENV, "").strip() or DEFAULT_HOST
+    if not os.environ.get(KEY_ENV, "").strip():
+        emit(f"rest       not configured ({KEY_ENV} unset) — "
+              f"filesystem subcommands unaffected")
+        return EXIT_OK
+    try:
+        info = rest_call("/")
+    except KbError as exc:
+        emit(f"rest       unavailable at {host}")
+        emit(f"           {exc}".replace("\n", "\n           "))
+        return EXIT_OK  # not a failure: the filesystem path still works
+    versions = info.get("versions", {})
+    emit(f"rest       reachable at {host} "
+          f"(obsidian {versions.get('obsidian', '?')}, "
+          f"plugin {versions.get('self', '?')}, "
+          f"authenticated={info.get('authenticated')})")
+    return EXIT_OK
+
+
+def cmd_ls(args) -> int:
+    root = vault_root()
+    count = 0
+    for path in iter_notes(root, args.subdir or ""):
+        emit(rel_of(root, path))
+        count += 1
+    return EXIT_OK if count else EXIT_FAIL
+
+
+def cmd_cat(args) -> int:
+    root = vault_root()
+    path = resolve_in_vault(root, args.path)
+    if not path.is_file():
+        raise KbError(f"no such note: {args.path}", EXIT_FAIL)
+    emit(path.read_text(encoding="utf-8").rstrip("\n"))
+    return EXIT_OK
+
+
+def _write(args, mode: str) -> int:
+    root = vault_root()
+    path = resolve_in_vault(root, args.path)
+    body = sys.stdin.read()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open(mode, encoding="utf-8", newline="\n") as handle:
+        handle.write(body)
+    # Read back rather than trusting the write: a successful open() says
+    # nothing about what actually landed on disk.
+    written = path.read_text(encoding="utf-8")
+    if mode == "w" and written != body:
+        raise KbError(f"write verification failed for {args.path}", EXIT_FAIL)
+    print(f"{'wrote' if mode == 'w' else 'appended to'} "
+          f"{rel_of(root, path)} ({len(body)} chars, file now "
+          f"{len(written)} chars)", file=sys.stderr)
+    return EXIT_OK
+
+
+def cmd_write(args) -> int:
+    return _write(args, "w")
+
+
+def cmd_append(args) -> int:
+    return _write(args, "a")
+
+
+def cmd_find(args) -> int:
+    root = vault_root()
+    needle = args.pattern.lower()
+    hits = [rel_of(root, p) for p in iter_notes(root)
+            if needle in p.name.lower()]
+    for hit in hits:
+        emit(hit)
+    return EXIT_OK if hits else EXIT_FAIL
+
+
+def cmd_grep(args) -> int:
+    root = vault_root()
+    needle = args.query if args.case_sensitive else args.query.lower()
+    hits = 0
+    for path in iter_notes(root):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            print(f"warning: skipped {rel_of(root, path)}: {exc}",
+                  file=sys.stderr)
+            continue
+        for lineno, line in enumerate(text.splitlines(), 1):
+            haystack = line if args.case_sensitive else line.lower()
+            if needle in haystack:
+                emit(f"{rel_of(root, path)}:{lineno}:{line.strip()}")
+                hits += 1
+    return EXIT_OK if hits else EXIT_FAIL
+
+
+def cmd_osearch(args) -> int:
+    """Obsidian's own search index — the filesystem cannot reproduce this."""
+    result = rest_call(f"/search/simple/?query="
+                       f"{urllib.parse.quote(args.query)}", method="POST")
+    if not result:
+        print("(no matches)", file=sys.stderr)
+        return EXIT_FAIL
+    emit(json.dumps(result, ensure_ascii=False, indent=2))
+    return EXIT_OK
+
+
+def cmd_commands(args) -> int:
+    """List Obsidian command-palette commands (REST-only capability)."""
+    result = rest_call("/commands/")
+    emit(json.dumps(result, ensure_ascii=False, indent=2))
+    return EXIT_OK
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="kb",
+        description="Mercury_KB access. Filesystem-first: ls/cat/write/append/"
+                    "find/grep work with Obsidian closed. osearch/commands "
+                    "need Obsidian running.")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("status", help="vault path, note count, REST reachability"
+                   ).set_defaults(func=cmd_status)
+
+    p = sub.add_parser("ls", help="list notes (filesystem)")
+    p.add_argument("subdir", nargs="?", help="limit to a subdirectory")
+    p.set_defaults(func=cmd_ls)
+
+    p = sub.add_parser("cat", help="print a note (filesystem)")
+    p.add_argument("path")
+    p.set_defaults(func=cmd_cat)
+
+    p = sub.add_parser("write", help="overwrite a note from stdin (filesystem)")
+    p.add_argument("path")
+    p.set_defaults(func=cmd_write)
+
+    p = sub.add_parser("append", help="append to a note from stdin (filesystem)")
+    p.add_argument("path")
+    p.set_defaults(func=cmd_append)
+
+    p = sub.add_parser("find", help="find notes by filename (filesystem)")
+    p.add_argument("pattern")
+    p.set_defaults(func=cmd_find)
+
+    p = sub.add_parser("grep", help="full-text search (filesystem)")
+    p.add_argument("query")
+    p.add_argument("-s", "--case-sensitive", action="store_true")
+    p.set_defaults(func=cmd_grep)
+
+    p = sub.add_parser("osearch", help="Obsidian index search (needs Obsidian)")
+    p.add_argument("query")
+    p.set_defaults(func=cmd_osearch)
+
+    sub.add_parser("commands", help="list Obsidian commands (needs Obsidian)"
+                   ).set_defaults(func=cmd_commands)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    # The vault is full of CJK. Emit UTF-8 regardless of the console code page
+    # so piping and redirection get correct bytes; `errors="replace"` keeps a
+    # legacy console from turning a display problem into a crash.
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="replace")
+        except (AttributeError, ValueError):
+            pass
+    try:
+        sys.stdin.reconfigure(encoding="utf-8")
+    except (AttributeError, ValueError):
+        pass
+
+    args = build_parser().parse_args(argv)
+    try:
+        rc = args.func(args)
+    except KbError as exc:
+        print(f"kb: {exc}", file=sys.stderr)
+        rc = exc.code
+    except _PipeClosed:
+        # `kb grep x | head` — the reader is done, we are done. Not a failure.
+        rc = EXIT_OK
+    except OSError as exc:
+        # A real filesystem failure. Report it like an error instead of
+        # dumping a traceback, and never as success. Note this is reached
+        # only for non-pipe errors: pipe-shaped ones are raised as
+        # _PipeClosed by emit(), from the write itself.
+        print(f"kb: {exc}", file=sys.stderr)
+        rc = EXIT_FAIL
+    return _finish(rc)
+
+
+def _finish(rc: int) -> int:
+    """Flush stdout before returning, classifying any failure honestly.
+
+    `kb grep x | head` is a normal way to use this, so a downstream close must
+    not become a failure. Catching the write was not enough, and the naive
+    version was wrong twice over:
+
+      1. Windows reports a closed pipe as OSError EINVAL, not BrokenPipeError,
+         so `except BrokenPipeError` never fires.
+      2. Whether the error surfaces inside a `try` at all depends on where the
+         buffer happens to fill. At ~700 lines it raised inside emit() and was
+         caught; at ~2000 it did not raise until the interpreter's own
+         exit-time flush — after main() had already returned 0 — turning the
+         exit code into 120 with an "Exception ignored" trailer.
+
+    So flush deliberately here, while there is still a frame to handle it.
+    Buffer size stops mattering. Crucially, only pipe-shaped failures are
+    absorbed: a real I/O failure while flushing must not be reported as
+    success, or the exit-code contract is a lie.
+    """
+    try:
+        sys.stdout.flush()
+    except ValueError:
+        # Stream already closed. Nothing buffered can still be lost.
+        return rc
+    except OSError as exc:
+        if _is_pipe_error(exc):
+            try:
+                os.dup2(os.open(os.devnull, os.O_WRONLY), sys.stdout.fileno())
+            except OSError:
+                pass  # exit code is already decided; nothing further to do
+            return rc
+        print(f"kb: could not flush stdout: {exc}", file=sys.stderr)
+        return rc if rc != EXIT_OK else EXIT_FAIL
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/kb_test.py
+++ b/scripts/kb_test.py
@@ -320,6 +320,33 @@ def main() -> int:
         finally:
             asrv.shutdown()
 
+        # rest_object checks the TOP LEVEL only. `{"versions": null}` is a
+        # valid object that passes that check and then hands a non-mapping to
+        # cmd_status's .get() calls. Checking the container is not the same as
+        # checking what you dereference out of it.
+        class _NullVersions(http.server.BaseHTTPRequestHandler):
+            def do_POST(self):  # noqa: N802
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(b'{"versions": null, "authenticated": true}')
+            do_GET = do_POST
+            def log_message(self, *a):
+                pass
+
+        nsrv = http.server.HTTPServer(("127.0.0.1", 0), _NullVersions)
+        threading.Thread(target=nsrv.serve_forever, daemon=True).start()
+        try:
+            rc, out, err = run(
+                ["status"], vault,
+                env_extra={"OBSIDIAN_API_KEY": "dummy",
+                           "OBSIDIAN_HOST": f"http://127.0.0.1:{nsrv.server_port}"})
+            check("status survives a null nested field without AttributeError",
+                  rc == 0 and "Traceback" not in err and "Traceback" not in out,
+                  f"rc={rc} out={out!r} err={err!r}")
+        finally:
+            nsrv.shutdown()
+
         # The 8 MiB cap had no test until the audit pointed that out: deleting
         # the capped read would have left the guard silently unexercised.
         class _Huge(http.server.BaseHTTPRequestHandler):

--- a/scripts/kb_test.py
+++ b/scripts/kb_test.py
@@ -281,6 +281,74 @@ def main() -> int:
         finally:
             srv.shutdown()
 
+        # A key with an embedded newline would reach http.client as a malformed
+        # header and raise ValueError, which is not an OSError.
+        rc, _, err = run(["osearch", "x"], vault,
+                         env_extra={"OBSIDIAN_API_KEY": "abc\ndef",
+                                    "OBSIDIAN_HOST": "http://127.0.0.1:9"})
+        check("a key containing a newline exits 3, not a traceback",
+              rc == 3 and "newline" in err and "Traceback" not in err,
+              f"rc={rc} err={err!r}")
+
+        # rest_call must NOT force a dict: the real /search/simple/ answers
+        # with an array, and enforcing dict there broke osearch outright.
+        # Only callers needing a mapping check, so a JSON array must be fine
+        # for osearch and rejected for status.
+        class _Array(http.server.BaseHTTPRequestHandler):
+            def do_POST(self):  # noqa: N802
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(b'[{"filename":"a.md"}]')
+            do_GET = do_POST
+            def log_message(self, *a):
+                pass
+
+        asrv = http.server.HTTPServer(("127.0.0.1", 0), _Array)
+        threading.Thread(target=asrv.serve_forever, daemon=True).start()
+        try:
+            aenv = {"OBSIDIAN_API_KEY": "dummy",
+                    "OBSIDIAN_HOST": f"http://127.0.0.1:{asrv.server_port}"}
+            rc, out, err = run(["osearch", "x"], vault, env_extra=aenv)
+            check("osearch accepts a JSON array (regression guard)",
+                  rc == 0 and "a.md" in out, f"rc={rc} err={err!r}")
+            rc, out, _ = run(["status"], vault, env_extra=aenv)
+            check("status reports rest unavailable on a non-object body "
+                  "instead of AttributeError",
+                  rc == 0 and "unavailable" in out and "Traceback" not in out,
+                  f"rc={rc} out={out!r}")
+        finally:
+            asrv.shutdown()
+
+        # The 8 MiB cap had no test until the audit pointed that out: deleting
+        # the capped read would have left the guard silently unexercised.
+        class _Huge(http.server.BaseHTTPRequestHandler):
+            def do_POST(self):  # noqa: N802
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                chunk = b"x" * (1 << 20)
+                for _ in range(9):          # 9 MiB > MAX_REST_BODY
+                    try:
+                        self.wfile.write(chunk)
+                    except OSError:
+                        return
+            do_GET = do_POST
+            def log_message(self, *a):
+                pass
+
+        hsrv = http.server.HTTPServer(("127.0.0.1", 0), _Huge)
+        threading.Thread(target=hsrv.serve_forever, daemon=True).start()
+        try:
+            rc, _, err = run(
+                ["osearch", "x"], vault,
+                env_extra={"OBSIDIAN_API_KEY": "dummy",
+                           "OBSIDIAN_HOST": f"http://127.0.0.1:{hsrv.server_port}"})
+            check("an oversized REST body is rejected, not buffered whole",
+                  rc == 3 and "more than" in err, f"rc={rc} err={err!r}")
+        finally:
+            hsrv.shutdown()
+
         # Invalid UTF-8 is the same class of hole one line earlier than the
         # JSON guard: UnicodeDecodeError is a ValueError, so main()'s OSError
         # handler misses it too.

--- a/scripts/kb_test.py
+++ b/scripts/kb_test.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Smoke tests for scripts/kb.py.
+
+Run: python scripts/kb_test.py
+
+Everything runs against a throwaway vault under the system temp directory, so
+the real Mercury_KB is never written to. Nothing here needs Obsidian running —
+that is the point of the tool, so the tests must not depend on it either. The
+REST path is exercised only for its *unconfigured* behaviour, which is the part
+that must stay correct when Obsidian is closed.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+KB = str(Path(__file__).resolve().parent / "kb.py")
+PASS = FAIL = 0
+
+
+def run(args: list[str], vault: str, stdin: str = "",
+        env_extra: dict | None = None):
+    """Invoke kb.py and return (returncode, stdout, stderr)."""
+    env = dict(os.environ)
+    env.pop("OBSIDIAN_API_KEY", None)
+    env.pop("OBSIDIAN_HOST", None)
+    env["MERCURY_KB_DIR"] = vault
+    env["PYTHONIOENCODING"] = "utf-8"
+    if env_extra:
+        env.update(env_extra)
+    proc = subprocess.run([sys.executable, KB, *args], input=stdin,
+                          env=env, text=True, encoding="utf-8",
+                          errors="replace", capture_output=True)
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def check(name: str, condition: bool, detail: str = "") -> None:
+    global PASS, FAIL
+    if condition:
+        PASS += 1
+        print(f"PASS {name}")
+    else:
+        FAIL += 1
+        print(f"FAIL {name}" + (f"\n     {detail}" if detail else ""))
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="kbtest-") as tmp:
+        vault = str(Path(tmp) / "vault")
+        (Path(vault) / "sub").mkdir(parents=True)
+        (Path(vault) / "sub" / "seed.md").write_text(
+            "seed note\n找得到的中文\n", encoding="utf-8")
+        outside = Path(tmp) / "OUTSIDE.md"
+        outside.write_text("must not be touched\n", encoding="utf-8")
+
+        # --- baseline: the happy paths must work, or every negative test
+        # --- below would "pass" for the wrong reason.
+        rc, out, _ = run(["status"], vault)
+        check("status exits 0 and finds the vault",
+              rc == 0 and "1 markdown" in out, f"rc={rc} out={out!r}")
+
+        rc, out, _ = run(["ls"], vault)
+        check("ls lists the seeded note", rc == 0 and "sub/seed.md" in out,
+              f"rc={rc} out={out!r}")
+
+        rc, out, _ = run(["cat", "sub/seed.md"], vault)
+        check("cat round-trips UTF-8", rc == 0 and "找得到的中文" in out,
+              f"rc={rc} out={out!r}")
+
+        rc, out, _ = run(["grep", "找得到"], vault)
+        check("grep finds CJK", rc == 0 and "sub/seed.md:2" in out,
+              f"rc={rc} out={out!r}")
+
+        rc, out, _ = run(["find", "seed"], vault)
+        check("find matches by filename", rc == 0 and "sub/seed.md" in out,
+              f"rc={rc} out={out!r}")
+
+        # --- write / append land on disk, verified by reading back
+        rc, _, _ = run(["write", "notes/new.md"], vault, stdin="# Hi\n汉字\n")
+        body = (Path(vault) / "notes" / "new.md").read_text(encoding="utf-8")
+        check("write creates parent dirs and writes UTF-8",
+              rc == 0 and body == "# Hi\n汉字\n", f"rc={rc} body={body!r}")
+
+        rc, _, _ = run(["append", "notes/new.md"], vault, stdin="more\n")
+        body = (Path(vault) / "notes" / "new.md").read_text(encoding="utf-8")
+        check("append preserves prior content",
+              rc == 0 and body == "# Hi\n汉字\nmore\n", f"rc={rc} body={body!r}")
+
+        rc, _, _ = run(["write", "lf.md"], vault, stdin="a\nb\n")
+        raw = (Path(vault) / "lf.md").read_bytes()
+        check("writes LF, not CRLF", b"\r\n" not in raw, f"raw={raw!r}")
+
+        # --- containment. Both directions: escapes refused AND a legal path
+        # --- still accepted, otherwise a blanket refusal would look correct.
+        for bad in ["../OUTSIDE.md", "../../OUTSIDE.md", "sub/../../OUTSIDE.md",
+                    "/etc/passwd", "C:/Windows/System32/drivers/etc/hosts"]:
+            rc, _, err = run(["write", bad], vault, stdin="PWNED\n")
+            check(f"write refuses escape {bad!r} with exit 2",
+                  rc == 2 and "outside the vault" in err, f"rc={rc} err={err!r}")
+        rc, _, err = run(["cat", "../OUTSIDE.md"], vault)
+        check("cat refuses escape with exit 2", rc == 2, f"rc={rc} err={err!r}")
+        check("escaped target was never modified",
+              outside.read_text(encoding="utf-8") == "must not be touched\n")
+        rc, _, _ = run(["write", "legal.md"], vault, stdin="ok\n")
+        check("legal path still accepted (guard is not blanket-deny)", rc == 0,
+              f"rc={rc}")
+
+        # --- containment through a directory alias. This is the case the
+        # --- straightforward `os.walk(followlinks=False)` does NOT cover on
+        # --- Windows: measured, a junction inside the vault gets walked
+        # --- straight through, so ls/grep returned a file living outside it.
+        # --- The fixture must be checked before the assertion is worth
+        # --- anything — a mklink that silently fails looks identical to a
+        # --- correctly-blocked alias.
+        alias = Path(vault) / "aliasdir"
+        secret_dir = Path(tmp) / "secret"
+        secret_dir.mkdir()
+        (secret_dir / "leak.md").write_text("SECRETSTRING\n", encoding="utf-8")
+        made = False
+        try:
+            if os.name == "nt":
+                subprocess.run(["cmd", "/c", "mklink", "/J", str(alias),
+                                str(secret_dir)], capture_output=True,
+                               check=False)
+            else:
+                os.symlink(secret_dir, alias, target_is_directory=True)
+            made = alias.exists() and (alias / "leak.md").exists()
+        except OSError:
+            made = False
+        check("fixture: directory alias was actually created", made,
+              "could not create a junction/symlink — the two alias assertions "
+              "below would pass vacuously, so treat them as unproven")
+        # kb.py guards this twice over — it prunes alias directories during the
+        # walk AND re-checks containment on every yielded file. Disabling
+        # either one alone leaves these tests green, because the other still
+        # holds; only disabling both turns them red. That is defence in depth
+        # working as intended, not a weak test — but it does mean a single-layer
+        # sabotage is not a valid way to check that these assertions bite.
+        if made:
+            rc, out, _ = run(["ls"], vault)
+            check("ls does not descend into an alias out of the vault",
+                  "leak.md" not in out, f"out={out!r}")
+            rc, out, _ = run(["grep", "SECRETSTRING"], vault)
+            check("grep cannot read through an alias out of the vault",
+                  rc == 1 and "SECRETSTRING" not in out,
+                  f"rc={rc} out={out!r}")
+            rc, out, _ = run(["grep", "seed note"], vault)
+            check("in-vault content still found (alias guard is not "
+                  "blanket-deny)", rc == 0 and "sub/seed.md" in out,
+                  f"rc={rc} out={out!r}")
+
+        # --- missing things fail as failures, not as success
+        rc, _, _ = run(["cat", "nope.md"], vault)
+        check("cat on a missing note exits 1", rc == 1, f"rc={rc}")
+        rc, _, _ = run(["grep", "zzz-no-such-string-zzz"], vault)
+        check("grep with no hits exits 1", rc == 1, f"rc={rc}")
+
+        # --- unconfigured vault is an environment error, not a crash
+        env_no_vault = dict(os.environ)
+        env_no_vault.pop("OBSIDIAN_API_KEY", None)
+        env_no_vault["MERCURY_KB_DIR"] = str(Path(tmp) / "does-not-exist")
+        proc = subprocess.run([sys.executable, KB, "status"], env=env_no_vault,
+                              text=True, encoding="utf-8", errors="replace",
+                              capture_output=True)
+        check("bad vault path exits 2", proc.returncode == 2,
+              f"rc={proc.returncode} err={proc.stderr!r}")
+
+        # --- REST subcommands must fail loudly when unconfigured, and must
+        # --- say that the filesystem path is unaffected. No Obsidian needed.
+        rc, _, err = run(["osearch", "x"], vault)
+        check("osearch without a key exits 3 and points at the filesystem path",
+              rc == 3 and "Filesystem subcommands" in err,
+              f"rc={rc} err={err!r}")
+        rc, _, err = run(["osearch", "x"], vault,
+                         env_extra={"OBSIDIAN_API_KEY": "dummy",
+                                    "OBSIDIAN_HOST": "http://127.0.0.1:9"})
+        check("osearch against a dead port exits 3 and names Obsidian",
+              rc == 3 and "Is Obsidian running" in err, f"rc={rc} err={err!r}")
+
+        # --- broken pipe. Needs output long enough that the downstream reader
+        # --- closes mid-write; a short listing finishes first and never
+        # --- reproduces it. Windows surfaces this as OSError EINVAL rather
+        # --- than BrokenPipeError, and the interpreter's exit-time flush
+        # --- re-raises it, which is how this first showed up as exit 120.
+        #
+        # NOTE ON HOW THIS IS MEASURED: an earlier version of this test ran
+        # `kb grep needle | head -2` through the shell and asserted on the
+        # return code. That assertion was worthless — a shell pipeline reports
+        # the *last* command's status, and `head` always exits 0, so it passed
+        # no matter what kb.py did. It was caught by deliberately breaking the
+        # pipe handling and seeing this test stay green. Close the read end
+        # directly instead, so the code under test is what determines the
+        # result.
+        for i in range(400):
+            (Path(vault) / f"bulk{i:03d}.md").write_text(
+                f"needle line {i}\n" * 5, encoding="utf-8")
+        env = dict(os.environ)
+        env.pop("OBSIDIAN_API_KEY", None)
+        env["MERCURY_KB_DIR"] = vault
+        env["PYTHONIOENCODING"] = "utf-8"
+        proc = subprocess.Popen(
+            [sys.executable, KB, "grep", "needle"], env=env, text=True,
+            encoding="utf-8", errors="replace",
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        proc.stdout.readline()
+        proc.stdout.readline()
+        proc.stdout.close()          # reader goes away mid-write
+        pipe_err = proc.stderr.read()
+        proc.stderr.close()
+        pipe_rc = proc.wait()
+        check("grep exits 0 when the reader closes early",
+              pipe_rc == 0, f"rc={pipe_rc} err={pipe_err!r}")
+        check("no 'Exception ignored' trailer on the closed pipe",
+              "Exception ignored" not in pipe_err, f"err={pipe_err!r}")
+        # COVERAGE, established by sabotage rather than assumed. kb.py guards
+        # the pipe twice: emit() maps a failed write to _PipeClosed, and
+        # _finish() proactively flushes before returning. Disabling either
+        # alone leaves these two checks green; disabling BOTH fails them. So
+        # they do bite, but they cannot attribute the behaviour to one layer.
+        # Recorded consequence: the emit() path and _is_pipe_error() itself
+        # are effectively unexercised here — the flush reaches the failure
+        # first on this platform and buffer size. They are kept as defence for
+        # orderings that do not reproduce on this machine, not because the
+        # green suite demonstrates them.
+        rc, out, _ = run(["grep", "needle"], vault)
+        check("same grep unpiped still exits 0 and is not truncated",
+              rc == 0 and len(out.splitlines()) == 2000,
+              f"rc={rc} lines={len(out.splitlines())}")
+
+    print()
+    print(f"{PASS} passed, {FAIL} failed")
+    return 0 if FAIL == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/kb_test.py
+++ b/scripts/kb_test.py
@@ -153,6 +153,16 @@ def main() -> int:
                   "blanket-deny)", rc == 0 and "sub/seed.md" in out,
                   f"rc={rc} out={out!r}")
 
+        # --- write boundary errors are reported, not tracebacked. Writing
+        # --- onto an existing directory is the one failure of this class that
+        # --- is trivial to construct; disk-full and ACL failures are NOT
+        # --- covered here, so those branches remain unexercised.
+        (Path(vault) / "adir").mkdir()
+        rc, _, err = run(["write", "adir"], vault, stdin="x\n")
+        check("write onto a directory reports cleanly, no traceback",
+              rc == 1 and "cannot write" in err and "Traceback" not in err,
+              f"rc={rc} err={err!r}")
+
         # --- missing things fail as failures, not as success
         rc, _, _ = run(["cat", "nope.md"], vault)
         check("cat on a missing note exits 1", rc == 1, f"rc={rc}")
@@ -180,6 +190,50 @@ def main() -> int:
                                     "OBSIDIAN_HOST": "http://127.0.0.1:9"})
         check("osearch against a dead port exits 3 and names Obsidian",
               rc == 3 and "Is Obsidian running" in err, f"rc={rc} err={err!r}")
+
+        # urlopen honours any scheme it is given, so an OBSIDIAN_HOST of
+        # `file://` would quietly become a local file read instead of a
+        # network call. Also covers the likelier mistake of omitting http://.
+        for bad_host, label in [
+                (f"file:///{Path(tmp).as_posix()}/", "file:// scheme"),
+                ("localhost:27123", "missing scheme"),
+                ("http://", "no host")]:
+            rc, out, err = run(["osearch", "x"], vault,
+                               env_extra={"OBSIDIAN_API_KEY": "dummy",
+                                          "OBSIDIAN_HOST": bad_host})
+            check(f"osearch rejects OBSIDIAN_HOST with {label} (exit 3)",
+                  rc == 3 and f"invalid {'OBSIDIAN_HOST'}" in err,
+                  f"rc={rc} err={err!r} out={out!r}")
+
+        # A wrong port or a proxy answers with HTML. json.loads raises
+        # JSONDecodeError, which is NOT an OSError, so main()'s handler does
+        # not catch it — without the guard this tracebacks instead of
+        # reporting REST trouble. Served from a real socket rather than mocked.
+        import http.server
+        import threading
+
+        class _Html(http.server.BaseHTTPRequestHandler):
+            def do_POST(self):  # noqa: N802 - stdlib callback name
+                self.send_response(200)
+                self.send_header("Content-Type", "text/html")
+                self.end_headers()
+                self.wfile.write(b"<html><body>not json</body></html>")
+            do_GET = do_POST
+            def log_message(self, *a):  # silence per-request logging
+                pass
+
+        srv = http.server.HTTPServer(("127.0.0.1", 0), _Html)
+        threading.Thread(target=srv.serve_forever, daemon=True).start()
+        try:
+            rc, _, err = run(
+                ["osearch", "x"], vault,
+                env_extra={"OBSIDIAN_API_KEY": "dummy",
+                           "OBSIDIAN_HOST": f"http://127.0.0.1:{srv.server_port}"})
+            check("non-JSON REST body exits 3 instead of tracebacking",
+                  rc == 3 and "non-JSON" in err and "Traceback" not in err,
+                  f"rc={rc} err={err!r}")
+        finally:
+            srv.shutdown()
 
         # --- broken pipe. Needs output long enough that the downstream reader
         # --- closes mid-write; a short listing finishes first and never

--- a/scripts/kb_test.py
+++ b/scripts/kb_test.py
@@ -222,6 +222,52 @@ def main() -> int:
             def log_message(self, *a):  # silence per-request logging
                 pass
 
+        # A redirect must NOT be followed: urllib resends the Authorization
+        # header to the new authority, so a hijacked or mistyped host could
+        # harvest OBSIDIAN_API_KEY by answering 302. Asserting on the error
+        # alone would be too weak — the real requirement is that the key never
+        # reaches the second hop, so the second hop records what it saw.
+        got_auth: list = []
+
+        class _Sink(http.server.BaseHTTPRequestHandler):
+            def do_POST(self):  # noqa: N802
+                got_auth.append(self.headers.get("Authorization"))
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(b"{}")
+            do_GET = do_POST
+            def log_message(self, *a):
+                pass
+
+        sink = http.server.HTTPServer(("127.0.0.1", 0), _Sink)
+        threading.Thread(target=sink.serve_forever, daemon=True).start()
+
+        class _Redir(http.server.BaseHTTPRequestHandler):
+            def do_POST(self):  # noqa: N802
+                self.send_response(302)
+                self.send_header(
+                    "Location", f"http://127.0.0.1:{sink.server_port}/moved")
+                self.end_headers()
+            do_GET = do_POST
+            def log_message(self, *a):
+                pass
+
+        redir = http.server.HTTPServer(("127.0.0.1", 0), _Redir)
+        threading.Thread(target=redir.serve_forever, daemon=True).start()
+        try:
+            rc, _, err = run(
+                ["osearch", "x"], vault,
+                env_extra={"OBSIDIAN_API_KEY": "SECRET-TOKEN",
+                           "OBSIDIAN_HOST": f"http://127.0.0.1:{redir.server_port}"})
+            check("a redirect is refused rather than followed (exit 3)",
+                  rc == 3 and "redirect" in err, f"rc={rc} err={err!r}")
+            check("the API key never reached the redirect target",
+                  got_auth == [], f"second hop saw: {got_auth!r}")
+        finally:
+            redir.shutdown()
+            sink.shutdown()
+
         srv = http.server.HTTPServer(("127.0.0.1", 0), _Html)
         threading.Thread(target=srv.serve_forever, daemon=True).start()
         try:
@@ -234,6 +280,32 @@ def main() -> int:
                   f"rc={rc} err={err!r}")
         finally:
             srv.shutdown()
+
+        # Invalid UTF-8 is the same class of hole one line earlier than the
+        # JSON guard: UnicodeDecodeError is a ValueError, so main()'s OSError
+        # handler misses it too.
+        class _Binary(http.server.BaseHTTPRequestHandler):
+            def do_POST(self):  # noqa: N802
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(b"\xff\xfe\x00 not utf-8 at all")
+            do_GET = do_POST
+            def log_message(self, *a):
+                pass
+
+        bsrv = http.server.HTTPServer(("127.0.0.1", 0), _Binary)
+        threading.Thread(target=bsrv.serve_forever, daemon=True).start()
+        try:
+            rc, _, err = run(
+                ["osearch", "x"], vault,
+                env_extra={"OBSIDIAN_API_KEY": "dummy",
+                           "OBSIDIAN_HOST": f"http://127.0.0.1:{bsrv.server_port}"})
+            check("non-UTF-8 REST body exits 3 instead of tracebacking",
+                  rc == 3 and "not valid UTF-8" in err
+                  and "Traceback" not in err, f"rc={rc} err={err!r}")
+        finally:
+            bsrv.shutdown()
 
         # --- broken pipe. Needs output long enough that the downstream reader
         # --- closes mid-write; a short listing finishes first and never

--- a/scripts/sot_id_map/sources.py
+++ b/scripts/sot_id_map/sources.py
@@ -515,8 +515,13 @@ def _is_reparse_dir(path: Path) -> bool:
     """True for a Windows junction, which `is_symlink()` reports as False.
 
     Junctions are a real alias mechanism on this platform (this repository's
-    own push-guard notes list them alongside `subst`), and `os.walk` skips
-    them exactly like symlinks, so they need the same treatment.
+    own push-guard notes list them alongside `subst`), so they need the same
+    treatment as symlinks — which is exactly why callers must prune them by
+    hand: `os.walk` does NOT skip a junction the way it skips a symlink. It
+    walks straight through. Measured with a real junction while writing
+    scripts/kb.py (#564); the walk below already prunes correctly, and its
+    own comment says so, but this docstring previously claimed the opposite
+    and was what made the same bug easy to write a second time.
     """
     try:
         return bool(path.stat(follow_symlinks=False).st_reparse_tag)


### PR DESCRIPTION
## Issue

Closes #564

## Summary

`scripts/kb.py` + `scripts/kb_test.py`, plus a one-docstring correction in `scripts/sot_id_map/sources.py`.

### One part of the request is not achievable the way it was framed

The ask was to swap the obsidian MCP for "the Obsidian CLI", citing three costs: system resources, having to keep Obsidian open, and token overhead. **The second one cannot be fixed by any Obsidian-side option:**

- the official CLI's own docs say ["Note that the Obsidian app must be running"](https://obsidian.md/cli) — it is a remote control for a live app, not a headless tool
- `localhost:27123` is the Local REST API **plugin**, so it dies with the app

Only reading the files directly removes that dependency — and the vault is a plain git repo of 59 markdown files. So the tool is **filesystem-first**: `ls`/`cat`/`write`/`append`/`find`/`grep` never touch Obsidian; only `osearch` and `commands` (Obsidian's search index and command palette, which the filesystem genuinely cannot provide) go over REST, and they say so plainly when it is unavailable.

Config via `MERCURY_KB_DIR` / `OBSIDIAN_HOST` / `OBSIDIAN_API_KEY`, vault falling back to `.handoff-config`'s `kb_dir`. Nothing hardcoded.

## The containment bug, and why it was easy to write

`resolve_in_vault()` covers the direct path, but `iter_notes()` did not go through it — and the assumption that `os.walk(followlinks=False)` will not enter a junction is **false on Windows**. Measured with a real junction inside a test vault pointing outside it:

```
os.walk(followlinks=False) descended into it : True
kb ls    listed   link/leak.md                (outside the vault)
kb grep  printed  "SECRET OUTSIDE VAULT"      (outside the vault)
```

Fixed with two layers: aliases pruned during the walk, and every yielded path re-checked with `resolve().is_relative_to(root)`.

`_is_reparse_dir`'s docstring in `sot_id_map/sources.py` asserted the opposite ("os.walk skips them exactly like symlinks") and is what made the bug easy to write. **Checked whether that module has the same hole — it does not**: its walk already prunes and re-checks, and the comment at the walk itself states the correct behaviour. The code was right; only the docstring was wrong, contradicting its own module. Corrected here rather than left to cause the same mistake a third time.

## Pipe handling, fixed twice

The first attempt caught `BrokenPipeError`, which never fires on Windows (it raises `OSError` EINVAL). The second added a proactive flush but deleted a blanket `except OSError` — removing the pipe protection along with the EINVAL misreading, so a pipe closed during a write would traceback, and ordinary filesystem errors degraded to tracebacks too.

The right shape binds pipe handling to the **output operation**, not the command: every stdout write goes through `emit()`, which maps a pipe-shaped failure to `_PipeClosed`; `main()` turns that into exit 0 and any other `OSError` into a reported `EXIT_FAIL`. A filesystem EINVAL can no longer be read as a closed pipe, and no failure exits as success.

## Recorded as limits, not claimed as solved

- **TOCTOU**: containment is verified at yield, not at open. An alias swapped in between would be followed. Unfixed — Windows has no portable `O_NOFOLLOW`, and setting the race up already requires write access to the vault.
- **EINVAL ambiguity**: on Windows a closed pipe is EINVAL, too generic to distinguish from a genuine stdout EINVAL. Exposure is bounded to stdout operations, but it is real.

## Test plan

- [x] 28 cases, none requiring Obsidian
- [x] Filesystem subcommands verified with `OBSIDIAN_API_KEY` unset **and** `OBSIDIAN_HOST` pointed at a dead port — stronger than "it worked while Obsidian happened to be open"
- [x] REST subcommands in four states: no key / dead port / wrong key / valid key, each with a distinct exit code
- [x] Containment: `..`, absolute POSIX, absolute Windows, nested escape, plus a positive control proving the guard is not blanket-deny
- [x] Real junction fixture, with a sanity check that the junction was actually created — a `mklink` that silently fails is indistinguishable from a correctly-blocked alias (it did silently fail twice while writing this, once from an MSYS argv rewrite)
- [x] `sot_id_map` checker `EXIT=0` and smoke suite pass after the docstring edit

**Suite validated by sabotage**, because a green suite proves nothing by itself:

| sabotage | result |
|---|---|
| path guard off | exactly 7 containment tests fail |
| proactive flush off | exactly 2 pipe tests fail |
| both containment layers off | exactly 2 alias tests fail |
| either containment layer alone | green — defence in depth, documented |
| `_is_pipe_error` forced false | green — call sites unexercised here, documented |

One test was found **worthless and rewritten**: it asserted on a shell pipeline's return code, which reports `head`'s status rather than the program's, so it passed regardless of what the code did.

## Cleanup (outside this diff, recorded on the issue)

The MCP server was already gone from the config; only debris remained. Removed 11 leaked `mcp-obsidian.exe` processes holding ~53 MB, and the stale `mcp__obsidian` permission entries in `~/.claude/settings.json` and `.claude/settings.local.json` — both verified semantically identical to their backups apart from that single removal, JSON still valid, `claude mcp list` unaffected. Obsidian itself and the REST API confirmed still working.

## Dual-verify

- Claude side: PASS
- Codex side: round 1 NEEDS-CHANGES (1 Critical + 2 High, all accepted and fixed) → round 2 NEEDS-CHANGES (3 High + 1 Medium + 1 Low; two Highs were regressions introduced by round 1's fix, now corrected; the remaining items recorded as limits above)

Generated with Claude Code
