### PR TITLE
fix(sot-id-map): 映射 Wave 4 的交刃载体 + 清掉指向已删 id 的 unmapped 条目

### DIFF
--- a/scripts/sot_id_map/id_map.json
+++ b/scripts/sot_id_map/id_map.json
@@ -723,6 +723,18 @@
       "cardinality": "1:1",
       "basis": "两侧同 id 同名（死线）、同 class_id（myrmidon）、同 rarity（稀有）；id / name / class_id / rarity / tags / trigger_event / trigger_object / trigger_source / trigger_condition / trigger_frequency / trigger_frequency_n / effect / rules 共 13 项逐字段比对全部相等（引擎 054f29c 对设计库 snapshots/talents.json）。引擎 data/talents/myrmidon_sixian.json 的 _mirror 字段自述镜像自设计库 snapshots/talents.json @ 2ea744b。设计库侧 shelf_state 为「在用」，故 design_shelved_not_imported 不适用。",
       "note": "设计库该条目的 levels_json 留有一份不含当前 effect 的旧版本文本（193 字符；另两张 Wave 3 卡该字段仅 2 字符），与引擎 _mirror 里的说明一致。属设计库单写域的过期残留，已记录交 SoT 侧判断，不影响本条映射的依据 —— 映射依据是 id 与上述 13 项镜像字段，不含 levels_json。"
+    },
+    {
+      "type": "talent",
+      "engine_ids": [
+        "kensei_jiaoren"
+      ],
+      "design_ids": [
+        "kensei_jiaoren"
+      ],
+      "cardinality": "1:1",
+      "basis": "两侧同 id 同名（交刃）、同 class_id（kensei）、同 rarity（史诗）；id / name / class_id / rarity / tags / trigger_event / trigger_object / trigger_source / trigger_condition / trigger_frequency / trigger_frequency_n / effect / rules 共 13 项逐字段比对全部相等（引擎 74acb57 对设计库 snapshots/talents.json @ d486d28；该文件在 74acb57..3ac65b1 之间无改动，故对当前引擎 HEAD 同样成立）。引擎 data/talents/kensei_jiaoren.json 的 _mirror 字段自述版本锚点 = 生产库 /api/talents 的 kensei_jiaoren，updated_at 2026-08-08T07:57:03.152679。设计库快照侧 shelf_state 为「在用」（status=待审阅），故 design_shelved_not_imported 不适用。",
+      "note": "引擎侧该条目另有 _designlib_wording 字段，记着设计库 rules 原文的「final_modifier」在引擎里实际键名是 final_multiplier。那属设计库生产库活数据（lane §2.1 单写方 = 用户 + SoT 组），已走转交协议交对方判断，不影响本条映射 —— 映射依据是 id 与上述 13 项镜像字段。"
     }
   ],
   "unmapped": [
@@ -1521,12 +1533,6 @@
     {
       "type": "talent",
       "side": "design",
-      "id": "kensei_jiaoren",
-      "reason": "engine_not_implemented"
-    },
-    {
-      "type": "talent",
-      "side": "design",
       "id": "kensei_jiutoulongshan",
       "reason": "engine_not_implemented"
     },
@@ -1649,13 +1655,6 @@
       "id": "kensei_wuxiangjian",
       "reason": "design_shelved_not_imported",
       "note": "设计库 shelf_state = 已归档，不是等待引擎实装的候选。设计库的非在用天赋，引擎侧一条都没有导入；已导入的天赋全部是「在用」条目。（此处刻意不写条数：这段 note 在多个条目里重复，写死计数会在每次交付后一起过期，而漏改一处比全错更难发现。）"
-    },
-    {
-      "type": "talent",
-      "side": "design",
-      "id": "kensei_xianzhixian",
-      "reason": "design_shelved_not_imported",
-      "note": "设计库 shelf_state = 待删除，trashed_at = 2026-08-01T09:08:03.970003，不是等待引擎实装的候选。设计库的非在用天赋，引擎侧一条都没有导入；已导入的天赋全部是「在用」条目。（此处刻意不写条数，理由同已归档那组 note。）"
     },
     {
       "type": "talent",


### PR DESCRIPTION
## 起因

SoT 组交付 Wave 4（防御侧反应：`受到攻击时` 事件 + 招架减伤 + 交刃），引擎 `74acb57` / `3ac65b1`，新增天赋载体 `kensei_jiaoren`，载体从 6 张增到 7 张。

**校验器按设计自己发现了漂移**，报出 3 个 finding：

```
FAIL: 3 finding(s)
  [unknown_id] unmapped[150] references design talent id 'kensei_xianzhixian',
    which does not exist in the design repository
  [cross_side_contradiction] design talent id 'kensei_jiaoren' is declared unmapped
    (reason 'engine_not_implemented'), but that same id also exists on the engine side
  [uncovered_id] engine talent id 'kensei_jiaoren' is neither mapped nor explicitly listed as unmapped
```

后两条是同一件事（交刃已实装）。**第一条是 SoT 没提、校验器自己抓出来的独立问题** —— 它只查了「新增了什么」，没查「引用的东西还在不在」。

## 两处修改

### 1. `kensei_jiaoren` 交刃：`unmapped` → `mappings`

原条目 `reason: engine_not_implemented` 已不成立。

`basis` 写了**四处可独立重跑的锚点**：

| 锚点 | 怎么复核 |
|---|---|
| 13 项逐字段相等 | 比对引擎 `data/talents/kensei_jiaoren.json` 与设计库 `snapshots/talents.json`：`id`/`name`/`class_id`/`rarity`/`tags`/trigger 五段/`effect`/`rules` |
| 引擎 `74acb57` | `git -C <engine> show 74acb57:data/talents/kensei_jiaoren.json` |
| 设计库快照 `@ d486d28` | `git -C <design> show d486d28:snapshots/talents.json` |
| 「该文件在 `74acb57..3ac65b1` 之间无改动」 | `git -C <engine> diff 74acb57 3ac65b1 -- data/talents/kensei_jiaoren.json` → 空 |

最后一条是复核阶段补的：没有它，读者拿 `74acb57` 去对当前 HEAD（`3ac65b1`）时会产生「这个 basis 还成不成立」的疑问。

### 2. `kensei_xianzhixian`：删除该 `unmapped` 条目

它的 note 记的是 `shelf_state = 待删除，trashed_at = 2026-08-01T09:08:03.970003`。**现在它已被真正删除** —— 设计库 `snapshots/talents.json` 的 48 条里查无此 id。

指向不存在 id 的条目本身就是过期状态，按「归档 / 待删除不进任何计量」的既定口径清掉，不留墓碑。

## 验证

```
$ SOT_ENGINE_REPO=... SOT_DESIGN_REPO=... python -m scripts.sot_id_map
OK: every id on both sides is mapped or explicitly unmapped, and every referenced id exists.
engine ids: 125   design ids: 142   mappings: 38   unmapped: 185

$ python -m scripts.sot_id_map.test_smoke
PASS test_missing_env_exits_2_with_guidance
PASS test_non_ascii_finding_is_printable
PASS test_packaged_map_is_wellformed (38 mappings, 185 unmapped)
ALL SMOKE PASS
```

计数：`mappings` 37 → 38，`unmapped` 187 → 185。

## Dual-verify

**Claude: PASS** — JSON 合法、计数正确、`xianzhixian` 全文零残留、`jiaoren` 无 mapped/unmapped 重叠、新条目字段集与同类型兄弟条目一致、全表无 id 重复、`cardinality` 取值合法。逐条实测核实了 `basis` 的三条原始断言（`74acb57` 与 HEAD 下该文件 diff 为空、设计库侧 `shelf_state='在用'`、13/13 字段相等），并据此补强了三处锚点。

**Codex: PASS** — 0 findings。

> **如实披露审查过程**：Codex 侧跑了三轮。
> - **Round 1: PASS（0 findings）**，但它审的是**改强 `basis` 之前**的版本 —— 我在它跑的期间改了那个字段。
> - **Round 2: FAILED**，原因是我让它跨仓核实 `D:/ShipOfTheseus/*`，而其 `workspaceRoot` 是本仓，harness 拒绝了仓外访问。**这是 prompt 设计错误，不是它发现了问题。**
> - **Round 2b: PASS（0 findings）** — 改为把跨仓证据逐条贴进 prompt、让它审证据是否支撑断言。它额外指出：`_mirror` 的 `updated_at` 与 `shelf_state` 两条断言不在 2b 的证据范围内，但属 Round 1 已覆盖的既有claim（不是本次强化的部分）—— 这个划分准确，两轮合起来覆盖完整。

Closes #569
Refs #550
